### PR TITLE
chore(function): bump default memory limit

### DIFF
--- a/internal/services/function/cron_test.go
+++ b/internal/services/function/cron_test.go
@@ -30,7 +30,7 @@ func TestAccFunctionCron_Basic(t *testing.T) {
 					resource scaleway_function main {
 						name = "tf-tests-cron-basic"
 						namespace_id = scaleway_function_namespace.main.id
-						runtime = "node14"
+						runtime = "node20"
 						privacy = "private"
 						handler = "handler.handle"
 					}
@@ -70,7 +70,7 @@ func TestAccFunctionCron_NameUpdate(t *testing.T) {
 					resource scaleway_function main {
 						name = "tf-tests-function-cron-name-update"
 						namespace_id = scaleway_function_namespace.main.id
-						runtime = "node14"
+						runtime = "node20"
 						privacy = "private"
 						handler = "handler.handle"
 					}
@@ -97,7 +97,7 @@ func TestAccFunctionCron_NameUpdate(t *testing.T) {
 					resource scaleway_function main {
 						name = "tf-tests-function-cron-name-update"
 						namespace_id = scaleway_function_namespace.main.id
-						runtime = "node14"
+						runtime = "node20"
 						privacy = "private"
 						handler = "handler.handle"
 					}
@@ -136,7 +136,7 @@ func TestAccFunctionCron_WithArgs(t *testing.T) {
 					resource scaleway_function main {
 						name = "tf-tests-cron-with-args"
 						namespace_id = scaleway_function_namespace.main.id
-						runtime = "node14"
+						runtime = "node20"
 						privacy = "private"
 						handler = "handler.handle"
 					}

--- a/internal/services/function/data_source_function_test.go
+++ b/internal/services/function/data_source_function_test.go
@@ -25,7 +25,7 @@ func TestAccDataSourceFunction_Basic(t *testing.T) {
 					resource scaleway_function main {
 						name = "tf-ds-function"
 						namespace_id = scaleway_function_namespace.main.id
-						runtime = "node14"
+						runtime = "node22"
 						privacy = "private"
 						handler = "handler.handle"
 					}
@@ -44,7 +44,7 @@ func TestAccDataSourceFunction_Basic(t *testing.T) {
 					resource scaleway_function main {
 						name = "tf-ds-function"
 						namespace_id = scaleway_function_namespace.main.id
-						runtime = "node14"
+						runtime = "node22"
 						privacy = "private"
 						handler = "handler.handle"
 					}					

--- a/internal/services/function/domain_test.go
+++ b/internal/services/function/domain_test.go
@@ -32,7 +32,7 @@ func TestAccFunctionDomain_Basic(t *testing.T) {
 
 				resource scaleway_function main {
 						namespace_id = scaleway_function_namespace.main.id
-						runtime = "go118"
+						runtime = "go122"
 						privacy = "private"
 						handler = "Handle"
 						zip_file = "testfixture/gofunction.zip"
@@ -47,7 +47,7 @@ func TestAccFunctionDomain_Basic(t *testing.T) {
 
 					resource scaleway_function main {
 						namespace_id = scaleway_function_namespace.main.id
-						runtime = "go118"
+						runtime = "go122"
 						privacy = "private"
 						handler = "Handle"
 						zip_file = "testfixture/gofunction.zip"

--- a/internal/services/function/function.go
+++ b/internal/services/function/function.go
@@ -104,9 +104,9 @@ func ResourceFunction() *schema.Resource {
 			},
 			"memory_limit": {
 				Type:        schema.TypeInt,
-				Description: "Memory limit in MB for your function, defaults to 128MB",
+				Description: "Memory limit in MB for your function, defaults to 256MB",
 				Optional:    true,
-				Default:     128,
+				Default:     256,
 			},
 			"handler": {
 				Type:        schema.TypeString,

--- a/internal/services/function/function_test.go
+++ b/internal/services/function/function_test.go
@@ -28,7 +28,7 @@ func TestAccFunction_Basic(t *testing.T) {
 					resource scaleway_function main {
 						name = "foobar"
 						namespace_id = scaleway_function_namespace.main.id
-						runtime = "node14"
+						runtime = "node22"
 						privacy = "private"
 						handler = "handler.handle"
 					}
@@ -36,7 +36,7 @@ func TestAccFunction_Basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFunctionExists(tt, "scaleway_function.main"),
 					resource.TestCheckResourceAttr("scaleway_function.main", "name", "foobar"),
-					resource.TestCheckResourceAttr("scaleway_function.main", "runtime", "node14"),
+					resource.TestCheckResourceAttr("scaleway_function.main", "runtime", "node22"),
 					resource.TestCheckResourceAttr("scaleway_function.main", "privacy", "private"),
 					resource.TestCheckResourceAttr("scaleway_function.main", "handler", "handler.handle"),
 					resource.TestCheckResourceAttrSet("scaleway_function.main", "namespace_id"),
@@ -63,7 +63,7 @@ func TestAccFunction_Timeout(t *testing.T) {
 					resource scaleway_function main {
 						name = "foobar"
 						namespace_id = scaleway_function_namespace.main.id
-						runtime = "node14"
+						runtime = "node22"
 						privacy = "private"
 						handler = "handler.handle"
 						timeout = 10
@@ -72,7 +72,7 @@ func TestAccFunction_Timeout(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFunctionExists(tt, "scaleway_function.main"),
 					resource.TestCheckResourceAttr("scaleway_function.main", "name", "foobar"),
-					resource.TestCheckResourceAttr("scaleway_function.main", "runtime", "node14"),
+					resource.TestCheckResourceAttr("scaleway_function.main", "runtime", "node22"),
 					resource.TestCheckResourceAttr("scaleway_function.main", "privacy", "private"),
 					resource.TestCheckResourceAttr("scaleway_function.main", "handler", "handler.handle"),
 					resource.TestCheckResourceAttr("scaleway_function.main", "timeout", "10"),
@@ -97,7 +97,7 @@ func TestAccFunction_NoName(t *testing.T) {
 
 					resource scaleway_function main {
 						namespace_id = scaleway_function_namespace.main.id
-						runtime = "node14"
+						runtime = "node22"
 						privacy = "private"
 						handler = "handler.handle"
 					}
@@ -127,7 +127,7 @@ func TestAccFunction_EnvironmentVariables(t *testing.T) {
 					resource scaleway_function main {
 						name = "foobar"
 						namespace_id = scaleway_function_namespace.main.id
-						runtime = "node14"
+						runtime = "node22"
 						privacy = "private"
 						handler = "handler.handle"
 						environment_variables = {
@@ -152,7 +152,7 @@ func TestAccFunction_EnvironmentVariables(t *testing.T) {
 					resource scaleway_function main {
 						name = "foobar"
 						namespace_id = scaleway_function_namespace.main.id
-						runtime = "node14"
+						runtime = "node22"
 						privacy = "private"
 						handler = "handler.handle"
 						environment_variables = {
@@ -190,7 +190,7 @@ func TestAccFunction_Upload(t *testing.T) {
 					resource scaleway_function main {
 						name = "foobar"
 						namespace_id = scaleway_function_namespace.main.id
-						runtime = "go118"
+						runtime = "go122"
 						privacy = "private"
 						handler = "Handle"
 						zip_file = "testfixture/gofunction.zip"
@@ -220,7 +220,7 @@ func TestAccFunction_Deploy(t *testing.T) {
 					resource scaleway_function main {
 						name = "foobar"
 						namespace_id = scaleway_function_namespace.main.id
-						runtime = "go118"
+						runtime = "go122"
 						privacy = "private"
 						handler = "Handle"
 						zip_file = "testfixture/gofunction.zip"
@@ -238,7 +238,7 @@ func TestAccFunction_Deploy(t *testing.T) {
 					resource scaleway_function main {
 						name = "foobar"
 						namespace_id = scaleway_function_namespace.main.id
-						runtime = "go118"
+						runtime = "go122"
 						privacy = "private"
 						handler = "Handle"
 						zip_file = "testfixture/gofunction.zip"
@@ -270,7 +270,7 @@ func TestAccFunction_HTTPOption(t *testing.T) {
 					resource scaleway_function main {
 						name = "foobar"
 						namespace_id = scaleway_function_namespace.main.id
-						runtime = "node14"
+						runtime = "node22"
 						privacy = "private"
 						handler = "handler.handle"
 						http_option = "enabled"
@@ -288,7 +288,7 @@ func TestAccFunction_HTTPOption(t *testing.T) {
 					resource scaleway_function main {
 						name = "foobar"
 						namespace_id = scaleway_function_namespace.main.id
-						runtime = "node14"
+						runtime = "node22"
 						privacy = "private"
 						handler = "handler.handle"
 						http_option = "redirected"
@@ -306,7 +306,7 @@ func TestAccFunction_HTTPOption(t *testing.T) {
 					resource scaleway_function main {
 						name = "foobar"
 						namespace_id = scaleway_function_namespace.main.id
-						runtime = "node14"
+						runtime = "node22"
 						privacy = "private"
 						handler = "handler.handle"
 					}

--- a/internal/services/function/testdata/data-source-function-basic.cassette.yaml
+++ b/internal/services/function/testdata/data-source-function-basic.cassette.yaml
@@ -1,1255 +1,1918 @@
 ---
 version: 2
 interactions:
-- request:
-    body: '{"name":"tf-ds-function","environment_variables":{},"project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","description":null,"secret_environment_variables":[]}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces
-    method: POST
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"63ed201d-62d0-4b8f-840f-735cc11093fd","name":"tf-ds-function","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "364"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 05 Jan 2023 09:23:07 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5312770d-060f-4eba-bffe-1cfe405df7e1
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/63ed201d-62d0-4b8f-840f-735cc11093fd
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"63ed201d-62d0-4b8f-840f-735cc11093fd","name":"tf-ds-function","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "364"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 05 Jan 2023 09:23:07 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 98c7f887-b8e2-477e-97ef-4e9108cd5daf
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/63ed201d-62d0-4b8f-840f-735cc11093fd
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"63ed201d-62d0-4b8f-840f-735cc11093fd","name":"tf-ds-function","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfdsfunctiongd0jpiiy","registry_namespace_id":"09ce1744-9a9a-4f13-be4a-dc7c07eebdd8","secret_environment_variables":[],"status":"ready"}'
-    headers:
-      Content-Length:
-      - "445"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 05 Jan 2023 09:23:12 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6df15ee1-4b1e-4a9a-87f3-73f1b7c666ec
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/63ed201d-62d0-4b8f-840f-735cc11093fd
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"63ed201d-62d0-4b8f-840f-735cc11093fd","name":"tf-ds-function","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfdsfunctiongd0jpiiy","registry_namespace_id":"09ce1744-9a9a-4f13-be4a-dc7c07eebdd8","secret_environment_variables":[],"status":"ready"}'
-    headers:
-      Content-Length:
-      - "445"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 05 Jan 2023 09:23:12 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6cc006b0-18f4-40a4-af34-8eec89e8e6ca
-    status: 200 OK
-    code: 200
-- request:
-    body: '{"name":"tf-ds-function","namespace_id":"63ed201d-62d0-4b8f-840f-735cc11093fd","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"node14","memory_limit":128,"timeout":null,"handler":"handler.handle","privacy":"private","description":null,"secret_environment_variables":[],"http_option":"enabled"}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions
-    method: POST
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tfdsfunctiongd0jpiiy-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"86849f5b-221c-496f-bc79-ec56b81fbabb","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-ds-function","namespace_id":"63ed201d-62d0-4b8f-840f-735cc11093fd","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "533"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 05 Jan 2023 09:23:12 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4d647d19-4cd5-487a-bb6a-4ebe0bea7fc3
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/86849f5b-221c-496f-bc79-ec56b81fbabb
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tfdsfunctiongd0jpiiy-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"86849f5b-221c-496f-bc79-ec56b81fbabb","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-ds-function","namespace_id":"63ed201d-62d0-4b8f-840f-735cc11093fd","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "533"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 05 Jan 2023 09:23:12 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ad05c1f1-e264-40fd-bec9-0a6bad26a0b1
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/86849f5b-221c-496f-bc79-ec56b81fbabb
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tfdsfunctiongd0jpiiy-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"86849f5b-221c-496f-bc79-ec56b81fbabb","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-ds-function","namespace_id":"63ed201d-62d0-4b8f-840f-735cc11093fd","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "533"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 05 Jan 2023 09:23:12 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - fcc2c276-20a9-45b8-b0c7-bca2836cca93
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/86849f5b-221c-496f-bc79-ec56b81fbabb
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tfdsfunctiongd0jpiiy-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"86849f5b-221c-496f-bc79-ec56b81fbabb","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-ds-function","namespace_id":"63ed201d-62d0-4b8f-840f-735cc11093fd","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "533"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 05 Jan 2023 09:23:12 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d90707e0-12ae-4c44-ab9e-7d2004d9c96d
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/63ed201d-62d0-4b8f-840f-735cc11093fd
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"63ed201d-62d0-4b8f-840f-735cc11093fd","name":"tf-ds-function","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfdsfunctiongd0jpiiy","registry_namespace_id":"09ce1744-9a9a-4f13-be4a-dc7c07eebdd8","secret_environment_variables":[],"status":"ready"}'
-    headers:
-      Content-Length:
-      - "445"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 05 Jan 2023 09:23:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - fd7af4e0-ee97-48ec-a75b-422c51d5c628
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/86849f5b-221c-496f-bc79-ec56b81fbabb
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tfdsfunctiongd0jpiiy-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"86849f5b-221c-496f-bc79-ec56b81fbabb","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-ds-function","namespace_id":"63ed201d-62d0-4b8f-840f-735cc11093fd","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "533"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 05 Jan 2023 09:23:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f107a101-e4a4-4a56-a2eb-3556709700b5
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/63ed201d-62d0-4b8f-840f-735cc11093fd
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"63ed201d-62d0-4b8f-840f-735cc11093fd","name":"tf-ds-function","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfdsfunctiongd0jpiiy","registry_namespace_id":"09ce1744-9a9a-4f13-be4a-dc7c07eebdd8","secret_environment_variables":[],"status":"ready"}'
-    headers:
-      Content-Length:
-      - "445"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 05 Jan 2023 09:23:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5f6f3238-98d3-4675-97e6-5981670c4f4a
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/86849f5b-221c-496f-bc79-ec56b81fbabb
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tfdsfunctiongd0jpiiy-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"86849f5b-221c-496f-bc79-ec56b81fbabb","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-ds-function","namespace_id":"63ed201d-62d0-4b8f-840f-735cc11093fd","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "533"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 05 Jan 2023 09:23:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d3ae8085-a311-4153-ba11-ddf038fc61e5
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/86849f5b-221c-496f-bc79-ec56b81fbabb
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tfdsfunctiongd0jpiiy-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"86849f5b-221c-496f-bc79-ec56b81fbabb","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-ds-function","namespace_id":"63ed201d-62d0-4b8f-840f-735cc11093fd","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "533"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 05 Jan 2023 09:23:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7873f8ab-b255-4b5c-83eb-7c29afa11c7a
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions?name=tf-ds-function&namespace_id=63ed201d-62d0-4b8f-840f-735cc11093fd&order_by=created_at_asc
-    method: GET
-  response:
-    body: '{"functions":[{"cpu_limit":70,"description":"","domain_name":"tfdsfunctiongd0jpiiy-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"86849f5b-221c-496f-bc79-ec56b81fbabb","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-ds-function","namespace_id":"63ed201d-62d0-4b8f-840f-735cc11093fd","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "565"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 05 Jan 2023 09:23:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b781e41a-a93b-4575-adfd-57e68750cefe
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/86849f5b-221c-496f-bc79-ec56b81fbabb
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tfdsfunctiongd0jpiiy-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"86849f5b-221c-496f-bc79-ec56b81fbabb","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-ds-function","namespace_id":"63ed201d-62d0-4b8f-840f-735cc11093fd","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "533"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 05 Jan 2023 09:23:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c543132d-978f-4e1c-8c0b-09a5e2344bdd
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/86849f5b-221c-496f-bc79-ec56b81fbabb
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tfdsfunctiongd0jpiiy-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"86849f5b-221c-496f-bc79-ec56b81fbabb","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-ds-function","namespace_id":"63ed201d-62d0-4b8f-840f-735cc11093fd","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "533"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 05 Jan 2023 09:23:14 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3ca8705f-4f7d-4a45-8227-f81145dbd3cb
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions?name=tf-ds-function&namespace_id=63ed201d-62d0-4b8f-840f-735cc11093fd&order_by=created_at_asc
-    method: GET
-  response:
-    body: '{"functions":[{"cpu_limit":70,"description":"","domain_name":"tfdsfunctiongd0jpiiy-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"86849f5b-221c-496f-bc79-ec56b81fbabb","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-ds-function","namespace_id":"63ed201d-62d0-4b8f-840f-735cc11093fd","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "565"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 05 Jan 2023 09:23:14 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e02df94a-ea39-4e18-9f7f-ff60d7e5c1dd
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/86849f5b-221c-496f-bc79-ec56b81fbabb
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tfdsfunctiongd0jpiiy-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"86849f5b-221c-496f-bc79-ec56b81fbabb","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-ds-function","namespace_id":"63ed201d-62d0-4b8f-840f-735cc11093fd","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "533"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 05 Jan 2023 09:23:14 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 89abae36-d031-47c5-abbf-63fb788e00f1
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/86849f5b-221c-496f-bc79-ec56b81fbabb
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tfdsfunctiongd0jpiiy-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"86849f5b-221c-496f-bc79-ec56b81fbabb","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-ds-function","namespace_id":"63ed201d-62d0-4b8f-840f-735cc11093fd","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "533"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 05 Jan 2023 09:23:14 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 411dbabc-da67-4513-b520-5333a036a87d
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions?name=tf-ds-function&namespace_id=63ed201d-62d0-4b8f-840f-735cc11093fd&order_by=created_at_asc
-    method: GET
-  response:
-    body: '{"functions":[{"cpu_limit":70,"description":"","domain_name":"tfdsfunctiongd0jpiiy-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"86849f5b-221c-496f-bc79-ec56b81fbabb","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-ds-function","namespace_id":"63ed201d-62d0-4b8f-840f-735cc11093fd","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "565"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 05 Jan 2023 09:23:14 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 68d5339b-856d-41ef-bc38-ba18db35f815
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/86849f5b-221c-496f-bc79-ec56b81fbabb
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tfdsfunctiongd0jpiiy-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"86849f5b-221c-496f-bc79-ec56b81fbabb","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-ds-function","namespace_id":"63ed201d-62d0-4b8f-840f-735cc11093fd","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "533"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 05 Jan 2023 09:23:14 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ad433079-95f3-4a91-b512-8d9c9aca35bc
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/86849f5b-221c-496f-bc79-ec56b81fbabb
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tfdsfunctiongd0jpiiy-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"86849f5b-221c-496f-bc79-ec56b81fbabb","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-ds-function","namespace_id":"63ed201d-62d0-4b8f-840f-735cc11093fd","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "533"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 05 Jan 2023 09:23:14 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f51b1a87-bd13-45a2-87b1-25d425bb180a
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/63ed201d-62d0-4b8f-840f-735cc11093fd
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"63ed201d-62d0-4b8f-840f-735cc11093fd","name":"tf-ds-function","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfdsfunctiongd0jpiiy","registry_namespace_id":"09ce1744-9a9a-4f13-be4a-dc7c07eebdd8","secret_environment_variables":[],"status":"ready"}'
-    headers:
-      Content-Length:
-      - "445"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 05 Jan 2023 09:23:14 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8b6236b9-7b01-4762-b0ce-8bc83d4e200c
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/86849f5b-221c-496f-bc79-ec56b81fbabb
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tfdsfunctiongd0jpiiy-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"86849f5b-221c-496f-bc79-ec56b81fbabb","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-ds-function","namespace_id":"63ed201d-62d0-4b8f-840f-735cc11093fd","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "533"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 05 Jan 2023 09:23:14 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c446e0ad-f199-44ab-b329-b75c695af896
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/86849f5b-221c-496f-bc79-ec56b81fbabb
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tfdsfunctiongd0jpiiy-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"86849f5b-221c-496f-bc79-ec56b81fbabb","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-ds-function","namespace_id":"63ed201d-62d0-4b8f-840f-735cc11093fd","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "533"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 05 Jan 2023 09:23:14 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 79de63b2-92c4-4cde-87f7-d91c894b0f6e
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions?name=tf-ds-function&namespace_id=63ed201d-62d0-4b8f-840f-735cc11093fd&order_by=created_at_asc
-    method: GET
-  response:
-    body: '{"functions":[{"cpu_limit":70,"description":"","domain_name":"tfdsfunctiongd0jpiiy-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"86849f5b-221c-496f-bc79-ec56b81fbabb","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-ds-function","namespace_id":"63ed201d-62d0-4b8f-840f-735cc11093fd","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "565"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 05 Jan 2023 09:23:14 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - aaa26a9f-c5b3-46ad-aaf0-aa0186ea9bdf
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/86849f5b-221c-496f-bc79-ec56b81fbabb
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tfdsfunctiongd0jpiiy-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"86849f5b-221c-496f-bc79-ec56b81fbabb","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-ds-function","namespace_id":"63ed201d-62d0-4b8f-840f-735cc11093fd","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "533"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 05 Jan 2023 09:23:15 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2b7e3f4f-bca7-4b2b-bf1a-73e9953150ce
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/86849f5b-221c-496f-bc79-ec56b81fbabb
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tfdsfunctiongd0jpiiy-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"86849f5b-221c-496f-bc79-ec56b81fbabb","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-ds-function","namespace_id":"63ed201d-62d0-4b8f-840f-735cc11093fd","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "533"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 05 Jan 2023 09:23:15 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6948120f-051d-45bb-aa1f-62872c0de2e3
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions?name=tf-ds-function&namespace_id=63ed201d-62d0-4b8f-840f-735cc11093fd&order_by=created_at_asc
-    method: GET
-  response:
-    body: '{"functions":[{"cpu_limit":70,"description":"","domain_name":"tfdsfunctiongd0jpiiy-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"86849f5b-221c-496f-bc79-ec56b81fbabb","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-ds-function","namespace_id":"63ed201d-62d0-4b8f-840f-735cc11093fd","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "565"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 05 Jan 2023 09:23:15 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b95f9033-7e08-4d97-a1ee-387cfde6aa3a
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/86849f5b-221c-496f-bc79-ec56b81fbabb
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tfdsfunctiongd0jpiiy-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"86849f5b-221c-496f-bc79-ec56b81fbabb","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-ds-function","namespace_id":"63ed201d-62d0-4b8f-840f-735cc11093fd","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "533"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 05 Jan 2023 09:23:15 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9936393c-ce32-4168-813b-a0b4addadf01
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/86849f5b-221c-496f-bc79-ec56b81fbabb
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tfdsfunctiongd0jpiiy-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"86849f5b-221c-496f-bc79-ec56b81fbabb","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-ds-function","namespace_id":"63ed201d-62d0-4b8f-840f-735cc11093fd","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "533"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 05 Jan 2023 09:23:15 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 84ab11e6-f6ab-4687-aa55-9f581c7168ab
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/86849f5b-221c-496f-bc79-ec56b81fbabb
-    method: DELETE
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tfdsfunctiongd0jpiiy-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"86849f5b-221c-496f-bc79-ec56b81fbabb","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-ds-function","namespace_id":"63ed201d-62d0-4b8f-840f-735cc11093fd","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"deleting","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "534"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 05 Jan 2023 09:23:15 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 25b541c4-e19c-44da-8459-d8fca5ecd988
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/63ed201d-62d0-4b8f-840f-735cc11093fd
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"63ed201d-62d0-4b8f-840f-735cc11093fd","name":"tf-ds-function","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfdsfunctiongd0jpiiy","registry_namespace_id":"09ce1744-9a9a-4f13-be4a-dc7c07eebdd8","secret_environment_variables":[],"status":"ready"}'
-    headers:
-      Content-Length:
-      - "445"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 05 Jan 2023 09:23:15 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e6dcdcc4-fa64-4ada-90dd-4dd6419b8c26
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/63ed201d-62d0-4b8f-840f-735cc11093fd
-    method: DELETE
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"63ed201d-62d0-4b8f-840f-735cc11093fd","name":"tf-ds-function","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfdsfunctiongd0jpiiy","registry_namespace_id":"09ce1744-9a9a-4f13-be4a-dc7c07eebdd8","secret_environment_variables":[],"status":"deleting"}'
-    headers:
-      Content-Length:
-      - "448"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 05 Jan 2023 09:23:15 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5eca665c-1c53-4bb6-9d71-c5441e3db67d
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/63ed201d-62d0-4b8f-840f-735cc11093fd
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"63ed201d-62d0-4b8f-840f-735cc11093fd","name":"tf-ds-function","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfdsfunctiongd0jpiiy","registry_namespace_id":"09ce1744-9a9a-4f13-be4a-dc7c07eebdd8","secret_environment_variables":[],"status":"deleting"}'
-    headers:
-      Content-Length:
-      - "448"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 05 Jan 2023 09:23:15 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 75ec40d0-b772-4814-81f7-33ab50c5b4ea
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/63ed201d-62d0-4b8f-840f-735cc11093fd
-    method: GET
-  response:
-    body: '{"message":"Namespace was not found"}'
-    headers:
-      Content-Length:
-      - "37"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 05 Jan 2023 09:23:20 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3cbe66c5-8ae0-4e2d-b4e8-c5b4fd16c180
-    status: 404 Not Found
-    code: 404
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/86849f5b-221c-496f-bc79-ec56b81fbabb
-    method: DELETE
-  response:
-    body: '{"message":"Function was not found"}'
-    headers:
-      Content-Length:
-      - "36"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 05 Jan 2023 09:23:20 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1aff4f8c-a6d5-4aa0-b4f0-68f5bebf6fba
-    status: 404 Not Found
-    code: 404
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/86849f5b-221c-496f-bc79-ec56b81fbabb
-    method: DELETE
-  response:
-    body: '{"message":"Function was not found"}'
-    headers:
-      Content-Length:
-      - "36"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 05 Jan 2023 09:23:20 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2c6d0fbf-460d-4bae-a605-a81325b2080b
-    status: 404 Not Found
-    code: 404
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/86849f5b-221c-496f-bc79-ec56b81fbabb
-    method: DELETE
-  response:
-    body: '{"message":"Function was not found"}'
-    headers:
-      Content-Length:
-      - "36"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 05 Jan 2023 09:23:21 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 58c76d94-ad3a-4466-9d23-528281801b8c
-    status: 404 Not Found
-    code: 404
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 138
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"name":"tf-ds-function","environment_variables":{},"project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","secret_environment_variables":[]}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 364
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"aaccbbb0-408a-4cc0-8273-748f97987c86","name":"tf-ds-function","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
+        headers:
+            Content-Length:
+                - "364"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 09:10:42 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 9b2c1904-73f4-4645-bac7-7c4ca75309e5
+        status: 200 OK
+        code: 200
+        duration: 395.900888ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/aaccbbb0-408a-4cc0-8273-748f97987c86
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 364
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"aaccbbb0-408a-4cc0-8273-748f97987c86","name":"tf-ds-function","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
+        headers:
+            Content-Length:
+                - "364"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 09:10:42 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 9d7fd759-abfe-4ade-8bbd-3f34a29c1c1e
+        status: 200 OK
+        code: 200
+        duration: 42.378335ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/aaccbbb0-408a-4cc0-8273-748f97987c86
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 445
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"aaccbbb0-408a-4cc0-8273-748f97987c86","name":"tf-ds-function","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfdsfunction9jzaqi1v","registry_namespace_id":"a8d1ec7c-7d88-4b65-8fc5-cede40e3af2c","secret_environment_variables":[],"status":"ready"}'
+        headers:
+            Content-Length:
+                - "445"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 09:10:47 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 22a351ed-4dd9-40b7-9113-e7dc61e382ab
+        status: 200 OK
+        code: 200
+        duration: 37.980682ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/aaccbbb0-408a-4cc0-8273-748f97987c86
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 445
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"aaccbbb0-408a-4cc0-8273-748f97987c86","name":"tf-ds-function","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfdsfunction9jzaqi1v","registry_namespace_id":"a8d1ec7c-7d88-4b65-8fc5-cede40e3af2c","secret_environment_variables":[],"status":"ready"}'
+        headers:
+            Content-Length:
+                - "445"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 09:10:47 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 2d1d339f-0849-4cad-a521-c853d2fc8f5b
+        status: 200 OK
+        code: 200
+        duration: 38.900492ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 306
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"name":"tf-ds-function","namespace_id":"aaccbbb0-408a-4cc0-8273-748f97987c86","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"node22","memory_limit":256,"handler":"handler.handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 570
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tfdsfunction9jzaqi1v-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"0ca73a65-e8ee-4e18-9373-aaebbc838bdd","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"aaccbbb0-408a-4cc0-8273-748f97987c86","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "570"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 09:10:47 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - a82bc977-365f-4cba-9f30-58e991c9a9dc
+        status: 200 OK
+        code: 200
+        duration: 291.913752ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0ca73a65-e8ee-4e18-9373-aaebbc838bdd
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 570
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tfdsfunction9jzaqi1v-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"0ca73a65-e8ee-4e18-9373-aaebbc838bdd","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"aaccbbb0-408a-4cc0-8273-748f97987c86","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "570"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 09:10:47 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 50a3ba28-8cc2-41de-b616-7aebf2b8b95a
+        status: 200 OK
+        code: 200
+        duration: 46.926461ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0ca73a65-e8ee-4e18-9373-aaebbc838bdd
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 570
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tfdsfunction9jzaqi1v-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"0ca73a65-e8ee-4e18-9373-aaebbc838bdd","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"aaccbbb0-408a-4cc0-8273-748f97987c86","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "570"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 09:10:47 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 2b9d7ad0-4a0b-4abe-8e80-72cf270eb7b8
+        status: 200 OK
+        code: 200
+        duration: 48.94595ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0ca73a65-e8ee-4e18-9373-aaebbc838bdd
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 570
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tfdsfunction9jzaqi1v-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"0ca73a65-e8ee-4e18-9373-aaebbc838bdd","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"aaccbbb0-408a-4cc0-8273-748f97987c86","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "570"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 09:10:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f324a980-f212-4663-a965-8f08852611e7
+        status: 200 OK
+        code: 200
+        duration: 47.550083ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/aaccbbb0-408a-4cc0-8273-748f97987c86
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 445
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"aaccbbb0-408a-4cc0-8273-748f97987c86","name":"tf-ds-function","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfdsfunction9jzaqi1v","registry_namespace_id":"a8d1ec7c-7d88-4b65-8fc5-cede40e3af2c","secret_environment_variables":[],"status":"ready"}'
+        headers:
+            Content-Length:
+                - "445"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 09:10:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 5ab5e362-a6a9-4d42-a338-0cb48f744d63
+        status: 200 OK
+        code: 200
+        duration: 39.849708ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0ca73a65-e8ee-4e18-9373-aaebbc838bdd
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 570
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tfdsfunction9jzaqi1v-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"0ca73a65-e8ee-4e18-9373-aaebbc838bdd","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"aaccbbb0-408a-4cc0-8273-748f97987c86","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "570"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 09:10:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 12242002-4dd8-44d1-ac08-a4966d93aa07
+        status: 200 OK
+        code: 200
+        duration: 42.401548ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/aaccbbb0-408a-4cc0-8273-748f97987c86
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 445
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"aaccbbb0-408a-4cc0-8273-748f97987c86","name":"tf-ds-function","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfdsfunction9jzaqi1v","registry_namespace_id":"a8d1ec7c-7d88-4b65-8fc5-cede40e3af2c","secret_environment_variables":[],"status":"ready"}'
+        headers:
+            Content-Length:
+                - "445"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 09:10:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ca2f118d-94fd-407d-bf72-bbe360f0eec7
+        status: 200 OK
+        code: 200
+        duration: 39.210715ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0ca73a65-e8ee-4e18-9373-aaebbc838bdd
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 570
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tfdsfunction9jzaqi1v-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"0ca73a65-e8ee-4e18-9373-aaebbc838bdd","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"aaccbbb0-408a-4cc0-8273-748f97987c86","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "570"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 09:10:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e2179acc-245d-43f3-afda-c09fed007b75
+        status: 200 OK
+        code: 200
+        duration: 43.445692ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0ca73a65-e8ee-4e18-9373-aaebbc838bdd
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 570
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tfdsfunction9jzaqi1v-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"0ca73a65-e8ee-4e18-9373-aaebbc838bdd","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"aaccbbb0-408a-4cc0-8273-748f97987c86","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "570"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 09:10:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 489af353-7553-45e4-b586-a211826b3e3f
+        status: 200 OK
+        code: 200
+        duration: 44.606465ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions?name=tf-ds-function&namespace_id=aaccbbb0-408a-4cc0-8273-748f97987c86&order_by=created_at_asc
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 602
+        uncompressed: false
+        body: '{"functions":[{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tfdsfunction9jzaqi1v-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"0ca73a65-e8ee-4e18-9373-aaebbc838bdd","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"aaccbbb0-408a-4cc0-8273-748f97987c86","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "602"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 09:10:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e450e7ee-590d-4a90-9cc5-9b646297d462
+        status: 200 OK
+        code: 200
+        duration: 45.477684ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0ca73a65-e8ee-4e18-9373-aaebbc838bdd
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 570
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tfdsfunction9jzaqi1v-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"0ca73a65-e8ee-4e18-9373-aaebbc838bdd","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"aaccbbb0-408a-4cc0-8273-748f97987c86","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "570"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 09:10:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 37fa03b3-3c7f-4f5a-b730-eb7412c9266c
+        status: 200 OK
+        code: 200
+        duration: 42.315747ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0ca73a65-e8ee-4e18-9373-aaebbc838bdd
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 570
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tfdsfunction9jzaqi1v-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"0ca73a65-e8ee-4e18-9373-aaebbc838bdd","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"aaccbbb0-408a-4cc0-8273-748f97987c86","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "570"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 09:10:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b4cbe924-4bff-4920-87b2-9d1da9ce2f13
+        status: 200 OK
+        code: 200
+        duration: 42.18448ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions?name=tf-ds-function&namespace_id=aaccbbb0-408a-4cc0-8273-748f97987c86&order_by=created_at_asc
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 602
+        uncompressed: false
+        body: '{"functions":[{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tfdsfunction9jzaqi1v-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"0ca73a65-e8ee-4e18-9373-aaebbc838bdd","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"aaccbbb0-408a-4cc0-8273-748f97987c86","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "602"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 09:10:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - d95883ec-0775-4fd1-8d5a-7fa92aba9e3b
+        status: 200 OK
+        code: 200
+        duration: 46.106277ms
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0ca73a65-e8ee-4e18-9373-aaebbc838bdd
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 570
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tfdsfunction9jzaqi1v-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"0ca73a65-e8ee-4e18-9373-aaebbc838bdd","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"aaccbbb0-408a-4cc0-8273-748f97987c86","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "570"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 09:10:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3ab69df6-e0f3-4cae-bb4e-623fd373f8b7
+        status: 200 OK
+        code: 200
+        duration: 40.863414ms
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0ca73a65-e8ee-4e18-9373-aaebbc838bdd
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 570
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tfdsfunction9jzaqi1v-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"0ca73a65-e8ee-4e18-9373-aaebbc838bdd","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"aaccbbb0-408a-4cc0-8273-748f97987c86","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "570"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 09:10:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f6e910c1-20af-4686-8fb8-e2a634ff749d
+        status: 200 OK
+        code: 200
+        duration: 47.938094ms
+    - id: 19
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0ca73a65-e8ee-4e18-9373-aaebbc838bdd
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 570
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tfdsfunction9jzaqi1v-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"0ca73a65-e8ee-4e18-9373-aaebbc838bdd","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"aaccbbb0-408a-4cc0-8273-748f97987c86","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "570"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 09:10:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 5a8540dc-e2f5-481d-a4fc-17ad7a99022f
+        status: 200 OK
+        code: 200
+        duration: 49.157097ms
+    - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions?name=tf-ds-function&namespace_id=aaccbbb0-408a-4cc0-8273-748f97987c86&order_by=created_at_asc
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 602
+        uncompressed: false
+        body: '{"functions":[{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tfdsfunction9jzaqi1v-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"0ca73a65-e8ee-4e18-9373-aaebbc838bdd","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"aaccbbb0-408a-4cc0-8273-748f97987c86","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "602"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 09:10:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b15291e8-2b65-43b0-b981-397a23ba5dbb
+        status: 200 OK
+        code: 200
+        duration: 52.006827ms
+    - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0ca73a65-e8ee-4e18-9373-aaebbc838bdd
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 570
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tfdsfunction9jzaqi1v-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"0ca73a65-e8ee-4e18-9373-aaebbc838bdd","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"aaccbbb0-408a-4cc0-8273-748f97987c86","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "570"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 09:10:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 099696f0-5593-4905-91e3-3fea366246e8
+        status: 200 OK
+        code: 200
+        duration: 41.611261ms
+    - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/aaccbbb0-408a-4cc0-8273-748f97987c86
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 445
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"aaccbbb0-408a-4cc0-8273-748f97987c86","name":"tf-ds-function","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfdsfunction9jzaqi1v","registry_namespace_id":"a8d1ec7c-7d88-4b65-8fc5-cede40e3af2c","secret_environment_variables":[],"status":"ready"}'
+        headers:
+            Content-Length:
+                - "445"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 09:10:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b55e0c56-0e4f-40a0-8ddd-384c3478455b
+        status: 200 OK
+        code: 200
+        duration: 40.132209ms
+    - id: 23
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0ca73a65-e8ee-4e18-9373-aaebbc838bdd
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 570
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tfdsfunction9jzaqi1v-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"0ca73a65-e8ee-4e18-9373-aaebbc838bdd","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"aaccbbb0-408a-4cc0-8273-748f97987c86","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "570"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 09:10:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 174f8c67-444b-44ba-bf97-38d356b281da
+        status: 200 OK
+        code: 200
+        duration: 38.076171ms
+    - id: 24
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0ca73a65-e8ee-4e18-9373-aaebbc838bdd
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 570
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tfdsfunction9jzaqi1v-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"0ca73a65-e8ee-4e18-9373-aaebbc838bdd","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"aaccbbb0-408a-4cc0-8273-748f97987c86","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "570"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 09:10:50 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 63c44be3-6a1e-4628-9a48-dff471e3eb26
+        status: 200 OK
+        code: 200
+        duration: 47.697691ms
+    - id: 25
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions?name=tf-ds-function&namespace_id=aaccbbb0-408a-4cc0-8273-748f97987c86&order_by=created_at_asc
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 602
+        uncompressed: false
+        body: '{"functions":[{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tfdsfunction9jzaqi1v-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"0ca73a65-e8ee-4e18-9373-aaebbc838bdd","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"aaccbbb0-408a-4cc0-8273-748f97987c86","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "602"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 09:10:50 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b70ac2f7-0df4-4774-b37c-54d83ca89cfb
+        status: 200 OK
+        code: 200
+        duration: 52.320047ms
+    - id: 26
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0ca73a65-e8ee-4e18-9373-aaebbc838bdd
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 570
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tfdsfunction9jzaqi1v-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"0ca73a65-e8ee-4e18-9373-aaebbc838bdd","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"aaccbbb0-408a-4cc0-8273-748f97987c86","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "570"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 09:10:50 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 734a5f26-0c8d-4177-9404-56a1857f60d1
+        status: 200 OK
+        code: 200
+        duration: 37.295913ms
+    - id: 27
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0ca73a65-e8ee-4e18-9373-aaebbc838bdd
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 570
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tfdsfunction9jzaqi1v-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"0ca73a65-e8ee-4e18-9373-aaebbc838bdd","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"aaccbbb0-408a-4cc0-8273-748f97987c86","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "570"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 09:10:50 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - bf226af6-14fa-4fe8-aca7-612f272005cb
+        status: 200 OK
+        code: 200
+        duration: 46.51665ms
+    - id: 28
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions?name=tf-ds-function&namespace_id=aaccbbb0-408a-4cc0-8273-748f97987c86&order_by=created_at_asc
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 602
+        uncompressed: false
+        body: '{"functions":[{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tfdsfunction9jzaqi1v-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"0ca73a65-e8ee-4e18-9373-aaebbc838bdd","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"aaccbbb0-408a-4cc0-8273-748f97987c86","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "602"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 09:10:50 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 218e4962-28aa-4b89-af00-dc9fa96416cb
+        status: 200 OK
+        code: 200
+        duration: 52.765114ms
+    - id: 29
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0ca73a65-e8ee-4e18-9373-aaebbc838bdd
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 570
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tfdsfunction9jzaqi1v-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"0ca73a65-e8ee-4e18-9373-aaebbc838bdd","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"aaccbbb0-408a-4cc0-8273-748f97987c86","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "570"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 09:10:50 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ca4bb618-2e71-465d-a2da-037d6b5ff628
+        status: 200 OK
+        code: 200
+        duration: 53.610355ms
+    - id: 30
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0ca73a65-e8ee-4e18-9373-aaebbc838bdd
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 570
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tfdsfunction9jzaqi1v-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"0ca73a65-e8ee-4e18-9373-aaebbc838bdd","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"aaccbbb0-408a-4cc0-8273-748f97987c86","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "570"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 09:10:50 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 4150e040-3c89-41dd-bbdc-0a21a41e42b2
+        status: 200 OK
+        code: 200
+        duration: 45.280434ms
+    - id: 31
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0ca73a65-e8ee-4e18-9373-aaebbc838bdd
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 571
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tfdsfunction9jzaqi1v-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"0ca73a65-e8ee-4e18-9373-aaebbc838bdd","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"aaccbbb0-408a-4cc0-8273-748f97987c86","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"deleting","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "571"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 09:10:50 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - adf52550-199c-4344-954c-e89a9f1c66c4
+        status: 200 OK
+        code: 200
+        duration: 95.295034ms
+    - id: 32
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/aaccbbb0-408a-4cc0-8273-748f97987c86
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 445
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"aaccbbb0-408a-4cc0-8273-748f97987c86","name":"tf-ds-function","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfdsfunction9jzaqi1v","registry_namespace_id":"a8d1ec7c-7d88-4b65-8fc5-cede40e3af2c","secret_environment_variables":[],"status":"ready"}'
+        headers:
+            Content-Length:
+                - "445"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 09:10:50 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - a6d75be5-f8f2-406a-9361-c05c6ead30b8
+        status: 200 OK
+        code: 200
+        duration: 31.669919ms
+    - id: 33
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/aaccbbb0-408a-4cc0-8273-748f97987c86
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 448
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"aaccbbb0-408a-4cc0-8273-748f97987c86","name":"tf-ds-function","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfdsfunction9jzaqi1v","registry_namespace_id":"a8d1ec7c-7d88-4b65-8fc5-cede40e3af2c","secret_environment_variables":[],"status":"deleting"}'
+        headers:
+            Content-Length:
+                - "448"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 09:10:50 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 7ed52fff-dee9-4bbb-9a04-13220edf6869
+        status: 200 OK
+        code: 200
+        duration: 186.428197ms
+    - id: 34
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/aaccbbb0-408a-4cc0-8273-748f97987c86
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 448
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"aaccbbb0-408a-4cc0-8273-748f97987c86","name":"tf-ds-function","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfdsfunction9jzaqi1v","registry_namespace_id":"a8d1ec7c-7d88-4b65-8fc5-cede40e3af2c","secret_environment_variables":[],"status":"deleting"}'
+        headers:
+            Content-Length:
+                - "448"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 09:10:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 6f5dc345-f4be-4f8d-83a2-85e07f805a61
+        status: 200 OK
+        code: 200
+        duration: 39.925349ms
+    - id: 35
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/aaccbbb0-408a-4cc0-8273-748f97987c86
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 37
+        uncompressed: false
+        body: '{"message":"Namespace was not found"}'
+        headers:
+            Content-Length:
+                - "37"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 09:10:56 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - c392abfb-b56b-455c-9236-b49aec720265
+        status: 404 Not Found
+        code: 404
+        duration: 37.095807ms
+    - id: 36
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0ca73a65-e8ee-4e18-9373-aaebbc838bdd
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 36
+        uncompressed: false
+        body: '{"message":"Function was not found"}'
+        headers:
+            Content-Length:
+                - "36"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 09:10:56 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 10a99182-dc39-46da-91c6-dafd632866b5
+        status: 404 Not Found
+        code: 404
+        duration: 19.763611ms
+    - id: 37
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0ca73a65-e8ee-4e18-9373-aaebbc838bdd
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 36
+        uncompressed: false
+        body: '{"message":"Function was not found"}'
+        headers:
+            Content-Length:
+                - "36"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 09:10:56 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 0497db77-88ab-47e0-9d3f-7422185a7b0e
+        status: 404 Not Found
+        code: 404
+        duration: 26.377954ms
+    - id: 38
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0ca73a65-e8ee-4e18-9373-aaebbc838bdd
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 36
+        uncompressed: false
+        body: '{"message":"Function was not found"}'
+        headers:
+            Content-Length:
+                - "36"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 09:10:56 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - dc54ac8e-1e02-4b87-a169-1c9811f31d3c
+        status: 404 Not Found
+        code: 404
+        duration: 26.885839ms

--- a/internal/services/function/testdata/function-basic.cassette.yaml
+++ b/internal/services/function/testdata/function-basic.cassette.yaml
@@ -1,935 +1,840 @@
 ---
 version: 2
 interactions:
-- request:
-    body: '{"name":"tf-func-festive-hofstadter","environment_variables":{},"project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","description":null,"secret_environment_variables":[]}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces
-    method: POST
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"b442a6b8-b8fd-4d57-bd90-18e1c2a9b423","name":"tf-func-festive-hofstadter","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "376"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:46:38 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ef7f421a-2e9e-4ae5-9f71-b052d5c76a92
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b442a6b8-b8fd-4d57-bd90-18e1c2a9b423
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"b442a6b8-b8fd-4d57-bd90-18e1c2a9b423","name":"tf-func-festive-hofstadter","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "376"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:46:38 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 615126fd-d749-4c80-87ef-e6781a8816b4
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b442a6b8-b8fd-4d57-bd90-18e1c2a9b423
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"b442a6b8-b8fd-4d57-bd90-18e1c2a9b423","name":"tf-func-festive-hofstadter","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "376"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:46:43 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1efe6b98-81ed-4f00-a807-b4e93bb9dfd4
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b442a6b8-b8fd-4d57-bd90-18e1c2a9b423
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"b442a6b8-b8fd-4d57-bd90-18e1c2a9b423","name":"tf-func-festive-hofstadter","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "376"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:46:48 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6ea32581-c09f-45e9-b0ce-4fc72ec9b747
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b442a6b8-b8fd-4d57-bd90-18e1c2a9b423
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"b442a6b8-b8fd-4d57-bd90-18e1c2a9b423","name":"tf-func-festive-hofstadter","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "376"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:46:53 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e0f1a443-8ecd-41ba-b0f2-0758fd6e1ac6
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b442a6b8-b8fd-4d57-bd90-18e1c2a9b423
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"b442a6b8-b8fd-4d57-bd90-18e1c2a9b423","name":"tf-func-festive-hofstadter","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "376"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:46:58 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ab5a50dd-45f1-420c-9125-e5ca86ea7bfa
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b442a6b8-b8fd-4d57-bd90-18e1c2a9b423
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"b442a6b8-b8fd-4d57-bd90-18e1c2a9b423","name":"tf-func-festive-hofstadter","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncfestivehofstadyccntlra","registry_namespace_id":"a53429e6-56ff-4a9c-bd66-e098bf84ce3a","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "467"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a152d610-b43f-4c9c-8127-7dbcd3e0eedb
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b442a6b8-b8fd-4d57-bd90-18e1c2a9b423
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"b442a6b8-b8fd-4d57-bd90-18e1c2a9b423","name":"tf-func-festive-hofstadter","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncfestivehofstadyccntlra","registry_namespace_id":"a53429e6-56ff-4a9c-bd66-e098bf84ce3a","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "467"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:08 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e57cf98b-5a73-47e3-a49c-aa7903dfcf55
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b442a6b8-b8fd-4d57-bd90-18e1c2a9b423
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"b442a6b8-b8fd-4d57-bd90-18e1c2a9b423","name":"tf-func-festive-hofstadter","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncfestivehofstadyccntlra","registry_namespace_id":"a53429e6-56ff-4a9c-bd66-e098bf84ce3a","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "467"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4672306e-ff3c-4ddc-902b-bfe4d94787bf
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b442a6b8-b8fd-4d57-bd90-18e1c2a9b423
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"b442a6b8-b8fd-4d57-bd90-18e1c2a9b423","name":"tf-func-festive-hofstadter","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncfestivehofstadyccntlra","registry_namespace_id":"a53429e6-56ff-4a9c-bd66-e098bf84ce3a","secret_environment_variables":[],"status":"ready"}'
-    headers:
-      Content-Length:
-      - "465"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:18 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - bf0bf92b-ca9b-4094-944f-fa2eef279354
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b442a6b8-b8fd-4d57-bd90-18e1c2a9b423
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"b442a6b8-b8fd-4d57-bd90-18e1c2a9b423","name":"tf-func-festive-hofstadter","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncfestivehofstadyccntlra","registry_namespace_id":"a53429e6-56ff-4a9c-bd66-e098bf84ce3a","secret_environment_variables":[],"status":"ready"}'
-    headers:
-      Content-Length:
-      - "465"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:18 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2e2d3e25-6417-4e1d-820f-89574917499a
-    status: 200 OK
-    code: 200
-- request:
-    body: '{"name":"foobar","namespace_id":"b442a6b8-b8fd-4d57-bd90-18e1c2a9b423","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"node14","memory_limit":128,"timeout":null,"handler":"handler.handle","privacy":"private","description":null,"secret_environment_variables":[],"http_option":"enabled"}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions
-    method: POST
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncfestivehofstadyccntlra-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"24fee1b9-eb2a-4949-a8c2-815123ce302b","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"b442a6b8-b8fd-4d57-bd90-18e1c2a9b423","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "525"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 30036b70-8d15-4d7b-94f0-0f77753c7172
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/24fee1b9-eb2a-4949-a8c2-815123ce302b
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncfestivehofstadyccntlra-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"24fee1b9-eb2a-4949-a8c2-815123ce302b","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"b442a6b8-b8fd-4d57-bd90-18e1c2a9b423","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "525"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ede6f665-6dd1-4385-8147-624e92933fb8
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/24fee1b9-eb2a-4949-a8c2-815123ce302b
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncfestivehofstadyccntlra-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"24fee1b9-eb2a-4949-a8c2-815123ce302b","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"b442a6b8-b8fd-4d57-bd90-18e1c2a9b423","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "525"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6f502445-c1d3-48ea-b09c-3613cf9abb6a
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/24fee1b9-eb2a-4949-a8c2-815123ce302b
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncfestivehofstadyccntlra-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"24fee1b9-eb2a-4949-a8c2-815123ce302b","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"b442a6b8-b8fd-4d57-bd90-18e1c2a9b423","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "525"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5d50d140-a216-4892-b606-91a799f34bb4
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b442a6b8-b8fd-4d57-bd90-18e1c2a9b423
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"b442a6b8-b8fd-4d57-bd90-18e1c2a9b423","name":"tf-func-festive-hofstadter","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncfestivehofstadyccntlra","registry_namespace_id":"a53429e6-56ff-4a9c-bd66-e098bf84ce3a","secret_environment_variables":[],"status":"ready"}'
-    headers:
-      Content-Length:
-      - "465"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d26c351e-939e-4bbb-9a6c-79a715d8dd59
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/24fee1b9-eb2a-4949-a8c2-815123ce302b
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncfestivehofstadyccntlra-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"24fee1b9-eb2a-4949-a8c2-815123ce302b","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"b442a6b8-b8fd-4d57-bd90-18e1c2a9b423","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "525"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8124b5bd-b845-4ef4-8291-2ac63608bb01
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/24fee1b9-eb2a-4949-a8c2-815123ce302b
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncfestivehofstadyccntlra-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"24fee1b9-eb2a-4949-a8c2-815123ce302b","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"b442a6b8-b8fd-4d57-bd90-18e1c2a9b423","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "525"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:20 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 838b15c4-f175-4d2b-a153-ced2503bc76b
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/24fee1b9-eb2a-4949-a8c2-815123ce302b
-    method: DELETE
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncfestivehofstadyccntlra-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"24fee1b9-eb2a-4949-a8c2-815123ce302b","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"b442a6b8-b8fd-4d57-bd90-18e1c2a9b423","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"deleting","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "526"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:20 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 34dcd10c-929e-409d-99ff-f76e4d4c4e68
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b442a6b8-b8fd-4d57-bd90-18e1c2a9b423
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"b442a6b8-b8fd-4d57-bd90-18e1c2a9b423","name":"tf-func-festive-hofstadter","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncfestivehofstadyccntlra","registry_namespace_id":"a53429e6-56ff-4a9c-bd66-e098bf84ce3a","secret_environment_variables":[],"status":"ready"}'
-    headers:
-      Content-Length:
-      - "465"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:20 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 96e443ba-689b-450a-a2f6-0bd16c14f40c
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b442a6b8-b8fd-4d57-bd90-18e1c2a9b423
-    method: DELETE
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"b442a6b8-b8fd-4d57-bd90-18e1c2a9b423","name":"tf-func-festive-hofstadter","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncfestivehofstadyccntlra","registry_namespace_id":"a53429e6-56ff-4a9c-bd66-e098bf84ce3a","secret_environment_variables":[],"status":"deleting"}'
-    headers:
-      Content-Length:
-      - "468"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:20 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7d8f9d54-4f5d-4a8e-bded-5a2a8a936e1e
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b442a6b8-b8fd-4d57-bd90-18e1c2a9b423
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"b442a6b8-b8fd-4d57-bd90-18e1c2a9b423","name":"tf-func-festive-hofstadter","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncfestivehofstadyccntlra","registry_namespace_id":"a53429e6-56ff-4a9c-bd66-e098bf84ce3a","secret_environment_variables":[],"status":"deleting"}'
-    headers:
-      Content-Length:
-      - "468"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:20 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8ac83b82-391d-4509-bffb-13064ab1e0cc
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b442a6b8-b8fd-4d57-bd90-18e1c2a9b423
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"b442a6b8-b8fd-4d57-bd90-18e1c2a9b423","name":"tf-func-festive-hofstadter","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncfestivehofstadyccntlra","registry_namespace_id":"a53429e6-56ff-4a9c-bd66-e098bf84ce3a","secret_environment_variables":[],"status":"deleting"}'
-    headers:
-      Content-Length:
-      - "468"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:25 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 632d232c-b89c-4d9a-bb32-7e5c2c78e011
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b442a6b8-b8fd-4d57-bd90-18e1c2a9b423
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"b442a6b8-b8fd-4d57-bd90-18e1c2a9b423","name":"tf-func-festive-hofstadter","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncfestivehofstadyccntlra","registry_namespace_id":"a53429e6-56ff-4a9c-bd66-e098bf84ce3a","secret_environment_variables":[],"status":"deleting"}'
-    headers:
-      Content-Length:
-      - "468"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:30 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8594a827-1f14-46c2-a1f8-5f3f87909d3c
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b442a6b8-b8fd-4d57-bd90-18e1c2a9b423
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"b442a6b8-b8fd-4d57-bd90-18e1c2a9b423","name":"tf-func-festive-hofstadter","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncfestivehofstadyccntlra","registry_namespace_id":"a53429e6-56ff-4a9c-bd66-e098bf84ce3a","secret_environment_variables":[],"status":"deleting"}'
-    headers:
-      Content-Length:
-      - "468"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:35 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c16c268a-8b81-4b84-8ed0-f9463dd215ea
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b442a6b8-b8fd-4d57-bd90-18e1c2a9b423
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"b442a6b8-b8fd-4d57-bd90-18e1c2a9b423","name":"tf-func-festive-hofstadter","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncfestivehofstadyccntlra","registry_namespace_id":"a53429e6-56ff-4a9c-bd66-e098bf84ce3a","secret_environment_variables":[],"status":"deleting"}'
-    headers:
-      Content-Length:
-      - "468"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:40 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a3d75c38-6646-4d97-bd22-5ea061434036
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b442a6b8-b8fd-4d57-bd90-18e1c2a9b423
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"b442a6b8-b8fd-4d57-bd90-18e1c2a9b423","name":"tf-func-festive-hofstadter","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncfestivehofstadyccntlra","registry_namespace_id":"a53429e6-56ff-4a9c-bd66-e098bf84ce3a","secret_environment_variables":[],"status":"deleting"}'
-    headers:
-      Content-Length:
-      - "468"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:45 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4f9c8253-9b85-45d0-b63e-0888e19d4a52
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b442a6b8-b8fd-4d57-bd90-18e1c2a9b423
-    method: GET
-  response:
-    body: '{"message":"Namespace was not found"}'
-    headers:
-      Content-Length:
-      - "37"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:50 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a3bb0972-532d-462e-a98b-d4fb9bef1276
-    status: 404 Not Found
-    code: 404
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/24fee1b9-eb2a-4949-a8c2-815123ce302b
-    method: DELETE
-  response:
-    body: '{"message":"Function was not found"}'
-    headers:
-      Content-Length:
-      - "36"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:50 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2386275b-74de-4a6a-a04c-c5dcc21f361f
-    status: 404 Not Found
-    code: 404
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 149
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"name":"tf-func-determined-golick","environment_variables":{},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","secret_environment_variables":[]}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 375
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"36b53cd1-3e1f-429e-93b9-de5157486c3a","name":"tf-func-determined-golick","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
+        headers:
+            Content-Length:
+                - "375"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:19 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 633ba79f-c73b-443b-adf3-3a6d3b215396
+        status: 200 OK
+        code: 200
+        duration: 1.224295504s
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/36b53cd1-3e1f-429e-93b9-de5157486c3a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 375
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"36b53cd1-3e1f-429e-93b9-de5157486c3a","name":"tf-func-determined-golick","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
+        headers:
+            Content-Length:
+                - "375"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:20 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 5de62e2e-13b0-4f75-9001-af5ae92f0b57
+        status: 200 OK
+        code: 200
+        duration: 68.162677ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/36b53cd1-3e1f-429e-93b9-de5157486c3a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 464
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"36b53cd1-3e1f-429e-93b9-de5157486c3a","name":"tf-func-determined-golick","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncdeterminedgoliqqs4why8","registry_namespace_id":"71d29c46-9d0d-44d1-b339-2cde012020a8","secret_environment_variables":[],"status":"ready"}'
+        headers:
+            Content-Length:
+                - "464"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:25 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 11651c94-2e22-4072-bdbd-04bd95a6653b
+        status: 200 OK
+        code: 200
+        duration: 51.543238ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/36b53cd1-3e1f-429e-93b9-de5157486c3a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 464
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"36b53cd1-3e1f-429e-93b9-de5157486c3a","name":"tf-func-determined-golick","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncdeterminedgoliqqs4why8","registry_namespace_id":"71d29c46-9d0d-44d1-b339-2cde012020a8","secret_environment_variables":[],"status":"ready"}'
+        headers:
+            Content-Length:
+                - "464"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:25 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - dd5f0795-38ea-4a1a-8130-9efdd9be982f
+        status: 200 OK
+        code: 200
+        duration: 49.301346ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 298
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"name":"foobar","namespace_id":"36b53cd1-3e1f-429e-93b9-de5157486c3a","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"node22","memory_limit":256,"handler":"handler.handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 562
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncdeterminedgoliqqs4why8-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"07d01251-71ac-45aa-b08b-ad0a68837ddb","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"36b53cd1-3e1f-429e-93b9-de5157486c3a","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "562"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:25 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 0a450416-c92e-4b95-9ebc-cd9121c102e1
+        status: 200 OK
+        code: 200
+        duration: 689.357067ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/07d01251-71ac-45aa-b08b-ad0a68837ddb
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 562
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncdeterminedgoliqqs4why8-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"07d01251-71ac-45aa-b08b-ad0a68837ddb","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"36b53cd1-3e1f-429e-93b9-de5157486c3a","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "562"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:25 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 2544db4e-a12f-4e03-96e6-33b6849c23ee
+        status: 200 OK
+        code: 200
+        duration: 58.5747ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/07d01251-71ac-45aa-b08b-ad0a68837ddb
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 562
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncdeterminedgoliqqs4why8-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"07d01251-71ac-45aa-b08b-ad0a68837ddb","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"36b53cd1-3e1f-429e-93b9-de5157486c3a","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "562"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:25 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - a7779962-e014-4bab-b2cf-62077a1856fe
+        status: 200 OK
+        code: 200
+        duration: 60.156042ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/07d01251-71ac-45aa-b08b-ad0a68837ddb
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 562
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncdeterminedgoliqqs4why8-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"07d01251-71ac-45aa-b08b-ad0a68837ddb","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"36b53cd1-3e1f-429e-93b9-de5157486c3a","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "562"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:26 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e7387242-d79e-4cf8-a890-ebbd02a34721
+        status: 200 OK
+        code: 200
+        duration: 71.218798ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/36b53cd1-3e1f-429e-93b9-de5157486c3a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 464
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"36b53cd1-3e1f-429e-93b9-de5157486c3a","name":"tf-func-determined-golick","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncdeterminedgoliqqs4why8","registry_namespace_id":"71d29c46-9d0d-44d1-b339-2cde012020a8","secret_environment_variables":[],"status":"ready"}'
+        headers:
+            Content-Length:
+                - "464"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:26 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - bb2cf5d5-4371-4d28-8dc6-b063a41ee631
+        status: 200 OK
+        code: 200
+        duration: 54.460169ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/07d01251-71ac-45aa-b08b-ad0a68837ddb
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 562
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncdeterminedgoliqqs4why8-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"07d01251-71ac-45aa-b08b-ad0a68837ddb","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"36b53cd1-3e1f-429e-93b9-de5157486c3a","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "562"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:26 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 88a7ee15-bc3e-42d7-9d83-cc543a538151
+        status: 200 OK
+        code: 200
+        duration: 68.725424ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/07d01251-71ac-45aa-b08b-ad0a68837ddb
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 562
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncdeterminedgoliqqs4why8-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"07d01251-71ac-45aa-b08b-ad0a68837ddb","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"36b53cd1-3e1f-429e-93b9-de5157486c3a","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "562"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:26 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 65050855-1802-4f17-9359-6b39c1b5e02a
+        status: 200 OK
+        code: 200
+        duration: 63.766987ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/07d01251-71ac-45aa-b08b-ad0a68837ddb
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 563
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncdeterminedgoliqqs4why8-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"07d01251-71ac-45aa-b08b-ad0a68837ddb","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"36b53cd1-3e1f-429e-93b9-de5157486c3a","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"deleting","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "563"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:27 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - befdbc7a-0d86-4fd7-80f9-8fac38ec7655
+        status: 200 OK
+        code: 200
+        duration: 137.859976ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/36b53cd1-3e1f-429e-93b9-de5157486c3a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 464
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"36b53cd1-3e1f-429e-93b9-de5157486c3a","name":"tf-func-determined-golick","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncdeterminedgoliqqs4why8","registry_namespace_id":"71d29c46-9d0d-44d1-b339-2cde012020a8","secret_environment_variables":[],"status":"ready"}'
+        headers:
+            Content-Length:
+                - "464"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:27 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 1ad8f1a9-6442-45e5-ac44-659e9e90cbde
+        status: 200 OK
+        code: 200
+        duration: 62.831469ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/36b53cd1-3e1f-429e-93b9-de5157486c3a
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 467
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"36b53cd1-3e1f-429e-93b9-de5157486c3a","name":"tf-func-determined-golick","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncdeterminedgoliqqs4why8","registry_namespace_id":"71d29c46-9d0d-44d1-b339-2cde012020a8","secret_environment_variables":[],"status":"deleting"}'
+        headers:
+            Content-Length:
+                - "467"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:27 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - af278425-725c-44ff-8ab2-4e15e75cf83f
+        status: 200 OK
+        code: 200
+        duration: 222.489523ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/36b53cd1-3e1f-429e-93b9-de5157486c3a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 467
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"36b53cd1-3e1f-429e-93b9-de5157486c3a","name":"tf-func-determined-golick","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncdeterminedgoliqqs4why8","registry_namespace_id":"71d29c46-9d0d-44d1-b339-2cde012020a8","secret_environment_variables":[],"status":"deleting"}'
+        headers:
+            Content-Length:
+                - "467"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:27 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f0df45d0-b001-44d5-991b-99fcaa90ae1f
+        status: 200 OK
+        code: 200
+        duration: 87.031601ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/36b53cd1-3e1f-429e-93b9-de5157486c3a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 37
+        uncompressed: false
+        body: '{"message":"Namespace was not found"}'
+        headers:
+            Content-Length:
+                - "37"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:32 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 9d82073c-0f83-491e-a830-a47e3b5309bd
+        status: 404 Not Found
+        code: 404
+        duration: 29.571124ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/07d01251-71ac-45aa-b08b-ad0a68837ddb
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 36
+        uncompressed: false
+        body: '{"message":"Function was not found"}'
+        headers:
+            Content-Length:
+                - "36"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:32 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f136669c-f4be-4524-b8d3-140033c6c0fb
+        status: 404 Not Found
+        code: 404
+        duration: 23.998292ms

--- a/internal/services/function/testdata/function-cron-basic.cassette.yaml
+++ b/internal/services/function/testdata/function-cron-basic.cassette.yaml
@@ -1,785 +1,1234 @@
 ---
 version: 2
 interactions:
-- request:
-    body: '{"name":"tf-tests-function-cron-basic","environment_variables":{},"project_id":"46fd79d8-1a35-4548-bfb8-03df51a0ebae","secret_environment_variables":[]}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces
-    method: POST
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"6a909978-dc7a-4cb7-adea-5fe700fcc57e","name":"tf-tests-function-cron-basic","organization_id":"46fd79d8-1a35-4548-bfb8-03df51a0ebae","project_id":"46fd79d8-1a35-4548-bfb8-03df51a0ebae","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "378"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:10:57 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 33e7f855-b649-4c8a-a253-f08f4a8a1793
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/6a909978-dc7a-4cb7-adea-5fe700fcc57e
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"6a909978-dc7a-4cb7-adea-5fe700fcc57e","name":"tf-tests-function-cron-basic","organization_id":"46fd79d8-1a35-4548-bfb8-03df51a0ebae","project_id":"46fd79d8-1a35-4548-bfb8-03df51a0ebae","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "378"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:10:57 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 013b813f-aa82-45f2-9b5d-7c30bfc03f9b
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/6a909978-dc7a-4cb7-adea-5fe700fcc57e
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"6a909978-dc7a-4cb7-adea-5fe700fcc57e","name":"tf-tests-function-cron-basic","organization_id":"46fd79d8-1a35-4548-bfb8-03df51a0ebae","project_id":"46fd79d8-1a35-4548-bfb8-03df51a0ebae","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronbb4qw0bdz","registry_namespace_id":"38fc83d3-cecc-434b-948b-e88dbf57c636","secret_environment_variables":[],"status":"ready"}'
-    headers:
-      Content-Length:
-      - "467"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:02 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - dfc448f9-7e31-4046-af98-2dd01b0bfb0e
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/6a909978-dc7a-4cb7-adea-5fe700fcc57e
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"6a909978-dc7a-4cb7-adea-5fe700fcc57e","name":"tf-tests-function-cron-basic","organization_id":"46fd79d8-1a35-4548-bfb8-03df51a0ebae","project_id":"46fd79d8-1a35-4548-bfb8-03df51a0ebae","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronbb4qw0bdz","registry_namespace_id":"38fc83d3-cecc-434b-948b-e88dbf57c636","secret_environment_variables":[],"status":"ready"}'
-    headers:
-      Content-Length:
-      - "467"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:02 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f80e0829-f2ff-4e67-980f-5056d9f28ee0
-    status: 200 OK
-    code: 200
-- request:
-    body: '{"name":"tf-tests-cron-basic","namespace_id":"6a909978-dc7a-4cb7-adea-5fe700fcc57e","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"node14","memory_limit":128,"handler":"handler.handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled"}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions
-    method: POST
-  response:
-    body: '{"build_message":null,"cpu_limit":70,"description":"","domain_name":"tftestsfunctioncronbb4qw0bdz-tf-tests-cron-basic.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"78656542-1e8a-4af9-860a-b83d273a9f1f","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-tests-cron-basic","namespace_id":"6a909978-dc7a-4cb7-adea-5fe700fcc57e","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "572"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c9dfcb41-5671-409f-8ac1-a1d653c3fa43
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/78656542-1e8a-4af9-860a-b83d273a9f1f
-    method: GET
-  response:
-    body: '{"build_message":null,"cpu_limit":70,"description":"","domain_name":"tftestsfunctioncronbb4qw0bdz-tf-tests-cron-basic.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"78656542-1e8a-4af9-860a-b83d273a9f1f","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-tests-cron-basic","namespace_id":"6a909978-dc7a-4cb7-adea-5fe700fcc57e","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "572"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 077ee5f0-7aa5-48a3-9b22-f36fe89f702e
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/78656542-1e8a-4af9-860a-b83d273a9f1f
-    method: GET
-  response:
-    body: '{"build_message":null,"cpu_limit":70,"description":"","domain_name":"tftestsfunctioncronbb4qw0bdz-tf-tests-cron-basic.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"78656542-1e8a-4af9-860a-b83d273a9f1f","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-tests-cron-basic","namespace_id":"6a909978-dc7a-4cb7-adea-5fe700fcc57e","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "572"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 58148287-b2c6-42ae-aff6-771bfa743cb6
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/78656542-1e8a-4af9-860a-b83d273a9f1f
-    method: GET
-  response:
-    body: '{"build_message":null,"cpu_limit":70,"description":"","domain_name":"tftestsfunctioncronbb4qw0bdz-tf-tests-cron-basic.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"78656542-1e8a-4af9-860a-b83d273a9f1f","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-tests-cron-basic","namespace_id":"6a909978-dc7a-4cb7-adea-5fe700fcc57e","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "572"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b9a2a7d6-a77f-4b92-881b-011ecfbf4f2f
-    status: 200 OK
-    code: 200
-- request:
-    body: '{"function_id":"78656542-1e8a-4af9-860a-b83d273a9f1f","schedule":"0 0 *
-      * *","args":{},"name":"tf-tests-cron-basic"}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons
-    method: POST
-  response:
-    body: '{"args":{},"function_id":"78656542-1e8a-4af9-860a-b83d273a9f1f","id":"b18e431c-11d3-4f2e-9c9c-7b49084533be","name":"tf-tests-cron-basic","schedule":"0
-      0 * * *","status":"pending"}'
-    headers:
-      Content-Length:
-      - "179"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6d9ef080-e27c-4a09-ac29-1988dd6bf3d1
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/b18e431c-11d3-4f2e-9c9c-7b49084533be
-    method: GET
-  response:
-    body: '{"args":{},"function_id":"78656542-1e8a-4af9-860a-b83d273a9f1f","id":"b18e431c-11d3-4f2e-9c9c-7b49084533be","name":"tf-tests-cron-basic","schedule":"0
-      0 * * *","status":"ready"}'
-    headers:
-      Content-Length:
-      - "177"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c2dd57b5-fd7e-473a-9f83-68d62f28f500
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/b18e431c-11d3-4f2e-9c9c-7b49084533be
-    method: GET
-  response:
-    body: '{"args":{},"function_id":"78656542-1e8a-4af9-860a-b83d273a9f1f","id":"b18e431c-11d3-4f2e-9c9c-7b49084533be","name":"tf-tests-cron-basic","schedule":"0
-      0 * * *","status":"ready"}'
-    headers:
-      Content-Length:
-      - "177"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2b4a5ad2-a8a0-45e3-8ba2-e99691bc6853
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/b18e431c-11d3-4f2e-9c9c-7b49084533be
-    method: GET
-  response:
-    body: '{"args":{},"function_id":"78656542-1e8a-4af9-860a-b83d273a9f1f","id":"b18e431c-11d3-4f2e-9c9c-7b49084533be","name":"tf-tests-cron-basic","schedule":"0
-      0 * * *","status":"ready"}'
-    headers:
-      Content-Length:
-      - "177"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f1c62ce5-ae56-4e08-8e08-201b8f85b7d3
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/6a909978-dc7a-4cb7-adea-5fe700fcc57e
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"6a909978-dc7a-4cb7-adea-5fe700fcc57e","name":"tf-tests-function-cron-basic","organization_id":"46fd79d8-1a35-4548-bfb8-03df51a0ebae","project_id":"46fd79d8-1a35-4548-bfb8-03df51a0ebae","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronbb4qw0bdz","registry_namespace_id":"38fc83d3-cecc-434b-948b-e88dbf57c636","secret_environment_variables":[],"status":"ready"}'
-    headers:
-      Content-Length:
-      - "467"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:04 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1968e8f0-7b44-40b5-9587-c28df090d3e9
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/78656542-1e8a-4af9-860a-b83d273a9f1f
-    method: GET
-  response:
-    body: '{"build_message":null,"cpu_limit":70,"description":"","domain_name":"tftestsfunctioncronbb4qw0bdz-tf-tests-cron-basic.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"78656542-1e8a-4af9-860a-b83d273a9f1f","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-tests-cron-basic","namespace_id":"6a909978-dc7a-4cb7-adea-5fe700fcc57e","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "572"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:04 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a40b90e8-be9d-45c6-9862-8092280b987c
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/b18e431c-11d3-4f2e-9c9c-7b49084533be
-    method: GET
-  response:
-    body: '{"args":{},"function_id":"78656542-1e8a-4af9-860a-b83d273a9f1f","id":"b18e431c-11d3-4f2e-9c9c-7b49084533be","name":"tf-tests-cron-basic","schedule":"0
-      0 * * *","status":"ready"}'
-    headers:
-      Content-Length:
-      - "177"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:04 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6528455c-1c37-4bf4-bba3-af9e316b6d8c
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/b18e431c-11d3-4f2e-9c9c-7b49084533be
-    method: GET
-  response:
-    body: '{"args":{},"function_id":"78656542-1e8a-4af9-860a-b83d273a9f1f","id":"b18e431c-11d3-4f2e-9c9c-7b49084533be","name":"tf-tests-cron-basic","schedule":"0
-      0 * * *","status":"ready"}'
-    headers:
-      Content-Length:
-      - "177"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:05 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a21518bd-f714-4aba-8dbe-68a74dd1b65e
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/b18e431c-11d3-4f2e-9c9c-7b49084533be
-    method: DELETE
-  response:
-    body: '{"args":{},"function_id":"78656542-1e8a-4af9-860a-b83d273a9f1f","id":"b18e431c-11d3-4f2e-9c9c-7b49084533be","name":"tf-tests-cron-basic","schedule":"0
-      0 * * *","status":"deleting"}'
-    headers:
-      Content-Length:
-      - "180"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:05 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 08618d90-6343-424c-9b1e-6c6e9a7bbda2
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/78656542-1e8a-4af9-860a-b83d273a9f1f
-    method: GET
-  response:
-    body: '{"build_message":null,"cpu_limit":70,"description":"","domain_name":"tftestsfunctioncronbb4qw0bdz-tf-tests-cron-basic.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"78656542-1e8a-4af9-860a-b83d273a9f1f","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-tests-cron-basic","namespace_id":"6a909978-dc7a-4cb7-adea-5fe700fcc57e","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "572"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:06 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e854d1e5-11d9-4920-a19d-97e3ae15ee24
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/78656542-1e8a-4af9-860a-b83d273a9f1f
-    method: DELETE
-  response:
-    body: '{"build_message":null,"cpu_limit":70,"description":"","domain_name":"tftestsfunctioncronbb4qw0bdz-tf-tests-cron-basic.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"78656542-1e8a-4af9-860a-b83d273a9f1f","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-tests-cron-basic","namespace_id":"6a909978-dc7a-4cb7-adea-5fe700fcc57e","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"deleting","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "573"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:06 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ca652e05-830b-4f97-ab82-22b126fda20b
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/6a909978-dc7a-4cb7-adea-5fe700fcc57e
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"6a909978-dc7a-4cb7-adea-5fe700fcc57e","name":"tf-tests-function-cron-basic","organization_id":"46fd79d8-1a35-4548-bfb8-03df51a0ebae","project_id":"46fd79d8-1a35-4548-bfb8-03df51a0ebae","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronbb4qw0bdz","registry_namespace_id":"38fc83d3-cecc-434b-948b-e88dbf57c636","secret_environment_variables":[],"status":"ready"}'
-    headers:
-      Content-Length:
-      - "467"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:06 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 35ce7acb-c136-4904-94ab-8ce1cceca8af
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/6a909978-dc7a-4cb7-adea-5fe700fcc57e
-    method: DELETE
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"6a909978-dc7a-4cb7-adea-5fe700fcc57e","name":"tf-tests-function-cron-basic","organization_id":"46fd79d8-1a35-4548-bfb8-03df51a0ebae","project_id":"46fd79d8-1a35-4548-bfb8-03df51a0ebae","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronbb4qw0bdz","registry_namespace_id":"38fc83d3-cecc-434b-948b-e88dbf57c636","secret_environment_variables":[],"status":"deleting"}'
-    headers:
-      Content-Length:
-      - "470"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:06 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9bdffca4-5a86-4810-885f-2e79dc6b774b
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/6a909978-dc7a-4cb7-adea-5fe700fcc57e
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"6a909978-dc7a-4cb7-adea-5fe700fcc57e","name":"tf-tests-function-cron-basic","organization_id":"46fd79d8-1a35-4548-bfb8-03df51a0ebae","project_id":"46fd79d8-1a35-4548-bfb8-03df51a0ebae","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronbb4qw0bdz","registry_namespace_id":"38fc83d3-cecc-434b-948b-e88dbf57c636","secret_environment_variables":[],"status":"deleting"}'
-    headers:
-      Content-Length:
-      - "470"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:06 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e2ed47ba-2923-43c7-84dd-a4695f099cae
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/6a909978-dc7a-4cb7-adea-5fe700fcc57e
-    method: GET
-  response:
-    body: '{"message":"Namespace was not found"}'
-    headers:
-      Content-Length:
-      - "37"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:11 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1674da29-96c9-4d8e-8ebb-b40bee96e8f5
-    status: 404 Not Found
-    code: 404
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/b18e431c-11d3-4f2e-9c9c-7b49084533be
-    method: DELETE
-  response:
-    body: '{"message":"Cron was not found"}'
-    headers:
-      Content-Length:
-      - "32"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:11 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e823539d-b1fc-4783-8ece-d7347c26fd3a
-    status: 404 Not Found
-    code: 404
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 152
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"name":"tf-tests-function-cron-basic","environment_variables":{},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","secret_environment_variables":[]}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 378
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"593a0f02-6c06-4440-8d8b-aec325ea5e8b","name":"tf-tests-function-cron-basic","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
+        headers:
+            Content-Length:
+                - "378"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:22 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3c135541-f8e7-4d98-9cff-811f633195e0
+        status: 200 OK
+        code: 200
+        duration: 460.774428ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/593a0f02-6c06-4440-8d8b-aec325ea5e8b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 378
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"593a0f02-6c06-4440-8d8b-aec325ea5e8b","name":"tf-tests-function-cron-basic","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
+        headers:
+            Content-Length:
+                - "378"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:22 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e90b7912-25bb-43ee-892c-b97d9dc933f8
+        status: 200 OK
+        code: 200
+        duration: 58.304697ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/593a0f02-6c06-4440-8d8b-aec325ea5e8b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 467
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"593a0f02-6c06-4440-8d8b-aec325ea5e8b","name":"tf-tests-function-cron-basic","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronbxbhqs92s","registry_namespace_id":"0386c8f3-0674-43c2-9cb2-60b7594004af","secret_environment_variables":[],"status":"ready"}'
+        headers:
+            Content-Length:
+                - "467"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:27 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 2fe53611-83fe-41c9-94fa-5fc0bd9e7918
+        status: 200 OK
+        code: 200
+        duration: 64.357058ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/593a0f02-6c06-4440-8d8b-aec325ea5e8b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 467
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"593a0f02-6c06-4440-8d8b-aec325ea5e8b","name":"tf-tests-function-cron-basic","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronbxbhqs92s","registry_namespace_id":"0386c8f3-0674-43c2-9cb2-60b7594004af","secret_environment_variables":[],"status":"ready"}'
+        headers:
+            Content-Length:
+                - "467"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:27 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f69b4a81-7067-40c4-b34f-c9888d09972e
+        status: 200 OK
+        code: 200
+        duration: 49.733472ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 311
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"name":"tf-tests-cron-basic","namespace_id":"593a0f02-6c06-4440-8d8b-aec325ea5e8b","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"node20","memory_limit":256,"handler":"handler.handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 588
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tftestsfunctioncronbxbhqs92s-tf-tests-cron-basic.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"09990595-fe1b-4889-9ccb-b1efa933abaa","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-cron-basic","namespace_id":"593a0f02-6c06-4440-8d8b-aec325ea5e8b","privacy":"private","region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "588"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:27 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 08812225-88ab-49c0-80b6-e3bdf75ce396
+        status: 200 OK
+        code: 200
+        duration: 355.154184ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/09990595-fe1b-4889-9ccb-b1efa933abaa
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 588
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tftestsfunctioncronbxbhqs92s-tf-tests-cron-basic.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"09990595-fe1b-4889-9ccb-b1efa933abaa","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-cron-basic","namespace_id":"593a0f02-6c06-4440-8d8b-aec325ea5e8b","privacy":"private","region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "588"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:27 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 6b5ba5d5-3f9d-4d17-b618-f0cc2b722913
+        status: 200 OK
+        code: 200
+        duration: 61.437081ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/09990595-fe1b-4889-9ccb-b1efa933abaa
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 588
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tftestsfunctioncronbxbhqs92s-tf-tests-cron-basic.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"09990595-fe1b-4889-9ccb-b1efa933abaa","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-cron-basic","namespace_id":"593a0f02-6c06-4440-8d8b-aec325ea5e8b","privacy":"private","region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "588"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:28 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 0fcefbfa-9bcc-4381-a1f9-d267fe7b13ad
+        status: 200 OK
+        code: 200
+        duration: 60.490743ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/09990595-fe1b-4889-9ccb-b1efa933abaa
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 588
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tftestsfunctioncronbxbhqs92s-tf-tests-cron-basic.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"09990595-fe1b-4889-9ccb-b1efa933abaa","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-cron-basic","namespace_id":"593a0f02-6c06-4440-8d8b-aec325ea5e8b","privacy":"private","region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "588"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:28 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - fadb4081-b24a-4e35-bb47-26dca2be7b31
+        status: 200 OK
+        code: 200
+        duration: 58.467602ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 116
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"function_id":"09990595-fe1b-4889-9ccb-b1efa933abaa","schedule":"0 0 * * *","args":{},"name":"tf-tests-cron-basic"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 179
+        uncompressed: false
+        body: '{"args":{},"function_id":"09990595-fe1b-4889-9ccb-b1efa933abaa","id":"56e85c23-44bf-4ee0-b26f-a8e361954ee6","name":"tf-tests-cron-basic","schedule":"0 0 * * *","status":"pending"}'
+        headers:
+            Content-Length:
+                - "179"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:28 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 05aec20d-1c0e-4f88-a181-58ad08a2096a
+        status: 200 OK
+        code: 200
+        duration: 88.476504ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/56e85c23-44bf-4ee0-b26f-a8e361954ee6
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 179
+        uncompressed: false
+        body: '{"args":{},"function_id":"09990595-fe1b-4889-9ccb-b1efa933abaa","id":"56e85c23-44bf-4ee0-b26f-a8e361954ee6","name":"tf-tests-cron-basic","schedule":"0 0 * * *","status":"pending"}'
+        headers:
+            Content-Length:
+                - "179"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:28 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - da1bf893-76d7-4dfa-8bcc-775519914757
+        status: 200 OK
+        code: 200
+        duration: 70.395133ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/56e85c23-44bf-4ee0-b26f-a8e361954ee6
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 177
+        uncompressed: false
+        body: '{"args":{},"function_id":"09990595-fe1b-4889-9ccb-b1efa933abaa","id":"56e85c23-44bf-4ee0-b26f-a8e361954ee6","name":"tf-tests-cron-basic","schedule":"0 0 * * *","status":"ready"}'
+        headers:
+            Content-Length:
+                - "177"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:33 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - c8698388-1539-4a4f-ac00-0ae00f8bc972
+        status: 200 OK
+        code: 200
+        duration: 75.037885ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/56e85c23-44bf-4ee0-b26f-a8e361954ee6
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 177
+        uncompressed: false
+        body: '{"args":{},"function_id":"09990595-fe1b-4889-9ccb-b1efa933abaa","id":"56e85c23-44bf-4ee0-b26f-a8e361954ee6","name":"tf-tests-cron-basic","schedule":"0 0 * * *","status":"ready"}'
+        headers:
+            Content-Length:
+                - "177"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:33 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 656ebea6-9375-47f7-aa03-3108b9098520
+        status: 200 OK
+        code: 200
+        duration: 81.158134ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/56e85c23-44bf-4ee0-b26f-a8e361954ee6
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 177
+        uncompressed: false
+        body: '{"args":{},"function_id":"09990595-fe1b-4889-9ccb-b1efa933abaa","id":"56e85c23-44bf-4ee0-b26f-a8e361954ee6","name":"tf-tests-cron-basic","schedule":"0 0 * * *","status":"ready"}'
+        headers:
+            Content-Length:
+                - "177"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:33 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - fa8d2b60-2579-4513-8f75-09b2ab794916
+        status: 200 OK
+        code: 200
+        duration: 69.554663ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/593a0f02-6c06-4440-8d8b-aec325ea5e8b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 467
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"593a0f02-6c06-4440-8d8b-aec325ea5e8b","name":"tf-tests-function-cron-basic","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronbxbhqs92s","registry_namespace_id":"0386c8f3-0674-43c2-9cb2-60b7594004af","secret_environment_variables":[],"status":"ready"}'
+        headers:
+            Content-Length:
+                - "467"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:33 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ac283568-b774-4099-98b9-8cddc99cf308
+        status: 200 OK
+        code: 200
+        duration: 54.035485ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/09990595-fe1b-4889-9ccb-b1efa933abaa
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 588
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tftestsfunctioncronbxbhqs92s-tf-tests-cron-basic.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"09990595-fe1b-4889-9ccb-b1efa933abaa","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-cron-basic","namespace_id":"593a0f02-6c06-4440-8d8b-aec325ea5e8b","privacy":"private","region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "588"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:33 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 0cc6dc39-76a0-41f5-8f20-12b0b0ac8dba
+        status: 200 OK
+        code: 200
+        duration: 56.058004ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/56e85c23-44bf-4ee0-b26f-a8e361954ee6
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 177
+        uncompressed: false
+        body: '{"args":{},"function_id":"09990595-fe1b-4889-9ccb-b1efa933abaa","id":"56e85c23-44bf-4ee0-b26f-a8e361954ee6","name":"tf-tests-cron-basic","schedule":"0 0 * * *","status":"ready"}'
+        headers:
+            Content-Length:
+                - "177"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 17f5ac36-2e17-4e95-b9a8-07f5d6d200bd
+        status: 200 OK
+        code: 200
+        duration: 72.824286ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/56e85c23-44bf-4ee0-b26f-a8e361954ee6
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 177
+        uncompressed: false
+        body: '{"args":{},"function_id":"09990595-fe1b-4889-9ccb-b1efa933abaa","id":"56e85c23-44bf-4ee0-b26f-a8e361954ee6","name":"tf-tests-cron-basic","schedule":"0 0 * * *","status":"ready"}'
+        headers:
+            Content-Length:
+                - "177"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - d827821a-c06b-4759-9a58-76e2ba612065
+        status: 200 OK
+        code: 200
+        duration: 70.172003ms
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/56e85c23-44bf-4ee0-b26f-a8e361954ee6
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 180
+        uncompressed: false
+        body: '{"args":{},"function_id":"09990595-fe1b-4889-9ccb-b1efa933abaa","id":"56e85c23-44bf-4ee0-b26f-a8e361954ee6","name":"tf-tests-cron-basic","schedule":"0 0 * * *","status":"deleting"}'
+        headers:
+            Content-Length:
+                - "180"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 7972477e-c762-43ca-865e-9df518f7d8b4
+        status: 200 OK
+        code: 200
+        duration: 138.30234ms
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/09990595-fe1b-4889-9ccb-b1efa933abaa
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 588
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tftestsfunctioncronbxbhqs92s-tf-tests-cron-basic.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"09990595-fe1b-4889-9ccb-b1efa933abaa","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-cron-basic","namespace_id":"593a0f02-6c06-4440-8d8b-aec325ea5e8b","privacy":"private","region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "588"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - a9bd0b50-8c5e-45a4-b0f6-190cad01efe2
+        status: 200 OK
+        code: 200
+        duration: 70.751411ms
+    - id: 19
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/09990595-fe1b-4889-9ccb-b1efa933abaa
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 589
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tftestsfunctioncronbxbhqs92s-tf-tests-cron-basic.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"09990595-fe1b-4889-9ccb-b1efa933abaa","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-cron-basic","namespace_id":"593a0f02-6c06-4440-8d8b-aec325ea5e8b","privacy":"private","region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"deleting","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "589"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 77429bae-37c8-40b2-95ec-af9e191d8679
+        status: 200 OK
+        code: 200
+        duration: 140.734029ms
+    - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/593a0f02-6c06-4440-8d8b-aec325ea5e8b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 467
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"593a0f02-6c06-4440-8d8b-aec325ea5e8b","name":"tf-tests-function-cron-basic","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronbxbhqs92s","registry_namespace_id":"0386c8f3-0674-43c2-9cb2-60b7594004af","secret_environment_variables":[],"status":"ready"}'
+        headers:
+            Content-Length:
+                - "467"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - a1107282-ce82-43a7-a0e1-45808c26588f
+        status: 200 OK
+        code: 200
+        duration: 62.748876ms
+    - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/593a0f02-6c06-4440-8d8b-aec325ea5e8b
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 470
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"593a0f02-6c06-4440-8d8b-aec325ea5e8b","name":"tf-tests-function-cron-basic","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronbxbhqs92s","registry_namespace_id":"0386c8f3-0674-43c2-9cb2-60b7594004af","secret_environment_variables":[],"status":"deleting"}'
+        headers:
+            Content-Length:
+                - "470"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 5db86f7f-2818-4596-9f6a-caf688e12a89
+        status: 200 OK
+        code: 200
+        duration: 227.379784ms
+    - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/593a0f02-6c06-4440-8d8b-aec325ea5e8b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 470
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"593a0f02-6c06-4440-8d8b-aec325ea5e8b","name":"tf-tests-function-cron-basic","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronbxbhqs92s","registry_namespace_id":"0386c8f3-0674-43c2-9cb2-60b7594004af","secret_environment_variables":[],"status":"deleting"}'
+        headers:
+            Content-Length:
+                - "470"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 43a7d017-dbc3-42be-97a3-c4d3c39e8a72
+        status: 200 OK
+        code: 200
+        duration: 71.147837ms
+    - id: 23
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/593a0f02-6c06-4440-8d8b-aec325ea5e8b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 37
+        uncompressed: false
+        body: '{"message":"Namespace was not found"}'
+        headers:
+            Content-Length:
+                - "37"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:40 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 25a3d5bf-4112-45d1-994b-f36493d8729d
+        status: 404 Not Found
+        code: 404
+        duration: 26.374383ms
+    - id: 24
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/56e85c23-44bf-4ee0-b26f-a8e361954ee6
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 32
+        uncompressed: false
+        body: '{"message":"Cron was not found"}'
+        headers:
+            Content-Length:
+                - "32"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:40 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b990a73c-b487-499b-a73c-d5058d346835
+        status: 404 Not Found
+        code: 404
+        duration: 22.557523ms

--- a/internal/services/function/testdata/function-cron-name-update.cassette.yaml
+++ b/internal/services/function/testdata/function-cron-name-update.cassette.yaml
@@ -1,1146 +1,1677 @@
 ---
 version: 2
 interactions:
-- request:
-    body: '{"name":"tf-tests-function-cron-name-update","environment_variables":{},"project_id":"46fd79d8-1a35-4548-bfb8-03df51a0ebae","secret_environment_variables":[]}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces
-    method: POST
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"08187fc1-783a-48c7-adf4-b78ded6f63be","name":"tf-tests-function-cron-name-update","organization_id":"46fd79d8-1a35-4548-bfb8-03df51a0ebae","project_id":"46fd79d8-1a35-4548-bfb8-03df51a0ebae","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "384"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:10:57 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 72c7e700-9876-460e-b600-05815c2f608a
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/08187fc1-783a-48c7-adf4-b78ded6f63be
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"08187fc1-783a-48c7-adf4-b78ded6f63be","name":"tf-tests-function-cron-name-update","organization_id":"46fd79d8-1a35-4548-bfb8-03df51a0ebae","project_id":"46fd79d8-1a35-4548-bfb8-03df51a0ebae","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "384"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:10:57 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c27125db-f485-4d67-be56-1a0ea70b0f66
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/08187fc1-783a-48c7-adf4-b78ded6f63be
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"08187fc1-783a-48c7-adf4-b78ded6f63be","name":"tf-tests-function-cron-name-update","organization_id":"46fd79d8-1a35-4548-bfb8-03df51a0ebae","project_id":"46fd79d8-1a35-4548-bfb8-03df51a0ebae","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronnsihn73oc","registry_namespace_id":"145e96e8-928e-4a71-8956-1c6911832ce8","secret_environment_variables":[],"status":"ready"}'
-    headers:
-      Content-Length:
-      - "473"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:02 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6034d908-e678-4f49-b080-4b628813f970
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/08187fc1-783a-48c7-adf4-b78ded6f63be
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"08187fc1-783a-48c7-adf4-b78ded6f63be","name":"tf-tests-function-cron-name-update","organization_id":"46fd79d8-1a35-4548-bfb8-03df51a0ebae","project_id":"46fd79d8-1a35-4548-bfb8-03df51a0ebae","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronnsihn73oc","registry_namespace_id":"145e96e8-928e-4a71-8956-1c6911832ce8","secret_environment_variables":[],"status":"ready"}'
-    headers:
-      Content-Length:
-      - "473"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:02 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f136320b-1531-477b-9a03-a9b35a22dc16
-    status: 200 OK
-    code: 200
-- request:
-    body: '{"name":"tf-tests-function-cron-name-update","namespace_id":"08187fc1-783a-48c7-adf4-b78ded6f63be","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"node14","memory_limit":128,"handler":"handler.handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled"}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions
-    method: POST
-  response:
-    body: '{"build_message":null,"cpu_limit":70,"description":"","domain_name":"tftestsfunctioncronnsihn73oc-tf-tests-function-cron-name-update.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"abac9fce-60e8-4b30-b375-92d523d8de47","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-tests-function-cron-name-update","namespace_id":"08187fc1-783a-48c7-adf4-b78ded6f63be","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "602"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4b7029f6-23ee-479b-8177-950b4b59c5ee
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/abac9fce-60e8-4b30-b375-92d523d8de47
-    method: GET
-  response:
-    body: '{"build_message":null,"cpu_limit":70,"description":"","domain_name":"tftestsfunctioncronnsihn73oc-tf-tests-function-cron-name-update.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"abac9fce-60e8-4b30-b375-92d523d8de47","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-tests-function-cron-name-update","namespace_id":"08187fc1-783a-48c7-adf4-b78ded6f63be","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "602"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 01c956a4-6b24-42b8-b7eb-3f1a061da918
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/abac9fce-60e8-4b30-b375-92d523d8de47
-    method: GET
-  response:
-    body: '{"build_message":null,"cpu_limit":70,"description":"","domain_name":"tftestsfunctioncronnsihn73oc-tf-tests-function-cron-name-update.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"abac9fce-60e8-4b30-b375-92d523d8de47","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-tests-function-cron-name-update","namespace_id":"08187fc1-783a-48c7-adf4-b78ded6f63be","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "602"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 60cb63b9-9603-4355-8554-9a6200623994
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/abac9fce-60e8-4b30-b375-92d523d8de47
-    method: GET
-  response:
-    body: '{"build_message":null,"cpu_limit":70,"description":"","domain_name":"tftestsfunctioncronnsihn73oc-tf-tests-function-cron-name-update.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"abac9fce-60e8-4b30-b375-92d523d8de47","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-tests-function-cron-name-update","namespace_id":"08187fc1-783a-48c7-adf4-b78ded6f63be","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "602"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0d7205c1-8c57-4e4a-98e7-0553d1836e78
-    status: 200 OK
-    code: 200
-- request:
-    body: '{"function_id":"abac9fce-60e8-4b30-b375-92d523d8de47","schedule":"0 0 *
-      * *","args":{},"name":"tf-tests-function-cron-name-update"}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons
-    method: POST
-  response:
-    body: '{"args":{},"function_id":"abac9fce-60e8-4b30-b375-92d523d8de47","id":"5e279af7-7c57-4677-befe-210bfe64b9d8","name":"tf-tests-function-cron-name-update","schedule":"0
-      0 * * *","status":"pending"}'
-    headers:
-      Content-Length:
-      - "194"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 016b698a-bde5-4ff1-897a-00fd00f1b019
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/5e279af7-7c57-4677-befe-210bfe64b9d8
-    method: GET
-  response:
-    body: '{"args":{},"function_id":"abac9fce-60e8-4b30-b375-92d523d8de47","id":"5e279af7-7c57-4677-befe-210bfe64b9d8","name":"tf-tests-function-cron-name-update","schedule":"0
-      0 * * *","status":"pending"}'
-    headers:
-      Content-Length:
-      - "194"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a8d1b442-3787-4eb3-892f-7f3ba6659fea
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/5e279af7-7c57-4677-befe-210bfe64b9d8
-    method: GET
-  response:
-    body: '{"args":{},"function_id":"abac9fce-60e8-4b30-b375-92d523d8de47","id":"5e279af7-7c57-4677-befe-210bfe64b9d8","name":"tf-tests-function-cron-name-update","schedule":"0
-      0 * * *","status":"ready"}'
-    headers:
-      Content-Length:
-      - "192"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:08 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 16b07735-2941-4fc3-b8c9-a33dbdf40580
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/5e279af7-7c57-4677-befe-210bfe64b9d8
-    method: GET
-  response:
-    body: '{"args":{},"function_id":"abac9fce-60e8-4b30-b375-92d523d8de47","id":"5e279af7-7c57-4677-befe-210bfe64b9d8","name":"tf-tests-function-cron-name-update","schedule":"0
-      0 * * *","status":"ready"}'
-    headers:
-      Content-Length:
-      - "192"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:08 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3b821a87-8b1f-455b-b5dc-a5389db2578d
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/5e279af7-7c57-4677-befe-210bfe64b9d8
-    method: GET
-  response:
-    body: '{"args":{},"function_id":"abac9fce-60e8-4b30-b375-92d523d8de47","id":"5e279af7-7c57-4677-befe-210bfe64b9d8","name":"tf-tests-function-cron-name-update","schedule":"0
-      0 * * *","status":"ready"}'
-    headers:
-      Content-Length:
-      - "192"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:08 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 40052568-9b97-4dec-ab58-d2e0a5db936c
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/08187fc1-783a-48c7-adf4-b78ded6f63be
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"08187fc1-783a-48c7-adf4-b78ded6f63be","name":"tf-tests-function-cron-name-update","organization_id":"46fd79d8-1a35-4548-bfb8-03df51a0ebae","project_id":"46fd79d8-1a35-4548-bfb8-03df51a0ebae","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronnsihn73oc","registry_namespace_id":"145e96e8-928e-4a71-8956-1c6911832ce8","secret_environment_variables":[],"status":"ready"}'
-    headers:
-      Content-Length:
-      - "473"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:09 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - aab741d2-8ce9-4673-a517-343e1a0d5e7a
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/abac9fce-60e8-4b30-b375-92d523d8de47
-    method: GET
-  response:
-    body: '{"build_message":null,"cpu_limit":70,"description":"","domain_name":"tftestsfunctioncronnsihn73oc-tf-tests-function-cron-name-update.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"abac9fce-60e8-4b30-b375-92d523d8de47","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-tests-function-cron-name-update","namespace_id":"08187fc1-783a-48c7-adf4-b78ded6f63be","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "602"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:09 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9ce88479-0dba-4b19-98ba-8cb9bf4353ba
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/5e279af7-7c57-4677-befe-210bfe64b9d8
-    method: GET
-  response:
-    body: '{"args":{},"function_id":"abac9fce-60e8-4b30-b375-92d523d8de47","id":"5e279af7-7c57-4677-befe-210bfe64b9d8","name":"tf-tests-function-cron-name-update","schedule":"0
-      0 * * *","status":"ready"}'
-    headers:
-      Content-Length:
-      - "192"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:09 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 15738700-366a-4af8-b015-ae00d618a560
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/08187fc1-783a-48c7-adf4-b78ded6f63be
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"08187fc1-783a-48c7-adf4-b78ded6f63be","name":"tf-tests-function-cron-name-update","organization_id":"46fd79d8-1a35-4548-bfb8-03df51a0ebae","project_id":"46fd79d8-1a35-4548-bfb8-03df51a0ebae","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronnsihn73oc","registry_namespace_id":"145e96e8-928e-4a71-8956-1c6911832ce8","secret_environment_variables":[],"status":"ready"}'
-    headers:
-      Content-Length:
-      - "473"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:11 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6fa83cb6-8acb-4486-8b58-b0e4ef980221
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/abac9fce-60e8-4b30-b375-92d523d8de47
-    method: GET
-  response:
-    body: '{"build_message":null,"cpu_limit":70,"description":"","domain_name":"tftestsfunctioncronnsihn73oc-tf-tests-function-cron-name-update.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"abac9fce-60e8-4b30-b375-92d523d8de47","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-tests-function-cron-name-update","namespace_id":"08187fc1-783a-48c7-adf4-b78ded6f63be","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "602"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:11 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c8c9d3b7-433e-4ce1-a439-a5f3d0f029f4
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/5e279af7-7c57-4677-befe-210bfe64b9d8
-    method: GET
-  response:
-    body: '{"args":{},"function_id":"abac9fce-60e8-4b30-b375-92d523d8de47","id":"5e279af7-7c57-4677-befe-210bfe64b9d8","name":"tf-tests-function-cron-name-update","schedule":"0
-      0 * * *","status":"ready"}'
-    headers:
-      Content-Length:
-      - "192"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:11 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ca19711f-d1f8-4d65-b357-593225d36bc6
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/5e279af7-7c57-4677-befe-210bfe64b9d8
-    method: GET
-  response:
-    body: '{"args":{},"function_id":"abac9fce-60e8-4b30-b375-92d523d8de47","id":"5e279af7-7c57-4677-befe-210bfe64b9d8","name":"tf-tests-function-cron-name-update","schedule":"0
-      0 * * *","status":"ready"}'
-    headers:
-      Content-Length:
-      - "192"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:12 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f7cfa001-7ab8-4908-9f98-5f8edb8248b7
-    status: 200 OK
-    code: 200
-- request:
-    body: '{"args":{"test":"scw"},"name":"name-changed"}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/5e279af7-7c57-4677-befe-210bfe64b9d8
-    method: PATCH
-  response:
-    body: '{"args":{"test":"scw"},"function_id":"abac9fce-60e8-4b30-b375-92d523d8de47","id":"5e279af7-7c57-4677-befe-210bfe64b9d8","name":"name-changed","schedule":"0
-      0 * * *","status":"pending"}'
-    headers:
-      Content-Length:
-      - "184"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:12 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 79e0482a-8bcd-4ebc-becc-fc70aa74b545
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/5e279af7-7c57-4677-befe-210bfe64b9d8
-    method: GET
-  response:
-    body: '{"args":{"test":"scw"},"function_id":"abac9fce-60e8-4b30-b375-92d523d8de47","id":"5e279af7-7c57-4677-befe-210bfe64b9d8","name":"name-changed","schedule":"0
-      0 * * *","status":"ready"}'
-    headers:
-      Content-Length:
-      - "182"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:12 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ac6de323-911b-4150-81ce-ea90905b0b91
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/5e279af7-7c57-4677-befe-210bfe64b9d8
-    method: GET
-  response:
-    body: '{"args":{"test":"scw"},"function_id":"abac9fce-60e8-4b30-b375-92d523d8de47","id":"5e279af7-7c57-4677-befe-210bfe64b9d8","name":"name-changed","schedule":"0
-      0 * * *","status":"ready"}'
-    headers:
-      Content-Length:
-      - "182"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:12 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ab9873ea-758b-4f75-8f1f-5820a0992bf6
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/08187fc1-783a-48c7-adf4-b78ded6f63be
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"08187fc1-783a-48c7-adf4-b78ded6f63be","name":"tf-tests-function-cron-name-update","organization_id":"46fd79d8-1a35-4548-bfb8-03df51a0ebae","project_id":"46fd79d8-1a35-4548-bfb8-03df51a0ebae","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronnsihn73oc","registry_namespace_id":"145e96e8-928e-4a71-8956-1c6911832ce8","secret_environment_variables":[],"status":"ready"}'
-    headers:
-      Content-Length:
-      - "473"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 219a36b0-7602-4fb4-bcff-915f7e3756b9
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/abac9fce-60e8-4b30-b375-92d523d8de47
-    method: GET
-  response:
-    body: '{"build_message":null,"cpu_limit":70,"description":"","domain_name":"tftestsfunctioncronnsihn73oc-tf-tests-function-cron-name-update.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"abac9fce-60e8-4b30-b375-92d523d8de47","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-tests-function-cron-name-update","namespace_id":"08187fc1-783a-48c7-adf4-b78ded6f63be","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "602"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f5e628a0-cb57-43f5-a15b-a6a5a6f8c4f8
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/5e279af7-7c57-4677-befe-210bfe64b9d8
-    method: GET
-  response:
-    body: '{"args":{"test":"scw"},"function_id":"abac9fce-60e8-4b30-b375-92d523d8de47","id":"5e279af7-7c57-4677-befe-210bfe64b9d8","name":"name-changed","schedule":"0
-      0 * * *","status":"ready"}'
-    headers:
-      Content-Length:
-      - "182"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - fa3887b7-70c9-433e-90fa-de2b3ab24038
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/5e279af7-7c57-4677-befe-210bfe64b9d8
-    method: GET
-  response:
-    body: '{"args":{"test":"scw"},"function_id":"abac9fce-60e8-4b30-b375-92d523d8de47","id":"5e279af7-7c57-4677-befe-210bfe64b9d8","name":"name-changed","schedule":"0
-      0 * * *","status":"ready"}'
-    headers:
-      Content-Length:
-      - "182"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:14 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 90226885-4334-4055-8c5a-ec16710a0833
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/5e279af7-7c57-4677-befe-210bfe64b9d8
-    method: DELETE
-  response:
-    body: '{"args":{"test":"scw"},"function_id":"abac9fce-60e8-4b30-b375-92d523d8de47","id":"5e279af7-7c57-4677-befe-210bfe64b9d8","name":"name-changed","schedule":"0
-      0 * * *","status":"deleting"}'
-    headers:
-      Content-Length:
-      - "185"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:14 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a185e682-5cdb-4638-916d-92dd23fadff2
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/abac9fce-60e8-4b30-b375-92d523d8de47
-    method: GET
-  response:
-    body: '{"build_message":null,"cpu_limit":70,"description":"","domain_name":"tftestsfunctioncronnsihn73oc-tf-tests-function-cron-name-update.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"abac9fce-60e8-4b30-b375-92d523d8de47","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-tests-function-cron-name-update","namespace_id":"08187fc1-783a-48c7-adf4-b78ded6f63be","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "602"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:15 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 22a66114-2649-4ae0-804f-4f2cf8ba45fe
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/abac9fce-60e8-4b30-b375-92d523d8de47
-    method: DELETE
-  response:
-    body: '{"build_message":null,"cpu_limit":70,"description":"","domain_name":"tftestsfunctioncronnsihn73oc-tf-tests-function-cron-name-update.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"abac9fce-60e8-4b30-b375-92d523d8de47","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-tests-function-cron-name-update","namespace_id":"08187fc1-783a-48c7-adf4-b78ded6f63be","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"deleting","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "603"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:15 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d7bcbd98-202c-4359-b2d8-86c16cec2561
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/08187fc1-783a-48c7-adf4-b78ded6f63be
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"08187fc1-783a-48c7-adf4-b78ded6f63be","name":"tf-tests-function-cron-name-update","organization_id":"46fd79d8-1a35-4548-bfb8-03df51a0ebae","project_id":"46fd79d8-1a35-4548-bfb8-03df51a0ebae","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronnsihn73oc","registry_namespace_id":"145e96e8-928e-4a71-8956-1c6911832ce8","secret_environment_variables":[],"status":"ready"}'
-    headers:
-      Content-Length:
-      - "473"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:15 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f07500a6-fa9d-47ca-869a-d67adbcc232a
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/08187fc1-783a-48c7-adf4-b78ded6f63be
-    method: DELETE
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"08187fc1-783a-48c7-adf4-b78ded6f63be","name":"tf-tests-function-cron-name-update","organization_id":"46fd79d8-1a35-4548-bfb8-03df51a0ebae","project_id":"46fd79d8-1a35-4548-bfb8-03df51a0ebae","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronnsihn73oc","registry_namespace_id":"145e96e8-928e-4a71-8956-1c6911832ce8","secret_environment_variables":[],"status":"deleting"}'
-    headers:
-      Content-Length:
-      - "476"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:15 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2ffe6070-d0ff-4a79-8f25-88a591e2f6a9
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/08187fc1-783a-48c7-adf4-b78ded6f63be
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"08187fc1-783a-48c7-adf4-b78ded6f63be","name":"tf-tests-function-cron-name-update","organization_id":"46fd79d8-1a35-4548-bfb8-03df51a0ebae","project_id":"46fd79d8-1a35-4548-bfb8-03df51a0ebae","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronnsihn73oc","registry_namespace_id":"145e96e8-928e-4a71-8956-1c6911832ce8","secret_environment_variables":[],"status":"deleting"}'
-    headers:
-      Content-Length:
-      - "476"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:15 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b1b30048-33d2-4b4e-ac0a-62a13d2d327c
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/08187fc1-783a-48c7-adf4-b78ded6f63be
-    method: GET
-  response:
-    body: '{"message":"Namespace was not found"}'
-    headers:
-      Content-Length:
-      - "37"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:20 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2ae692d0-2cde-4b09-a456-57b7e19a1e01
-    status: 404 Not Found
-    code: 404
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/5e279af7-7c57-4677-befe-210bfe64b9d8
-    method: DELETE
-  response:
-    body: '{"message":"Cron was not found"}'
-    headers:
-      Content-Length:
-      - "32"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:20 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f24a0d67-31e9-4698-b20a-e2ba6944a763
-    status: 404 Not Found
-    code: 404
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 158
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"name":"tf-tests-function-cron-name-update","environment_variables":{},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","secret_environment_variables":[]}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 384
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"32f5f68a-c9db-4317-9ef4-90d5bf2e37b0","name":"tf-tests-function-cron-name-update","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
+        headers:
+            Content-Length:
+                - "384"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:22 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 789d147b-2314-4174-a9a3-444144908bcf
+        status: 200 OK
+        code: 200
+        duration: 562.212516ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/32f5f68a-c9db-4317-9ef4-90d5bf2e37b0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 384
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"32f5f68a-c9db-4317-9ef4-90d5bf2e37b0","name":"tf-tests-function-cron-name-update","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
+        headers:
+            Content-Length:
+                - "384"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:22 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 64f44e94-84e4-43a6-8892-2ae23a63da93
+        status: 200 OK
+        code: 200
+        duration: 66.46569ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/32f5f68a-c9db-4317-9ef4-90d5bf2e37b0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 473
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"32f5f68a-c9db-4317-9ef4-90d5bf2e37b0","name":"tf-tests-function-cron-name-update","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronn02hcu1sg","registry_namespace_id":"c9fdefa9-5cd1-4a54-8979-ef82bfc96aee","secret_environment_variables":[],"status":"ready"}'
+        headers:
+            Content-Length:
+                - "473"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:27 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 8bc7ea37-87dc-4145-9f87-c8bb7c20742c
+        status: 200 OK
+        code: 200
+        duration: 57.068473ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/32f5f68a-c9db-4317-9ef4-90d5bf2e37b0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 473
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"32f5f68a-c9db-4317-9ef4-90d5bf2e37b0","name":"tf-tests-function-cron-name-update","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronn02hcu1sg","registry_namespace_id":"c9fdefa9-5cd1-4a54-8979-ef82bfc96aee","secret_environment_variables":[],"status":"ready"}'
+        headers:
+            Content-Length:
+                - "473"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:27 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - cfbb2fbd-b002-4588-b431-529dc6458013
+        status: 200 OK
+        code: 200
+        duration: 67.298214ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 326
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"name":"tf-tests-function-cron-name-update","namespace_id":"32f5f68a-c9db-4317-9ef4-90d5bf2e37b0","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"node20","memory_limit":256,"handler":"handler.handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 618
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tftestsfunctioncronn02hcu1sg-tf-tests-function-cron-name-update.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"42e58e60-ba1b-4359-9881-c499164ad6f8","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-function-cron-name-update","namespace_id":"32f5f68a-c9db-4317-9ef4-90d5bf2e37b0","privacy":"private","region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "618"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:28 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 8bf7e1a1-0c56-4902-9fb4-2a0f4676aa07
+        status: 200 OK
+        code: 200
+        duration: 386.765537ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/42e58e60-ba1b-4359-9881-c499164ad6f8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 618
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tftestsfunctioncronn02hcu1sg-tf-tests-function-cron-name-update.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"42e58e60-ba1b-4359-9881-c499164ad6f8","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-function-cron-name-update","namespace_id":"32f5f68a-c9db-4317-9ef4-90d5bf2e37b0","privacy":"private","region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "618"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:28 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e30a172d-617c-47d6-9d09-109812c126f2
+        status: 200 OK
+        code: 200
+        duration: 52.319ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/42e58e60-ba1b-4359-9881-c499164ad6f8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 618
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tftestsfunctioncronn02hcu1sg-tf-tests-function-cron-name-update.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"42e58e60-ba1b-4359-9881-c499164ad6f8","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-function-cron-name-update","namespace_id":"32f5f68a-c9db-4317-9ef4-90d5bf2e37b0","privacy":"private","region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "618"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:28 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 9f350d67-f540-4762-ad3f-4894f5655c4b
+        status: 200 OK
+        code: 200
+        duration: 70.387679ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/42e58e60-ba1b-4359-9881-c499164ad6f8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 618
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tftestsfunctioncronn02hcu1sg-tf-tests-function-cron-name-update.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"42e58e60-ba1b-4359-9881-c499164ad6f8","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-function-cron-name-update","namespace_id":"32f5f68a-c9db-4317-9ef4-90d5bf2e37b0","privacy":"private","region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "618"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:28 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 4100f87d-733d-40b9-bb78-52be0764f60d
+        status: 200 OK
+        code: 200
+        duration: 50.633995ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 131
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"function_id":"42e58e60-ba1b-4359-9881-c499164ad6f8","schedule":"0 0 * * *","args":{},"name":"tf-tests-function-cron-name-update"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 194
+        uncompressed: false
+        body: '{"args":{},"function_id":"42e58e60-ba1b-4359-9881-c499164ad6f8","id":"fd6c29d4-99bc-48ac-ac54-745b9eb73eba","name":"tf-tests-function-cron-name-update","schedule":"0 0 * * *","status":"pending"}'
+        headers:
+            Content-Length:
+                - "194"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:28 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - abf59fa0-6609-44d5-bc66-c6be22824e93
+        status: 200 OK
+        code: 200
+        duration: 97.435927ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/fd6c29d4-99bc-48ac-ac54-745b9eb73eba
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 192
+        uncompressed: false
+        body: '{"args":{},"function_id":"42e58e60-ba1b-4359-9881-c499164ad6f8","id":"fd6c29d4-99bc-48ac-ac54-745b9eb73eba","name":"tf-tests-function-cron-name-update","schedule":"0 0 * * *","status":"ready"}'
+        headers:
+            Content-Length:
+                - "192"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:28 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 40dfe373-0cc3-4889-ad00-7be36d6ce57a
+        status: 200 OK
+        code: 200
+        duration: 62.72447ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/fd6c29d4-99bc-48ac-ac54-745b9eb73eba
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 192
+        uncompressed: false
+        body: '{"args":{},"function_id":"42e58e60-ba1b-4359-9881-c499164ad6f8","id":"fd6c29d4-99bc-48ac-ac54-745b9eb73eba","name":"tf-tests-function-cron-name-update","schedule":"0 0 * * *","status":"ready"}'
+        headers:
+            Content-Length:
+                - "192"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:28 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - c59bf415-001d-463a-8fa2-32e145f01dd9
+        status: 200 OK
+        code: 200
+        duration: 74.504343ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/fd6c29d4-99bc-48ac-ac54-745b9eb73eba
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 192
+        uncompressed: false
+        body: '{"args":{},"function_id":"42e58e60-ba1b-4359-9881-c499164ad6f8","id":"fd6c29d4-99bc-48ac-ac54-745b9eb73eba","name":"tf-tests-function-cron-name-update","schedule":"0 0 * * *","status":"ready"}'
+        headers:
+            Content-Length:
+                - "192"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:28 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 27fdc087-1cdf-4153-8594-6bebd0a389e5
+        status: 200 OK
+        code: 200
+        duration: 69.136467ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/32f5f68a-c9db-4317-9ef4-90d5bf2e37b0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 473
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"32f5f68a-c9db-4317-9ef4-90d5bf2e37b0","name":"tf-tests-function-cron-name-update","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronn02hcu1sg","registry_namespace_id":"c9fdefa9-5cd1-4a54-8979-ef82bfc96aee","secret_environment_variables":[],"status":"ready"}'
+        headers:
+            Content-Length:
+                - "473"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:29 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b5ad5359-df7e-4b33-b628-3227d503c9b9
+        status: 200 OK
+        code: 200
+        duration: 55.244226ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/42e58e60-ba1b-4359-9881-c499164ad6f8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 618
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tftestsfunctioncronn02hcu1sg-tf-tests-function-cron-name-update.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"42e58e60-ba1b-4359-9881-c499164ad6f8","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-function-cron-name-update","namespace_id":"32f5f68a-c9db-4317-9ef4-90d5bf2e37b0","privacy":"private","region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "618"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:29 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 2cd35d03-cdc2-461d-92a2-3949c2a7a704
+        status: 200 OK
+        code: 200
+        duration: 173.438766ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/fd6c29d4-99bc-48ac-ac54-745b9eb73eba
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 192
+        uncompressed: false
+        body: '{"args":{},"function_id":"42e58e60-ba1b-4359-9881-c499164ad6f8","id":"fd6c29d4-99bc-48ac-ac54-745b9eb73eba","name":"tf-tests-function-cron-name-update","schedule":"0 0 * * *","status":"ready"}'
+        headers:
+            Content-Length:
+                - "192"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:29 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - a59c8307-ee28-4b68-82c0-47a7710d78fa
+        status: 200 OK
+        code: 200
+        duration: 85.59976ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/32f5f68a-c9db-4317-9ef4-90d5bf2e37b0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 473
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"32f5f68a-c9db-4317-9ef4-90d5bf2e37b0","name":"tf-tests-function-cron-name-update","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronn02hcu1sg","registry_namespace_id":"c9fdefa9-5cd1-4a54-8979-ef82bfc96aee","secret_environment_variables":[],"status":"ready"}'
+        headers:
+            Content-Length:
+                - "473"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:29 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 2c1b40c9-dabb-47bb-92fc-072b32d0a076
+        status: 200 OK
+        code: 200
+        duration: 66.19451ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/42e58e60-ba1b-4359-9881-c499164ad6f8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 618
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tftestsfunctioncronn02hcu1sg-tf-tests-function-cron-name-update.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"42e58e60-ba1b-4359-9881-c499164ad6f8","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-function-cron-name-update","namespace_id":"32f5f68a-c9db-4317-9ef4-90d5bf2e37b0","privacy":"private","region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "618"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:29 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - c0b02670-9b5b-4f00-a94d-b9a89c0af5eb
+        status: 200 OK
+        code: 200
+        duration: 65.942216ms
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/fd6c29d4-99bc-48ac-ac54-745b9eb73eba
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 192
+        uncompressed: false
+        body: '{"args":{},"function_id":"42e58e60-ba1b-4359-9881-c499164ad6f8","id":"fd6c29d4-99bc-48ac-ac54-745b9eb73eba","name":"tf-tests-function-cron-name-update","schedule":"0 0 * * *","status":"ready"}'
+        headers:
+            Content-Length:
+                - "192"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:29 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f443d35a-0a36-4447-80fd-dbcdbf4731de
+        status: 200 OK
+        code: 200
+        duration: 76.554074ms
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/fd6c29d4-99bc-48ac-ac54-745b9eb73eba
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 192
+        uncompressed: false
+        body: '{"args":{},"function_id":"42e58e60-ba1b-4359-9881-c499164ad6f8","id":"fd6c29d4-99bc-48ac-ac54-745b9eb73eba","name":"tf-tests-function-cron-name-update","schedule":"0 0 * * *","status":"ready"}'
+        headers:
+            Content-Length:
+                - "192"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:30 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 610590e8-fd4f-45aa-a832-64d0b74ca18e
+        status: 200 OK
+        code: 200
+        duration: 64.681397ms
+    - id: 19
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 45
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"args":{"test":"scw"},"name":"name-changed"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/fd6c29d4-99bc-48ac-ac54-745b9eb73eba
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 184
+        uncompressed: false
+        body: '{"args":{"test":"scw"},"function_id":"42e58e60-ba1b-4359-9881-c499164ad6f8","id":"fd6c29d4-99bc-48ac-ac54-745b9eb73eba","name":"name-changed","schedule":"0 0 * * *","status":"pending"}'
+        headers:
+            Content-Length:
+                - "184"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:30 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f1d7bd88-4384-44be-80f1-18326e682af0
+        status: 200 OK
+        code: 200
+        duration: 140.239339ms
+    - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/fd6c29d4-99bc-48ac-ac54-745b9eb73eba
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 182
+        uncompressed: false
+        body: '{"args":{"test":"scw"},"function_id":"42e58e60-ba1b-4359-9881-c499164ad6f8","id":"fd6c29d4-99bc-48ac-ac54-745b9eb73eba","name":"name-changed","schedule":"0 0 * * *","status":"ready"}'
+        headers:
+            Content-Length:
+                - "182"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:30 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 07bc18f2-ce91-43a2-97d2-c7abbf9edfe7
+        status: 200 OK
+        code: 200
+        duration: 79.271349ms
+    - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/fd6c29d4-99bc-48ac-ac54-745b9eb73eba
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 182
+        uncompressed: false
+        body: '{"args":{"test":"scw"},"function_id":"42e58e60-ba1b-4359-9881-c499164ad6f8","id":"fd6c29d4-99bc-48ac-ac54-745b9eb73eba","name":"name-changed","schedule":"0 0 * * *","status":"ready"}'
+        headers:
+            Content-Length:
+                - "182"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:30 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 7d9f9fef-3a64-4f25-aa79-ae32b06cac1c
+        status: 200 OK
+        code: 200
+        duration: 86.011112ms
+    - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/32f5f68a-c9db-4317-9ef4-90d5bf2e37b0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 473
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"32f5f68a-c9db-4317-9ef4-90d5bf2e37b0","name":"tf-tests-function-cron-name-update","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronn02hcu1sg","registry_namespace_id":"c9fdefa9-5cd1-4a54-8979-ef82bfc96aee","secret_environment_variables":[],"status":"ready"}'
+        headers:
+            Content-Length:
+                - "473"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:31 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 9b72ced4-2be6-48d8-9c40-3cff75f64d07
+        status: 200 OK
+        code: 200
+        duration: 61.178666ms
+    - id: 23
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/42e58e60-ba1b-4359-9881-c499164ad6f8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 618
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tftestsfunctioncronn02hcu1sg-tf-tests-function-cron-name-update.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"42e58e60-ba1b-4359-9881-c499164ad6f8","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-function-cron-name-update","namespace_id":"32f5f68a-c9db-4317-9ef4-90d5bf2e37b0","privacy":"private","region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "618"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:31 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e0534450-3568-4909-9fcb-45faefe35b2a
+        status: 200 OK
+        code: 200
+        duration: 57.94516ms
+    - id: 24
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/fd6c29d4-99bc-48ac-ac54-745b9eb73eba
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 182
+        uncompressed: false
+        body: '{"args":{"test":"scw"},"function_id":"42e58e60-ba1b-4359-9881-c499164ad6f8","id":"fd6c29d4-99bc-48ac-ac54-745b9eb73eba","name":"name-changed","schedule":"0 0 * * *","status":"ready"}'
+        headers:
+            Content-Length:
+                - "182"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:31 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f8dc9d9c-0ba6-4751-ad51-44a812eb5183
+        status: 200 OK
+        code: 200
+        duration: 69.141497ms
+    - id: 25
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/fd6c29d4-99bc-48ac-ac54-745b9eb73eba
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 182
+        uncompressed: false
+        body: '{"args":{"test":"scw"},"function_id":"42e58e60-ba1b-4359-9881-c499164ad6f8","id":"fd6c29d4-99bc-48ac-ac54-745b9eb73eba","name":"name-changed","schedule":"0 0 * * *","status":"ready"}'
+        headers:
+            Content-Length:
+                - "182"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:31 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 4595a702-0820-4250-8d21-e269a2afd3f7
+        status: 200 OK
+        code: 200
+        duration: 71.241513ms
+    - id: 26
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/fd6c29d4-99bc-48ac-ac54-745b9eb73eba
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 185
+        uncompressed: false
+        body: '{"args":{"test":"scw"},"function_id":"42e58e60-ba1b-4359-9881-c499164ad6f8","id":"fd6c29d4-99bc-48ac-ac54-745b9eb73eba","name":"name-changed","schedule":"0 0 * * *","status":"deleting"}'
+        headers:
+            Content-Length:
+                - "185"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:32 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 0be6aa32-0ee6-4c6e-bc61-d1b94c93ef22
+        status: 200 OK
+        code: 200
+        duration: 97.301906ms
+    - id: 27
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/42e58e60-ba1b-4359-9881-c499164ad6f8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 618
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tftestsfunctioncronn02hcu1sg-tf-tests-function-cron-name-update.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"42e58e60-ba1b-4359-9881-c499164ad6f8","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-function-cron-name-update","namespace_id":"32f5f68a-c9db-4317-9ef4-90d5bf2e37b0","privacy":"private","region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "618"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:32 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - a67275bb-bb17-4048-8abb-27755b5ba3a6
+        status: 200 OK
+        code: 200
+        duration: 88.481974ms
+    - id: 28
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/42e58e60-ba1b-4359-9881-c499164ad6f8
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 619
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tftestsfunctioncronn02hcu1sg-tf-tests-function-cron-name-update.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"42e58e60-ba1b-4359-9881-c499164ad6f8","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-function-cron-name-update","namespace_id":"32f5f68a-c9db-4317-9ef4-90d5bf2e37b0","privacy":"private","region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"deleting","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "619"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:32 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 4df52d5c-fa6f-4d43-93fd-99b75b1c08df
+        status: 200 OK
+        code: 200
+        duration: 265.369181ms
+    - id: 29
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/32f5f68a-c9db-4317-9ef4-90d5bf2e37b0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 473
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"32f5f68a-c9db-4317-9ef4-90d5bf2e37b0","name":"tf-tests-function-cron-name-update","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronn02hcu1sg","registry_namespace_id":"c9fdefa9-5cd1-4a54-8979-ef82bfc96aee","secret_environment_variables":[],"status":"ready"}'
+        headers:
+            Content-Length:
+                - "473"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:32 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ebe30cd7-0e7f-479e-a092-8ae32fb0b433
+        status: 200 OK
+        code: 200
+        duration: 64.204861ms
+    - id: 30
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/32f5f68a-c9db-4317-9ef4-90d5bf2e37b0
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 476
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"32f5f68a-c9db-4317-9ef4-90d5bf2e37b0","name":"tf-tests-function-cron-name-update","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronn02hcu1sg","registry_namespace_id":"c9fdefa9-5cd1-4a54-8979-ef82bfc96aee","secret_environment_variables":[],"status":"deleting"}'
+        headers:
+            Content-Length:
+                - "476"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:32 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ec835ecb-98f5-4272-b6ed-eda1f8869350
+        status: 200 OK
+        code: 200
+        duration: 237.697429ms
+    - id: 31
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/32f5f68a-c9db-4317-9ef4-90d5bf2e37b0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 476
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"32f5f68a-c9db-4317-9ef4-90d5bf2e37b0","name":"tf-tests-function-cron-name-update","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronn02hcu1sg","registry_namespace_id":"c9fdefa9-5cd1-4a54-8979-ef82bfc96aee","secret_environment_variables":[],"status":"deleting"}'
+        headers:
+            Content-Length:
+                - "476"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:32 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 478e1622-585b-472c-b837-105c868a8de2
+        status: 200 OK
+        code: 200
+        duration: 62.329709ms
+    - id: 32
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/32f5f68a-c9db-4317-9ef4-90d5bf2e37b0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 37
+        uncompressed: false
+        body: '{"message":"Namespace was not found"}'
+        headers:
+            Content-Length:
+                - "37"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:37 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 23d36cac-2fbd-4125-a9a6-e1ef99e32c5d
+        status: 404 Not Found
+        code: 404
+        duration: 26.476234ms
+    - id: 33
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/fd6c29d4-99bc-48ac-ac54-745b9eb73eba
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 32
+        uncompressed: false
+        body: '{"message":"Cron was not found"}'
+        headers:
+            Content-Length:
+                - "32"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:37 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ad83899a-a4ab-40df-8482-3c452f0ddb67
+        status: 404 Not Found
+        code: 404
+        duration: 29.094134ms

--- a/internal/services/function/testdata/function-cron-with-args.cassette.yaml
+++ b/internal/services/function/testdata/function-cron-with-args.cassette.yaml
@@ -1,818 +1,1234 @@
 ---
 version: 2
 interactions:
-- request:
-    body: '{"name":"tf-tests-function-cron-with-args","environment_variables":{},"project_id":"46fd79d8-1a35-4548-bfb8-03df51a0ebae","secret_environment_variables":[]}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces
-    method: POST
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"6b6b7d77-d8ad-4499-9f7e-1b8cfa37b530","name":"tf-tests-function-cron-with-args","organization_id":"46fd79d8-1a35-4548-bfb8-03df51a0ebae","project_id":"46fd79d8-1a35-4548-bfb8-03df51a0ebae","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "382"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:10:57 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1952eb21-f3cf-4939-bd9c-f725c4c6afe2
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/6b6b7d77-d8ad-4499-9f7e-1b8cfa37b530
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"6b6b7d77-d8ad-4499-9f7e-1b8cfa37b530","name":"tf-tests-function-cron-with-args","organization_id":"46fd79d8-1a35-4548-bfb8-03df51a0ebae","project_id":"46fd79d8-1a35-4548-bfb8-03df51a0ebae","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "382"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:10:57 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4b55e3f9-aaa5-420f-bda4-23d5e85a2611
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/6b6b7d77-d8ad-4499-9f7e-1b8cfa37b530
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"6b6b7d77-d8ad-4499-9f7e-1b8cfa37b530","name":"tf-tests-function-cron-with-args","organization_id":"46fd79d8-1a35-4548-bfb8-03df51a0ebae","project_id":"46fd79d8-1a35-4548-bfb8-03df51a0ebae","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronwpwjzynzb","registry_namespace_id":"3f131962-3136-4391-bb00-aca098831d98","secret_environment_variables":[],"status":"ready"}'
-    headers:
-      Content-Length:
-      - "471"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:02 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 920f53af-0354-4594-8a53-34e8405353ab
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/6b6b7d77-d8ad-4499-9f7e-1b8cfa37b530
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"6b6b7d77-d8ad-4499-9f7e-1b8cfa37b530","name":"tf-tests-function-cron-with-args","organization_id":"46fd79d8-1a35-4548-bfb8-03df51a0ebae","project_id":"46fd79d8-1a35-4548-bfb8-03df51a0ebae","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronwpwjzynzb","registry_namespace_id":"3f131962-3136-4391-bb00-aca098831d98","secret_environment_variables":[],"status":"ready"}'
-    headers:
-      Content-Length:
-      - "471"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:02 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 275166f0-6e40-4691-8454-268555929911
-    status: 200 OK
-    code: 200
-- request:
-    body: '{"name":"tf-tests-cron-with-args","namespace_id":"6b6b7d77-d8ad-4499-9f7e-1b8cfa37b530","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"node14","memory_limit":128,"handler":"handler.handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled"}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions
-    method: POST
-  response:
-    body: '{"build_message":null,"cpu_limit":70,"description":"","domain_name":"tftestsfunctioncronwpwjzynzb-tf-tests-cron-with-args.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"a3973c7c-9c60-4b31-9075-f61132df80b9","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-tests-cron-with-args","namespace_id":"6b6b7d77-d8ad-4499-9f7e-1b8cfa37b530","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "580"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 17460f88-1fe9-4831-a65a-66144e6b006c
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/a3973c7c-9c60-4b31-9075-f61132df80b9
-    method: GET
-  response:
-    body: '{"build_message":null,"cpu_limit":70,"description":"","domain_name":"tftestsfunctioncronwpwjzynzb-tf-tests-cron-with-args.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"a3973c7c-9c60-4b31-9075-f61132df80b9","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-tests-cron-with-args","namespace_id":"6b6b7d77-d8ad-4499-9f7e-1b8cfa37b530","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "580"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3f6b0613-21da-4b19-8c1c-64e2a832bf3a
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/a3973c7c-9c60-4b31-9075-f61132df80b9
-    method: GET
-  response:
-    body: '{"build_message":null,"cpu_limit":70,"description":"","domain_name":"tftestsfunctioncronwpwjzynzb-tf-tests-cron-with-args.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"a3973c7c-9c60-4b31-9075-f61132df80b9","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-tests-cron-with-args","namespace_id":"6b6b7d77-d8ad-4499-9f7e-1b8cfa37b530","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "580"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9769c816-5920-454a-9f78-240beaa5c908
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/a3973c7c-9c60-4b31-9075-f61132df80b9
-    method: GET
-  response:
-    body: '{"build_message":null,"cpu_limit":70,"description":"","domain_name":"tftestsfunctioncronwpwjzynzb-tf-tests-cron-with-args.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"a3973c7c-9c60-4b31-9075-f61132df80b9","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-tests-cron-with-args","namespace_id":"6b6b7d77-d8ad-4499-9f7e-1b8cfa37b530","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "580"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e68f1656-8430-46d6-9b09-0eb0464db2a1
-    status: 200 OK
-    code: 200
-- request:
-    body: '{"function_id":"a3973c7c-9c60-4b31-9075-f61132df80b9","schedule":"0 0 *
-      * *","args":{"test":"scw"},"name":"tf-tests-cron-with-args"}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons
-    method: POST
-  response:
-    body: '{"args":{"test":"scw"},"function_id":"a3973c7c-9c60-4b31-9075-f61132df80b9","id":"170782ca-acc8-4695-954c-510001f1dadb","name":"tf-tests-cron-with-args","schedule":"0
-      0 * * *","status":"pending"}'
-    headers:
-      Content-Length:
-      - "195"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e379e7b0-d266-4b16-ae37-a6bfcc7d1dc1
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/170782ca-acc8-4695-954c-510001f1dadb
-    method: GET
-  response:
-    body: '{"args":{"test":"scw"},"function_id":"a3973c7c-9c60-4b31-9075-f61132df80b9","id":"170782ca-acc8-4695-954c-510001f1dadb","name":"tf-tests-cron-with-args","schedule":"0
-      0 * * *","status":"pending"}'
-    headers:
-      Content-Length:
-      - "195"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2a69a635-eda1-464d-99a6-74e61a0be753
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/170782ca-acc8-4695-954c-510001f1dadb
-    method: GET
-  response:
-    body: '{"args":{"test":"scw"},"function_id":"a3973c7c-9c60-4b31-9075-f61132df80b9","id":"170782ca-acc8-4695-954c-510001f1dadb","name":"tf-tests-cron-with-args","schedule":"0
-      0 * * *","status":"ready"}'
-    headers:
-      Content-Length:
-      - "193"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:08 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - cabb32cc-4162-4d99-b955-58eecfd2f5c2
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/170782ca-acc8-4695-954c-510001f1dadb
-    method: GET
-  response:
-    body: '{"args":{"test":"scw"},"function_id":"a3973c7c-9c60-4b31-9075-f61132df80b9","id":"170782ca-acc8-4695-954c-510001f1dadb","name":"tf-tests-cron-with-args","schedule":"0
-      0 * * *","status":"ready"}'
-    headers:
-      Content-Length:
-      - "193"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:08 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c81dad36-b870-4315-baac-4abdebe37d36
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/170782ca-acc8-4695-954c-510001f1dadb
-    method: GET
-  response:
-    body: '{"args":{"test":"scw"},"function_id":"a3973c7c-9c60-4b31-9075-f61132df80b9","id":"170782ca-acc8-4695-954c-510001f1dadb","name":"tf-tests-cron-with-args","schedule":"0
-      0 * * *","status":"ready"}'
-    headers:
-      Content-Length:
-      - "193"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:08 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 21c545be-4645-4ce3-a952-e6b3d0eacade
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/6b6b7d77-d8ad-4499-9f7e-1b8cfa37b530
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"6b6b7d77-d8ad-4499-9f7e-1b8cfa37b530","name":"tf-tests-function-cron-with-args","organization_id":"46fd79d8-1a35-4548-bfb8-03df51a0ebae","project_id":"46fd79d8-1a35-4548-bfb8-03df51a0ebae","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronwpwjzynzb","registry_namespace_id":"3f131962-3136-4391-bb00-aca098831d98","secret_environment_variables":[],"status":"ready"}'
-    headers:
-      Content-Length:
-      - "471"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:09 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - fadb088d-fa45-4b65-abfc-bdf20a6979ae
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/a3973c7c-9c60-4b31-9075-f61132df80b9
-    method: GET
-  response:
-    body: '{"build_message":null,"cpu_limit":70,"description":"","domain_name":"tftestsfunctioncronwpwjzynzb-tf-tests-cron-with-args.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"a3973c7c-9c60-4b31-9075-f61132df80b9","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-tests-cron-with-args","namespace_id":"6b6b7d77-d8ad-4499-9f7e-1b8cfa37b530","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "580"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:09 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - fe22e03b-9b43-438e-8a70-58fb3ee7b56a
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/170782ca-acc8-4695-954c-510001f1dadb
-    method: GET
-  response:
-    body: '{"args":{"test":"scw"},"function_id":"a3973c7c-9c60-4b31-9075-f61132df80b9","id":"170782ca-acc8-4695-954c-510001f1dadb","name":"tf-tests-cron-with-args","schedule":"0
-      0 * * *","status":"ready"}'
-    headers:
-      Content-Length:
-      - "193"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:09 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 98536a22-2779-410d-9e91-627ef6342a72
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/170782ca-acc8-4695-954c-510001f1dadb
-    method: GET
-  response:
-    body: '{"args":{"test":"scw"},"function_id":"a3973c7c-9c60-4b31-9075-f61132df80b9","id":"170782ca-acc8-4695-954c-510001f1dadb","name":"tf-tests-cron-with-args","schedule":"0
-      0 * * *","status":"ready"}'
-    headers:
-      Content-Length:
-      - "193"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:11 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 25c06073-8ff9-4b30-9820-910662e0e88a
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/170782ca-acc8-4695-954c-510001f1dadb
-    method: DELETE
-  response:
-    body: '{"args":{"test":"scw"},"function_id":"a3973c7c-9c60-4b31-9075-f61132df80b9","id":"170782ca-acc8-4695-954c-510001f1dadb","name":"tf-tests-cron-with-args","schedule":"0
-      0 * * *","status":"deleting"}'
-    headers:
-      Content-Length:
-      - "196"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:11 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4dc0c910-8866-4888-8f72-cf40ee0e9689
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/a3973c7c-9c60-4b31-9075-f61132df80b9
-    method: GET
-  response:
-    body: '{"build_message":null,"cpu_limit":70,"description":"","domain_name":"tftestsfunctioncronwpwjzynzb-tf-tests-cron-with-args.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"a3973c7c-9c60-4b31-9075-f61132df80b9","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-tests-cron-with-args","namespace_id":"6b6b7d77-d8ad-4499-9f7e-1b8cfa37b530","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "580"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:11 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8d489dfc-ae36-4255-a53d-f8d2c7fc89b6
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/a3973c7c-9c60-4b31-9075-f61132df80b9
-    method: DELETE
-  response:
-    body: '{"build_message":null,"cpu_limit":70,"description":"","domain_name":"tftestsfunctioncronwpwjzynzb-tf-tests-cron-with-args.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"a3973c7c-9c60-4b31-9075-f61132df80b9","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-tests-cron-with-args","namespace_id":"6b6b7d77-d8ad-4499-9f7e-1b8cfa37b530","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"deleting","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "581"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:11 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 82b188a6-06d2-4f6c-af89-adb9fb902241
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/6b6b7d77-d8ad-4499-9f7e-1b8cfa37b530
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"6b6b7d77-d8ad-4499-9f7e-1b8cfa37b530","name":"tf-tests-function-cron-with-args","organization_id":"46fd79d8-1a35-4548-bfb8-03df51a0ebae","project_id":"46fd79d8-1a35-4548-bfb8-03df51a0ebae","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronwpwjzynzb","registry_namespace_id":"3f131962-3136-4391-bb00-aca098831d98","secret_environment_variables":[],"status":"ready"}'
-    headers:
-      Content-Length:
-      - "471"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:11 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 139549c9-0344-4116-8ca5-35a344e445ac
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/6b6b7d77-d8ad-4499-9f7e-1b8cfa37b530
-    method: DELETE
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"6b6b7d77-d8ad-4499-9f7e-1b8cfa37b530","name":"tf-tests-function-cron-with-args","organization_id":"46fd79d8-1a35-4548-bfb8-03df51a0ebae","project_id":"46fd79d8-1a35-4548-bfb8-03df51a0ebae","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronwpwjzynzb","registry_namespace_id":"3f131962-3136-4391-bb00-aca098831d98","secret_environment_variables":[],"status":"deleting"}'
-    headers:
-      Content-Length:
-      - "474"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:11 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 85383c47-f4b8-4cf6-92a5-a6a8632d5ead
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/6b6b7d77-d8ad-4499-9f7e-1b8cfa37b530
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"6b6b7d77-d8ad-4499-9f7e-1b8cfa37b530","name":"tf-tests-function-cron-with-args","organization_id":"46fd79d8-1a35-4548-bfb8-03df51a0ebae","project_id":"46fd79d8-1a35-4548-bfb8-03df51a0ebae","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronwpwjzynzb","registry_namespace_id":"3f131962-3136-4391-bb00-aca098831d98","secret_environment_variables":[],"status":"deleting"}'
-    headers:
-      Content-Length:
-      - "474"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:11 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 153671a4-97c2-4970-b02a-32179a8a4676
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/6b6b7d77-d8ad-4499-9f7e-1b8cfa37b530
-    method: GET
-  response:
-    body: '{"message":"Namespace was not found"}'
-    headers:
-      Content-Length:
-      - "37"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:16 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6a76d6eb-13c1-46b8-9897-3244151f2739
-    status: 404 Not Found
-    code: 404
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.5; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/170782ca-acc8-4695-954c-510001f1dadb
-    method: DELETE
-  response:
-    body: '{"message":"Cron was not found"}'
-    headers:
-      Content-Length:
-      - "32"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 17 Jan 2024 09:11:16 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5858359a-5751-4f7c-bc22-829da7800876
-    status: 404 Not Found
-    code: 404
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 156
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"name":"tf-tests-function-cron-with-args","environment_variables":{},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","secret_environment_variables":[]}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 382
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"8d8bd4ff-b680-4260-ab92-5061e75c44db","name":"tf-tests-function-cron-with-args","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
+        headers:
+            Content-Length:
+                - "382"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:22 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b2daaad8-c9f5-47b0-be6c-d6d90d8a9ce1
+        status: 200 OK
+        code: 200
+        duration: 574.201001ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8d8bd4ff-b680-4260-ab92-5061e75c44db
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 382
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"8d8bd4ff-b680-4260-ab92-5061e75c44db","name":"tf-tests-function-cron-with-args","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
+        headers:
+            Content-Length:
+                - "382"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:22 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 83e20016-4a6f-437b-92c6-ad5c7ebc4d06
+        status: 200 OK
+        code: 200
+        duration: 61.34071ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8d8bd4ff-b680-4260-ab92-5061e75c44db
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 471
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"8d8bd4ff-b680-4260-ab92-5061e75c44db","name":"tf-tests-function-cron-with-args","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronwjilagxll","registry_namespace_id":"e7d4f568-a618-499a-8a63-44703d1b1c30","secret_environment_variables":[],"status":"ready"}'
+        headers:
+            Content-Length:
+                - "471"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:27 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f8581ccb-f55d-4d89-96e3-685c7d045cae
+        status: 200 OK
+        code: 200
+        duration: 63.804249ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8d8bd4ff-b680-4260-ab92-5061e75c44db
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 471
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"8d8bd4ff-b680-4260-ab92-5061e75c44db","name":"tf-tests-function-cron-with-args","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronwjilagxll","registry_namespace_id":"e7d4f568-a618-499a-8a63-44703d1b1c30","secret_environment_variables":[],"status":"ready"}'
+        headers:
+            Content-Length:
+                - "471"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:27 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 9a29b55e-7f1b-4931-9fa9-c9cd7d6524ad
+        status: 200 OK
+        code: 200
+        duration: 65.280743ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 315
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"name":"tf-tests-cron-with-args","namespace_id":"8d8bd4ff-b680-4260-ab92-5061e75c44db","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"node20","memory_limit":256,"handler":"handler.handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 596
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tftestsfunctioncronwjilagxll-tf-tests-cron-with-args.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"e6bb7ad9-ac2f-4325-8b50-dc401ce2110c","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-cron-with-args","namespace_id":"8d8bd4ff-b680-4260-ab92-5061e75c44db","privacy":"private","region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "596"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:28 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 49898ac5-1ee2-42b2-b907-e855d9ad5724
+        status: 200 OK
+        code: 200
+        duration: 374.645895ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e6bb7ad9-ac2f-4325-8b50-dc401ce2110c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 596
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tftestsfunctioncronwjilagxll-tf-tests-cron-with-args.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"e6bb7ad9-ac2f-4325-8b50-dc401ce2110c","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-cron-with-args","namespace_id":"8d8bd4ff-b680-4260-ab92-5061e75c44db","privacy":"private","region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "596"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:28 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 4d72d448-4dbb-4fbb-b524-e6a73fb29b05
+        status: 200 OK
+        code: 200
+        duration: 62.329578ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e6bb7ad9-ac2f-4325-8b50-dc401ce2110c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 596
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tftestsfunctioncronwjilagxll-tf-tests-cron-with-args.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"e6bb7ad9-ac2f-4325-8b50-dc401ce2110c","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-cron-with-args","namespace_id":"8d8bd4ff-b680-4260-ab92-5061e75c44db","privacy":"private","region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "596"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:28 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ca6fc953-ba43-4abb-baf6-854ddcf35f55
+        status: 200 OK
+        code: 200
+        duration: 59.038455ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e6bb7ad9-ac2f-4325-8b50-dc401ce2110c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 596
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tftestsfunctioncronwjilagxll-tf-tests-cron-with-args.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"e6bb7ad9-ac2f-4325-8b50-dc401ce2110c","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-cron-with-args","namespace_id":"8d8bd4ff-b680-4260-ab92-5061e75c44db","privacy":"private","region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "596"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:28 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - fb246fa6-9b80-44e5-956e-2de774fba0b2
+        status: 200 OK
+        code: 200
+        duration: 60.565113ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 132
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"function_id":"e6bb7ad9-ac2f-4325-8b50-dc401ce2110c","schedule":"0 0 * * *","args":{"test":"scw"},"name":"tf-tests-cron-with-args"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 195
+        uncompressed: false
+        body: '{"args":{"test":"scw"},"function_id":"e6bb7ad9-ac2f-4325-8b50-dc401ce2110c","id":"79d9de33-93b8-4255-af4d-1d646e4478d3","name":"tf-tests-cron-with-args","schedule":"0 0 * * *","status":"pending"}'
+        headers:
+            Content-Length:
+                - "195"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:28 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 415e6a65-6f61-4d9f-8d77-6b8a58689694
+        status: 200 OK
+        code: 200
+        duration: 77.469835ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/79d9de33-93b8-4255-af4d-1d646e4478d3
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 195
+        uncompressed: false
+        body: '{"args":{"test":"scw"},"function_id":"e6bb7ad9-ac2f-4325-8b50-dc401ce2110c","id":"79d9de33-93b8-4255-af4d-1d646e4478d3","name":"tf-tests-cron-with-args","schedule":"0 0 * * *","status":"pending"}'
+        headers:
+            Content-Length:
+                - "195"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:28 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - de0a60d1-edd5-44a5-a747-07e5aa8cc737
+        status: 200 OK
+        code: 200
+        duration: 64.379911ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/79d9de33-93b8-4255-af4d-1d646e4478d3
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 193
+        uncompressed: false
+        body: '{"args":{"test":"scw"},"function_id":"e6bb7ad9-ac2f-4325-8b50-dc401ce2110c","id":"79d9de33-93b8-4255-af4d-1d646e4478d3","name":"tf-tests-cron-with-args","schedule":"0 0 * * *","status":"ready"}'
+        headers:
+            Content-Length:
+                - "193"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:33 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b5a1a93d-95b1-4cae-8ea7-c92eaa6fd037
+        status: 200 OK
+        code: 200
+        duration: 72.138628ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/79d9de33-93b8-4255-af4d-1d646e4478d3
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 193
+        uncompressed: false
+        body: '{"args":{"test":"scw"},"function_id":"e6bb7ad9-ac2f-4325-8b50-dc401ce2110c","id":"79d9de33-93b8-4255-af4d-1d646e4478d3","name":"tf-tests-cron-with-args","schedule":"0 0 * * *","status":"ready"}'
+        headers:
+            Content-Length:
+                - "193"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:33 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e0aa0516-da88-43a5-81a9-ec1abfd71d89
+        status: 200 OK
+        code: 200
+        duration: 72.324096ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/79d9de33-93b8-4255-af4d-1d646e4478d3
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 193
+        uncompressed: false
+        body: '{"args":{"test":"scw"},"function_id":"e6bb7ad9-ac2f-4325-8b50-dc401ce2110c","id":"79d9de33-93b8-4255-af4d-1d646e4478d3","name":"tf-tests-cron-with-args","schedule":"0 0 * * *","status":"ready"}'
+        headers:
+            Content-Length:
+                - "193"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:33 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b0eb88c5-c2fd-49aa-b704-14045ff827f5
+        status: 200 OK
+        code: 200
+        duration: 54.816362ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8d8bd4ff-b680-4260-ab92-5061e75c44db
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 471
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"8d8bd4ff-b680-4260-ab92-5061e75c44db","name":"tf-tests-function-cron-with-args","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronwjilagxll","registry_namespace_id":"e7d4f568-a618-499a-8a63-44703d1b1c30","secret_environment_variables":[],"status":"ready"}'
+        headers:
+            Content-Length:
+                - "471"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 45e2d646-ee37-4643-a6a7-8abf14d5b3ec
+        status: 200 OK
+        code: 200
+        duration: 56.276886ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e6bb7ad9-ac2f-4325-8b50-dc401ce2110c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 596
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tftestsfunctioncronwjilagxll-tf-tests-cron-with-args.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"e6bb7ad9-ac2f-4325-8b50-dc401ce2110c","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-cron-with-args","namespace_id":"8d8bd4ff-b680-4260-ab92-5061e75c44db","privacy":"private","region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "596"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 2e7d51a3-7e22-4b3d-bdcb-c777142c1aa2
+        status: 200 OK
+        code: 200
+        duration: 67.686032ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/79d9de33-93b8-4255-af4d-1d646e4478d3
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 193
+        uncompressed: false
+        body: '{"args":{"test":"scw"},"function_id":"e6bb7ad9-ac2f-4325-8b50-dc401ce2110c","id":"79d9de33-93b8-4255-af4d-1d646e4478d3","name":"tf-tests-cron-with-args","schedule":"0 0 * * *","status":"ready"}'
+        headers:
+            Content-Length:
+                - "193"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - fc7ad65c-ac88-4c22-a7c6-b07766bb7fb3
+        status: 200 OK
+        code: 200
+        duration: 68.645085ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/79d9de33-93b8-4255-af4d-1d646e4478d3
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 193
+        uncompressed: false
+        body: '{"args":{"test":"scw"},"function_id":"e6bb7ad9-ac2f-4325-8b50-dc401ce2110c","id":"79d9de33-93b8-4255-af4d-1d646e4478d3","name":"tf-tests-cron-with-args","schedule":"0 0 * * *","status":"ready"}'
+        headers:
+            Content-Length:
+                - "193"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ea83282d-71ce-4aaf-b9b7-251ed12f176c
+        status: 200 OK
+        code: 200
+        duration: 93.893442ms
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/79d9de33-93b8-4255-af4d-1d646e4478d3
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 196
+        uncompressed: false
+        body: '{"args":{"test":"scw"},"function_id":"e6bb7ad9-ac2f-4325-8b50-dc401ce2110c","id":"79d9de33-93b8-4255-af4d-1d646e4478d3","name":"tf-tests-cron-with-args","schedule":"0 0 * * *","status":"deleting"}'
+        headers:
+            Content-Length:
+                - "196"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b1121774-272c-4d36-9b14-3c415c2b7058
+        status: 200 OK
+        code: 200
+        duration: 137.100582ms
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e6bb7ad9-ac2f-4325-8b50-dc401ce2110c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 596
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tftestsfunctioncronwjilagxll-tf-tests-cron-with-args.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"e6bb7ad9-ac2f-4325-8b50-dc401ce2110c","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-cron-with-args","namespace_id":"8d8bd4ff-b680-4260-ab92-5061e75c44db","privacy":"private","region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "596"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 2a7f6fc9-ed66-4bd3-8873-ba572331f0a5
+        status: 200 OK
+        code: 200
+        duration: 67.499222ms
+    - id: 19
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e6bb7ad9-ac2f-4325-8b50-dc401ce2110c
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 597
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tftestsfunctioncronwjilagxll-tf-tests-cron-with-args.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"e6bb7ad9-ac2f-4325-8b50-dc401ce2110c","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-cron-with-args","namespace_id":"8d8bd4ff-b680-4260-ab92-5061e75c44db","privacy":"private","region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"deleting","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "597"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 1f10cf67-61f3-47be-9722-b87439856955
+        status: 200 OK
+        code: 200
+        duration: 173.520109ms
+    - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8d8bd4ff-b680-4260-ab92-5061e75c44db
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 471
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"8d8bd4ff-b680-4260-ab92-5061e75c44db","name":"tf-tests-function-cron-with-args","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronwjilagxll","registry_namespace_id":"e7d4f568-a618-499a-8a63-44703d1b1c30","secret_environment_variables":[],"status":"ready"}'
+        headers:
+            Content-Length:
+                - "471"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - be5e69e3-5412-4c17-bb13-4c5169e25e31
+        status: 200 OK
+        code: 200
+        duration: 52.37744ms
+    - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8d8bd4ff-b680-4260-ab92-5061e75c44db
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 474
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"8d8bd4ff-b680-4260-ab92-5061e75c44db","name":"tf-tests-function-cron-with-args","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronwjilagxll","registry_namespace_id":"e7d4f568-a618-499a-8a63-44703d1b1c30","secret_environment_variables":[],"status":"deleting"}'
+        headers:
+            Content-Length:
+                - "474"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - da1f24fd-a1f0-48e3-b8de-ef422bc88e90
+        status: 200 OK
+        code: 200
+        duration: 246.134451ms
+    - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8d8bd4ff-b680-4260-ab92-5061e75c44db
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 474
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"8d8bd4ff-b680-4260-ab92-5061e75c44db","name":"tf-tests-function-cron-with-args","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronwjilagxll","registry_namespace_id":"e7d4f568-a618-499a-8a63-44703d1b1c30","secret_environment_variables":[],"status":"deleting"}'
+        headers:
+            Content-Length:
+                - "474"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 7c81071a-6793-4f21-bc8c-c68a576ecba7
+        status: 200 OK
+        code: 200
+        duration: 52.557789ms
+    - id: 23
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8d8bd4ff-b680-4260-ab92-5061e75c44db
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 37
+        uncompressed: false
+        body: '{"message":"Namespace was not found"}'
+        headers:
+            Content-Length:
+                - "37"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:40 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 5b04799a-1773-440e-8661-a7be814b8058
+        status: 404 Not Found
+        code: 404
+        duration: 23.835564ms
+    - id: 24
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/79d9de33-93b8-4255-af4d-1d646e4478d3
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 32
+        uncompressed: false
+        body: '{"message":"Cron was not found"}'
+        headers:
+            Content-Length:
+                - "32"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:31:40 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - a8eb14c4-5634-42ec-8dca-d9c015768a10
+        status: 404 Not Found
+        code: 404
+        duration: 24.455188ms

--- a/internal/services/function/testdata/function-deploy.cassette.yaml
+++ b/internal/services/function/testdata/function-deploy.cassette.yaml
@@ -1,3655 +1,4549 @@
 ---
 version: 2
 interactions:
-- request:
-    body: '{"name":"tf-func-quirky-hellman","environment_variables":{},"project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","description":null,"secret_environment_variables":[]}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces
-    method: POST
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","name":"tf-func-quirky-hellman","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "372"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:46:38 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 30814d65-eb74-443a-bfc7-12a98086012a
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/509de7bb-4dcd-47ab-92db-98d03aa9b6f1
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","name":"tf-func-quirky-hellman","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "372"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:46:38 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d96560f9-2ed3-482a-b000-3fa57ad1aa54
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/509de7bb-4dcd-47ab-92db-98d03aa9b6f1
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","name":"tf-func-quirky-hellman","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "372"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:46:43 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 149f06d9-9f20-458e-8fdd-74994af21e89
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/509de7bb-4dcd-47ab-92db-98d03aa9b6f1
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","name":"tf-func-quirky-hellman","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "372"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:46:48 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9a29375e-4c45-472c-a616-ec7b8dd1f965
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/509de7bb-4dcd-47ab-92db-98d03aa9b6f1
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","name":"tf-func-quirky-hellman","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "372"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:46:53 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 455c9436-0573-450d-bc3f-bd93356ac1ea
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/509de7bb-4dcd-47ab-92db-98d03aa9b6f1
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","name":"tf-func-quirky-hellman","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "372"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:46:58 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a90e7747-6ebc-487b-91cf-eb2d5fb766c4
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/509de7bb-4dcd-47ab-92db-98d03aa9b6f1
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","name":"tf-func-quirky-hellman","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "372"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 02a68241-6288-4dc6-a025-d2e1b08fef84
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/509de7bb-4dcd-47ab-92db-98d03aa9b6f1
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","name":"tf-func-quirky-hellman","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncquirkyhellmanfkpkeioo","registry_namespace_id":"269b4e4e-df1f-45fa-a3c4-c383aa4378c6","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "462"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:08 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d2c8e24b-3eb4-401e-955d-d7e4b233a347
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/509de7bb-4dcd-47ab-92db-98d03aa9b6f1
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","name":"tf-func-quirky-hellman","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncquirkyhellmanfkpkeioo","registry_namespace_id":"269b4e4e-df1f-45fa-a3c4-c383aa4378c6","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "462"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d2364d01-9c6c-4542-b195-0a0e99f823da
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/509de7bb-4dcd-47ab-92db-98d03aa9b6f1
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","name":"tf-func-quirky-hellman","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncquirkyhellmanfkpkeioo","registry_namespace_id":"269b4e4e-df1f-45fa-a3c4-c383aa4378c6","secret_environment_variables":[],"status":"ready"}'
-    headers:
-      Content-Length:
-      - "460"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:18 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f7abb066-6d47-40d7-b4ab-301d72a3d790
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/509de7bb-4dcd-47ab-92db-98d03aa9b6f1
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","name":"tf-func-quirky-hellman","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncquirkyhellmanfkpkeioo","registry_namespace_id":"269b4e4e-df1f-45fa-a3c4-c383aa4378c6","secret_environment_variables":[],"status":"ready"}'
-    headers:
-      Content-Length:
-      - "460"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:18 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 86346e9a-868e-44b8-bd49-1855b3299362
-    status: 200 OK
-    code: 200
-- request:
-    body: '{"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"go118","memory_limit":128,"timeout":null,"handler":"Handle","privacy":"private","description":null,"secret_environment_variables":[],"http_option":"enabled"}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions
-    method: POST
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 42028948-7f78-449d-b142-fb2f12e4414a
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e/upload-url?content_length=780
-    method: GET
-  response:
-    body: '{"headers":{"content-length":["780"],"content-type":["application/octet-stream"]},"url":"https://s3.fr-par.scw.cloud/scw-database-srvless-prod/uploads/function-0de8800c-90a9-4595-8778-c011b7e3e35e.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256\u0026X-Amz-Credential=SCW6Z6VKJVG81FQZVB14%2F20230104%2Ffr-par%2Fs3%2Faws4_request\u0026X-Amz-Date=20230104T104719Z\u0026X-Amz-Expires=3600\u0026X-Amz-SignedHeaders=content-length%3Bcontent-type%3Bhost\u0026X-Amz-Signature=ffc2bab4b869c81f44d79c7bdd03a2cad3981c7056313b503c7850295698827b"}'
-    headers:
-      Content-Length:
-      - "523"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1547bc1a-8763-48bd-a7b6-08b184b70752
-    status: 200 OK
-    code: 200
-- request:
-    body: !!binary |
-      UEsDBAoAAAAAAGZZzVTiYkURGgAAABoAAAAGABwAZ28ubW9kVVQJAAMw/6ZiYP+mYnV4Cw
-      ABBOgDAAAE6AMAAG1vZHVsZSBteWhhbmRsZXIKCmdvIDEuMTgKUEsDBAoAAAAAACuFzVQA
-      AAAAAAAAAAAAAAAGABwAZ28uc3VtVVQJAAOSTKdil0ynYnV4CwABBOgDAAAE6AMAAFBLAw
-      QUAAAACABFgs1U1odLbzABAADKAQAACgAcAGhhbmRsZXIuZ29VVAkAAyJHp2IlR6didXgL
-      AAEE6AMAAAToAwAARVCxTsMwEJ3jrzi8kKA02RgqdSkClYGFInVADCa5NAHHNudLo6rqv2
-      OnKUw+v3t3791zqvpWe4T+2AymEqLrnSWGVCQSTWXrzuzLL2+NDEDTc3wMctkyOykyIcoS
-      NsrUGmFxLfCAhkVcNyPpCJFfvKJ31njcUcdIORDczfjPgJ4zOImEZg4sV9Ar9+6ZgoWPzo
-      SJRlV4OgdSInv0PtiWS5A7vCUEpTXsra1lHtstKs3tMbSZBpwgM/SfSAGB+/A/i3+pdQ5I
-      FAXjocWLIt8qnV7bmUi6ZmLcrMB0OrpMxmI6YoOqRkqnK7asePDP0ahReot0QHokshQWBC
-      0eyFx0x2Iey4otciofbJgxvHg7OpQ5SOWc7irFnTWX6MOCEH3x5EIUnI45XEL5c7jOMnEW
-      v1BLAQIeAwoAAAAAAGZZzVTiYkURGgAAABoAAAAGABgAAAAAAAEAAACkgQAAAABnby5tb2
-      RVVAUAAzD/pmJ1eAsAAQToAwAABOgDAABQSwECHgMKAAAAAAArhc1UAAAAAAAAAAAAAAAA
-      BgAYAAAAAAAAAAAApIFaAAAAZ28uc3VtVVQFAAOSTKdidXgLAAEE6AMAAAToAwAAUEsBAh
-      4DFAAAAAgARYLNVNaHS28wAQAAygEAAAoAGAAAAAAAAQAAAKSBmgAAAGhhbmRsZXIuZ29V
-      VAUAAyJHp2J1eAsAAQToAwAABOgDAABQSwUGAAAAAAMAAwDoAAAADgIAAAAA
-    form: {}
-    headers:
-      Content-Length:
-      - "780"
-      Content-Type:
-      - application/octet-stream
-    url: https://s3.fr-par.scw.cloud/scw-database-srvless-prod/uploads/function-0de8800c-90a9-4595-8778-c011b7e3e35e.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=SCW6Z6VKJVG81FQZVB14%2F20230104%2Ffr-par%2Fs3%2Faws4_request&X-Amz-Date=20230104T104719Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=content-length%3Bcontent-type%3Bhost&X-Amz-Signature=ffc2bab4b869c81f44d79c7bdd03a2cad3981c7056313b503c7850295698827b
-    method: PUT
-  response:
-    body: ""
-    headers:
-      Content-Length:
-      - "0"
-      Content-Type:
-      - text/html; charset=UTF-8
-      Date:
-      - Wed, 04 Jan 2023 10:47:20 GMT
-      Etag:
-      - '"10633bf7a5ff211d8f3eee3856a28101"'
-      Last-Modified:
-      - Wed, 04 Jan 2023 10:47:19 GMT
-      X-Amz-Id-2:
-      - tx35edae385fae42bcae132-0063b55937
-      X-Amz-Request-Id:
-      - tx35edae385fae42bcae132-0063b55937
-      X-Amz-Version-Id:
-      - "1672829239770381"
-    status: 200 OK
-    code: 200
-- request:
-    body: '{}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e/deploy
-    method: POST
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:20 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 08116ebe-f2bc-4434-b3c3-bb388c730da6
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:20 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e1d8a577-c893-4f75-8ee9-8cfb92ae2e98
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:25 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6570c292-f628-41b5-942d-628039877d39
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:30 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ab35c494-a174-413b-8515-43580db72528
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:35 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 80f83b1f-9366-46a8-8d7c-3bbf39e4116e
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:40 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a21af02c-b870-40eb-a7bd-4901a5a337be
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:45 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d6a54c78-6192-44a1-8e9a-22f6ceb6e2d9
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:50 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7c1d20bc-4b2a-49d8-a667-057ea151ff74
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:55 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1f8ac4bf-f392-41e6-9fc4-1a55c83cdea7
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:48:00 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - fb667844-d308-4ac7-80b3-c6211e13df05
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:48:05 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 05a8cce9-f45a-4ed1-a5b3-6c7698369ed7
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:48:10 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d3146587-85b8-4ee7-aecc-05a955beef65
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:48:15 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - dbf03c46-6663-4be0-993e-f46b4b2cf62b
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:48:21 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a0fc10dc-b651-483b-96ba-c93cc40fc80c
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:48:26 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b8d7328a-579c-47c0-a4b0-33f7388c19e4
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:48:31 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1634fa83-384c-4860-aee6-930d751b7781
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:48:36 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - fd71075f-a29a-4c52-b07f-be0238b6517d
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:48:41 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5a67b4fc-33f9-4c0a-9cf5-b51b94831371
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:48:46 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 817074f4-be7f-4f2e-bbf1-f37f59b4cd6a
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:48:51 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4aa8ef49-39de-4312-b4cb-e44bcc3763fa
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:48:56 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c0f8be94-c932-40b4-884f-44194bb0b85e
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:49:01 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 86c6cf99-33e3-42d2-b8bc-bd87e3d12eca
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:49:06 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 17b5b199-5651-4736-8589-974bd1ac81b2
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:49:11 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4154a399-3885-41ed-ab9d-994ef80e2c64
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:49:16 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 74817d9e-57aa-41f6-8666-d57442bf306a
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:49:21 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f4e4bb6a-3930-4b7c-9326-38641eaa3035
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:49:26 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f0815790-ea57-470b-84ad-86c2bb561b17
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:49:31 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 19cc843b-bffe-41c4-8eff-fac08b9c8901
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:49:36 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - de0b843d-aff8-46a1-aa32-4e0073921c4e
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:49:41 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 55e94434-8afd-4a05-a4f1-e75f085d9e29
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:49:46 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d311da66-8255-4dd3-a019-0302d5c8b785
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:49:52 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - cbdce1bc-4aef-48e7-9a68-df2c8b1182b2
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:49:57 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 92df3081-bf4a-4c2b-bbe2-8597c44ea73a
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:50:02 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6806c66f-773e-4e5e-bb43-7bae829f0dfd
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:50:07 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 22540c51-19d2-471c-8bbb-65d82e535bd4
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"ready","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "513"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:50:12 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b64178e8-6cc8-4b5d-a4b4-e76a857aa264
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"ready","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "513"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:50:12 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - bf4f4f2a-7e59-41b2-8093-d1e9b3f69d7e
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"ready","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "513"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:50:12 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1798f3a8-1822-45ef-90f4-1c04a6142cc3
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/509de7bb-4dcd-47ab-92db-98d03aa9b6f1
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","name":"tf-func-quirky-hellman","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncquirkyhellmanfkpkeioo","registry_namespace_id":"269b4e4e-df1f-45fa-a3c4-c383aa4378c6","secret_environment_variables":[],"status":"ready"}'
-    headers:
-      Content-Length:
-      - "460"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:50:12 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 37dd94c2-3569-47f1-9581-0fa9e75769c1
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"ready","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "513"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:50:12 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ad766be5-60ab-4ec7-b802-ef01525bd2e7
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/509de7bb-4dcd-47ab-92db-98d03aa9b6f1
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","name":"tf-func-quirky-hellman","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncquirkyhellmanfkpkeioo","registry_namespace_id":"269b4e4e-df1f-45fa-a3c4-c383aa4378c6","secret_environment_variables":[],"status":"ready"}'
-    headers:
-      Content-Length:
-      - "460"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:50:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 14f154a0-c07c-4289-a065-d26650c6458a
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"ready","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "513"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:50:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e5623c1c-54a5-43a8-9cf3-2911ff3a337a
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"ready","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "513"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:50:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b821c3fc-0920-4287-b975-6b2c095abdf0
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e/upload-url?content_length=780
-    method: GET
-  response:
-    body: '{"headers":{"content-length":["780"],"content-type":["application/octet-stream"]},"url":"https://s3.fr-par.scw.cloud/scw-database-srvless-prod/uploads/function-0de8800c-90a9-4595-8778-c011b7e3e35e.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256\u0026X-Amz-Credential=SCW6Z6VKJVG81FQZVB14%2F20230104%2Ffr-par%2Fs3%2Faws4_request\u0026X-Amz-Date=20230104T105013Z\u0026X-Amz-Expires=3600\u0026X-Amz-SignedHeaders=content-length%3Bcontent-type%3Bhost\u0026X-Amz-Signature=200458dd6a5e66f4a58dac7f8aa8dd1d7d1e931286568c14f5561652c083b84c"}'
-    headers:
-      Content-Length:
-      - "523"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:50:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f2bd4fe7-315d-4b14-a54d-03da3509ec11
-    status: 200 OK
-    code: 200
-- request:
-    body: !!binary |
-      UEsDBAoAAAAAAGZZzVTiYkURGgAAABoAAAAGABwAZ28ubW9kVVQJAAMw/6ZiYP+mYnV4Cw
-      ABBOgDAAAE6AMAAG1vZHVsZSBteWhhbmRsZXIKCmdvIDEuMTgKUEsDBAoAAAAAACuFzVQA
-      AAAAAAAAAAAAAAAGABwAZ28uc3VtVVQJAAOSTKdil0ynYnV4CwABBOgDAAAE6AMAAFBLAw
-      QUAAAACABFgs1U1odLbzABAADKAQAACgAcAGhhbmRsZXIuZ29VVAkAAyJHp2IlR6didXgL
-      AAEE6AMAAAToAwAARVCxTsMwEJ3jrzi8kKA02RgqdSkClYGFInVADCa5NAHHNudLo6rqv2
-      OnKUw+v3t3791zqvpWe4T+2AymEqLrnSWGVCQSTWXrzuzLL2+NDEDTc3wMctkyOykyIcoS
-      NsrUGmFxLfCAhkVcNyPpCJFfvKJ31njcUcdIORDczfjPgJ4zOImEZg4sV9Ar9+6ZgoWPzo
-      SJRlV4OgdSInv0PtiWS5A7vCUEpTXsra1lHtstKs3tMbSZBpwgM/SfSAGB+/A/i3+pdQ5I
-      FAXjocWLIt8qnV7bmUi6ZmLcrMB0OrpMxmI6YoOqRkqnK7asePDP0ahReot0QHokshQWBC
-      0eyFx0x2Iey4otciofbJgxvHg7OpQ5SOWc7irFnTWX6MOCEH3x5EIUnI45XEL5c7jOMnEW
-      v1BLAQIeAwoAAAAAAGZZzVTiYkURGgAAABoAAAAGABgAAAAAAAEAAACkgQAAAABnby5tb2
-      RVVAUAAzD/pmJ1eAsAAQToAwAABOgDAABQSwECHgMKAAAAAAArhc1UAAAAAAAAAAAAAAAA
-      BgAYAAAAAAAAAAAApIFaAAAAZ28uc3VtVVQFAAOSTKdidXgLAAEE6AMAAAToAwAAUEsBAh
-      4DFAAAAAgARYLNVNaHS28wAQAAygEAAAoAGAAAAAAAAQAAAKSBmgAAAGhhbmRsZXIuZ29V
-      VAUAAyJHp2J1eAsAAQToAwAABOgDAABQSwUGAAAAAAMAAwDoAAAADgIAAAAA
-    form: {}
-    headers:
-      Content-Length:
-      - "780"
-      Content-Type:
-      - application/octet-stream
-    url: https://s3.fr-par.scw.cloud/scw-database-srvless-prod/uploads/function-0de8800c-90a9-4595-8778-c011b7e3e35e.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=SCW6Z6VKJVG81FQZVB14%2F20230104%2Ffr-par%2Fs3%2Faws4_request&X-Amz-Date=20230104T105013Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=content-length%3Bcontent-type%3Bhost&X-Amz-Signature=200458dd6a5e66f4a58dac7f8aa8dd1d7d1e931286568c14f5561652c083b84c
-    method: PUT
-  response:
-    body: ""
-    headers:
-      Content-Length:
-      - "0"
-      Content-Type:
-      - text/html; charset=UTF-8
-      Date:
-      - Wed, 04 Jan 2023 10:50:15 GMT
-      Etag:
-      - '"10633bf7a5ff211d8f3eee3856a28101"'
-      Last-Modified:
-      - Wed, 04 Jan 2023 10:50:14 GMT
-      X-Amz-Id-2:
-      - tx29b01d6fd3df4c48b9df4-0063b559e5
-      X-Amz-Request-Id:
-      - tx29b01d6fd3df4c48b9df4-0063b559e5
-      X-Amz-Version-Id:
-      - "1672829414814292"
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"ready","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "513"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:50:15 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ffdd5344-6259-4342-ab37-9e50353f7ec3
-    status: 200 OK
-    code: 200
-- request:
-    body: '{}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e/deploy
-    method: POST
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:50:15 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 973db3f2-b2f3-4cce-b857-76fb14ea8d4f
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:50:15 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3c88175c-d1d7-46c4-8763-0cd029809123
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:50:20 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - beb6c26b-d87d-47a0-b631-d6fb75504aa8
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:50:25 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ddb45abd-062c-4223-838a-3b84efe13d2a
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:50:30 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 483e5557-be40-4103-a1ce-bedf4c1f186b
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:50:35 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1e5ec5db-1f18-413a-965d-ef4e9e6d2287
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:50:40 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5f7da9dc-7cd2-4e09-a7dc-bd3b3797d33d
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:50:45 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 581fc84b-be42-4af3-87c5-11f6daba3ad0
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:50:50 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - fb4db248-9ad0-4de4-8646-dd8dda88f2a2
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:50:55 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5c088441-a4df-490b-9176-686a3b82b851
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:51:01 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e6b4b4b3-d9f9-4d19-98b6-c2d8c565e04d
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:51:06 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f400e030-c968-46db-8a58-b04f4571de57
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:51:11 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2e12c577-6f33-4931-b855-b0618be1bf1e
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:51:16 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8daacac3-2fdf-44dd-bfc5-7c1ae30963ba
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:51:21 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6a8ea8f7-0eba-4fbf-addf-68b24b7b3acf
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:51:26 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 042bf6df-280b-4d9b-9184-bfa7d5819047
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:51:31 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 513c61d5-d650-4363-b043-0169133f921b
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:51:36 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - acbc2a04-f48e-4e5f-976f-0a118e00daef
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:51:41 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 59208138-9d2f-43c9-9f75-672403661f45
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:51:46 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ac387e0d-96bf-4162-9944-fd3d2dab0c09
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:51:51 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0dbfe201-423c-44d3-8c32-1103a6506041
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:51:56 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0d557459-a83a-4d1e-ac9b-e84937596b55
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:52:01 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 540694a3-7daf-4ffe-9775-4724829a92a1
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:52:06 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 71868606-8b77-40d0-8f52-fc8292195f69
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:52:11 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6e513c69-a9e2-484d-823e-37f153433dd1
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:52:16 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 52d2fa03-56a5-485a-b6c7-8cd0d79f717a
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:52:21 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c3a5fa09-4e4b-41fd-910e-b3a01095b882
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:52:26 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - fbd6e977-c215-4c94-a4df-87430888be68
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:52:31 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3184d4e4-45b1-40b8-b48e-3453b4646579
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:52:36 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7dc61674-8bf0-4af4-962c-ec23373337a3
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:52:41 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2826f04f-19a9-4097-8635-2c9626eae618
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:52:47 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 77822d9f-14ff-4ea6-931d-ddd50da0ff98
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:52:52 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2c750fed-08ba-4077-be90-380c2718a1b5
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:52:57 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - bf369c44-3a0c-4ded-9e7e-fbbdc214032a
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:53:02 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ae542e59-34e4-475a-9331-8e9c19b04a7b
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"ready","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "513"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:53:07 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8d5cbfc5-383e-43dc-8f0e-88cd2f7a3289
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"ready","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "513"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:53:07 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e05dbeec-b988-458f-b483-2c82a649f972
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/509de7bb-4dcd-47ab-92db-98d03aa9b6f1
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","name":"tf-func-quirky-hellman","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncquirkyhellmanfkpkeioo","registry_namespace_id":"269b4e4e-df1f-45fa-a3c4-c383aa4378c6","secret_environment_variables":[],"status":"ready"}'
-    headers:
-      Content-Length:
-      - "460"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:53:07 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - fc8c40ba-6afa-45a7-a6df-8c10f349ac11
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"ready","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "513"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:53:07 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ff3c7e6d-1356-4422-bc7c-1b87d4bd39e6
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"ready","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "513"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:53:08 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 831e596a-ed93-4ecf-902f-c62916d6412d
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: DELETE
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncquirkyhellmanfkpkeioo-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de8800c-90a9-4595-8778-c011b7e3e35e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"deleting","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "516"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:53:08 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e74b6776-55f6-452f-8e2c-7648082594c0
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/509de7bb-4dcd-47ab-92db-98d03aa9b6f1
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","name":"tf-func-quirky-hellman","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncquirkyhellmanfkpkeioo","registry_namespace_id":"269b4e4e-df1f-45fa-a3c4-c383aa4378c6","secret_environment_variables":[],"status":"ready"}'
-    headers:
-      Content-Length:
-      - "460"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:53:08 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - acdddeec-8dbf-4f7c-994e-bb3783d807c3
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/509de7bb-4dcd-47ab-92db-98d03aa9b6f1
-    method: DELETE
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","name":"tf-func-quirky-hellman","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncquirkyhellmanfkpkeioo","registry_namespace_id":"269b4e4e-df1f-45fa-a3c4-c383aa4378c6","secret_environment_variables":[],"status":"deleting"}'
-    headers:
-      Content-Length:
-      - "463"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:53:08 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 775550d3-4cd0-4c20-b684-44e590ac6123
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/509de7bb-4dcd-47ab-92db-98d03aa9b6f1
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","name":"tf-func-quirky-hellman","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncquirkyhellmanfkpkeioo","registry_namespace_id":"269b4e4e-df1f-45fa-a3c4-c383aa4378c6","secret_environment_variables":[],"status":"deleting"}'
-    headers:
-      Content-Length:
-      - "463"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:53:08 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6c31df07-6d49-4b42-b5b3-20f55f7bfd6a
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/509de7bb-4dcd-47ab-92db-98d03aa9b6f1
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","name":"tf-func-quirky-hellman","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncquirkyhellmanfkpkeioo","registry_namespace_id":"269b4e4e-df1f-45fa-a3c4-c383aa4378c6","secret_environment_variables":[],"status":"deleting"}'
-    headers:
-      Content-Length:
-      - "463"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:53:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4a2d8178-d640-49fb-b553-9c1712634999
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/509de7bb-4dcd-47ab-92db-98d03aa9b6f1
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","name":"tf-func-quirky-hellman","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncquirkyhellmanfkpkeioo","registry_namespace_id":"269b4e4e-df1f-45fa-a3c4-c383aa4378c6","secret_environment_variables":[],"status":"deleting"}'
-    headers:
-      Content-Length:
-      - "463"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:53:18 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9310c2f3-fa58-47e7-80a4-8f1ce8c2bd78
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/509de7bb-4dcd-47ab-92db-98d03aa9b6f1
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","name":"tf-func-quirky-hellman","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncquirkyhellmanfkpkeioo","registry_namespace_id":"269b4e4e-df1f-45fa-a3c4-c383aa4378c6","secret_environment_variables":[],"status":"deleting"}'
-    headers:
-      Content-Length:
-      - "463"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:53:23 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 60749175-0a1b-4ce3-bf35-0079ad447c42
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/509de7bb-4dcd-47ab-92db-98d03aa9b6f1
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","name":"tf-func-quirky-hellman","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncquirkyhellmanfkpkeioo","registry_namespace_id":"269b4e4e-df1f-45fa-a3c4-c383aa4378c6","secret_environment_variables":[],"status":"deleting"}'
-    headers:
-      Content-Length:
-      - "463"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:53:28 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6042321e-216a-4371-9465-839a3ab51d90
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/509de7bb-4dcd-47ab-92db-98d03aa9b6f1
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","name":"tf-func-quirky-hellman","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncquirkyhellmanfkpkeioo","registry_namespace_id":"269b4e4e-df1f-45fa-a3c4-c383aa4378c6","secret_environment_variables":[],"status":"deleting"}'
-    headers:
-      Content-Length:
-      - "463"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:53:33 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - fc2ee786-40da-4684-956c-12871a1c06d1
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/509de7bb-4dcd-47ab-92db-98d03aa9b6f1
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","name":"tf-func-quirky-hellman","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncquirkyhellmanfkpkeioo","registry_namespace_id":"269b4e4e-df1f-45fa-a3c4-c383aa4378c6","secret_environment_variables":[],"status":"deleting"}'
-    headers:
-      Content-Length:
-      - "463"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:53:38 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8423d9b3-98e9-4514-adbd-a1bc1334277e
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/509de7bb-4dcd-47ab-92db-98d03aa9b6f1
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"509de7bb-4dcd-47ab-92db-98d03aa9b6f1","name":"tf-func-quirky-hellman","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncquirkyhellmanfkpkeioo","registry_namespace_id":"269b4e4e-df1f-45fa-a3c4-c383aa4378c6","secret_environment_variables":[],"status":"deleting"}'
-    headers:
-      Content-Length:
-      - "463"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:53:43 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 64ab46a7-0d34-4417-93df-482657a07a33
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/509de7bb-4dcd-47ab-92db-98d03aa9b6f1
-    method: GET
-  response:
-    body: '{"message":"Namespace was not found"}'
-    headers:
-      Content-Length:
-      - "37"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:53:48 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 02d4540b-a254-480d-890c-7ea7f555b9ca
-    status: 404 Not Found
-    code: 404
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de8800c-90a9-4595-8778-c011b7e3e35e
-    method: DELETE
-  response:
-    body: '{"message":"Function was not found"}'
-    headers:
-      Content-Length:
-      - "36"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:53:48 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c6a48bd8-f2bf-4f52-b11f-3199241c73d3
-    status: 404 Not Found
-    code: 404
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 145
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"name":"tf-func-nervous-nobel","environment_variables":{},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","secret_environment_variables":[]}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 371
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"5e2b037e-5ee7-4181-86c3-d54621006a61","name":"tf-func-nervous-nobel","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
+        headers:
+            Content-Length:
+                - "371"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:19 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 03a95158-1b5e-4478-9c93-b446adc57437
+        status: 200 OK
+        code: 200
+        duration: 1.227617436s
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/5e2b037e-5ee7-4181-86c3-d54621006a61
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 371
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"5e2b037e-5ee7-4181-86c3-d54621006a61","name":"tf-func-nervous-nobel","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
+        headers:
+            Content-Length:
+                - "371"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:20 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - d9ed9c48-5a9a-4301-9486-dc04ca7d5e0e
+        status: 200 OK
+        code: 200
+        duration: 67.275319ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/5e2b037e-5ee7-4181-86c3-d54621006a61
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 458
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"5e2b037e-5ee7-4181-86c3-d54621006a61","name":"tf-func-nervous-nobel","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncnervousnobelf9gpv9ka","registry_namespace_id":"bdabd883-e583-44f6-8378-96d3ee8143ec","secret_environment_variables":[],"status":"ready"}'
+        headers:
+            Content-Length:
+                - "458"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:25 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3f27cd7f-de51-42a4-839a-8fe1c4fb8cc6
+        status: 200 OK
+        code: 200
+        duration: 64.555508ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/5e2b037e-5ee7-4181-86c3-d54621006a61
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 458
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"5e2b037e-5ee7-4181-86c3-d54621006a61","name":"tf-func-nervous-nobel","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncnervousnobelf9gpv9ka","registry_namespace_id":"bdabd883-e583-44f6-8378-96d3ee8143ec","secret_environment_variables":[],"status":"ready"}'
+        headers:
+            Content-Length:
+                - "458"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:25 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b6349460-6165-4550-bf53-6ec58c18b6ad
+        status: 200 OK
+        code: 200
+        duration: 60.949734ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 289
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"go122","memory_limit":256,"handler":"Handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 551
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "551"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:25 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b129d980-1b26-4892-8962-ebd38b2f55a1
+        status: 200 OK
+        code: 200
+        duration: 757.844152ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2/upload-url?content_length=780
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 510
+        uncompressed: false
+        body: '{"headers":{"content-length":["780"],"content-type":["application/octet-stream"]},"url":"https://s3.fr-par.scw.cloud/serverless-functions-code-prod-fr-par/uploads/function-35eb35c8-729a-4f8e-9528-d0d24eafbec2.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256\u0026X-Amz-Credential=SCW3S98HDC0MAE9CBTQ5%2F20240705%2Ffr-par%2Fs3%2Faws4_request\u0026X-Amz-Date=20240705T082425Z\u0026X-Amz-Expires=3600\u0026X-Amz-SignedHeaders=content-length%3Bcontent-type%3Bhost\u0026X-Amz-Signature=bddd64d6987856eac89e550df938fdf27bfb95a378eac2629569d7511039884a"}'
+        headers:
+            Content-Length:
+                - "510"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:25 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 62ffaa54-f5ee-4fc8-ae31-2eedacfbed01
+        status: 200 OK
+        code: 200
+        duration: 55.560337ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 780
+        transfer_encoding: []
+        trailer: {}
+        host: s3.fr-par.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: !!binary |
+            UEsDBAoAAAAAAGZZzVTiYkURGgAAABoAAAAGABwAZ28ubW9kVVQJAAMw/6ZiYP+mYnV4Cw
+            ABBOgDAAAE6AMAAG1vZHVsZSBteWhhbmRsZXIKCmdvIDEuMTgKUEsDBAoAAAAAACuFzVQA
+            AAAAAAAAAAAAAAAGABwAZ28uc3VtVVQJAAOSTKdil0ynYnV4CwABBOgDAAAE6AMAAFBLAw
+            QUAAAACABFgs1U1odLbzABAADKAQAACgAcAGhhbmRsZXIuZ29VVAkAAyJHp2IlR6didXgL
+            AAEE6AMAAAToAwAARVCxTsMwEJ3jrzi8kKA02RgqdSkClYGFInVADCa5NAHHNudLo6rqv2
+            OnKUw+v3t3791zqvpWe4T+2AymEqLrnSWGVCQSTWXrzuzLL2+NDEDTc3wMctkyOykyIcoS
+            NsrUGmFxLfCAhkVcNyPpCJFfvKJ31njcUcdIORDczfjPgJ4zOImEZg4sV9Ar9+6ZgoWPzo
+            SJRlV4OgdSInv0PtiWS5A7vCUEpTXsra1lHtstKs3tMbSZBpwgM/SfSAGB+/A/i3+pdQ5I
+            FAXjocWLIt8qnV7bmUi6ZmLcrMB0OrpMxmI6YoOqRkqnK7asePDP0ahReot0QHokshQWBC
+            0eyFx0x2Iey4otciofbJgxvHg7OpQ5SOWc7irFnTWX6MOCEH3x5EIUnI45XEL5c7jOMnEW
+            v1BLAQIeAwoAAAAAAGZZzVTiYkURGgAAABoAAAAGABgAAAAAAAEAAACkgQAAAABnby5tb2
+            RVVAUAAzD/pmJ1eAsAAQToAwAABOgDAABQSwECHgMKAAAAAAArhc1UAAAAAAAAAAAAAAAA
+            BgAYAAAAAAAAAAAApIFaAAAAZ28uc3VtVVQFAAOSTKdidXgLAAEE6AMAAAToAwAAUEsBAh
+            4DFAAAAAgARYLNVNaHS28wAQAAygEAAAoAGAAAAAAAAQAAAKSBmgAAAGhhbmRsZXIuZ29V
+            VAUAAyJHp2J1eAsAAQToAwAABOgDAABQSwUGAAAAAAMAAwDoAAAADgIAAAAA
+        form: {}
+        headers:
+            Content-Length:
+                - "780"
+            Content-Type:
+                - application/octet-stream
+        url: https://s3.fr-par.scw.cloud/serverless-functions-code-prod-fr-par/uploads/function-35eb35c8-729a-4f8e-9528-d0d24eafbec2.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=SCW3S98HDC0MAE9CBTQ5%2F20240705%2Ffr-par%2Fs3%2Faws4_request&X-Amz-Date=20240705T082425Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=content-length%3Bcontent-type%3Bhost&X-Amz-Signature=bddd64d6987856eac89e550df938fdf27bfb95a378eac2629569d7511039884a
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Length:
+                - "0"
+            Content-Type:
+                - text/html; charset=UTF-8
+            Date:
+                - Fri, 05 Jul 2024 08:24:26 GMT
+            Etag:
+                - '"10633bf7a5ff211d8f3eee3856a28101"'
+            Last-Modified:
+                - Fri, 05 Jul 2024 08:24:26 GMT
+            X-Amz-Id-2:
+                - tx7631b48aac2b4a2991529-006687adba
+            X-Amz-Request-Id:
+                - tx7631b48aac2b4a2991529-006687adba
+            X-Amz-Version-Id:
+                - "1720167866259209"
+        status: 200 OK
+        code: 200
+        duration: 524.720458ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 2
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2/deploy
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 551
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "551"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:26 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 0b1d1dcd-6eb2-4542-aa8e-b4769f73adce
+        status: 200 OK
+        code: 200
+        duration: 84.637683ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 551
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "551"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:26 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - bfbbc030-49d3-46d4-87ae-0aabf29385ab
+        status: 200 OK
+        code: 200
+        duration: 60.798328ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 600
+        uncompressed: false
+        body: '{"build_message":"step 1 of 3: function build preparation in progress","cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "600"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:31 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b24ffa81-f6a8-48bb-bf1a-f32a953dc65e
+        status: 200 OK
+        code: 200
+        duration: 59.720744ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 588
+        uncompressed: false
+        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "588"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:36 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 1b700bdd-087c-4932-9db4-cfdcd7eb68e1
+        status: 200 OK
+        code: 200
+        duration: 64.166327ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 588
+        uncompressed: false
+        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "588"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:41 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - cf83fe21-0aa0-402b-9870-006ddabc3cbe
+        status: 200 OK
+        code: 200
+        duration: 59.516991ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 588
+        uncompressed: false
+        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "588"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:46 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 36970c32-5f83-4697-95ed-123fdc2e5c17
+        status: 200 OK
+        code: 200
+        duration: 61.038059ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 588
+        uncompressed: false
+        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "588"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 1c0de29e-0071-465e-a398-c4b069e9bdd0
+        status: 200 OK
+        code: 200
+        duration: 74.949886ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 588
+        uncompressed: false
+        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "588"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:57 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e01c87a5-06f6-4eb0-9cf6-a496292baf01
+        status: 200 OK
+        code: 200
+        duration: 57.791291ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 588
+        uncompressed: false
+        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "588"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:25:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 5925eeee-07c2-4a13-9270-9b9e9caca527
+        status: 200 OK
+        code: 200
+        duration: 67.840115ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 588
+        uncompressed: false
+        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "588"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:25:07 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b036bcb6-2f17-4053-b64b-496d752fffae
+        status: 200 OK
+        code: 200
+        duration: 74.627379ms
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 588
+        uncompressed: false
+        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "588"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:25:12 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 05954bd3-68ef-428b-a553-a95301c21278
+        status: 200 OK
+        code: 200
+        duration: 63.088887ms
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 614
+        uncompressed: false
+        body: '{"build_message":"step 3 of 3: function image is being pushed to container registry","cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "614"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:25:17 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 5f84feec-e610-4ced-9915-50358856b258
+        status: 200 OK
+        code: 200
+        duration: 65.13393ms
+    - id: 19
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 614
+        uncompressed: false
+        body: '{"build_message":"step 3 of 3: function image is being pushed to container registry","cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "614"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:25:22 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 609bcc9f-2e51-4b57-9351-25ee4c9eb9dd
+        status: 200 OK
+        code: 200
+        duration: 65.583945ms
+    - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 614
+        uncompressed: false
+        body: '{"build_message":"step 3 of 3: function image is being pushed to container registry","cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "614"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:25:27 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - d3395ccd-a856-45cc-9b25-263bea7057d1
+        status: 200 OK
+        code: 200
+        duration: 77.12853ms
+    - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 614
+        uncompressed: false
+        body: '{"build_message":"step 3 of 3: function image is being pushed to container registry","cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "614"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:25:32 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 881facfd-2cd5-4598-a1d1-022485eb54f2
+        status: 200 OK
+        code: 200
+        duration: 70.465378ms
+    - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 614
+        uncompressed: false
+        body: '{"build_message":"step 3 of 3: function image is being pushed to container registry","cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "614"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:25:37 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ab40cac5-46e0-437a-adcd-ca72a84bd1f1
+        status: 200 OK
+        code: 200
+        duration: 138.916081ms
+    - id: 23
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 614
+        uncompressed: false
+        body: '{"build_message":"step 3 of 3: function image is being pushed to container registry","cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "614"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:25:42 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f22e4c49-713c-4955-bc01-6cf77edc4d06
+        status: 200 OK
+        code: 200
+        duration: 64.734659ms
+    - id: 24
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 614
+        uncompressed: false
+        body: '{"build_message":"step 3 of 3: function image is being pushed to container registry","cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "614"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:25:47 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 0b9be48b-3a8d-46bc-a9cc-330df5b91960
+        status: 200 OK
+        code: 200
+        duration: 62.736845ms
+    - id: 25
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 614
+        uncompressed: false
+        body: '{"build_message":"step 3 of 3: function image is being pushed to container registry","cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "614"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:25:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3c95ff8e-3044-45a1-99b9-3821c44caa07
+        status: 200 OK
+        code: 200
+        duration: 63.426622ms
+    - id: 26
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 614
+        uncompressed: false
+        body: '{"build_message":"step 3 of 3: function image is being pushed to container registry","cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "614"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:25:57 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - c13e818f-a63e-4b42-b02f-3f15abeb69b2
+        status: 200 OK
+        code: 200
+        duration: 66.399257ms
+    - id: 27
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 614
+        uncompressed: false
+        body: '{"build_message":"step 3 of 3: function image is being pushed to container registry","cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "614"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:26:03 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 5b675ca2-3524-4959-a56b-a13fd84f0a25
+        status: 200 OK
+        code: 200
+        duration: 64.492094ms
+    - id: 28
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 614
+        uncompressed: false
+        body: '{"build_message":"step 3 of 3: function image is being pushed to container registry","cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "614"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:26:08 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 73084da3-41cd-48d8-81e3-5089061341f7
+        status: 200 OK
+        code: 200
+        duration: 77.211666ms
+    - id: 29
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 614
+        uncompressed: false
+        body: '{"build_message":"step 3 of 3: function image is being pushed to container registry","cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "614"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:26:13 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ac0895fd-498f-4572-a151-b9626b7f8303
+        status: 200 OK
+        code: 200
+        duration: 87.918837ms
+    - id: 30
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 614
+        uncompressed: false
+        body: '{"build_message":"step 3 of 3: function image is being pushed to container registry","cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "614"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:26:18 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 9892cee1-eb3f-4222-ba78-3e9ce51bae9e
+        status: 200 OK
+        code: 200
+        duration: 70.448787ms
+    - id: 31
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 551
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "551"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:26:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 8a708c48-1c7f-4299-a32f-6516e1bbe611
+        status: 200 OK
+        code: 200
+        duration: 73.718872ms
+    - id: 32
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 551
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "551"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:26:28 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 38080572-225b-4266-9d72-80c0eaabfbe3
+        status: 200 OK
+        code: 200
+        duration: 78.288249ms
+    - id: 33
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 551
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "551"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:26:33 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 9a52b100-8db4-4286-a816-665b3d28f565
+        status: 200 OK
+        code: 200
+        duration: 61.917315ms
+    - id: 34
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 551
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "551"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:26:38 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 2d2537fa-d70b-40de-98c2-eceb991699f4
+        status: 200 OK
+        code: 200
+        duration: 71.785951ms
+    - id: 35
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 551
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "551"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:26:43 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 68c870f7-dacd-4047-9c0b-97b9fbf44ee6
+        status: 200 OK
+        code: 200
+        duration: 75.893068ms
+    - id: 36
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 551
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "551"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:26:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 5c47dd45-2b3e-4bd8-afcf-0dcb226df5f9
+        status: 200 OK
+        code: 200
+        duration: 53.912763ms
+    - id: 37
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 551
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "551"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:26:53 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - a3e0bf5f-02d5-4a58-9859-980552ab52a9
+        status: 200 OK
+        code: 200
+        duration: 63.123812ms
+    - id: 38
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 551
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "551"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:26:58 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 52ac36b4-2804-4ac5-b8b8-834a4f38f02d
+        status: 200 OK
+        code: 200
+        duration: 64.365436ms
+    - id: 39
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 549
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"ready","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "549"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:27:03 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 976143a8-310f-4c78-b6de-8719233e245d
+        status: 200 OK
+        code: 200
+        duration: 61.672925ms
+    - id: 40
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 549
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"ready","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "549"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:27:03 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 52c282ac-bd4d-41fd-8b6c-fb64375a6879
+        status: 200 OK
+        code: 200
+        duration: 73.758441ms
+    - id: 41
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 549
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"ready","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "549"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:27:04 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ddfc4038-27e5-4e67-995b-b68b381d56b8
+        status: 200 OK
+        code: 200
+        duration: 81.381534ms
+    - id: 42
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/5e2b037e-5ee7-4181-86c3-d54621006a61
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 458
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"5e2b037e-5ee7-4181-86c3-d54621006a61","name":"tf-func-nervous-nobel","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncnervousnobelf9gpv9ka","registry_namespace_id":"bdabd883-e583-44f6-8378-96d3ee8143ec","secret_environment_variables":[],"status":"ready"}'
+        headers:
+            Content-Length:
+                - "458"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:27:04 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 92b2b678-2ae0-43e7-920d-d097d6987e3e
+        status: 200 OK
+        code: 200
+        duration: 58.986337ms
+    - id: 43
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 549
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"ready","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "549"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:27:04 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 9b43bc7b-5ed3-4952-affd-b45430936802
+        status: 200 OK
+        code: 200
+        duration: 68.822126ms
+    - id: 44
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/5e2b037e-5ee7-4181-86c3-d54621006a61
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 458
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"5e2b037e-5ee7-4181-86c3-d54621006a61","name":"tf-func-nervous-nobel","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncnervousnobelf9gpv9ka","registry_namespace_id":"bdabd883-e583-44f6-8378-96d3ee8143ec","secret_environment_variables":[],"status":"ready"}'
+        headers:
+            Content-Length:
+                - "458"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:27:05 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ae9222f8-9fd9-4239-a35e-aa3cf8023f54
+        status: 200 OK
+        code: 200
+        duration: 66.416978ms
+    - id: 45
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 549
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"ready","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "549"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:27:05 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 7a932b73-08a0-46b2-94dd-86d9446bf667
+        status: 200 OK
+        code: 200
+        duration: 52.56423ms
+    - id: 46
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 549
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"ready","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "549"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:27:05 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - eba60325-90f9-47cc-9b95-ee4353ef9f4f
+        status: 200 OK
+        code: 200
+        duration: 64.503312ms
+    - id: 47
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2/upload-url?content_length=780
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 510
+        uncompressed: false
+        body: '{"headers":{"content-length":["780"],"content-type":["application/octet-stream"]},"url":"https://s3.fr-par.scw.cloud/serverless-functions-code-prod-fr-par/uploads/function-35eb35c8-729a-4f8e-9528-d0d24eafbec2.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256\u0026X-Amz-Credential=SCW3S98HDC0MAE9CBTQ5%2F20240705%2Ffr-par%2Fs3%2Faws4_request\u0026X-Amz-Date=20240705T082705Z\u0026X-Amz-Expires=3600\u0026X-Amz-SignedHeaders=content-length%3Bcontent-type%3Bhost\u0026X-Amz-Signature=147b964a9ac2d25d85379f96769a38ba0904f0bd500ee3c0e8198a9d0df0f388"}'
+        headers:
+            Content-Length:
+                - "510"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:27:05 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - d697fe81-55ec-48b3-9821-93fb9dccd9f8
+        status: 200 OK
+        code: 200
+        duration: 66.341456ms
+    - id: 48
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 780
+        transfer_encoding: []
+        trailer: {}
+        host: s3.fr-par.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: !!binary |
+            UEsDBAoAAAAAAGZZzVTiYkURGgAAABoAAAAGABwAZ28ubW9kVVQJAAMw/6ZiYP+mYnV4Cw
+            ABBOgDAAAE6AMAAG1vZHVsZSBteWhhbmRsZXIKCmdvIDEuMTgKUEsDBAoAAAAAACuFzVQA
+            AAAAAAAAAAAAAAAGABwAZ28uc3VtVVQJAAOSTKdil0ynYnV4CwABBOgDAAAE6AMAAFBLAw
+            QUAAAACABFgs1U1odLbzABAADKAQAACgAcAGhhbmRsZXIuZ29VVAkAAyJHp2IlR6didXgL
+            AAEE6AMAAAToAwAARVCxTsMwEJ3jrzi8kKA02RgqdSkClYGFInVADCa5NAHHNudLo6rqv2
+            OnKUw+v3t3791zqvpWe4T+2AymEqLrnSWGVCQSTWXrzuzLL2+NDEDTc3wMctkyOykyIcoS
+            NsrUGmFxLfCAhkVcNyPpCJFfvKJ31njcUcdIORDczfjPgJ4zOImEZg4sV9Ar9+6ZgoWPzo
+            SJRlV4OgdSInv0PtiWS5A7vCUEpTXsra1lHtstKs3tMbSZBpwgM/SfSAGB+/A/i3+pdQ5I
+            FAXjocWLIt8qnV7bmUi6ZmLcrMB0OrpMxmI6YoOqRkqnK7asePDP0ahReot0QHokshQWBC
+            0eyFx0x2Iey4otciofbJgxvHg7OpQ5SOWc7irFnTWX6MOCEH3x5EIUnI45XEL5c7jOMnEW
+            v1BLAQIeAwoAAAAAAGZZzVTiYkURGgAAABoAAAAGABgAAAAAAAEAAACkgQAAAABnby5tb2
+            RVVAUAAzD/pmJ1eAsAAQToAwAABOgDAABQSwECHgMKAAAAAAArhc1UAAAAAAAAAAAAAAAA
+            BgAYAAAAAAAAAAAApIFaAAAAZ28uc3VtVVQFAAOSTKdidXgLAAEE6AMAAAToAwAAUEsBAh
+            4DFAAAAAgARYLNVNaHS28wAQAAygEAAAoAGAAAAAAAAQAAAKSBmgAAAGhhbmRsZXIuZ29V
+            VAUAAyJHp2J1eAsAAQToAwAABOgDAABQSwUGAAAAAAMAAwDoAAAADgIAAAAA
+        form: {}
+        headers:
+            Content-Length:
+                - "780"
+            Content-Type:
+                - application/octet-stream
+        url: https://s3.fr-par.scw.cloud/serverless-functions-code-prod-fr-par/uploads/function-35eb35c8-729a-4f8e-9528-d0d24eafbec2.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=SCW3S98HDC0MAE9CBTQ5%2F20240705%2Ffr-par%2Fs3%2Faws4_request&X-Amz-Date=20240705T082705Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=content-length%3Bcontent-type%3Bhost&X-Amz-Signature=147b964a9ac2d25d85379f96769a38ba0904f0bd500ee3c0e8198a9d0df0f388
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Length:
+                - "0"
+            Content-Type:
+                - text/html; charset=UTF-8
+            Date:
+                - Fri, 05 Jul 2024 08:27:06 GMT
+            Etag:
+                - '"10633bf7a5ff211d8f3eee3856a28101"'
+            Last-Modified:
+                - Fri, 05 Jul 2024 08:27:06 GMT
+            X-Amz-Id-2:
+                - tx0b5eb548ad7e432a92d46-006687ae59
+            X-Amz-Request-Id:
+                - tx0b5eb548ad7e432a92d46-006687ae59
+            X-Amz-Version-Id:
+                - "1720168026061693"
+        status: 200 OK
+        code: 200
+        duration: 665.763892ms
+    - id: 49
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 549
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"ready","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "549"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:27:06 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e53f513d-dcff-490f-b6ae-acc6a6826621
+        status: 200 OK
+        code: 200
+        duration: 54.103794ms
+    - id: 50
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 2
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2/deploy
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 551
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "551"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:27:06 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 349f2ee7-754e-4d56-833b-d4ef15356115
+        status: 200 OK
+        code: 200
+        duration: 95.959774ms
+    - id: 51
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 551
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "551"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:27:06 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 1a0fc879-ec21-45c9-945b-a811ce62fc49
+        status: 200 OK
+        code: 200
+        duration: 68.375848ms
+    - id: 52
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 600
+        uncompressed: false
+        body: '{"build_message":"step 1 of 3: function build preparation in progress","cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "600"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:27:11 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3cda4135-d3ff-43ca-8591-84cd7c2f028c
+        status: 200 OK
+        code: 200
+        duration: 76.453896ms
+    - id: 53
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 588
+        uncompressed: false
+        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "588"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:27:16 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 47a5c95d-94ad-4c91-b4b0-3a15739fd675
+        status: 200 OK
+        code: 200
+        duration: 57.190973ms
+    - id: 54
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 588
+        uncompressed: false
+        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "588"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:27:21 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ba09c235-e640-4681-bf47-f26bd86355fd
+        status: 200 OK
+        code: 200
+        duration: 63.819487ms
+    - id: 55
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 588
+        uncompressed: false
+        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "588"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:27:26 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f6fc03b9-66d0-4f57-a771-8616000de109
+        status: 200 OK
+        code: 200
+        duration: 63.267249ms
+    - id: 56
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 588
+        uncompressed: false
+        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "588"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:27:32 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 7e37f5b1-b793-4938-b6a8-8891cc24e43d
+        status: 200 OK
+        code: 200
+        duration: 57.337819ms
+    - id: 57
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 588
+        uncompressed: false
+        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "588"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:27:37 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 7d1ae3fa-3f22-4c56-9214-6d0fe8b0ec6d
+        status: 200 OK
+        code: 200
+        duration: 65.794818ms
+    - id: 58
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 588
+        uncompressed: false
+        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "588"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:27:42 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 0767ea75-43d8-406f-8043-0e8bcb662da6
+        status: 200 OK
+        code: 200
+        duration: 73.110825ms
+    - id: 59
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 588
+        uncompressed: false
+        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "588"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:27:47 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e61518e8-d7e7-4509-a075-af800059c97f
+        status: 200 OK
+        code: 200
+        duration: 77.135756ms
+    - id: 60
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 588
+        uncompressed: false
+        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "588"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:27:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 2e32fafd-befe-4b85-8bb9-37b816b578c2
+        status: 200 OK
+        code: 200
+        duration: 77.20645ms
+    - id: 61
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 614
+        uncompressed: false
+        body: '{"build_message":"step 3 of 3: function image is being pushed to container registry","cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "614"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:27:57 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b3c0836a-85de-48ce-8192-91359f482ec7
+        status: 200 OK
+        code: 200
+        duration: 67.040519ms
+    - id: 62
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 614
+        uncompressed: false
+        body: '{"build_message":"step 3 of 3: function image is being pushed to container registry","cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "614"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:28:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f986b1dc-a3e5-4b07-9037-1d502d31aa71
+        status: 200 OK
+        code: 200
+        duration: 79.531207ms
+    - id: 63
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 614
+        uncompressed: false
+        body: '{"build_message":"step 3 of 3: function image is being pushed to container registry","cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "614"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:28:07 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 5a59fcba-270b-450d-9faa-d41e31c18e66
+        status: 200 OK
+        code: 200
+        duration: 61.008656ms
+    - id: 64
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 614
+        uncompressed: false
+        body: '{"build_message":"step 3 of 3: function image is being pushed to container registry","cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "614"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:28:12 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - c44fa7b5-52df-454f-ba8d-63de24d32d1d
+        status: 200 OK
+        code: 200
+        duration: 61.708631ms
+    - id: 65
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 614
+        uncompressed: false
+        body: '{"build_message":"step 3 of 3: function image is being pushed to container registry","cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "614"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:28:17 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 0f012a6b-6c00-4065-875e-2487703e6aea
+        status: 200 OK
+        code: 200
+        duration: 67.762205ms
+    - id: 66
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 614
+        uncompressed: false
+        body: '{"build_message":"step 3 of 3: function image is being pushed to container registry","cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "614"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:28:22 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 0c13c2d0-5a85-4a31-801f-8e00f9d931b1
+        status: 200 OK
+        code: 200
+        duration: 75.796461ms
+    - id: 67
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 614
+        uncompressed: false
+        body: '{"build_message":"step 3 of 3: function image is being pushed to container registry","cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "614"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:28:27 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 37865dfc-361f-4edd-ac04-971b265b4acf
+        status: 200 OK
+        code: 200
+        duration: 65.001548ms
+    - id: 68
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 614
+        uncompressed: false
+        body: '{"build_message":"step 3 of 3: function image is being pushed to container registry","cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "614"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:28:32 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b0bfccb8-295c-4d39-afce-09380ba1c611
+        status: 200 OK
+        code: 200
+        duration: 63.760026ms
+    - id: 69
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 614
+        uncompressed: false
+        body: '{"build_message":"step 3 of 3: function image is being pushed to container registry","cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "614"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:28:38 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3b309abd-be83-406f-8ffb-6f8bf1496c7c
+        status: 200 OK
+        code: 200
+        duration: 233.436302ms
+    - id: 70
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 614
+        uncompressed: false
+        body: '{"build_message":"step 3 of 3: function image is being pushed to container registry","cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "614"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:28:43 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 0a5ee392-fde2-4c8f-aee5-4f093ddb803d
+        status: 200 OK
+        code: 200
+        duration: 67.330354ms
+    - id: 71
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 551
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "551"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:28:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 86c5278b-34af-4d2e-a463-7789a9f74311
+        status: 200 OK
+        code: 200
+        duration: 58.754061ms
+    - id: 72
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 551
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "551"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:28:53 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 6920766b-1e91-4049-bfe0-7d4cd9c3ce89
+        status: 200 OK
+        code: 200
+        duration: 71.336701ms
+    - id: 73
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 551
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "551"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:28:58 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - fd3ded46-9e91-435c-85cb-21261ca86528
+        status: 200 OK
+        code: 200
+        duration: 67.781191ms
+    - id: 74
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 551
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "551"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:29:03 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 451f06ef-d4a3-4925-ab42-ee41938c6d0d
+        status: 200 OK
+        code: 200
+        duration: 63.067685ms
+    - id: 75
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 551
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "551"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:29:08 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - d5bcdbb3-777c-43f3-94bb-4baeeda3bd91
+        status: 200 OK
+        code: 200
+        duration: 72.440415ms
+    - id: 76
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 551
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "551"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:29:13 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 053a9a9f-753f-485c-b18f-9a07962cc8fa
+        status: 200 OK
+        code: 200
+        duration: 64.702016ms
+    - id: 77
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 551
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "551"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:29:18 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 56b83c5e-80cb-46a7-ae46-aade581325ce
+        status: 200 OK
+        code: 200
+        duration: 74.270773ms
+    - id: 78
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 551
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "551"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:29:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 5c6cb1e8-0176-46aa-a3e1-e4e5e0955bad
+        status: 200 OK
+        code: 200
+        duration: 60.783025ms
+    - id: 79
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 551
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "551"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:29:28 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 79526d31-eac4-4665-aedc-705ac749af1d
+        status: 200 OK
+        code: 200
+        duration: 62.390018ms
+    - id: 80
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 549
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"ready","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "549"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:29:33 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - fbf24bc2-36c4-4c10-88fe-6f6918e8f1db
+        status: 200 OK
+        code: 200
+        duration: 62.069194ms
+    - id: 81
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 549
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"ready","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "549"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:29:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 5d7f1c0c-175a-4cc9-a4a8-5ca14382c1aa
+        status: 200 OK
+        code: 200
+        duration: 70.033183ms
+    - id: 82
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/5e2b037e-5ee7-4181-86c3-d54621006a61
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 458
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"5e2b037e-5ee7-4181-86c3-d54621006a61","name":"tf-func-nervous-nobel","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncnervousnobelf9gpv9ka","registry_namespace_id":"bdabd883-e583-44f6-8378-96d3ee8143ec","secret_environment_variables":[],"status":"ready"}'
+        headers:
+            Content-Length:
+                - "458"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:29:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b9f0d8f5-27bb-4c36-b734-4ead9d84eae1
+        status: 200 OK
+        code: 200
+        duration: 62.596305ms
+    - id: 83
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 549
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"ready","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "549"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:29:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 23315cc6-a98f-4608-a951-cfc9aa90d65b
+        status: 200 OK
+        code: 200
+        duration: 62.26372ms
+    - id: 84
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 549
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"ready","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "549"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:29:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 2302227a-960c-4fc3-9c2e-6f5f4e1c571e
+        status: 200 OK
+        code: 200
+        duration: 66.438342ms
+    - id: 85
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 552
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncnervousnobelf9gpv9ka-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"35eb35c8-729a-4f8e-9528-d0d24eafbec2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5e2b037e-5ee7-4181-86c3-d54621006a61","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"deleting","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "552"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:29:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 69595dd0-a063-4db1-ba91-a74d40cbe2a6
+        status: 200 OK
+        code: 200
+        duration: 151.263426ms
+    - id: 86
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/5e2b037e-5ee7-4181-86c3-d54621006a61
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 458
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"5e2b037e-5ee7-4181-86c3-d54621006a61","name":"tf-func-nervous-nobel","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncnervousnobelf9gpv9ka","registry_namespace_id":"bdabd883-e583-44f6-8378-96d3ee8143ec","secret_environment_variables":[],"status":"ready"}'
+        headers:
+            Content-Length:
+                - "458"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:29:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - cecaac64-9b4c-40f3-9f9e-5c8b8ee32789
+        status: 200 OK
+        code: 200
+        duration: 52.3747ms
+    - id: 87
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/5e2b037e-5ee7-4181-86c3-d54621006a61
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 461
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"5e2b037e-5ee7-4181-86c3-d54621006a61","name":"tf-func-nervous-nobel","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncnervousnobelf9gpv9ka","registry_namespace_id":"bdabd883-e583-44f6-8378-96d3ee8143ec","secret_environment_variables":[],"status":"deleting"}'
+        headers:
+            Content-Length:
+                - "461"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:29:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 65d99400-6e86-4204-be30-a7eb1bde2b7d
+        status: 200 OK
+        code: 200
+        duration: 317.166137ms
+    - id: 88
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/5e2b037e-5ee7-4181-86c3-d54621006a61
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 461
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"5e2b037e-5ee7-4181-86c3-d54621006a61","name":"tf-func-nervous-nobel","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncnervousnobelf9gpv9ka","registry_namespace_id":"bdabd883-e583-44f6-8378-96d3ee8143ec","secret_environment_variables":[],"status":"deleting"}'
+        headers:
+            Content-Length:
+                - "461"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:29:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e5780721-7cdf-4248-9eda-9dca6860b663
+        status: 200 OK
+        code: 200
+        duration: 61.52477ms
+    - id: 89
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/5e2b037e-5ee7-4181-86c3-d54621006a61
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 461
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"5e2b037e-5ee7-4181-86c3-d54621006a61","name":"tf-func-nervous-nobel","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncnervousnobelf9gpv9ka","registry_namespace_id":"bdabd883-e583-44f6-8378-96d3ee8143ec","secret_environment_variables":[],"status":"deleting"}'
+        headers:
+            Content-Length:
+                - "461"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:29:40 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - c50b79a9-7c03-497d-ae0e-dee93ef9f19c
+        status: 200 OK
+        code: 200
+        duration: 60.917607ms
+    - id: 90
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/5e2b037e-5ee7-4181-86c3-d54621006a61
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 37
+        uncompressed: false
+        body: '{"message":"Namespace was not found"}'
+        headers:
+            Content-Length:
+                - "37"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:29:45 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 2f90c15b-9f99-4d50-83c1-3356ee9de019
+        status: 404 Not Found
+        code: 404
+        duration: 23.518555ms
+    - id: 91
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/35eb35c8-729a-4f8e-9528-d0d24eafbec2
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 36
+        uncompressed: false
+        body: '{"message":"Function was not found"}'
+        headers:
+            Content-Length:
+                - "36"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:29:45 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 00f0c5e0-c396-4896-a06f-8bbaa1b07d9c
+        status: 404 Not Found
+        code: 404
+        duration: 24.131418ms

--- a/internal/services/function/testdata/function-domain-basic.cassette.yaml
+++ b/internal/services/function/testdata/function-domain-basic.cassette.yaml
@@ -6,19 +6,19 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 148
+        content_length: 149
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-func-practical-snyder","environment_variables":{},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","secret_environment_variables":[]}'
+        body: '{"name":"tf-func-unruffled-perlman","environment_variables":{},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","secret_environment_variables":[]}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces
         method: POST
       response:
@@ -27,20 +27,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 385
+        content_length: 375
         uncompressed: false
-        body: '{"description":"","environment_variables":{},"error_message":null,"id":"dba63885-5261-4b30-a454-22045bbec32f","name":"tf-func-practical-snyder","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"a6109d4f-b972-4daf-a379-c287e625c00d","name":"tf-func-unruffled-perlman","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
         headers:
             Content-Length:
-                - "385"
+                - "375"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 25 Jun 2024 15:01:06 GMT
+                - Fri, 05 Jul 2024 08:35:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4da39df8-931a-4a37-9815-cec9a2c1597a
+                - 79b10890-99e4-4b09-8efb-0b7910a50a44
         status: 200 OK
         code: 200
-        duration: 1.616440438s
+        duration: 554.746967ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -67,8 +67,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/dba63885-5261-4b30-a454-22045bbec32f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a6109d4f-b972-4daf-a379-c287e625c00d
         method: GET
       response:
         proto: HTTP/2.0
@@ -76,20 +76,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 385
+        content_length: 375
         uncompressed: false
-        body: '{"description":"","environment_variables":{},"error_message":null,"id":"dba63885-5261-4b30-a454-22045bbec32f","name":"tf-func-practical-snyder","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"a6109d4f-b972-4daf-a379-c287e625c00d","name":"tf-func-unruffled-perlman","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
         headers:
             Content-Length:
-                - "385"
+                - "375"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 25 Jun 2024 15:01:06 GMT
+                - Fri, 05 Jul 2024 08:35:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2673204d-dac4-4462-ae27-743a7cf2f990
+                - 56393c7f-c4ca-4c48-808b-f652a028d996
         status: 200 OK
         code: 200
-        duration: 62.88562ms
+        duration: 52.964301ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -116,8 +116,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/dba63885-5261-4b30-a454-22045bbec32f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a6109d4f-b972-4daf-a379-c287e625c00d
         method: GET
       response:
         proto: HTTP/2.0
@@ -125,20 +125,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 474
+        content_length: 464
         uncompressed: false
-        body: '{"description":"","environment_variables":{},"error_message":null,"id":"dba63885-5261-4b30-a454-22045bbec32f","name":"tf-func-practical-snyder","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncpracticalsnyde1eejycco","registry_namespace_id":"896c22a4-b3f1-4ed7-9fec-6e0e7f69e3c5","secret_environment_variables":[],"status":"ready"}'
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"a6109d4f-b972-4daf-a379-c287e625c00d","name":"tf-func-unruffled-perlman","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncunruffledperlmv1mnq4p4","registry_namespace_id":"2ce80c58-94cd-4437-b6ae-df094cac46ff","secret_environment_variables":[],"status":"ready"}'
         headers:
             Content-Length:
-                - "474"
+                - "464"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 25 Jun 2024 15:01:11 GMT
+                - Fri, 05 Jul 2024 08:35:18 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -146,10 +146,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fe1fddb7-8043-4475-95ba-e37029946bc7
+                - 61e42484-ce68-4937-a0f5-7ac799caebd0
         status: 200 OK
         code: 200
-        duration: 51.424116ms
+        duration: 86.417957ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -165,8 +165,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/dba63885-5261-4b30-a454-22045bbec32f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a6109d4f-b972-4daf-a379-c287e625c00d
         method: GET
       response:
         proto: HTTP/2.0
@@ -174,20 +174,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 474
+        content_length: 464
         uncompressed: false
-        body: '{"description":"","environment_variables":{},"error_message":null,"id":"dba63885-5261-4b30-a454-22045bbec32f","name":"tf-func-practical-snyder","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncpracticalsnyde1eejycco","registry_namespace_id":"896c22a4-b3f1-4ed7-9fec-6e0e7f69e3c5","secret_environment_variables":[],"status":"ready"}'
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"a6109d4f-b972-4daf-a379-c287e625c00d","name":"tf-func-unruffled-perlman","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncunruffledperlmv1mnq4p4","registry_namespace_id":"2ce80c58-94cd-4437-b6ae-df094cac46ff","secret_environment_variables":[],"status":"ready"}'
         headers:
             Content-Length:
-                - "474"
+                - "464"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 25 Jun 2024 15:01:11 GMT
+                - Fri, 05 Jul 2024 08:35:18 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -195,28 +195,28 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e1ec454c-4831-4f9c-a057-3116f6450736
+                - 0336f1e9-f2b0-45e5-89a7-35c9b2e51149
         status: 200 OK
         code: 200
-        duration: 59.054806ms
+        duration: 60.77297ms
     - id: 4
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 279
+        content_length: 305
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-func-admiring-wescoff","namespace_id":"dba63885-5261-4b30-a454-22045bbec32f","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"go118","memory_limit":128,"handler":"Handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled"}'
+        body: '{"name":"tf-func-serene-taussig","namespace_id":"a6109d4f-b972-4daf-a379-c287e625c00d","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"go122","memory_limit":256,"handler":"Handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox"}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions
         method: POST
       response:
@@ -225,20 +225,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 593
+        content_length: 585
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":70,"description":"","domain_name":"tffuncpracticalsnyde1eejycco-tf-func-admiring-wescoff.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"6658bd06-9799-4a07-9e0f-18dd19c2eb8f","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-func-admiring-wescoff","namespace_id":"dba63885-5261-4b30-a454-22045bbec32f","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncunruffledperlmv1mnq4p4-tf-func-serene-taussig.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"573d15a7-c2da-45cc-a30b-f3752faf71fb","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-serene-taussig","namespace_id":"a6109d4f-b972-4daf-a379-c287e625c00d","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
         headers:
             Content-Length:
-                - "593"
+                - "585"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 25 Jun 2024 15:01:12 GMT
+                - Fri, 05 Jul 2024 08:35:18 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -246,10 +246,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 83adecbf-c2d5-4a25-ba8a-5aaaba0d61a7
+                - 9f0ba884-cc29-40a5-8ded-2e9d6b57135a
         status: 200 OK
         code: 200
-        duration: 544.499324ms
+        duration: 307.507515ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -265,8 +265,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/6658bd06-9799-4a07-9e0f-18dd19c2eb8f/upload-url?content_length=780
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/573d15a7-c2da-45cc-a30b-f3752faf71fb/upload-url?content_length=780
         method: GET
       response:
         proto: HTTP/2.0
@@ -274,20 +274,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 512
+        content_length: 510
         uncompressed: false
-        body: '{"headers":{"content-length":["780"],"content-type":["application/octet-stream"]},"url":"https://s3.fr-par.scw.cloud/serverless-functions-code-prod-fr-par/uploads/function-6658bd06-9799-4a07-9e0f-18dd19c2eb8f.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256\u0026X-Amz-Credential=SCW3S98HDC0MAE9CBTQ5%2F20240625%2Ffr-par%2Fs3%2Faws4_request\u0026X-Amz-Date=20240625T150112Z\u0026X-Amz-Expires=3600\u0026X-Amz-SignedHeaders=content-length%3Bcontent-type%3Bhost\u0026X-Amz-Signature=5d99a1f60f0c4d1f6c48f3cfa4e2a6a2cd6669087e6a0283ce103cd5cca8aa18"}'
+        body: '{"headers":{"content-length":["780"],"content-type":["application/octet-stream"]},"url":"https://s3.fr-par.scw.cloud/serverless-functions-code-prod-fr-par/uploads/function-573d15a7-c2da-45cc-a30b-f3752faf71fb.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256\u0026X-Amz-Credential=SCW3S98HDC0MAE9CBTQ5%2F20240705%2Ffr-par%2Fs3%2Faws4_request\u0026X-Amz-Date=20240705T083518Z\u0026X-Amz-Expires=3600\u0026X-Amz-SignedHeaders=content-length%3Bcontent-type%3Bhost\u0026X-Amz-Signature=6f013125c8950855a372c9c1184834d708c4f0eac2a5583efcb90e01b0ccb494"}'
         headers:
             Content-Length:
-                - "512"
+                - "510"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 25 Jun 2024 15:01:12 GMT
+                - Fri, 05 Jul 2024 08:35:18 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -295,10 +295,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 564cbd9d-e77c-4899-88b6-e68ba9ebe4a6
+                - 00484d1b-81fb-4adc-a75b-8f9d836b4081
         status: 200 OK
         code: 200
-        duration: 58.128923ms
+        duration: 68.240539ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -332,7 +332,7 @@ interactions:
                 - "780"
             Content-Type:
                 - application/octet-stream
-        url: https://s3.fr-par.scw.cloud/serverless-functions-code-prod-fr-par/uploads/function-6658bd06-9799-4a07-9e0f-18dd19c2eb8f.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=SCW3S98HDC0MAE9CBTQ5%2F20240625%2Ffr-par%2Fs3%2Faws4_request&X-Amz-Date=20240625T150112Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=content-length%3Bcontent-type%3Bhost&X-Amz-Signature=5d99a1f60f0c4d1f6c48f3cfa4e2a6a2cd6669087e6a0283ce103cd5cca8aa18
+        url: https://s3.fr-par.scw.cloud/serverless-functions-code-prod-fr-par/uploads/function-573d15a7-c2da-45cc-a30b-f3752faf71fb.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=SCW3S98HDC0MAE9CBTQ5%2F20240705%2Ffr-par%2Fs3%2Faws4_request&X-Amz-Date=20240705T083518Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=content-length%3Bcontent-type%3Bhost&X-Amz-Signature=6f013125c8950855a372c9c1184834d708c4f0eac2a5583efcb90e01b0ccb494
         method: PUT
       response:
         proto: HTTP/2.0
@@ -349,20 +349,20 @@ interactions:
             Content-Type:
                 - text/html; charset=UTF-8
             Date:
-                - Tue, 25 Jun 2024 15:01:12 GMT
+                - Fri, 05 Jul 2024 08:35:19 GMT
             Etag:
                 - '"10633bf7a5ff211d8f3eee3856a28101"'
             Last-Modified:
-                - Tue, 25 Jun 2024 15:01:12 GMT
+                - Fri, 05 Jul 2024 08:35:19 GMT
             X-Amz-Id-2:
-                - tx589aa7554ebd46d6b1b79-00667adbb8
+                - txb77abd8d7be342eda6a4e-006687b046
             X-Amz-Request-Id:
-                - tx589aa7554ebd46d6b1b79-00667adbb8
+                - txb77abd8d7be342eda6a4e-006687b046
             X-Amz-Version-Id:
-                - "1719327672391001"
+                - "1720168519013390"
         status: 200 OK
         code: 200
-        duration: 440.652888ms
+        duration: 442.136292ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -380,8 +380,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/6658bd06-9799-4a07-9e0f-18dd19c2eb8f/deploy
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/573d15a7-c2da-45cc-a30b-f3752faf71fb/deploy
         method: POST
       response:
         proto: HTTP/2.0
@@ -389,20 +389,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 593
+        content_length: 585
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":70,"description":"","domain_name":"tffuncpracticalsnyde1eejycco-tf-func-admiring-wescoff.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"6658bd06-9799-4a07-9e0f-18dd19c2eb8f","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-func-admiring-wescoff","namespace_id":"dba63885-5261-4b30-a454-22045bbec32f","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncunruffledperlmv1mnq4p4-tf-func-serene-taussig.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"573d15a7-c2da-45cc-a30b-f3752faf71fb","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-serene-taussig","namespace_id":"a6109d4f-b972-4daf-a379-c287e625c00d","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
         headers:
             Content-Length:
-                - "593"
+                - "585"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 25 Jun 2024 15:01:12 GMT
+                - Fri, 05 Jul 2024 08:35:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -410,10 +410,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0f2e59db-9f32-4992-a668-094babff3e77
+                - f739add4-e6e7-48bb-af9b-1eda9ff406aa
         status: 200 OK
         code: 200
-        duration: 99.549841ms
+        duration: 105.474429ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -429,8 +429,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/6658bd06-9799-4a07-9e0f-18dd19c2eb8f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/573d15a7-c2da-45cc-a30b-f3752faf71fb
         method: GET
       response:
         proto: HTTP/2.0
@@ -438,20 +438,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 593
+        content_length: 585
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":70,"description":"","domain_name":"tffuncpracticalsnyde1eejycco-tf-func-admiring-wescoff.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"6658bd06-9799-4a07-9e0f-18dd19c2eb8f","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-func-admiring-wescoff","namespace_id":"dba63885-5261-4b30-a454-22045bbec32f","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncunruffledperlmv1mnq4p4-tf-func-serene-taussig.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"573d15a7-c2da-45cc-a30b-f3752faf71fb","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-serene-taussig","namespace_id":"a6109d4f-b972-4daf-a379-c287e625c00d","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
         headers:
             Content-Length:
-                - "593"
+                - "585"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 25 Jun 2024 15:01:12 GMT
+                - Fri, 05 Jul 2024 08:35:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -459,10 +459,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2cdda987-3652-4b16-a661-999d247184a4
+                - a77dac51-b0c3-4288-a680-892520613730
         status: 200 OK
         code: 200
-        duration: 71.194458ms
+        duration: 60.663615ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -478,8 +478,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/6658bd06-9799-4a07-9e0f-18dd19c2eb8f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/573d15a7-c2da-45cc-a30b-f3752faf71fb
         method: GET
       response:
         proto: HTTP/2.0
@@ -487,20 +487,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 642
+        content_length: 634
         uncompressed: false
-        body: '{"build_message":"step 1 of 3: function build preparation in progress","cpu_limit":70,"description":"","domain_name":"tffuncpracticalsnyde1eejycco-tf-func-admiring-wescoff.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"6658bd06-9799-4a07-9e0f-18dd19c2eb8f","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-func-admiring-wescoff","namespace_id":"dba63885-5261-4b30-a454-22045bbec32f","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        body: '{"build_message":"step 1 of 3: function build preparation in progress","cpu_limit":140,"description":"","domain_name":"tffuncunruffledperlmv1mnq4p4-tf-func-serene-taussig.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"573d15a7-c2da-45cc-a30b-f3752faf71fb","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-serene-taussig","namespace_id":"a6109d4f-b972-4daf-a379-c287e625c00d","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
         headers:
             Content-Length:
-                - "642"
+                - "634"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 25 Jun 2024 15:01:17 GMT
+                - Fri, 05 Jul 2024 08:35:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -508,10 +508,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 525919af-e64f-49d9-878c-0a4a446f3850
+                - e2bf517e-547e-432b-a054-5b9c914243a7
         status: 200 OK
         code: 200
-        duration: 79.764956ms
+        duration: 59.533642ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -527,8 +527,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/6658bd06-9799-4a07-9e0f-18dd19c2eb8f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/573d15a7-c2da-45cc-a30b-f3752faf71fb
         method: GET
       response:
         proto: HTTP/2.0
@@ -536,20 +536,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 630
+        content_length: 622
         uncompressed: false
-        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":70,"description":"","domain_name":"tffuncpracticalsnyde1eejycco-tf-func-admiring-wescoff.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"6658bd06-9799-4a07-9e0f-18dd19c2eb8f","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-func-admiring-wescoff","namespace_id":"dba63885-5261-4b30-a454-22045bbec32f","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"description":"","domain_name":"tffuncunruffledperlmv1mnq4p4-tf-func-serene-taussig.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"573d15a7-c2da-45cc-a30b-f3752faf71fb","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-serene-taussig","namespace_id":"a6109d4f-b972-4daf-a379-c287e625c00d","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
         headers:
             Content-Length:
-                - "630"
+                - "622"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 25 Jun 2024 15:01:23 GMT
+                - Fri, 05 Jul 2024 08:35:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -557,10 +557,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d7c073ef-7b5d-4336-8b29-526d93359ff2
+                - 356c9f69-e450-4e66-be48-77ec3b137990
         status: 200 OK
         code: 200
-        duration: 726.276018ms
+        duration: 75.3844ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -576,8 +576,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/6658bd06-9799-4a07-9e0f-18dd19c2eb8f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/573d15a7-c2da-45cc-a30b-f3752faf71fb
         method: GET
       response:
         proto: HTTP/2.0
@@ -585,20 +585,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 630
+        content_length: 622
         uncompressed: false
-        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":70,"description":"","domain_name":"tffuncpracticalsnyde1eejycco-tf-func-admiring-wescoff.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"6658bd06-9799-4a07-9e0f-18dd19c2eb8f","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-func-admiring-wescoff","namespace_id":"dba63885-5261-4b30-a454-22045bbec32f","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"description":"","domain_name":"tffuncunruffledperlmv1mnq4p4-tf-func-serene-taussig.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"573d15a7-c2da-45cc-a30b-f3752faf71fb","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-serene-taussig","namespace_id":"a6109d4f-b972-4daf-a379-c287e625c00d","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
         headers:
             Content-Length:
-                - "630"
+                - "622"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 25 Jun 2024 15:01:28 GMT
+                - Fri, 05 Jul 2024 08:35:34 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -606,10 +606,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 38883d4e-8379-4cdd-b660-0cd1d0806115
+                - 46e404f3-05c1-4f31-bcf4-d0f8cb10a26d
         status: 200 OK
         code: 200
-        duration: 153.720584ms
+        duration: 63.234725ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -625,8 +625,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/6658bd06-9799-4a07-9e0f-18dd19c2eb8f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/573d15a7-c2da-45cc-a30b-f3752faf71fb
         method: GET
       response:
         proto: HTTP/2.0
@@ -634,20 +634,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 630
+        content_length: 622
         uncompressed: false
-        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":70,"description":"","domain_name":"tffuncpracticalsnyde1eejycco-tf-func-admiring-wescoff.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"6658bd06-9799-4a07-9e0f-18dd19c2eb8f","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-func-admiring-wescoff","namespace_id":"dba63885-5261-4b30-a454-22045bbec32f","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"description":"","domain_name":"tffuncunruffledperlmv1mnq4p4-tf-func-serene-taussig.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"573d15a7-c2da-45cc-a30b-f3752faf71fb","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-serene-taussig","namespace_id":"a6109d4f-b972-4daf-a379-c287e625c00d","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
         headers:
             Content-Length:
-                - "630"
+                - "622"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 25 Jun 2024 15:01:33 GMT
+                - Fri, 05 Jul 2024 08:35:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -655,10 +655,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1e8848c5-30ae-444c-82e3-4e5eda69fc7f
+                - 80157d79-f2e4-4ee3-b199-daa49698537c
         status: 200 OK
         code: 200
-        duration: 75.078603ms
+        duration: 71.423951ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -674,8 +674,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/6658bd06-9799-4a07-9e0f-18dd19c2eb8f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/573d15a7-c2da-45cc-a30b-f3752faf71fb
         method: GET
       response:
         proto: HTTP/2.0
@@ -683,20 +683,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 630
+        content_length: 622
         uncompressed: false
-        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":70,"description":"","domain_name":"tffuncpracticalsnyde1eejycco-tf-func-admiring-wescoff.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"6658bd06-9799-4a07-9e0f-18dd19c2eb8f","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-func-admiring-wescoff","namespace_id":"dba63885-5261-4b30-a454-22045bbec32f","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"description":"","domain_name":"tffuncunruffledperlmv1mnq4p4-tf-func-serene-taussig.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"573d15a7-c2da-45cc-a30b-f3752faf71fb","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-serene-taussig","namespace_id":"a6109d4f-b972-4daf-a379-c287e625c00d","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
         headers:
             Content-Length:
-                - "630"
+                - "622"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 25 Jun 2024 15:01:38 GMT
+                - Fri, 05 Jul 2024 08:35:44 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -704,10 +704,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 97f7f45d-f645-4020-a987-6b2eb86ac6d1
+                - a4891a60-6c5a-4e96-a765-7ed03ca2125b
         status: 200 OK
         code: 200
-        duration: 62.311895ms
+        duration: 69.293776ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -723,8 +723,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/6658bd06-9799-4a07-9e0f-18dd19c2eb8f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/573d15a7-c2da-45cc-a30b-f3752faf71fb
         method: GET
       response:
         proto: HTTP/2.0
@@ -732,20 +732,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 630
+        content_length: 622
         uncompressed: false
-        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":70,"description":"","domain_name":"tffuncpracticalsnyde1eejycco-tf-func-admiring-wescoff.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"6658bd06-9799-4a07-9e0f-18dd19c2eb8f","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-func-admiring-wescoff","namespace_id":"dba63885-5261-4b30-a454-22045bbec32f","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"description":"","domain_name":"tffuncunruffledperlmv1mnq4p4-tf-func-serene-taussig.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"573d15a7-c2da-45cc-a30b-f3752faf71fb","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-serene-taussig","namespace_id":"a6109d4f-b972-4daf-a379-c287e625c00d","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
         headers:
             Content-Length:
-                - "630"
+                - "622"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 25 Jun 2024 15:01:43 GMT
+                - Fri, 05 Jul 2024 08:35:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -753,10 +753,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b26a1726-395c-41ab-9694-7c576f8e3f63
+                - 8db6d87f-9da4-4ae5-a6bb-03b461a9eba8
         status: 200 OK
         code: 200
-        duration: 726.341798ms
+        duration: 55.426388ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -772,8 +772,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/6658bd06-9799-4a07-9e0f-18dd19c2eb8f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/573d15a7-c2da-45cc-a30b-f3752faf71fb
         method: GET
       response:
         proto: HTTP/2.0
@@ -781,20 +781,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 656
+        content_length: 622
         uncompressed: false
-        body: '{"build_message":"step 3 of 3: function image is being pushed to container registry","cpu_limit":70,"description":"","domain_name":"tffuncpracticalsnyde1eejycco-tf-func-admiring-wescoff.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"6658bd06-9799-4a07-9e0f-18dd19c2eb8f","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-func-admiring-wescoff","namespace_id":"dba63885-5261-4b30-a454-22045bbec32f","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"description":"","domain_name":"tffuncunruffledperlmv1mnq4p4-tf-func-serene-taussig.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"573d15a7-c2da-45cc-a30b-f3752faf71fb","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-serene-taussig","namespace_id":"a6109d4f-b972-4daf-a379-c287e625c00d","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
         headers:
             Content-Length:
-                - "656"
+                - "622"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 25 Jun 2024 15:01:49 GMT
+                - Fri, 05 Jul 2024 08:35:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -802,10 +802,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 48fdbc5c-eda9-492b-8aed-fc95bcd56c9f
+                - 431ed2fe-89e3-4cbe-bfd2-3cf32b5391fb
         status: 200 OK
         code: 200
-        duration: 58.787027ms
+        duration: 64.134478ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -821,8 +821,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/6658bd06-9799-4a07-9e0f-18dd19c2eb8f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/573d15a7-c2da-45cc-a30b-f3752faf71fb
         method: GET
       response:
         proto: HTTP/2.0
@@ -830,20 +830,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 656
+        content_length: 622
         uncompressed: false
-        body: '{"build_message":"step 3 of 3: function image is being pushed to container registry","cpu_limit":70,"description":"","domain_name":"tffuncpracticalsnyde1eejycco-tf-func-admiring-wescoff.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"6658bd06-9799-4a07-9e0f-18dd19c2eb8f","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-func-admiring-wescoff","namespace_id":"dba63885-5261-4b30-a454-22045bbec32f","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"description":"","domain_name":"tffuncunruffledperlmv1mnq4p4-tf-func-serene-taussig.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"573d15a7-c2da-45cc-a30b-f3752faf71fb","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-serene-taussig","namespace_id":"a6109d4f-b972-4daf-a379-c287e625c00d","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
         headers:
             Content-Length:
-                - "656"
+                - "622"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 25 Jun 2024 15:01:54 GMT
+                - Fri, 05 Jul 2024 08:35:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -851,10 +851,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - dfbe1a7b-d6f7-4d8b-be9f-e2eac32d726e
+                - 5877b94d-3067-4b6c-b04e-0342e3bec7bd
         status: 200 OK
         code: 200
-        duration: 54.504273ms
+        duration: 86.629093ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -870,8 +870,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/6658bd06-9799-4a07-9e0f-18dd19c2eb8f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/573d15a7-c2da-45cc-a30b-f3752faf71fb
         method: GET
       response:
         proto: HTTP/2.0
@@ -879,20 +879,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 656
+        content_length: 622
         uncompressed: false
-        body: '{"build_message":"step 3 of 3: function image is being pushed to container registry","cpu_limit":70,"description":"","domain_name":"tffuncpracticalsnyde1eejycco-tf-func-admiring-wescoff.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"6658bd06-9799-4a07-9e0f-18dd19c2eb8f","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-func-admiring-wescoff","namespace_id":"dba63885-5261-4b30-a454-22045bbec32f","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"description":"","domain_name":"tffuncunruffledperlmv1mnq4p4-tf-func-serene-taussig.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"573d15a7-c2da-45cc-a30b-f3752faf71fb","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-serene-taussig","namespace_id":"a6109d4f-b972-4daf-a379-c287e625c00d","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
         headers:
             Content-Length:
-                - "656"
+                - "622"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 25 Jun 2024 15:01:59 GMT
+                - Fri, 05 Jul 2024 08:36:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -900,10 +900,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 95d4d66b-e6cb-4ba6-b82b-b96302004911
+                - 5506249f-e9d3-48e3-a269-a4227e18129d
         status: 200 OK
         code: 200
-        duration: 65.873733ms
+        duration: 60.799168ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -919,8 +919,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/6658bd06-9799-4a07-9e0f-18dd19c2eb8f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/573d15a7-c2da-45cc-a30b-f3752faf71fb
         method: GET
       response:
         proto: HTTP/2.0
@@ -928,20 +928,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 656
+        content_length: 648
         uncompressed: false
-        body: '{"build_message":"step 3 of 3: function image is being pushed to container registry","cpu_limit":70,"description":"","domain_name":"tffuncpracticalsnyde1eejycco-tf-func-admiring-wescoff.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"6658bd06-9799-4a07-9e0f-18dd19c2eb8f","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-func-admiring-wescoff","namespace_id":"dba63885-5261-4b30-a454-22045bbec32f","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        body: '{"build_message":"step 3 of 3: function image is being pushed to container registry","cpu_limit":140,"description":"","domain_name":"tffuncunruffledperlmv1mnq4p4-tf-func-serene-taussig.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"573d15a7-c2da-45cc-a30b-f3752faf71fb","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-serene-taussig","namespace_id":"a6109d4f-b972-4daf-a379-c287e625c00d","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
         headers:
             Content-Length:
-                - "656"
+                - "648"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 25 Jun 2024 15:02:04 GMT
+                - Fri, 05 Jul 2024 08:36:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -949,10 +949,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - eac87a1d-4d53-4560-911c-e5b266392b56
+                - 7f7c23ae-82fe-43c1-ba96-fa9570022a3e
         status: 200 OK
         code: 200
-        duration: 67.145152ms
+        duration: 67.75851ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -968,8 +968,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/6658bd06-9799-4a07-9e0f-18dd19c2eb8f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/573d15a7-c2da-45cc-a30b-f3752faf71fb
         method: GET
       response:
         proto: HTTP/2.0
@@ -977,20 +977,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 593
+        content_length: 648
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":70,"description":"","domain_name":"tffuncpracticalsnyde1eejycco-tf-func-admiring-wescoff.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"6658bd06-9799-4a07-9e0f-18dd19c2eb8f","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-func-admiring-wescoff","namespace_id":"dba63885-5261-4b30-a454-22045bbec32f","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        body: '{"build_message":"step 3 of 3: function image is being pushed to container registry","cpu_limit":140,"description":"","domain_name":"tffuncunruffledperlmv1mnq4p4-tf-func-serene-taussig.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"573d15a7-c2da-45cc-a30b-f3752faf71fb","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-serene-taussig","namespace_id":"a6109d4f-b972-4daf-a379-c287e625c00d","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
         headers:
             Content-Length:
-                - "593"
+                - "648"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 25 Jun 2024 15:02:09 GMT
+                - Fri, 05 Jul 2024 08:36:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -998,10 +998,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4114e0b9-f8e2-45e2-aa57-35e25fa79214
+                - c2809053-9de4-4d8d-ae4d-be6aba9ac43a
         status: 200 OK
         code: 200
-        duration: 62.371823ms
+        duration: 73.973262ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1017,8 +1017,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/6658bd06-9799-4a07-9e0f-18dd19c2eb8f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/573d15a7-c2da-45cc-a30b-f3752faf71fb
         method: GET
       response:
         proto: HTTP/2.0
@@ -1026,20 +1026,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 593
+        content_length: 648
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":70,"description":"","domain_name":"tffuncpracticalsnyde1eejycco-tf-func-admiring-wescoff.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"6658bd06-9799-4a07-9e0f-18dd19c2eb8f","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-func-admiring-wescoff","namespace_id":"dba63885-5261-4b30-a454-22045bbec32f","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        body: '{"build_message":"step 3 of 3: function image is being pushed to container registry","cpu_limit":140,"description":"","domain_name":"tffuncunruffledperlmv1mnq4p4-tf-func-serene-taussig.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"573d15a7-c2da-45cc-a30b-f3752faf71fb","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-serene-taussig","namespace_id":"a6109d4f-b972-4daf-a379-c287e625c00d","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
         headers:
             Content-Length:
-                - "593"
+                - "648"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 25 Jun 2024 15:02:14 GMT
+                - Fri, 05 Jul 2024 08:36:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1047,10 +1047,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c4bb6ffc-59e1-4099-82b0-8962300094b2
+                - 6e58872a-639a-4156-8060-023cafb0f984
         status: 200 OK
         code: 200
-        duration: 61.735272ms
+        duration: 74.836826ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1066,8 +1066,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/6658bd06-9799-4a07-9e0f-18dd19c2eb8f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/573d15a7-c2da-45cc-a30b-f3752faf71fb
         method: GET
       response:
         proto: HTTP/2.0
@@ -1075,20 +1075,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 593
+        content_length: 648
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":70,"description":"","domain_name":"tffuncpracticalsnyde1eejycco-tf-func-admiring-wescoff.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"6658bd06-9799-4a07-9e0f-18dd19c2eb8f","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-func-admiring-wescoff","namespace_id":"dba63885-5261-4b30-a454-22045bbec32f","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        body: '{"build_message":"step 3 of 3: function image is being pushed to container registry","cpu_limit":140,"description":"","domain_name":"tffuncunruffledperlmv1mnq4p4-tf-func-serene-taussig.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"573d15a7-c2da-45cc-a30b-f3752faf71fb","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-serene-taussig","namespace_id":"a6109d4f-b972-4daf-a379-c287e625c00d","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
         headers:
             Content-Length:
-                - "593"
+                - "648"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 25 Jun 2024 15:02:20 GMT
+                - Fri, 05 Jul 2024 08:36:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1096,10 +1096,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e60aaf4e-6397-4887-ad6a-8fb5352985f4
+                - 010cddae-47a7-4140-bcf2-111593cc2ecb
         status: 200 OK
         code: 200
-        duration: 69.719926ms
+        duration: 75.188347ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1115,8 +1115,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/6658bd06-9799-4a07-9e0f-18dd19c2eb8f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/573d15a7-c2da-45cc-a30b-f3752faf71fb
         method: GET
       response:
         proto: HTTP/2.0
@@ -1124,20 +1124,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 593
+        content_length: 585
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":70,"description":"","domain_name":"tffuncpracticalsnyde1eejycco-tf-func-admiring-wescoff.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"6658bd06-9799-4a07-9e0f-18dd19c2eb8f","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-func-admiring-wescoff","namespace_id":"dba63885-5261-4b30-a454-22045bbec32f","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncunruffledperlmv1mnq4p4-tf-func-serene-taussig.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"573d15a7-c2da-45cc-a30b-f3752faf71fb","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-serene-taussig","namespace_id":"a6109d4f-b972-4daf-a379-c287e625c00d","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
         headers:
             Content-Length:
-                - "593"
+                - "585"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 25 Jun 2024 15:02:25 GMT
+                - Fri, 05 Jul 2024 08:36:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1145,10 +1145,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 07a1feda-8853-41db-aeb5-1cf9f29f8632
+                - ab351b46-0240-4815-9a7e-7d28c7d75c6a
         status: 200 OK
         code: 200
-        duration: 698.622087ms
+        duration: 57.064248ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1164,8 +1164,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/6658bd06-9799-4a07-9e0f-18dd19c2eb8f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/573d15a7-c2da-45cc-a30b-f3752faf71fb
         method: GET
       response:
         proto: HTTP/2.0
@@ -1173,20 +1173,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 593
+        content_length: 585
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":70,"description":"","domain_name":"tffuncpracticalsnyde1eejycco-tf-func-admiring-wescoff.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"6658bd06-9799-4a07-9e0f-18dd19c2eb8f","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-func-admiring-wescoff","namespace_id":"dba63885-5261-4b30-a454-22045bbec32f","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncunruffledperlmv1mnq4p4-tf-func-serene-taussig.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"573d15a7-c2da-45cc-a30b-f3752faf71fb","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-serene-taussig","namespace_id":"a6109d4f-b972-4daf-a379-c287e625c00d","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
         headers:
             Content-Length:
-                - "593"
+                - "585"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 25 Jun 2024 15:02:30 GMT
+                - Fri, 05 Jul 2024 08:36:35 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1194,10 +1194,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 705bedd8-01c0-4cac-b5e4-b9f7ebb3d1e3
+                - a520ab91-9746-45f0-ad31-a2bc1b35bbed
         status: 200 OK
         code: 200
-        duration: 68.077616ms
+        duration: 77.348237ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1213,8 +1213,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/6658bd06-9799-4a07-9e0f-18dd19c2eb8f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/573d15a7-c2da-45cc-a30b-f3752faf71fb
         method: GET
       response:
         proto: HTTP/2.0
@@ -1222,20 +1222,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 593
+        content_length: 585
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":70,"description":"","domain_name":"tffuncpracticalsnyde1eejycco-tf-func-admiring-wescoff.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"6658bd06-9799-4a07-9e0f-18dd19c2eb8f","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-func-admiring-wescoff","namespace_id":"dba63885-5261-4b30-a454-22045bbec32f","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncunruffledperlmv1mnq4p4-tf-func-serene-taussig.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"573d15a7-c2da-45cc-a30b-f3752faf71fb","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-serene-taussig","namespace_id":"a6109d4f-b972-4daf-a379-c287e625c00d","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
         headers:
             Content-Length:
-                - "593"
+                - "585"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 25 Jun 2024 15:02:35 GMT
+                - Fri, 05 Jul 2024 08:36:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1243,10 +1243,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ea794862-6660-41e1-b6b8-f49ac705428f
+                - 5d6a1972-aa8f-445e-aa0a-a361011ed822
         status: 200 OK
         code: 200
-        duration: 61.540887ms
+        duration: 57.44886ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1262,8 +1262,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/6658bd06-9799-4a07-9e0f-18dd19c2eb8f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/573d15a7-c2da-45cc-a30b-f3752faf71fb
         method: GET
       response:
         proto: HTTP/2.0
@@ -1271,20 +1271,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 591
+        content_length: 585
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":70,"description":"","domain_name":"tffuncpracticalsnyde1eejycco-tf-func-admiring-wescoff.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"6658bd06-9799-4a07-9e0f-18dd19c2eb8f","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-func-admiring-wescoff","namespace_id":"dba63885-5261-4b30-a454-22045bbec32f","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"ready","timeout":"300s"}'
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncunruffledperlmv1mnq4p4-tf-func-serene-taussig.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"573d15a7-c2da-45cc-a30b-f3752faf71fb","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-serene-taussig","namespace_id":"a6109d4f-b972-4daf-a379-c287e625c00d","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
         headers:
             Content-Length:
-                - "591"
+                - "585"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 25 Jun 2024 15:02:40 GMT
+                - Fri, 05 Jul 2024 08:36:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1292,10 +1292,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3a233bf6-17f3-4bd9-8415-246f043cd96b
+                - 05734447-dfef-4025-8de0-ed911c46bcf1
         status: 200 OK
         code: 200
-        duration: 68.642466ms
+        duration: 86.682844ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1311,8 +1311,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/6658bd06-9799-4a07-9e0f-18dd19c2eb8f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/573d15a7-c2da-45cc-a30b-f3752faf71fb
         method: GET
       response:
         proto: HTTP/2.0
@@ -1320,20 +1320,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 591
+        content_length: 585
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":70,"description":"","domain_name":"tffuncpracticalsnyde1eejycco-tf-func-admiring-wescoff.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"6658bd06-9799-4a07-9e0f-18dd19c2eb8f","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-func-admiring-wescoff","namespace_id":"dba63885-5261-4b30-a454-22045bbec32f","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"ready","timeout":"300s"}'
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncunruffledperlmv1mnq4p4-tf-func-serene-taussig.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"573d15a7-c2da-45cc-a30b-f3752faf71fb","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-serene-taussig","namespace_id":"a6109d4f-b972-4daf-a379-c287e625c00d","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
         headers:
             Content-Length:
-                - "591"
+                - "585"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 25 Jun 2024 15:02:41 GMT
+                - Fri, 05 Jul 2024 08:36:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1341,10 +1341,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 21e2cec3-a02a-4e72-8b4c-c3b392f22237
+                - 928e8f4b-3aef-47ac-aaa3-2c7fab323bbc
         status: 200 OK
         code: 200
-        duration: 57.265769ms
+        duration: 57.944913ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1360,8 +1360,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/dba63885-5261-4b30-a454-22045bbec32f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/573d15a7-c2da-45cc-a30b-f3752faf71fb
         method: GET
       response:
         proto: HTTP/2.0
@@ -1369,20 +1369,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 474
+        content_length: 585
         uncompressed: false
-        body: '{"description":"","environment_variables":{},"error_message":null,"id":"dba63885-5261-4b30-a454-22045bbec32f","name":"tf-func-practical-snyder","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncpracticalsnyde1eejycco","registry_namespace_id":"896c22a4-b3f1-4ed7-9fec-6e0e7f69e3c5","secret_environment_variables":[],"status":"ready"}'
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncunruffledperlmv1mnq4p4-tf-func-serene-taussig.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"573d15a7-c2da-45cc-a30b-f3752faf71fb","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-serene-taussig","namespace_id":"a6109d4f-b972-4daf-a379-c287e625c00d","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
         headers:
             Content-Length:
-                - "474"
+                - "585"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 25 Jun 2024 15:02:41 GMT
+                - Fri, 05 Jul 2024 08:36:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1390,10 +1390,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 16c1c288-13d5-47cc-bf88-5ca01b552235
+                - 4c374504-73d0-4424-99da-dca26ac24888
         status: 200 OK
         code: 200
-        duration: 61.274515ms
+        duration: 61.271346ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1409,8 +1409,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/dba63885-5261-4b30-a454-22045bbec32f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/573d15a7-c2da-45cc-a30b-f3752faf71fb
         method: GET
       response:
         proto: HTTP/2.0
@@ -1418,20 +1418,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 474
+        content_length: 585
         uncompressed: false
-        body: '{"description":"","environment_variables":{},"error_message":null,"id":"dba63885-5261-4b30-a454-22045bbec32f","name":"tf-func-practical-snyder","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncpracticalsnyde1eejycco","registry_namespace_id":"896c22a4-b3f1-4ed7-9fec-6e0e7f69e3c5","secret_environment_variables":[],"status":"ready"}'
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncunruffledperlmv1mnq4p4-tf-func-serene-taussig.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"573d15a7-c2da-45cc-a30b-f3752faf71fb","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-serene-taussig","namespace_id":"a6109d4f-b972-4daf-a379-c287e625c00d","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
         headers:
             Content-Length:
-                - "474"
+                - "585"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 25 Jun 2024 15:03:04 GMT
+                - Fri, 05 Jul 2024 08:37:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1439,10 +1439,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0bc617e0-dfca-48e6-a883-cbf6800fae70
+                - e6928bcf-7888-40f3-8454-3e23d20fdca8
         status: 200 OK
         code: 200
-        duration: 50.154973ms
+        duration: 58.416119ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1458,8 +1458,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/dba63885-5261-4b30-a454-22045bbec32f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/573d15a7-c2da-45cc-a30b-f3752faf71fb
         method: GET
       response:
         proto: HTTP/2.0
@@ -1467,20 +1467,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 474
+        content_length: 585
         uncompressed: false
-        body: '{"description":"","environment_variables":{},"error_message":null,"id":"dba63885-5261-4b30-a454-22045bbec32f","name":"tf-func-practical-snyder","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncpracticalsnyde1eejycco","registry_namespace_id":"896c22a4-b3f1-4ed7-9fec-6e0e7f69e3c5","secret_environment_variables":[],"status":"ready"}'
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncunruffledperlmv1mnq4p4-tf-func-serene-taussig.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"573d15a7-c2da-45cc-a30b-f3752faf71fb","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-serene-taussig","namespace_id":"a6109d4f-b972-4daf-a379-c287e625c00d","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
         headers:
             Content-Length:
-                - "474"
+                - "585"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 25 Jun 2024 15:03:05 GMT
+                - Fri, 05 Jul 2024 08:37:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1488,10 +1488,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e54bd9d8-af25-46d9-a729-507f48af81d1
+                - 62406c30-6d11-466e-8458-5c5161a6c232
         status: 200 OK
         code: 200
-        duration: 304.317572ms
+        duration: 59.16141ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1507,8 +1507,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/6658bd06-9799-4a07-9e0f-18dd19c2eb8f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/573d15a7-c2da-45cc-a30b-f3752faf71fb
         method: GET
       response:
         proto: HTTP/2.0
@@ -1516,20 +1516,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 591
+        content_length: 585
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":70,"description":"","domain_name":"tffuncpracticalsnyde1eejycco-tf-func-admiring-wescoff.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"6658bd06-9799-4a07-9e0f-18dd19c2eb8f","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-func-admiring-wescoff","namespace_id":"dba63885-5261-4b30-a454-22045bbec32f","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"ready","timeout":"300s"}'
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncunruffledperlmv1mnq4p4-tf-func-serene-taussig.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"573d15a7-c2da-45cc-a30b-f3752faf71fb","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-serene-taussig","namespace_id":"a6109d4f-b972-4daf-a379-c287e625c00d","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
         headers:
             Content-Length:
-                - "591"
+                - "585"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 25 Jun 2024 15:03:05 GMT
+                - Fri, 05 Jul 2024 08:37:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1537,10 +1537,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c4ec104c-fc55-4df6-b60a-0b85ebff033c
+                - 5e57eef3-7c11-4831-ab71-2b746c3a62a4
         status: 200 OK
         code: 200
-        duration: 64.746508ms
+        duration: 61.172221ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1556,8 +1556,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/dba63885-5261-4b30-a454-22045bbec32f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/573d15a7-c2da-45cc-a30b-f3752faf71fb
         method: GET
       response:
         proto: HTTP/2.0
@@ -1565,20 +1565,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 474
+        content_length: 585
         uncompressed: false
-        body: '{"description":"","environment_variables":{},"error_message":null,"id":"dba63885-5261-4b30-a454-22045bbec32f","name":"tf-func-practical-snyder","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncpracticalsnyde1eejycco","registry_namespace_id":"896c22a4-b3f1-4ed7-9fec-6e0e7f69e3c5","secret_environment_variables":[],"status":"ready"}'
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncunruffledperlmv1mnq4p4-tf-func-serene-taussig.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"573d15a7-c2da-45cc-a30b-f3752faf71fb","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-serene-taussig","namespace_id":"a6109d4f-b972-4daf-a379-c287e625c00d","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
         headers:
             Content-Length:
-                - "474"
+                - "585"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 25 Jun 2024 15:03:05 GMT
+                - Fri, 05 Jul 2024 08:37:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1586,10 +1586,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e0ec0e69-bb34-4342-b21d-81195d283912
+                - f7224531-5cae-428f-a601-7d2552151327
         status: 200 OK
         code: 200
-        duration: 67.07745ms
+        duration: 62.535693ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1605,8 +1605,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/6658bd06-9799-4a07-9e0f-18dd19c2eb8f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/573d15a7-c2da-45cc-a30b-f3752faf71fb
         method: GET
       response:
         proto: HTTP/2.0
@@ -1614,20 +1614,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 591
+        content_length: 583
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":70,"description":"","domain_name":"tffuncpracticalsnyde1eejycco-tf-func-admiring-wescoff.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"6658bd06-9799-4a07-9e0f-18dd19c2eb8f","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-func-admiring-wescoff","namespace_id":"dba63885-5261-4b30-a454-22045bbec32f","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"ready","timeout":"300s"}'
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncunruffledperlmv1mnq4p4-tf-func-serene-taussig.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"573d15a7-c2da-45cc-a30b-f3752faf71fb","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-serene-taussig","namespace_id":"a6109d4f-b972-4daf-a379-c287e625c00d","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"ready","timeout":"300s"}'
         headers:
             Content-Length:
-                - "591"
+                - "583"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 25 Jun 2024 15:03:06 GMT
+                - Fri, 05 Jul 2024 08:37:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1635,50 +1635,48 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fad9c129-db18-4d2e-bb5f-00885125f2c1
+                - 1637001c-6dac-4172-a7b5-84c185c71df0
         status: 200 OK
         code: 200
-        duration: 58.471213ms
+        duration: 69.091596ms
     - id: 33
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 273
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"changes":[{"add":{"records":[{"data":"tffuncpracticalsnyde1eejycco-tf-func-admiring-wescoff.functions.fnc.fr-par.scw.cloud.","name":"container","priority":0,"ttl":60,"type":"CNAME","comment":null,"id":""}]}}],"return_all_records":false,"disallow_new_zone_creation":false}'
+        body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/domain/v2beta1/dns-zones/function-basic.scaleway-terraform.com/records
-        method: PATCH
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/573d15a7-c2da-45cc-a30b-f3752faf71fb
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 231
+        content_length: 583
         uncompressed: false
-        body: '{"records":[{"comment":null,"data":"tffuncpracticalsnyde1eejycco-tf-func-admiring-wescoff.functions.fnc.fr-par.scw.cloud.","id":"94fd4408-d3a5-4acd-96f0-5e439c236ead","name":"container","priority":0,"ttl":60,"type":"CNAME"}]}'
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncunruffledperlmv1mnq4p4-tf-func-serene-taussig.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"573d15a7-c2da-45cc-a30b-f3752faf71fb","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-serene-taussig","namespace_id":"a6109d4f-b972-4daf-a379-c287e625c00d","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"ready","timeout":"300s"}'
         headers:
             Content-Length:
-                - "231"
+                - "583"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 25 Jun 2024 15:03:06 GMT
+                - Fri, 05 Jul 2024 08:37:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1686,10 +1684,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0900683e-dba2-4e77-90e0-112d6a5df8c2
+                - 9b82577b-d09b-465d-ac3a-ff5797926b09
         status: 200 OK
         code: 200
-        duration: 534.805176ms
+        duration: 77.349049ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1705,8 +1703,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/domain/v2beta1/dns-zones/function-basic.scaleway-terraform.com/records?name=container&order_by=name_asc&type=CNAME
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/a6109d4f-b972-4daf-a379-c287e625c00d
         method: GET
       response:
         proto: HTTP/2.0
@@ -1714,20 +1712,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 248
+        content_length: 464
         uncompressed: false
-        body: '{"records":[{"comment":null,"data":"tffuncpracticalsnyde1eejycco-tf-func-admiring-wescoff.functions.fnc.fr-par.scw.cloud.","id":"94fd4408-d3a5-4acd-96f0-5e439c236ead","name":"container","priority":0,"ttl":60,"type":"CNAME"}],"total_count":1}'
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"a6109d4f-b972-4daf-a379-c287e625c00d","name":"tf-func-unruffled-perlman","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncunruffledperlmv1mnq4p4","registry_namespace_id":"2ce80c58-94cd-4437-b6ae-df094cac46ff","secret_environment_variables":[],"status":"ready"}'
         headers:
             Content-Length:
-                - "248"
+                - "464"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 25 Jun 2024 15:03:07 GMT
+                - Fri, 05 Jul 2024 08:37:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1735,10 +1733,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 52a57370-dfb8-4d13-a82d-4f5a9775b0e5
+                - 089b25d6-6153-45f9-9418-e727ac09750f
         status: 200 OK
         code: 200
-        duration: 55.290474ms
+        duration: 70.921386ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1754,8 +1752,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/domain/v2beta1/dns-zones/function-basic.scaleway-terraform.com/records?name=container&order_by=name_asc&page=1&type=CNAME
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/a6109d4f-b972-4daf-a379-c287e625c00d
         method: GET
       response:
         proto: HTTP/2.0
@@ -1763,20 +1761,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 248
+        content_length: 464
         uncompressed: false
-        body: '{"records":[{"comment":null,"data":"tffuncpracticalsnyde1eejycco-tf-func-admiring-wescoff.functions.fnc.fr-par.scw.cloud.","id":"94fd4408-d3a5-4acd-96f0-5e439c236ead","name":"container","priority":0,"ttl":60,"type":"CNAME"}],"total_count":1}'
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"a6109d4f-b972-4daf-a379-c287e625c00d","name":"tf-func-unruffled-perlman","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncunruffledperlmv1mnq4p4","registry_namespace_id":"2ce80c58-94cd-4437-b6ae-df094cac46ff","secret_environment_variables":[],"status":"ready"}'
         headers:
             Content-Length:
-                - "248"
+                - "464"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 25 Jun 2024 15:03:07 GMT
+                - Fri, 05 Jul 2024 08:37:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1784,10 +1782,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f6912afe-3dff-4654-b96c-ec6125484920
+                - 038af346-892e-4dcb-b77b-1e6fbf5f2c95
         status: 200 OK
         code: 200
-        duration: 66.362436ms
+        duration: 64.093291ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1803,8 +1801,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/domain/v2beta1/dns-zones/function-basic.scaleway-terraform.com/records?id=94fd4408-d3a5-4acd-96f0-5e439c236ead&name=&order_by=name_asc&page=1&type=unknown
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a6109d4f-b972-4daf-a379-c287e625c00d
         method: GET
       response:
         proto: HTTP/2.0
@@ -1812,20 +1810,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 248
+        content_length: 464
         uncompressed: false
-        body: '{"records":[{"comment":null,"data":"tffuncpracticalsnyde1eejycco-tf-func-admiring-wescoff.functions.fnc.fr-par.scw.cloud.","id":"94fd4408-d3a5-4acd-96f0-5e439c236ead","name":"container","priority":0,"ttl":60,"type":"CNAME"}],"total_count":1}'
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"a6109d4f-b972-4daf-a379-c287e625c00d","name":"tf-func-unruffled-perlman","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncunruffledperlmv1mnq4p4","registry_namespace_id":"2ce80c58-94cd-4437-b6ae-df094cac46ff","secret_environment_variables":[],"status":"ready"}'
         headers:
             Content-Length:
-                - "248"
+                - "464"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 25 Jun 2024 15:03:07 GMT
+                - Fri, 05 Jul 2024 08:37:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1833,10 +1831,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6aca13df-1484-4b76-9c31-a7f030d2daba
+                - 46fc32e5-31db-4181-bc8a-4d08c886a865
         status: 200 OK
         code: 200
-        duration: 237.206779ms
+        duration: 67.485697ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1852,8 +1850,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zones=function-basic.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/573d15a7-c2da-45cc-a30b-f3752faf71fb
         method: GET
       response:
         proto: HTTP/2.0
@@ -1861,20 +1859,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 368
+        content_length: 583
         uncompressed: false
-        body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"function-basic","updated_at":"2024-06-25T15:03:06Z"}],"total_count":1}'
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncunruffledperlmv1mnq4p4-tf-func-serene-taussig.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"573d15a7-c2da-45cc-a30b-f3752faf71fb","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-serene-taussig","namespace_id":"a6109d4f-b972-4daf-a379-c287e625c00d","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"ready","timeout":"300s"}'
         headers:
             Content-Length:
-                - "368"
+                - "583"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 25 Jun 2024 15:03:07 GMT
+                - Fri, 05 Jul 2024 08:37:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1882,10 +1880,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ab68faae-1f5c-4409-8105-bc0d42d4bb96
+                - f90d753f-6f88-4465-96ca-72fcc004b19e
         status: 200 OK
         code: 200
-        duration: 89.711335ms
+        duration: 70.382412ms
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1901,8 +1899,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/6658bd06-9799-4a07-9e0f-18dd19c2eb8f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a6109d4f-b972-4daf-a379-c287e625c00d
         method: GET
       response:
         proto: HTTP/2.0
@@ -1910,20 +1908,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 591
+        content_length: 464
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":70,"description":"","domain_name":"tffuncpracticalsnyde1eejycco-tf-func-admiring-wescoff.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"6658bd06-9799-4a07-9e0f-18dd19c2eb8f","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-func-admiring-wescoff","namespace_id":"dba63885-5261-4b30-a454-22045bbec32f","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"ready","timeout":"300s"}'
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"a6109d4f-b972-4daf-a379-c287e625c00d","name":"tf-func-unruffled-perlman","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncunruffledperlmv1mnq4p4","registry_namespace_id":"2ce80c58-94cd-4437-b6ae-df094cac46ff","secret_environment_variables":[],"status":"ready"}'
         headers:
             Content-Length:
-                - "591"
+                - "464"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 25 Jun 2024 15:03:07 GMT
+                - Fri, 05 Jul 2024 08:37:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1931,62 +1929,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c2131c4b-7bf5-4eee-9639-aa7096313bbb
+                - f3564687-b74c-42a7-af7f-27e85aa1a636
         status: 200 OK
         code: 200
-        duration: 55.039994ms
+        duration: 70.150527ms
     - id: 39
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 115
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"hostname":"container.function-basic.scaleway-terraform.com","function_id":"6658bd06-9799-4a07-9e0f-18dd19c2eb8f"}'
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 213
-        uncompressed: false
-        body: '{"error_message":null,"function_id":"6658bd06-9799-4a07-9e0f-18dd19c2eb8f","hostname":"container.function-basic.scaleway-terraform.com","id":"344d1939-01db-4ab4-83eb-dc14585609b5","status":"pending","url":""}'
-        headers:
-            Content-Length:
-                - "213"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 25 Jun 2024 15:03:12 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - b5c6b521-4dab-4cb4-b712-23c5efbb036b
-        status: 200 OK
-        code: 200
-        duration: 76.996673ms
-    - id: 40
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2001,8 +1948,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/344d1939-01db-4ab4-83eb-dc14585609b5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/573d15a7-c2da-45cc-a30b-f3752faf71fb
         method: GET
       response:
         proto: HTTP/2.0
@@ -2010,20 +1957,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 213
+        content_length: 583
         uncompressed: false
-        body: '{"error_message":null,"function_id":"6658bd06-9799-4a07-9e0f-18dd19c2eb8f","hostname":"container.function-basic.scaleway-terraform.com","id":"344d1939-01db-4ab4-83eb-dc14585609b5","status":"pending","url":""}'
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncunruffledperlmv1mnq4p4-tf-func-serene-taussig.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"573d15a7-c2da-45cc-a30b-f3752faf71fb","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-serene-taussig","namespace_id":"a6109d4f-b972-4daf-a379-c287e625c00d","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"ready","timeout":"300s"}'
         headers:
             Content-Length:
-                - "213"
+                - "583"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 25 Jun 2024 15:03:12 GMT
+                - Fri, 05 Jul 2024 08:37:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2031,10 +1978,61 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8ff66125-21e9-47c2-b1be-42803f8ba0e3
+                - 976c42a6-1370-432e-907c-5bb21b15bf5f
         status: 200 OK
         code: 200
-        duration: 60.576043ms
+        duration: 76.140627ms
+    - id: 40
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 271
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"changes":[{"add":{"records":[{"data":"tffuncunruffledperlmv1mnq4p4-tf-func-serene-taussig.functions.fnc.fr-par.scw.cloud.","name":"container","priority":0,"ttl":60,"type":"CNAME","comment":null,"id":""}]}}],"return_all_records":false,"disallow_new_zone_creation":false}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/domain/v2beta1/dns-zones/function-basic.scaleway-terraform.com/records
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 223
+        uncompressed: false
+        body: '{"records":[{"comment":null,"data":"tffuncunruffledperlmv1mnq4p4-tf-func-serene-taussig.functions.fnc.fr-par.scw.cloud.","id":"9d42c723-66da-414a-930a-5791c26a0edd","name":"container","priority":0,"ttl":60,"type":"CNAME"}]}'
+        headers:
+            Content-Length:
+                - "223"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:37:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 1ca6dc2a-82e6-4057-b2ef-14a160058eda
+        status: 200 OK
+        code: 200
+        duration: 503.193911ms
     - id: 41
       request:
         proto: HTTP/1.1
@@ -2050,8 +2048,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/344d1939-01db-4ab4-83eb-dc14585609b5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/domain/v2beta1/dns-zones/function-basic.scaleway-terraform.com/records?name=container&order_by=name_asc&type=CNAME
         method: GET
       response:
         proto: HTTP/2.0
@@ -2059,20 +2057,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 213
+        content_length: 239
         uncompressed: false
-        body: '{"error_message":null,"function_id":"6658bd06-9799-4a07-9e0f-18dd19c2eb8f","hostname":"container.function-basic.scaleway-terraform.com","id":"344d1939-01db-4ab4-83eb-dc14585609b5","status":"pending","url":""}'
+        body: '{"records":[{"comment":null,"data":"tffuncunruffledperlmv1mnq4p4-tf-func-serene-taussig.functions.fnc.fr-par.scw.cloud.","id":"9d42c723-66da-414a-930a-5791c26a0edd","name":"container","priority":0,"ttl":60,"type":"CNAME"}],"total_count":1}'
         headers:
             Content-Length:
-                - "213"
+                - "239"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 25 Jun 2024 15:03:17 GMT
+                - Fri, 05 Jul 2024 08:37:52 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2080,10 +2078,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1f30cf0b-c8cd-403f-b8c0-065c35c8d4ac
+                - 3a678cec-c1e6-4320-b69d-6f6637991af4
         status: 200 OK
         code: 200
-        duration: 77.929501ms
+        duration: 72.076367ms
     - id: 42
       request:
         proto: HTTP/1.1
@@ -2099,8 +2097,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/344d1939-01db-4ab4-83eb-dc14585609b5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/domain/v2beta1/dns-zones/function-basic.scaleway-terraform.com/records?name=container&order_by=name_asc&page=1&type=CNAME
         method: GET
       response:
         proto: HTTP/2.0
@@ -2108,20 +2106,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 213
+        content_length: 239
         uncompressed: false
-        body: '{"error_message":null,"function_id":"6658bd06-9799-4a07-9e0f-18dd19c2eb8f","hostname":"container.function-basic.scaleway-terraform.com","id":"344d1939-01db-4ab4-83eb-dc14585609b5","status":"pending","url":""}'
+        body: '{"records":[{"comment":null,"data":"tffuncunruffledperlmv1mnq4p4-tf-func-serene-taussig.functions.fnc.fr-par.scw.cloud.","id":"9d42c723-66da-414a-930a-5791c26a0edd","name":"container","priority":0,"ttl":60,"type":"CNAME"}],"total_count":1}'
         headers:
             Content-Length:
-                - "213"
+                - "239"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 25 Jun 2024 15:03:22 GMT
+                - Fri, 05 Jul 2024 08:37:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2129,10 +2127,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9fcd3a63-7016-49d9-87c0-454105ca5ce6
+                - 6b1cc6d0-3f7e-4fb6-ae71-ed05ecb5012c
         status: 200 OK
         code: 200
-        duration: 68.878753ms
+        duration: 78.068891ms
     - id: 43
       request:
         proto: HTTP/1.1
@@ -2148,8 +2146,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/344d1939-01db-4ab4-83eb-dc14585609b5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/domain/v2beta1/dns-zones/function-basic.scaleway-terraform.com/records?id=9d42c723-66da-414a-930a-5791c26a0edd&name=&order_by=name_asc&page=1&type=unknown
         method: GET
       response:
         proto: HTTP/2.0
@@ -2157,20 +2155,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 213
+        content_length: 239
         uncompressed: false
-        body: '{"error_message":null,"function_id":"6658bd06-9799-4a07-9e0f-18dd19c2eb8f","hostname":"container.function-basic.scaleway-terraform.com","id":"344d1939-01db-4ab4-83eb-dc14585609b5","status":"pending","url":""}'
+        body: '{"records":[{"comment":null,"data":"tffuncunruffledperlmv1mnq4p4-tf-func-serene-taussig.functions.fnc.fr-par.scw.cloud.","id":"9d42c723-66da-414a-930a-5791c26a0edd","name":"container","priority":0,"ttl":60,"type":"CNAME"}],"total_count":1}'
         headers:
             Content-Length:
-                - "213"
+                - "239"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 25 Jun 2024 15:03:27 GMT
+                - Fri, 05 Jul 2024 08:37:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2178,10 +2176,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 782bd5c9-53e7-4277-b75d-6534a04b3623
+                - 6e5f3cf3-e11c-46a6-91da-c39e3e16d5ac
         status: 200 OK
         code: 200
-        duration: 83.869893ms
+        duration: 70.776013ms
     - id: 44
       request:
         proto: HTTP/1.1
@@ -2197,8 +2195,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/344d1939-01db-4ab4-83eb-dc14585609b5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zones=function-basic.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -2206,20 +2204,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 213
+        content_length: 356
         uncompressed: false
-        body: '{"error_message":null,"function_id":"6658bd06-9799-4a07-9e0f-18dd19c2eb8f","hostname":"container.function-basic.scaleway-terraform.com","id":"344d1939-01db-4ab4-83eb-dc14585609b5","status":"pending","url":""}'
+        body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"function-basic","updated_at":"2024-07-05T08:37:52Z"}],"total_count":1}'
         headers:
             Content-Length:
-                - "213"
+                - "356"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 25 Jun 2024 15:03:33 GMT
+                - Fri, 05 Jul 2024 08:37:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2227,10 +2225,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d26b2411-5854-442d-b1f5-8e6748c6fff1
+                - fceb4134-d91a-4da3-82a2-7882c3060693
         status: 200 OK
         code: 200
-        duration: 96.875968ms
+        duration: 68.530612ms
     - id: 45
       request:
         proto: HTTP/1.1
@@ -2246,8 +2244,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/344d1939-01db-4ab4-83eb-dc14585609b5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/573d15a7-c2da-45cc-a30b-f3752faf71fb
         method: GET
       response:
         proto: HTTP/2.0
@@ -2255,20 +2253,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 213
+        content_length: 583
         uncompressed: false
-        body: '{"error_message":null,"function_id":"6658bd06-9799-4a07-9e0f-18dd19c2eb8f","hostname":"container.function-basic.scaleway-terraform.com","id":"344d1939-01db-4ab4-83eb-dc14585609b5","status":"pending","url":""}'
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncunruffledperlmv1mnq4p4-tf-func-serene-taussig.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"573d15a7-c2da-45cc-a30b-f3752faf71fb","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-serene-taussig","namespace_id":"a6109d4f-b972-4daf-a379-c287e625c00d","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"ready","timeout":"300s"}'
         headers:
             Content-Length:
-                - "213"
+                - "583"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 25 Jun 2024 15:03:38 GMT
+                - Fri, 05 Jul 2024 08:37:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2276,48 +2274,50 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - eff9e78b-b03f-4b82-938d-22195b8d9663
+                - 8aee6b31-554c-4da6-b260-40cc4ded7699
         status: 200 OK
         code: 200
-        duration: 71.959593ms
+        duration: 72.077379ms
     - id: 46
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 115
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"hostname":"container.function-basic.scaleway-terraform.com","function_id":"573d15a7-c2da-45cc-a30b-f3752faf71fb"}'
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/344d1939-01db-4ab4-83eb-dc14585609b5
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 213
+        content_length: 208
         uncompressed: false
-        body: '{"error_message":null,"function_id":"6658bd06-9799-4a07-9e0f-18dd19c2eb8f","hostname":"container.function-basic.scaleway-terraform.com","id":"344d1939-01db-4ab4-83eb-dc14585609b5","status":"pending","url":""}'
+        body: '{"error_message":null,"function_id":"573d15a7-c2da-45cc-a30b-f3752faf71fb","hostname":"container.function-basic.scaleway-terraform.com","id":"6185b610-e3c3-4c76-8422-d484a785ff39","status":"pending","url":""}'
         headers:
             Content-Length:
-                - "213"
+                - "208"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 25 Jun 2024 15:03:43 GMT
+                - Fri, 05 Jul 2024 08:37:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2325,10 +2325,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f0dda817-46d3-486a-b59c-9ce87fff3f71
+                - 58bdc042-8aed-490d-a808-70e234995922
         status: 200 OK
         code: 200
-        duration: 84.58606ms
+        duration: 79.114377ms
     - id: 47
       request:
         proto: HTTP/1.1
@@ -2344,8 +2344,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/344d1939-01db-4ab4-83eb-dc14585609b5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/6185b610-e3c3-4c76-8422-d484a785ff39
         method: GET
       response:
         proto: HTTP/2.0
@@ -2353,20 +2353,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 213
+        content_length: 208
         uncompressed: false
-        body: '{"error_message":null,"function_id":"6658bd06-9799-4a07-9e0f-18dd19c2eb8f","hostname":"container.function-basic.scaleway-terraform.com","id":"344d1939-01db-4ab4-83eb-dc14585609b5","status":"pending","url":""}'
+        body: '{"error_message":null,"function_id":"573d15a7-c2da-45cc-a30b-f3752faf71fb","hostname":"container.function-basic.scaleway-terraform.com","id":"6185b610-e3c3-4c76-8422-d484a785ff39","status":"pending","url":""}'
         headers:
             Content-Length:
-                - "213"
+                - "208"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 25 Jun 2024 15:03:48 GMT
+                - Fri, 05 Jul 2024 08:37:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2374,10 +2374,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7fa0e784-de05-47ae-bdfe-70c84f04ba93
+                - 05ddd323-1731-4a26-9aea-bb6ccdd7492e
         status: 200 OK
         code: 200
-        duration: 86.088725ms
+        duration: 148.221423ms
     - id: 48
       request:
         proto: HTTP/1.1
@@ -2393,8 +2393,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/344d1939-01db-4ab4-83eb-dc14585609b5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/6185b610-e3c3-4c76-8422-d484a785ff39
         method: GET
       response:
         proto: HTTP/2.0
@@ -2402,20 +2402,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 213
+        content_length: 208
         uncompressed: false
-        body: '{"error_message":null,"function_id":"6658bd06-9799-4a07-9e0f-18dd19c2eb8f","hostname":"container.function-basic.scaleway-terraform.com","id":"344d1939-01db-4ab4-83eb-dc14585609b5","status":"pending","url":""}'
+        body: '{"error_message":null,"function_id":"573d15a7-c2da-45cc-a30b-f3752faf71fb","hostname":"container.function-basic.scaleway-terraform.com","id":"6185b610-e3c3-4c76-8422-d484a785ff39","status":"pending","url":""}'
         headers:
             Content-Length:
-                - "213"
+                - "208"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 25 Jun 2024 15:03:53 GMT
+                - Fri, 05 Jul 2024 08:38:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2423,10 +2423,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c5b6b92e-084a-4ea6-a579-6750137a5e7d
+                - 1b4c6800-0f6f-4ec1-a6b7-6562e6da9342
         status: 200 OK
         code: 200
-        duration: 99.143673ms
+        duration: 65.330407ms
     - id: 49
       request:
         proto: HTTP/1.1
@@ -2442,8 +2442,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/344d1939-01db-4ab4-83eb-dc14585609b5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/6185b610-e3c3-4c76-8422-d484a785ff39
         method: GET
       response:
         proto: HTTP/2.0
@@ -2451,20 +2451,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 213
+        content_length: 261
         uncompressed: false
-        body: '{"error_message":null,"function_id":"6658bd06-9799-4a07-9e0f-18dd19c2eb8f","hostname":"container.function-basic.scaleway-terraform.com","id":"344d1939-01db-4ab4-83eb-dc14585609b5","status":"pending","url":""}'
+        body: '{"error_message":null,"function_id":"573d15a7-c2da-45cc-a30b-f3752faf71fb","hostname":"container.function-basic.scaleway-terraform.com","id":"6185b610-e3c3-4c76-8422-d484a785ff39","status":"ready","url":"https://container.function-basic.scaleway-terraform.com"}'
         headers:
             Content-Length:
-                - "213"
+                - "261"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 25 Jun 2024 15:03:58 GMT
+                - Fri, 05 Jul 2024 08:38:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2472,10 +2472,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cdab9d91-5ce4-409f-bc70-87af1061130b
+                - 25f8666a-08ed-4620-8a7e-76192272a6f9
         status: 200 OK
         code: 200
-        duration: 71.807742ms
+        duration: 86.725064ms
     - id: 50
       request:
         proto: HTTP/1.1
@@ -2491,8 +2491,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/344d1939-01db-4ab4-83eb-dc14585609b5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/6185b610-e3c3-4c76-8422-d484a785ff39
         method: GET
       response:
         proto: HTTP/2.0
@@ -2500,20 +2500,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 213
+        content_length: 261
         uncompressed: false
-        body: '{"error_message":null,"function_id":"6658bd06-9799-4a07-9e0f-18dd19c2eb8f","hostname":"container.function-basic.scaleway-terraform.com","id":"344d1939-01db-4ab4-83eb-dc14585609b5","status":"pending","url":""}'
+        body: '{"error_message":null,"function_id":"573d15a7-c2da-45cc-a30b-f3752faf71fb","hostname":"container.function-basic.scaleway-terraform.com","id":"6185b610-e3c3-4c76-8422-d484a785ff39","status":"ready","url":"https://container.function-basic.scaleway-terraform.com"}'
         headers:
             Content-Length:
-                - "213"
+                - "261"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 25 Jun 2024 15:04:04 GMT
+                - Fri, 05 Jul 2024 08:38:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2521,10 +2521,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e6041994-f903-44c2-a213-809f9b63fd1d
+                - 8b9cd445-d8a1-4586-8efe-350fe60e2caf
         status: 200 OK
         code: 200
-        duration: 685.86092ms
+        duration: 77.71652ms
     - id: 51
       request:
         proto: HTTP/1.1
@@ -2540,8 +2540,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/344d1939-01db-4ab4-83eb-dc14585609b5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/6185b610-e3c3-4c76-8422-d484a785ff39
         method: GET
       response:
         proto: HTTP/2.0
@@ -2549,20 +2549,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 213
+        content_length: 261
         uncompressed: false
-        body: '{"error_message":null,"function_id":"6658bd06-9799-4a07-9e0f-18dd19c2eb8f","hostname":"container.function-basic.scaleway-terraform.com","id":"344d1939-01db-4ab4-83eb-dc14585609b5","status":"pending","url":""}'
+        body: '{"error_message":null,"function_id":"573d15a7-c2da-45cc-a30b-f3752faf71fb","hostname":"container.function-basic.scaleway-terraform.com","id":"6185b610-e3c3-4c76-8422-d484a785ff39","status":"ready","url":"https://container.function-basic.scaleway-terraform.com"}'
         headers:
             Content-Length:
-                - "213"
+                - "261"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 25 Jun 2024 15:04:09 GMT
+                - Fri, 05 Jul 2024 08:38:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2570,10 +2570,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7cc164d4-b861-4e64-9317-06714de7ddfc
+                - 03882ec9-c41e-467c-bcda-77c93bd0d974
         status: 200 OK
         code: 200
-        duration: 84.693112ms
+        duration: 82.916304ms
     - id: 52
       request:
         proto: HTTP/1.1
@@ -2589,8 +2589,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/344d1939-01db-4ab4-83eb-dc14585609b5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a6109d4f-b972-4daf-a379-c287e625c00d
         method: GET
       response:
         proto: HTTP/2.0
@@ -2598,20 +2598,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 213
+        content_length: 464
         uncompressed: false
-        body: '{"error_message":null,"function_id":"6658bd06-9799-4a07-9e0f-18dd19c2eb8f","hostname":"container.function-basic.scaleway-terraform.com","id":"344d1939-01db-4ab4-83eb-dc14585609b5","status":"pending","url":""}'
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"a6109d4f-b972-4daf-a379-c287e625c00d","name":"tf-func-unruffled-perlman","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncunruffledperlmv1mnq4p4","registry_namespace_id":"2ce80c58-94cd-4437-b6ae-df094cac46ff","secret_environment_variables":[],"status":"ready"}'
         headers:
             Content-Length:
-                - "213"
+                - "464"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 25 Jun 2024 15:04:14 GMT
+                - Fri, 05 Jul 2024 08:38:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2619,10 +2619,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8527e782-1c7d-4e3b-9ea9-229f417b115a
+                - 7e148547-35ec-48fe-97e1-970b2e77a25c
         status: 200 OK
         code: 200
-        duration: 68.222398ms
+        duration: 55.776867ms
     - id: 53
       request:
         proto: HTTP/1.1
@@ -2638,8 +2638,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/344d1939-01db-4ab4-83eb-dc14585609b5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/573d15a7-c2da-45cc-a30b-f3752faf71fb
         method: GET
       response:
         proto: HTTP/2.0
@@ -2647,20 +2647,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 213
+        content_length: 583
         uncompressed: false
-        body: '{"error_message":null,"function_id":"6658bd06-9799-4a07-9e0f-18dd19c2eb8f","hostname":"container.function-basic.scaleway-terraform.com","id":"344d1939-01db-4ab4-83eb-dc14585609b5","status":"pending","url":""}'
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncunruffledperlmv1mnq4p4-tf-func-serene-taussig.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"573d15a7-c2da-45cc-a30b-f3752faf71fb","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-serene-taussig","namespace_id":"a6109d4f-b972-4daf-a379-c287e625c00d","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"ready","timeout":"300s"}'
         headers:
             Content-Length:
-                - "213"
+                - "583"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 25 Jun 2024 15:04:19 GMT
+                - Fri, 05 Jul 2024 08:38:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2668,10 +2668,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 28bf60a0-4f39-4221-9461-45b5bb1b0d1e
+                - f1d8f637-c451-4f90-a4dd-350cd671d5ff
         status: 200 OK
         code: 200
-        duration: 80.454824ms
+        duration: 64.511537ms
     - id: 54
       request:
         proto: HTTP/1.1
@@ -2687,8 +2687,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/344d1939-01db-4ab4-83eb-dc14585609b5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/domain/v2beta1/dns-zones/function-basic.scaleway-terraform.com/records?id=9d42c723-66da-414a-930a-5791c26a0edd&name=container&order_by=name_asc&page=1&type=CNAME
         method: GET
       response:
         proto: HTTP/2.0
@@ -2696,20 +2696,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 213
+        content_length: 239
         uncompressed: false
-        body: '{"error_message":null,"function_id":"6658bd06-9799-4a07-9e0f-18dd19c2eb8f","hostname":"container.function-basic.scaleway-terraform.com","id":"344d1939-01db-4ab4-83eb-dc14585609b5","status":"pending","url":""}'
+        body: '{"records":[{"comment":null,"data":"tffuncunruffledperlmv1mnq4p4-tf-func-serene-taussig.functions.fnc.fr-par.scw.cloud.","id":"9d42c723-66da-414a-930a-5791c26a0edd","name":"container","priority":0,"ttl":60,"type":"CNAME"}],"total_count":1}'
         headers:
             Content-Length:
-                - "213"
+                - "239"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 25 Jun 2024 15:04:24 GMT
+                - Fri, 05 Jul 2024 08:38:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2717,10 +2717,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c5422b71-c155-4da2-bab9-9e73c73f7eac
+                - ca91f1c9-4f3f-4167-8daf-bf5da1c5736f
         status: 200 OK
         code: 200
-        duration: 98.730707ms
+        duration: 61.570138ms
     - id: 55
       request:
         proto: HTTP/1.1
@@ -2736,8 +2736,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/344d1939-01db-4ab4-83eb-dc14585609b5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zones=function-basic.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -2745,20 +2745,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 213
+        content_length: 355
         uncompressed: false
-        body: '{"error_message":null,"function_id":"6658bd06-9799-4a07-9e0f-18dd19c2eb8f","hostname":"container.function-basic.scaleway-terraform.com","id":"344d1939-01db-4ab4-83eb-dc14585609b5","status":"pending","url":""}'
+        body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"function-basic","updated_at":"2024-07-05T08:38:03Z"}],"total_count":1}'
         headers:
             Content-Length:
-                - "213"
+                - "355"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 25 Jun 2024 15:04:29 GMT
+                - Fri, 05 Jul 2024 08:38:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2766,10 +2766,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f68a58a5-7bc0-4a62-af30-3930df90266e
+                - e38e2674-bbc9-4d41-8306-41d56042cc6c
         status: 200 OK
         code: 200
-        duration: 429.184255ms
+        duration: 61.767218ms
     - id: 56
       request:
         proto: HTTP/1.1
@@ -2785,8 +2785,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/344d1939-01db-4ab4-83eb-dc14585609b5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/6185b610-e3c3-4c76-8422-d484a785ff39
         method: GET
       response:
         proto: HTTP/2.0
@@ -2794,20 +2794,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 213
+        content_length: 261
         uncompressed: false
-        body: '{"error_message":null,"function_id":"6658bd06-9799-4a07-9e0f-18dd19c2eb8f","hostname":"container.function-basic.scaleway-terraform.com","id":"344d1939-01db-4ab4-83eb-dc14585609b5","status":"pending","url":""}'
+        body: '{"error_message":null,"function_id":"573d15a7-c2da-45cc-a30b-f3752faf71fb","hostname":"container.function-basic.scaleway-terraform.com","id":"6185b610-e3c3-4c76-8422-d484a785ff39","status":"ready","url":"https://container.function-basic.scaleway-terraform.com"}'
         headers:
             Content-Length:
-                - "213"
+                - "261"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 25 Jun 2024 15:04:34 GMT
+                - Fri, 05 Jul 2024 08:38:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2815,10 +2815,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 075e90a1-7468-487f-8c91-74cec75ab1e2
+                - 5f1ccdd7-cb66-4873-ab67-23e46169e36a
         status: 200 OK
         code: 200
-        duration: 65.569833ms
+        duration: 91.642657ms
     - id: 57
       request:
         proto: HTTP/1.1
@@ -2834,8 +2834,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/344d1939-01db-4ab4-83eb-dc14585609b5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/6185b610-e3c3-4c76-8422-d484a785ff39
         method: GET
       response:
         proto: HTTP/2.0
@@ -2843,20 +2843,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 213
+        content_length: 261
         uncompressed: false
-        body: '{"error_message":null,"function_id":"6658bd06-9799-4a07-9e0f-18dd19c2eb8f","hostname":"container.function-basic.scaleway-terraform.com","id":"344d1939-01db-4ab4-83eb-dc14585609b5","status":"pending","url":""}'
+        body: '{"error_message":null,"function_id":"573d15a7-c2da-45cc-a30b-f3752faf71fb","hostname":"container.function-basic.scaleway-terraform.com","id":"6185b610-e3c3-4c76-8422-d484a785ff39","status":"ready","url":"https://container.function-basic.scaleway-terraform.com"}'
         headers:
             Content-Length:
-                - "213"
+                - "261"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 25 Jun 2024 15:04:40 GMT
+                - Fri, 05 Jul 2024 08:38:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2864,10 +2864,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e7f0843b-9a7a-492a-8923-b4f0151f1feb
+                - 9fe0b875-05d6-4580-8772-308b87e725cb
         status: 200 OK
         code: 200
-        duration: 150.593433ms
+        duration: 67.507629ms
     - id: 58
       request:
         proto: HTTP/1.1
@@ -2883,29 +2883,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/344d1939-01db-4ab4-83eb-dc14585609b5
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/6185b610-e3c3-4c76-8422-d484a785ff39
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 213
+        content_length: 264
         uncompressed: false
-        body: '{"error_message":null,"function_id":"6658bd06-9799-4a07-9e0f-18dd19c2eb8f","hostname":"container.function-basic.scaleway-terraform.com","id":"344d1939-01db-4ab4-83eb-dc14585609b5","status":"pending","url":""}'
+        body: '{"error_message":null,"function_id":"573d15a7-c2da-45cc-a30b-f3752faf71fb","hostname":"container.function-basic.scaleway-terraform.com","id":"6185b610-e3c3-4c76-8422-d484a785ff39","status":"deleting","url":"https://container.function-basic.scaleway-terraform.com"}'
         headers:
             Content-Length:
-                - "213"
+                - "264"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 25 Jun 2024 15:04:45 GMT
+                - Fri, 05 Jul 2024 08:38:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2913,10 +2913,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2b9e959e-1f4a-41ab-86af-c7bf6dcfaf08
+                - 3ddd4282-28cb-49da-b267-ccefa175dd05
         status: 200 OK
         code: 200
-        duration: 75.681584ms
+        duration: 79.376911ms
     - id: 59
       request:
         proto: HTTP/1.1
@@ -2932,8 +2932,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/344d1939-01db-4ab4-83eb-dc14585609b5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/6185b610-e3c3-4c76-8422-d484a785ff39
         method: GET
       response:
         proto: HTTP/2.0
@@ -2941,20 +2941,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 213
+        content_length: 264
         uncompressed: false
-        body: '{"error_message":null,"function_id":"6658bd06-9799-4a07-9e0f-18dd19c2eb8f","hostname":"container.function-basic.scaleway-terraform.com","id":"344d1939-01db-4ab4-83eb-dc14585609b5","status":"pending","url":""}'
+        body: '{"error_message":null,"function_id":"573d15a7-c2da-45cc-a30b-f3752faf71fb","hostname":"container.function-basic.scaleway-terraform.com","id":"6185b610-e3c3-4c76-8422-d484a785ff39","status":"deleting","url":"https://container.function-basic.scaleway-terraform.com"}'
         headers:
             Content-Length:
-                - "213"
+                - "264"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 25 Jun 2024 15:04:50 GMT
+                - Fri, 05 Jul 2024 08:38:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2962,10 +2962,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6b3380f5-c5bb-4539-bcb1-2ece7b12e16d
+                - 8a37e2dd-5cb0-4eda-95d6-58fbdb36ceb9
         status: 200 OK
         code: 200
-        duration: 76.407473ms
+        duration: 68.18332ms
     - id: 60
       request:
         proto: HTTP/1.1
@@ -2981,1331 +2981,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/344d1939-01db-4ab4-83eb-dc14585609b5
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 213
-        uncompressed: false
-        body: '{"error_message":null,"function_id":"6658bd06-9799-4a07-9e0f-18dd19c2eb8f","hostname":"container.function-basic.scaleway-terraform.com","id":"344d1939-01db-4ab4-83eb-dc14585609b5","status":"pending","url":""}'
-        headers:
-            Content-Length:
-                - "213"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 25 Jun 2024 15:04:55 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - b8414e36-f153-4213-9764-b586d1130e0d
-        status: 200 OK
-        code: 200
-        duration: 770.6859ms
-    - id: 61
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/344d1939-01db-4ab4-83eb-dc14585609b5
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 213
-        uncompressed: false
-        body: '{"error_message":null,"function_id":"6658bd06-9799-4a07-9e0f-18dd19c2eb8f","hostname":"container.function-basic.scaleway-terraform.com","id":"344d1939-01db-4ab4-83eb-dc14585609b5","status":"pending","url":""}'
-        headers:
-            Content-Length:
-                - "213"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 25 Jun 2024 15:05:01 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - cf440d9d-2f2c-4a12-8943-95b51d1e9ad2
-        status: 200 OK
-        code: 200
-        duration: 62.08838ms
-    - id: 62
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/344d1939-01db-4ab4-83eb-dc14585609b5
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 213
-        uncompressed: false
-        body: '{"error_message":null,"function_id":"6658bd06-9799-4a07-9e0f-18dd19c2eb8f","hostname":"container.function-basic.scaleway-terraform.com","id":"344d1939-01db-4ab4-83eb-dc14585609b5","status":"pending","url":""}'
-        headers:
-            Content-Length:
-                - "213"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 25 Jun 2024 15:05:06 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 4df2629e-f0e7-4539-8a5b-7547047fda19
-        status: 200 OK
-        code: 200
-        duration: 77.091797ms
-    - id: 63
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/344d1939-01db-4ab4-83eb-dc14585609b5
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 213
-        uncompressed: false
-        body: '{"error_message":null,"function_id":"6658bd06-9799-4a07-9e0f-18dd19c2eb8f","hostname":"container.function-basic.scaleway-terraform.com","id":"344d1939-01db-4ab4-83eb-dc14585609b5","status":"pending","url":""}'
-        headers:
-            Content-Length:
-                - "213"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 25 Jun 2024 15:05:11 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - e5deeb2b-78cc-48c2-8183-101da82eba00
-        status: 200 OK
-        code: 200
-        duration: 77.052886ms
-    - id: 64
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/344d1939-01db-4ab4-83eb-dc14585609b5
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 213
-        uncompressed: false
-        body: '{"error_message":null,"function_id":"6658bd06-9799-4a07-9e0f-18dd19c2eb8f","hostname":"container.function-basic.scaleway-terraform.com","id":"344d1939-01db-4ab4-83eb-dc14585609b5","status":"pending","url":""}'
-        headers:
-            Content-Length:
-                - "213"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 25 Jun 2024 15:05:16 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 30734b36-285d-487c-9dad-8ff69fad1e8c
-        status: 200 OK
-        code: 200
-        duration: 77.036288ms
-    - id: 65
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/344d1939-01db-4ab4-83eb-dc14585609b5
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 213
-        uncompressed: false
-        body: '{"error_message":null,"function_id":"6658bd06-9799-4a07-9e0f-18dd19c2eb8f","hostname":"container.function-basic.scaleway-terraform.com","id":"344d1939-01db-4ab4-83eb-dc14585609b5","status":"pending","url":""}'
-        headers:
-            Content-Length:
-                - "213"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 25 Jun 2024 15:05:21 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 9032a3f0-02a3-4c78-9568-685d0e2236f0
-        status: 200 OK
-        code: 200
-        duration: 87.546229ms
-    - id: 66
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/344d1939-01db-4ab4-83eb-dc14585609b5
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 213
-        uncompressed: false
-        body: '{"error_message":null,"function_id":"6658bd06-9799-4a07-9e0f-18dd19c2eb8f","hostname":"container.function-basic.scaleway-terraform.com","id":"344d1939-01db-4ab4-83eb-dc14585609b5","status":"pending","url":""}'
-        headers:
-            Content-Length:
-                - "213"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 25 Jun 2024 15:05:26 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 6d07544a-bfad-43fd-bb04-9ba32cf268ca
-        status: 200 OK
-        code: 200
-        duration: 60.793573ms
-    - id: 67
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/344d1939-01db-4ab4-83eb-dc14585609b5
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 213
-        uncompressed: false
-        body: '{"error_message":null,"function_id":"6658bd06-9799-4a07-9e0f-18dd19c2eb8f","hostname":"container.function-basic.scaleway-terraform.com","id":"344d1939-01db-4ab4-83eb-dc14585609b5","status":"pending","url":""}'
-        headers:
-            Content-Length:
-                - "213"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 25 Jun 2024 15:05:31 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 056b5dbd-03ff-4cdd-944a-1ffc2f1e8e77
-        status: 200 OK
-        code: 200
-        duration: 86.879054ms
-    - id: 68
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/344d1939-01db-4ab4-83eb-dc14585609b5
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 213
-        uncompressed: false
-        body: '{"error_message":null,"function_id":"6658bd06-9799-4a07-9e0f-18dd19c2eb8f","hostname":"container.function-basic.scaleway-terraform.com","id":"344d1939-01db-4ab4-83eb-dc14585609b5","status":"pending","url":""}'
-        headers:
-            Content-Length:
-                - "213"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 25 Jun 2024 15:05:36 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 6b46e916-1793-4fe8-9bc9-d22fb5b8367e
-        status: 200 OK
-        code: 200
-        duration: 197.13316ms
-    - id: 69
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/344d1939-01db-4ab4-83eb-dc14585609b5
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 213
-        uncompressed: false
-        body: '{"error_message":null,"function_id":"6658bd06-9799-4a07-9e0f-18dd19c2eb8f","hostname":"container.function-basic.scaleway-terraform.com","id":"344d1939-01db-4ab4-83eb-dc14585609b5","status":"pending","url":""}'
-        headers:
-            Content-Length:
-                - "213"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 25 Jun 2024 15:05:41 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 3f906c00-af81-4b06-93c4-e531182eb10a
-        status: 200 OK
-        code: 200
-        duration: 79.914962ms
-    - id: 70
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/344d1939-01db-4ab4-83eb-dc14585609b5
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 213
-        uncompressed: false
-        body: '{"error_message":null,"function_id":"6658bd06-9799-4a07-9e0f-18dd19c2eb8f","hostname":"container.function-basic.scaleway-terraform.com","id":"344d1939-01db-4ab4-83eb-dc14585609b5","status":"pending","url":""}'
-        headers:
-            Content-Length:
-                - "213"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 25 Jun 2024 15:05:46 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 175b078f-35cb-4658-ba98-65d521b6ba7d
-        status: 200 OK
-        code: 200
-        duration: 79.752478ms
-    - id: 71
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/344d1939-01db-4ab4-83eb-dc14585609b5
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 213
-        uncompressed: false
-        body: '{"error_message":null,"function_id":"6658bd06-9799-4a07-9e0f-18dd19c2eb8f","hostname":"container.function-basic.scaleway-terraform.com","id":"344d1939-01db-4ab4-83eb-dc14585609b5","status":"pending","url":""}'
-        headers:
-            Content-Length:
-                - "213"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 25 Jun 2024 15:05:51 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 17c5c74f-f33c-40c5-a469-943dc2c51c35
-        status: 200 OK
-        code: 200
-        duration: 68.795212ms
-    - id: 72
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/344d1939-01db-4ab4-83eb-dc14585609b5
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 213
-        uncompressed: false
-        body: '{"error_message":null,"function_id":"6658bd06-9799-4a07-9e0f-18dd19c2eb8f","hostname":"container.function-basic.scaleway-terraform.com","id":"344d1939-01db-4ab4-83eb-dc14585609b5","status":"pending","url":""}'
-        headers:
-            Content-Length:
-                - "213"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 25 Jun 2024 15:05:57 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 070897d6-b36a-4291-89c9-2274ca197806
-        status: 200 OK
-        code: 200
-        duration: 77.11495ms
-    - id: 73
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/344d1939-01db-4ab4-83eb-dc14585609b5
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 213
-        uncompressed: false
-        body: '{"error_message":null,"function_id":"6658bd06-9799-4a07-9e0f-18dd19c2eb8f","hostname":"container.function-basic.scaleway-terraform.com","id":"344d1939-01db-4ab4-83eb-dc14585609b5","status":"pending","url":""}'
-        headers:
-            Content-Length:
-                - "213"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 25 Jun 2024 15:06:02 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 29c358f3-c0bc-4317-a0c0-425538131141
-        status: 200 OK
-        code: 200
-        duration: 80.072525ms
-    - id: 74
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/344d1939-01db-4ab4-83eb-dc14585609b5
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 213
-        uncompressed: false
-        body: '{"error_message":null,"function_id":"6658bd06-9799-4a07-9e0f-18dd19c2eb8f","hostname":"container.function-basic.scaleway-terraform.com","id":"344d1939-01db-4ab4-83eb-dc14585609b5","status":"pending","url":""}'
-        headers:
-            Content-Length:
-                - "213"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 25 Jun 2024 15:06:07 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - c6b7765b-b948-4bdf-a98b-1ae173c9310b
-        status: 200 OK
-        code: 200
-        duration: 75.638252ms
-    - id: 75
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/344d1939-01db-4ab4-83eb-dc14585609b5
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 213
-        uncompressed: false
-        body: '{"error_message":null,"function_id":"6658bd06-9799-4a07-9e0f-18dd19c2eb8f","hostname":"container.function-basic.scaleway-terraform.com","id":"344d1939-01db-4ab4-83eb-dc14585609b5","status":"pending","url":""}'
-        headers:
-            Content-Length:
-                - "213"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 25 Jun 2024 15:06:12 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 961f9c52-6812-4814-9155-9473a07de0a7
-        status: 200 OK
-        code: 200
-        duration: 86.781062ms
-    - id: 76
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/344d1939-01db-4ab4-83eb-dc14585609b5
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 387
-        uncompressed: false
-        body: '{"error_message":"failed to create domain: check that the domain correctly points to the function URL (https://tffuncpracticalsnyde1eejycco-tf-func-admiring-wescoff.functions.fnc.fr-par.scw.cloud)","function_id":"6658bd06-9799-4a07-9e0f-18dd19c2eb8f","hostname":"container.function-basic.scaleway-terraform.com","id":"344d1939-01db-4ab4-83eb-dc14585609b5","status":"error","url":""}'
-        headers:
-            Content-Length:
-                - "387"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 25 Jun 2024 15:06:17 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 24932a1e-ed2a-45ae-a260-d96b2ca25f97
-        status: 200 OK
-        code: 200
-        duration: 69.887082ms
-    - id: 77
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/344d1939-01db-4ab4-83eb-dc14585609b5
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 387
-        uncompressed: false
-        body: '{"error_message":"failed to create domain: check that the domain correctly points to the function URL (https://tffuncpracticalsnyde1eejycco-tf-func-admiring-wescoff.functions.fnc.fr-par.scw.cloud)","function_id":"6658bd06-9799-4a07-9e0f-18dd19c2eb8f","hostname":"container.function-basic.scaleway-terraform.com","id":"344d1939-01db-4ab4-83eb-dc14585609b5","status":"error","url":""}'
-        headers:
-            Content-Length:
-                - "387"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 25 Jun 2024 15:06:17 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 02a3bfbb-d072-4739-827a-bba810d81354
-        status: 200 OK
-        code: 200
-        duration: 98.435736ms
-    - id: 78
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/344d1939-01db-4ab4-83eb-dc14585609b5
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 387
-        uncompressed: false
-        body: '{"error_message":"failed to create domain: check that the domain correctly points to the function URL (https://tffuncpracticalsnyde1eejycco-tf-func-admiring-wescoff.functions.fnc.fr-par.scw.cloud)","function_id":"6658bd06-9799-4a07-9e0f-18dd19c2eb8f","hostname":"container.function-basic.scaleway-terraform.com","id":"344d1939-01db-4ab4-83eb-dc14585609b5","status":"error","url":""}'
-        headers:
-            Content-Length:
-                - "387"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 25 Jun 2024 15:06:17 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - e26d6315-e656-4cc4-9ca4-cafe2465baed
-        status: 200 OK
-        code: 200
-        duration: 59.873455ms
-    - id: 79
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/dba63885-5261-4b30-a454-22045bbec32f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 474
-        uncompressed: false
-        body: '{"description":"","environment_variables":{},"error_message":null,"id":"dba63885-5261-4b30-a454-22045bbec32f","name":"tf-func-practical-snyder","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncpracticalsnyde1eejycco","registry_namespace_id":"896c22a4-b3f1-4ed7-9fec-6e0e7f69e3c5","secret_environment_variables":[],"status":"ready"}'
-        headers:
-            Content-Length:
-                - "474"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 25 Jun 2024 15:06:18 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - f6f60249-e97a-41d1-980d-7f5f5a3caab9
-        status: 200 OK
-        code: 200
-        duration: 70.986881ms
-    - id: 80
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/6658bd06-9799-4a07-9e0f-18dd19c2eb8f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 591
-        uncompressed: false
-        body: '{"build_message":null,"cpu_limit":70,"description":"","domain_name":"tffuncpracticalsnyde1eejycco-tf-func-admiring-wescoff.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"6658bd06-9799-4a07-9e0f-18dd19c2eb8f","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-func-admiring-wescoff","namespace_id":"dba63885-5261-4b30-a454-22045bbec32f","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"ready","timeout":"300s"}'
-        headers:
-            Content-Length:
-                - "591"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 25 Jun 2024 15:06:18 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 1cdad146-500e-4307-bb78-1dc706b63492
-        status: 200 OK
-        code: 200
-        duration: 60.280224ms
-    - id: 81
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/domain/v2beta1/dns-zones/function-basic.scaleway-terraform.com/records?id=94fd4408-d3a5-4acd-96f0-5e439c236ead&name=container&order_by=name_asc&page=1&type=CNAME
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 248
-        uncompressed: false
-        body: '{"records":[{"comment":null,"data":"tffuncpracticalsnyde1eejycco-tf-func-admiring-wescoff.functions.fnc.fr-par.scw.cloud.","id":"94fd4408-d3a5-4acd-96f0-5e439c236ead","name":"container","priority":0,"ttl":60,"type":"CNAME"}],"total_count":1}'
-        headers:
-            Content-Length:
-                - "248"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 25 Jun 2024 15:06:18 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - ead2dbef-6860-42bc-9817-b97389545b00
-        status: 200 OK
-        code: 200
-        duration: 57.812414ms
-    - id: 82
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zones=function-basic.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 367
-        uncompressed: false
-        body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"function-basic","updated_at":"2024-06-25T15:03:17Z"}],"total_count":1}'
-        headers:
-            Content-Length:
-                - "367"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 25 Jun 2024 15:06:18 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 89e7c5e7-198c-43c7-8012-b1d261166b8a
-        status: 200 OK
-        code: 200
-        duration: 70.652564ms
-    - id: 83
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/344d1939-01db-4ab4-83eb-dc14585609b5
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 387
-        uncompressed: false
-        body: '{"error_message":"failed to create domain: check that the domain correctly points to the function URL (https://tffuncpracticalsnyde1eejycco-tf-func-admiring-wescoff.functions.fnc.fr-par.scw.cloud)","function_id":"6658bd06-9799-4a07-9e0f-18dd19c2eb8f","hostname":"container.function-basic.scaleway-terraform.com","id":"344d1939-01db-4ab4-83eb-dc14585609b5","status":"error","url":""}'
-        headers:
-            Content-Length:
-                - "387"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 25 Jun 2024 15:06:18 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 587444bc-1208-4159-b7f9-78cfd4d3948a
-        status: 200 OK
-        code: 200
-        duration: 66.246211ms
-    - id: 84
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/344d1939-01db-4ab4-83eb-dc14585609b5
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 387
-        uncompressed: false
-        body: '{"error_message":"failed to create domain: check that the domain correctly points to the function URL (https://tffuncpracticalsnyde1eejycco-tf-func-admiring-wescoff.functions.fnc.fr-par.scw.cloud)","function_id":"6658bd06-9799-4a07-9e0f-18dd19c2eb8f","hostname":"container.function-basic.scaleway-terraform.com","id":"344d1939-01db-4ab4-83eb-dc14585609b5","status":"error","url":""}'
-        headers:
-            Content-Length:
-                - "387"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 25 Jun 2024 15:06:18 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - e0f83a63-0ad0-48c5-ac98-c6452a6991c4
-        status: 200 OK
-        code: 200
-        duration: 65.854552ms
-    - id: 85
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/344d1939-01db-4ab4-83eb-dc14585609b5
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 214
-        uncompressed: false
-        body: '{"error_message":null,"function_id":"6658bd06-9799-4a07-9e0f-18dd19c2eb8f","hostname":"container.function-basic.scaleway-terraform.com","id":"344d1939-01db-4ab4-83eb-dc14585609b5","status":"deleting","url":""}'
-        headers:
-            Content-Length:
-                - "214"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 25 Jun 2024 15:06:18 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - b1c2f99e-0ca8-42a3-9388-e5b90bd811d2
-        status: 200 OK
-        code: 200
-        duration: 97.117428ms
-    - id: 86
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/344d1939-01db-4ab4-83eb-dc14585609b5
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 214
-        uncompressed: false
-        body: '{"error_message":null,"function_id":"6658bd06-9799-4a07-9e0f-18dd19c2eb8f","hostname":"container.function-basic.scaleway-terraform.com","id":"344d1939-01db-4ab4-83eb-dc14585609b5","status":"deleting","url":""}'
-        headers:
-            Content-Length:
-                - "214"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 25 Jun 2024 15:06:18 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - f0dff2a4-6edb-429b-ba48-e68fdb02e0b5
-        status: 200 OK
-        code: 200
-        duration: 60.898241ms
-    - id: 87
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/344d1939-01db-4ab4-83eb-dc14585609b5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/6185b610-e3c3-4c76-8422-d484a785ff39
         method: GET
       response:
         proto: HTTP/2.0
@@ -4324,9 +3001,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 25 Jun 2024 15:06:23 GMT
+                - Fri, 05 Jul 2024 08:38:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4334,11 +3011,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1e73f0df-7610-4669-a24e-660158fcb847
+                - ff40283c-2eef-4cdc-b70e-7f307139c7ca
         status: 404 Not Found
         code: 404
-        duration: 28.526533ms
-    - id: 88
+        duration: 27.486589ms
+    - id: 61
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -4349,13 +3026,13 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"changes":[{"delete":{"id":"94fd4408-d3a5-4acd-96f0-5e439c236ead"}}],"return_all_records":false,"disallow_new_zone_creation":false}'
+        body: '{"changes":[{"delete":{"id":"9d42c723-66da-414a-930a-5791c26a0edd"}}],"return_all_records":false,"disallow_new_zone_creation":false}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/domain/v2beta1/dns-zones/function-basic.scaleway-terraform.com/records
         method: PATCH
       response:
@@ -4375,9 +3052,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 25 Jun 2024 15:06:24 GMT
+                - Fri, 05 Jul 2024 08:38:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4385,11 +3062,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 88441cf0-3c43-4645-b0ec-05b8d726a4d4
+                - 701299d2-0f8a-4ef8-9d61-b3e727650c3c
         status: 200 OK
         code: 200
-        duration: 101.931227ms
-    - id: 89
+        duration: 204.641349ms
+    - id: 62
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -4404,7 +3081,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/domain/v2beta1/dns-zones/function-basic.scaleway-terraform.com/records?name=&order_by=name_asc&type=unknown
         method: GET
       response:
@@ -4413,20 +3090,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 313
+        content_length: 299
         uncompressed: false
-        body: '{"records":[{"comment":null,"data":"ns0.dom.scw.cloud.","id":"0d1b2b62-a549-437c-bd34-d58317a560bc","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns1.dom.scw.cloud.","id":"13190a61-6513-425d-8008-4ad405d81acd","name":"","priority":0,"ttl":1800,"type":"NS"}],"total_count":2}'
+        body: '{"records":[{"comment":null,"data":"ns0.dom.scw.cloud.","id":"8d87abc6-def7-4ce8-9d99-50b1a868be54","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns1.dom.scw.cloud.","id":"450db47a-382b-400d-98c0-7f123b9e6fa7","name":"","priority":0,"ttl":1800,"type":"NS"}],"total_count":2}'
         headers:
             Content-Length:
-                - "313"
+                - "299"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 25 Jun 2024 15:06:24 GMT
+                - Fri, 05 Jul 2024 08:38:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4434,11 +3111,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 109edddf-f8e0-4948-a70e-805035e29689
+                - 134529ea-1576-4641-b0ed-6980af598da9
         status: 200 OK
         code: 200
-        duration: 58.13724ms
-    - id: 90
+        duration: 71.242259ms
+    - id: 63
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -4453,7 +3130,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=function-basic.scaleway-terraform.com&domain=&order_by=domain_asc
         method: GET
       response:
@@ -4462,20 +3139,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 368
+        content_length: 356
         uncompressed: false
-        body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"function-basic","updated_at":"2024-06-25T15:06:24Z"}],"total_count":1}'
+        body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"function-basic","updated_at":"2024-07-05T08:38:15Z"}],"total_count":1}'
         headers:
             Content-Length:
-                - "368"
+                - "356"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 25 Jun 2024 15:06:24 GMT
+                - Fri, 05 Jul 2024 08:38:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4483,11 +3160,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6571f9cd-7d72-4cfb-9533-45ba5d8b4b7d
+                - 6064c024-ef1e-47fc-8201-8000ebe3ac5c
         status: 200 OK
         code: 200
-        duration: 63.657112ms
-    - id: 91
+        duration: 66.454279ms
+    - id: 64
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -4502,7 +3179,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=function-basic.scaleway-terraform.com&domain=&order_by=domain_asc
         method: GET
       response:
@@ -4511,20 +3188,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 367
+        content_length: 356
         uncompressed: false
-        body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"function-basic","updated_at":"2024-06-25T15:06:27Z"}],"total_count":1}'
+        body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"function-basic","updated_at":"2024-07-05T08:38:15Z"}],"total_count":1}'
         headers:
             Content-Length:
-                - "367"
+                - "356"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 25 Jun 2024 15:06:29 GMT
+                - Fri, 05 Jul 2024 08:38:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4532,11 +3209,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 534d9b46-3c78-422c-a1d9-157fa45851d7
+                - f744d90f-adbc-44c0-8a74-2c32c853b8da
         status: 200 OK
         code: 200
-        duration: 675.88692ms
-    - id: 92
+        duration: 82.032753ms
+    - id: 65
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -4551,7 +3228,56 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=function-basic.scaleway-terraform.com&domain=&order_by=domain_asc
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 355
+        uncompressed: false
+        body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"function-basic","updated_at":"2024-07-05T08:38:25Z"}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "355"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:38:25 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e24592be-b252-4859-b4ec-b524051d948c
+        status: 200 OK
+        code: 200
+        duration: 65.868257ms
+    - id: 66
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/domain/v2beta1/dns-zones/function-basic.scaleway-terraform.com?project_id=105bdce1-64c0-48ab-899d-868455867ecf
         method: DELETE
       response:
@@ -4571,9 +3297,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 25 Jun 2024 15:06:30 GMT
+                - Fri, 05 Jul 2024 08:38:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4581,11 +3307,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3023fffd-efbe-4cdf-a955-0faa44d50d28
+                - a3696c83-a093-4cfa-9433-2f0efe514cbe
         status: 200 OK
         code: 200
-        duration: 185.957745ms
-    - id: 93
+        duration: 259.388462ms
+    - id: 67
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -4600,8 +3326,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/6658bd06-9799-4a07-9e0f-18dd19c2eb8f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/573d15a7-c2da-45cc-a30b-f3752faf71fb
         method: GET
       response:
         proto: HTTP/2.0
@@ -4609,20 +3335,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 591
+        content_length: 583
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":70,"description":"","domain_name":"tffuncpracticalsnyde1eejycco-tf-func-admiring-wescoff.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"6658bd06-9799-4a07-9e0f-18dd19c2eb8f","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-func-admiring-wescoff","namespace_id":"dba63885-5261-4b30-a454-22045bbec32f","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"ready","timeout":"300s"}'
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncunruffledperlmv1mnq4p4-tf-func-serene-taussig.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"573d15a7-c2da-45cc-a30b-f3752faf71fb","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-serene-taussig","namespace_id":"a6109d4f-b972-4daf-a379-c287e625c00d","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"ready","timeout":"300s"}'
         headers:
             Content-Length:
-                - "591"
+                - "583"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 25 Jun 2024 15:06:30 GMT
+                - Fri, 05 Jul 2024 08:38:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4630,11 +3356,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 43876e9c-73a1-438e-8690-5e5a7f24067d
+                - 03456def-4e25-47c4-9057-3b60e9d993b9
         status: 200 OK
         code: 200
-        duration: 54.87384ms
-    - id: 94
+        duration: 59.436867ms
+    - id: 68
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -4649,8 +3375,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/6658bd06-9799-4a07-9e0f-18dd19c2eb8f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/573d15a7-c2da-45cc-a30b-f3752faf71fb
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -4658,20 +3384,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 594
+        content_length: 586
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":70,"description":"","domain_name":"tffuncpracticalsnyde1eejycco-tf-func-admiring-wescoff.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"6658bd06-9799-4a07-9e0f-18dd19c2eb8f","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-func-admiring-wescoff","namespace_id":"dba63885-5261-4b30-a454-22045bbec32f","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"deleting","timeout":"300s"}'
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncunruffledperlmv1mnq4p4-tf-func-serene-taussig.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"573d15a7-c2da-45cc-a30b-f3752faf71fb","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-serene-taussig","namespace_id":"a6109d4f-b972-4daf-a379-c287e625c00d","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"deleting","timeout":"300s"}'
         headers:
             Content-Length:
-                - "594"
+                - "586"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 25 Jun 2024 15:06:30 GMT
+                - Fri, 05 Jul 2024 08:38:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4679,11 +3405,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7dde3424-d5dd-403a-a4f8-148b6b556128
+                - edd779c1-32b8-4781-b8dc-eb1aa9ff1f15
         status: 200 OK
         code: 200
-        duration: 116.68829ms
-    - id: 95
+        duration: 129.537852ms
+    - id: 69
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -4698,8 +3424,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/dba63885-5261-4b30-a454-22045bbec32f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a6109d4f-b972-4daf-a379-c287e625c00d
         method: GET
       response:
         proto: HTTP/2.0
@@ -4707,20 +3433,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 474
+        content_length: 464
         uncompressed: false
-        body: '{"description":"","environment_variables":{},"error_message":null,"id":"dba63885-5261-4b30-a454-22045bbec32f","name":"tf-func-practical-snyder","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncpracticalsnyde1eejycco","registry_namespace_id":"896c22a4-b3f1-4ed7-9fec-6e0e7f69e3c5","secret_environment_variables":[],"status":"ready"}'
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"a6109d4f-b972-4daf-a379-c287e625c00d","name":"tf-func-unruffled-perlman","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncunruffledperlmv1mnq4p4","registry_namespace_id":"2ce80c58-94cd-4437-b6ae-df094cac46ff","secret_environment_variables":[],"status":"ready"}'
         headers:
             Content-Length:
-                - "474"
+                - "464"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 25 Jun 2024 15:06:30 GMT
+                - Fri, 05 Jul 2024 08:38:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4728,11 +3454,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c5aa8773-edba-47e0-9b83-ca3e9efad766
+                - d938f3cd-6672-4b00-b039-0511713c21de
         status: 200 OK
         code: 200
-        duration: 66.93134ms
-    - id: 96
+        duration: 52.269976ms
+    - id: 70
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -4747,8 +3473,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/dba63885-5261-4b30-a454-22045bbec32f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a6109d4f-b972-4daf-a379-c287e625c00d
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -4756,20 +3482,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 477
+        content_length: 467
         uncompressed: false
-        body: '{"description":"","environment_variables":{},"error_message":null,"id":"dba63885-5261-4b30-a454-22045bbec32f","name":"tf-func-practical-snyder","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncpracticalsnyde1eejycco","registry_namespace_id":"896c22a4-b3f1-4ed7-9fec-6e0e7f69e3c5","secret_environment_variables":[],"status":"deleting"}'
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"a6109d4f-b972-4daf-a379-c287e625c00d","name":"tf-func-unruffled-perlman","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncunruffledperlmv1mnq4p4","registry_namespace_id":"2ce80c58-94cd-4437-b6ae-df094cac46ff","secret_environment_variables":[],"status":"deleting"}'
         headers:
             Content-Length:
-                - "477"
+                - "467"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 25 Jun 2024 15:06:30 GMT
+                - Fri, 05 Jul 2024 08:38:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4777,11 +3503,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7c0e4dc1-bbe4-46ec-9769-9800226113bc
+                - f0b93943-c9d7-485f-a8ba-8b76f88a019c
         status: 200 OK
         code: 200
-        duration: 180.705785ms
-    - id: 97
+        duration: 255.288785ms
+    - id: 71
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -4796,8 +3522,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/dba63885-5261-4b30-a454-22045bbec32f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a6109d4f-b972-4daf-a379-c287e625c00d
         method: GET
       response:
         proto: HTTP/2.0
@@ -4805,20 +3531,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 477
+        content_length: 467
         uncompressed: false
-        body: '{"description":"","environment_variables":{},"error_message":null,"id":"dba63885-5261-4b30-a454-22045bbec32f","name":"tf-func-practical-snyder","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncpracticalsnyde1eejycco","registry_namespace_id":"896c22a4-b3f1-4ed7-9fec-6e0e7f69e3c5","secret_environment_variables":[],"status":"deleting"}'
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"a6109d4f-b972-4daf-a379-c287e625c00d","name":"tf-func-unruffled-perlman","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncunruffledperlmv1mnq4p4","registry_namespace_id":"2ce80c58-94cd-4437-b6ae-df094cac46ff","secret_environment_variables":[],"status":"deleting"}'
         headers:
             Content-Length:
-                - "477"
+                - "467"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 25 Jun 2024 15:06:30 GMT
+                - Fri, 05 Jul 2024 08:38:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4826,11 +3552,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 035ae485-746b-434f-98af-4e2f656aa201
+                - 20d8ca8d-b9f4-4e86-87d9-c4753767d005
         status: 200 OK
         code: 200
-        duration: 50.289788ms
-    - id: 98
+        duration: 56.70898ms
+    - id: 72
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -4845,8 +3571,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/dba63885-5261-4b30-a454-22045bbec32f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a6109d4f-b972-4daf-a379-c287e625c00d
         method: GET
       response:
         proto: HTTP/2.0
@@ -4865,9 +3591,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 25 Jun 2024 15:06:35 GMT
+                - Fri, 05 Jul 2024 08:38:31 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4875,11 +3601,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a32d371d-049a-4fa6-884c-1ca385af41c0
+                - 14f23afc-6915-4c1f-8df9-f71b3a38c399
         status: 404 Not Found
         code: 404
-        duration: 37.449488ms
-    - id: 99
+        duration: 31.311999ms
+    - id: 73
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -4894,8 +3620,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.4; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/344d1939-01db-4ab4-83eb-dc14585609b5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/6185b610-e3c3-4c76-8422-d484a785ff39
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -4914,9 +3640,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 25 Jun 2024 15:06:35 GMT
+                - Fri, 05 Jul 2024 08:38:31 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4924,7 +3650,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 98256463-1994-4a0c-ac56-48a8253456f1
+                - 75dea625-d0eb-4f84-85b5-7f14c4e5570a
         status: 404 Not Found
         code: 404
-        duration: 31.375897ms
+        duration: 22.880079ms

--- a/internal/services/function/testdata/function-environment-variables.cassette.yaml
+++ b/internal/services/function/testdata/function-environment-variables.cassette.yaml
@@ -1,1133 +1,1283 @@
 ---
 version: 2
 interactions:
-- request:
-    body: '{"name":"tf-func-optimistic-lederberg","environment_variables":{},"project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","description":null,"secret_environment_variables":[]}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces
-    method: POST
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"0cc5f17a-65f6-44e2-be19-21e563ecbaeb","name":"tf-func-optimistic-lederberg","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "378"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:46:38 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3092d02e-adf4-4284-a7c9-39a657ebc959
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/0cc5f17a-65f6-44e2-be19-21e563ecbaeb
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"0cc5f17a-65f6-44e2-be19-21e563ecbaeb","name":"tf-func-optimistic-lederberg","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "378"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:46:38 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - aef45780-1861-40c8-878e-dbae63c6d964
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/0cc5f17a-65f6-44e2-be19-21e563ecbaeb
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"0cc5f17a-65f6-44e2-be19-21e563ecbaeb","name":"tf-func-optimistic-lederberg","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "378"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:46:43 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3b513743-7679-4e2f-88a8-74a4b1092113
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/0cc5f17a-65f6-44e2-be19-21e563ecbaeb
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"0cc5f17a-65f6-44e2-be19-21e563ecbaeb","name":"tf-func-optimistic-lederberg","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "378"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:46:48 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 65616e0a-4887-430f-9c4a-dce44fdecfe5
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/0cc5f17a-65f6-44e2-be19-21e563ecbaeb
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"0cc5f17a-65f6-44e2-be19-21e563ecbaeb","name":"tf-func-optimistic-lederberg","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "378"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:46:53 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9a77ebde-d796-4d05-a0cb-18bed36852fc
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/0cc5f17a-65f6-44e2-be19-21e563ecbaeb
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"0cc5f17a-65f6-44e2-be19-21e563ecbaeb","name":"tf-func-optimistic-lederberg","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "378"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:46:58 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b0a53d9d-e528-4b19-ae4a-54fe4d81e9d4
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/0cc5f17a-65f6-44e2-be19-21e563ecbaeb
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"0cc5f17a-65f6-44e2-be19-21e563ecbaeb","name":"tf-func-optimistic-lederberg","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "378"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6f678a43-35fa-4865-b6c1-bf3c5ea4e420
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/0cc5f17a-65f6-44e2-be19-21e563ecbaeb
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"0cc5f17a-65f6-44e2-be19-21e563ecbaeb","name":"tf-func-optimistic-lederberg","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "378"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:08 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 906d39f5-ab9a-4c77-9eec-2ba341d0b15e
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/0cc5f17a-65f6-44e2-be19-21e563ecbaeb
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"0cc5f17a-65f6-44e2-be19-21e563ecbaeb","name":"tf-func-optimistic-lederberg","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "378"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 353cdcdd-11ac-4308-b3e7-ebc3393e80f4
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/0cc5f17a-65f6-44e2-be19-21e563ecbaeb
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"0cc5f17a-65f6-44e2-be19-21e563ecbaeb","name":"tf-func-optimistic-lederberg","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncoptimisticledezjooj5mt","registry_namespace_id":"ef6057c1-dccb-4344-b023-1a02888a9647","secret_environment_variables":[],"status":"ready"}'
-    headers:
-      Content-Length:
-      - "467"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:18 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c2d67f40-f792-4066-a6a9-35c7f03a5a7b
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/0cc5f17a-65f6-44e2-be19-21e563ecbaeb
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"0cc5f17a-65f6-44e2-be19-21e563ecbaeb","name":"tf-func-optimistic-lederberg","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncoptimisticledezjooj5mt","registry_namespace_id":"ef6057c1-dccb-4344-b023-1a02888a9647","secret_environment_variables":[],"status":"ready"}'
-    headers:
-      Content-Length:
-      - "467"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:18 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0085f3d7-3341-42fa-b63e-225e52b0fee3
-    status: 200 OK
-    code: 200
-- request:
-    body: '{"name":"foobar","namespace_id":"0cc5f17a-65f6-44e2-be19-21e563ecbaeb","environment_variables":{"test":"test"},"min_scale":0,"max_scale":20,"runtime":"node14","memory_limit":128,"timeout":null,"handler":"handler.handle","privacy":"private","description":null,"secret_environment_variables":[{"key":"test_secret","value":"test_secret"}],"http_option":"enabled"}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions
-    method: POST
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncoptimisticledezjooj5mt-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"test":"test"},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"525ffa28-ec28-4b97-9ea8-a576632f7e1e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"0cc5f17a-65f6-44e2-be19-21e563ecbaeb","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$x22PaCExcx8iKNuipf/7Kg$C5qp3liMdW4l2dE6FDKmywByifkXX6a5fti6xDn5TF0","key":"test_secret"}],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "674"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e671e945-31ae-4aeb-b18d-0855cb014400
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/525ffa28-ec28-4b97-9ea8-a576632f7e1e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncoptimisticledezjooj5mt-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"test":"test"},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"525ffa28-ec28-4b97-9ea8-a576632f7e1e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"0cc5f17a-65f6-44e2-be19-21e563ecbaeb","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$x22PaCExcx8iKNuipf/7Kg$C5qp3liMdW4l2dE6FDKmywByifkXX6a5fti6xDn5TF0","key":"test_secret"}],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "674"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0b201b6c-4abc-42d2-936f-742d122c382d
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/525ffa28-ec28-4b97-9ea8-a576632f7e1e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncoptimisticledezjooj5mt-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"test":"test"},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"525ffa28-ec28-4b97-9ea8-a576632f7e1e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"0cc5f17a-65f6-44e2-be19-21e563ecbaeb","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$x22PaCExcx8iKNuipf/7Kg$C5qp3liMdW4l2dE6FDKmywByifkXX6a5fti6xDn5TF0","key":"test_secret"}],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "674"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0694a093-4d2b-4bb3-9418-f3a32cd35d1e
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/525ffa28-ec28-4b97-9ea8-a576632f7e1e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncoptimisticledezjooj5mt-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"test":"test"},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"525ffa28-ec28-4b97-9ea8-a576632f7e1e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"0cc5f17a-65f6-44e2-be19-21e563ecbaeb","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$x22PaCExcx8iKNuipf/7Kg$C5qp3liMdW4l2dE6FDKmywByifkXX6a5fti6xDn5TF0","key":"test_secret"}],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "674"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 23804f59-82a0-49aa-8ca4-0f14b092fd00
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/0cc5f17a-65f6-44e2-be19-21e563ecbaeb
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"0cc5f17a-65f6-44e2-be19-21e563ecbaeb","name":"tf-func-optimistic-lederberg","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncoptimisticledezjooj5mt","registry_namespace_id":"ef6057c1-dccb-4344-b023-1a02888a9647","secret_environment_variables":[],"status":"ready"}'
-    headers:
-      Content-Length:
-      - "467"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 97405665-66f3-4ddd-839e-19295b78e6da
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/525ffa28-ec28-4b97-9ea8-a576632f7e1e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncoptimisticledezjooj5mt-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"test":"test"},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"525ffa28-ec28-4b97-9ea8-a576632f7e1e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"0cc5f17a-65f6-44e2-be19-21e563ecbaeb","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$x22PaCExcx8iKNuipf/7Kg$C5qp3liMdW4l2dE6FDKmywByifkXX6a5fti6xDn5TF0","key":"test_secret"}],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "674"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 26a6f182-833b-4c31-a54c-dd57a199709a
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/0cc5f17a-65f6-44e2-be19-21e563ecbaeb
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"0cc5f17a-65f6-44e2-be19-21e563ecbaeb","name":"tf-func-optimistic-lederberg","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncoptimisticledezjooj5mt","registry_namespace_id":"ef6057c1-dccb-4344-b023-1a02888a9647","secret_environment_variables":[],"status":"ready"}'
-    headers:
-      Content-Length:
-      - "467"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:20 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - fe926bfc-36d7-4f0f-b13f-51cf5bcc5a9c
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/525ffa28-ec28-4b97-9ea8-a576632f7e1e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncoptimisticledezjooj5mt-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"test":"test"},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"525ffa28-ec28-4b97-9ea8-a576632f7e1e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"0cc5f17a-65f6-44e2-be19-21e563ecbaeb","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$x22PaCExcx8iKNuipf/7Kg$C5qp3liMdW4l2dE6FDKmywByifkXX6a5fti6xDn5TF0","key":"test_secret"}],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "674"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:20 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0207f8c0-6558-4d80-8fb4-47400d5acf1f
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/525ffa28-ec28-4b97-9ea8-a576632f7e1e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncoptimisticledezjooj5mt-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"test":"test"},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"525ffa28-ec28-4b97-9ea8-a576632f7e1e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"0cc5f17a-65f6-44e2-be19-21e563ecbaeb","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$x22PaCExcx8iKNuipf/7Kg$C5qp3liMdW4l2dE6FDKmywByifkXX6a5fti6xDn5TF0","key":"test_secret"}],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "674"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:20 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 64807ab2-574b-4143-8f04-c7bef064be7a
-    status: 200 OK
-    code: 200
-- request:
-    body: '{"environment_variables":{"foo":"bar"},"min_scale":null,"max_scale":null,"runtime":"unknown_runtime","memory_limit":null,"timeout":null,"redeploy":null,"handler":null,"privacy":"unknown_privacy","description":null,"secret_environment_variables":[{"key":"foo_secret","value":"bar_secret"}],"http_option":"unknown_http_option"}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/525ffa28-ec28-4b97-9ea8-a576632f7e1e
-    method: PATCH
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncoptimisticledezjooj5mt-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"bar"},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"525ffa28-ec28-4b97-9ea8-a576632f7e1e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"0cc5f17a-65f6-44e2-be19-21e563ecbaeb","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$x22PaCExcx8iKNuipf/7Kg$C5qp3liMdW4l2dE6FDKmywByifkXX6a5fti6xDn5TF0","key":"test_secret"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$E6weMECLPKle/+GTDhl4WA$TkWtSNjd6j19BT0bYoz4HZ8ky/nAn//6S5rKDyPfhgI","key":"foo_secret"}],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "808"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:20 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ca524560-5464-4763-9ca0-19604133d5ab
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/525ffa28-ec28-4b97-9ea8-a576632f7e1e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncoptimisticledezjooj5mt-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"bar"},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"525ffa28-ec28-4b97-9ea8-a576632f7e1e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"0cc5f17a-65f6-44e2-be19-21e563ecbaeb","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$x22PaCExcx8iKNuipf/7Kg$C5qp3liMdW4l2dE6FDKmywByifkXX6a5fti6xDn5TF0","key":"test_secret"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$E6weMECLPKle/+GTDhl4WA$TkWtSNjd6j19BT0bYoz4HZ8ky/nAn//6S5rKDyPfhgI","key":"foo_secret"}],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "808"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:22 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f3f1a130-5e64-437c-9688-2d1eea5a1a5b
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/525ffa28-ec28-4b97-9ea8-a576632f7e1e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncoptimisticledezjooj5mt-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"bar"},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"525ffa28-ec28-4b97-9ea8-a576632f7e1e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"0cc5f17a-65f6-44e2-be19-21e563ecbaeb","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$x22PaCExcx8iKNuipf/7Kg$C5qp3liMdW4l2dE6FDKmywByifkXX6a5fti6xDn5TF0","key":"test_secret"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$E6weMECLPKle/+GTDhl4WA$TkWtSNjd6j19BT0bYoz4HZ8ky/nAn//6S5rKDyPfhgI","key":"foo_secret"}],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "808"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:27 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 312982ee-7bbd-489b-8d4d-bdb145dcb507
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/525ffa28-ec28-4b97-9ea8-a576632f7e1e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncoptimisticledezjooj5mt-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"bar"},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"525ffa28-ec28-4b97-9ea8-a576632f7e1e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"0cc5f17a-65f6-44e2-be19-21e563ecbaeb","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$x22PaCExcx8iKNuipf/7Kg$C5qp3liMdW4l2dE6FDKmywByifkXX6a5fti6xDn5TF0","key":"test_secret"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$E6weMECLPKle/+GTDhl4WA$TkWtSNjd6j19BT0bYoz4HZ8ky/nAn//6S5rKDyPfhgI","key":"foo_secret"}],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "808"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:32 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 073edba8-d78a-42ec-aeba-233c029dd5b1
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/525ffa28-ec28-4b97-9ea8-a576632f7e1e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncoptimisticledezjooj5mt-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"bar"},"error_message":"an
-      error occurred during function source code build step","handler":"handler.handle","http_option":"enabled","id":"525ffa28-ec28-4b97-9ea8-a576632f7e1e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"0cc5f17a-65f6-44e2-be19-21e563ecbaeb","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$x22PaCExcx8iKNuipf/7Kg$C5qp3liMdW4l2dE6FDKmywByifkXX6a5fti6xDn5TF0","key":"test_secret"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$E6weMECLPKle/+GTDhl4WA$TkWtSNjd6j19BT0bYoz4HZ8ky/nAn//6S5rKDyPfhgI","key":"foo_secret"}],"status":"error","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "860"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:37 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7e0dd7cf-f81b-4827-9698-e11e0994efe7
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/525ffa28-ec28-4b97-9ea8-a576632f7e1e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncoptimisticledezjooj5mt-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"bar"},"error_message":"an
-      error occurred during function source code build step","handler":"handler.handle","http_option":"enabled","id":"525ffa28-ec28-4b97-9ea8-a576632f7e1e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"0cc5f17a-65f6-44e2-be19-21e563ecbaeb","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$x22PaCExcx8iKNuipf/7Kg$C5qp3liMdW4l2dE6FDKmywByifkXX6a5fti6xDn5TF0","key":"test_secret"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$E6weMECLPKle/+GTDhl4WA$TkWtSNjd6j19BT0bYoz4HZ8ky/nAn//6S5rKDyPfhgI","key":"foo_secret"}],"status":"error","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "860"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:37 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 81f006b4-6422-47e4-a9d0-3b5076490b20
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/0cc5f17a-65f6-44e2-be19-21e563ecbaeb
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"0cc5f17a-65f6-44e2-be19-21e563ecbaeb","name":"tf-func-optimistic-lederberg","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncoptimisticledezjooj5mt","registry_namespace_id":"ef6057c1-dccb-4344-b023-1a02888a9647","secret_environment_variables":[],"status":"ready"}'
-    headers:
-      Content-Length:
-      - "467"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:37 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 269f4060-f8ee-41f4-bec4-d7870a895d6f
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/525ffa28-ec28-4b97-9ea8-a576632f7e1e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncoptimisticledezjooj5mt-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"bar"},"error_message":"an
-      error occurred during function source code build step","handler":"handler.handle","http_option":"enabled","id":"525ffa28-ec28-4b97-9ea8-a576632f7e1e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"0cc5f17a-65f6-44e2-be19-21e563ecbaeb","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$x22PaCExcx8iKNuipf/7Kg$C5qp3liMdW4l2dE6FDKmywByifkXX6a5fti6xDn5TF0","key":"test_secret"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$E6weMECLPKle/+GTDhl4WA$TkWtSNjd6j19BT0bYoz4HZ8ky/nAn//6S5rKDyPfhgI","key":"foo_secret"}],"status":"error","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "860"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:37 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9012b08d-925b-412c-b7aa-ea46fe356484
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/525ffa28-ec28-4b97-9ea8-a576632f7e1e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncoptimisticledezjooj5mt-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"bar"},"error_message":"an
-      error occurred during function source code build step","handler":"handler.handle","http_option":"enabled","id":"525ffa28-ec28-4b97-9ea8-a576632f7e1e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"0cc5f17a-65f6-44e2-be19-21e563ecbaeb","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$x22PaCExcx8iKNuipf/7Kg$C5qp3liMdW4l2dE6FDKmywByifkXX6a5fti6xDn5TF0","key":"test_secret"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$E6weMECLPKle/+GTDhl4WA$TkWtSNjd6j19BT0bYoz4HZ8ky/nAn//6S5rKDyPfhgI","key":"foo_secret"}],"status":"error","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "860"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:38 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 80c58456-6a84-4a38-8623-a01598878e94
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/525ffa28-ec28-4b97-9ea8-a576632f7e1e
-    method: DELETE
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncoptimisticledezjooj5mt-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"bar"},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"525ffa28-ec28-4b97-9ea8-a576632f7e1e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"0cc5f17a-65f6-44e2-be19-21e563ecbaeb","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$x22PaCExcx8iKNuipf/7Kg$C5qp3liMdW4l2dE6FDKmywByifkXX6a5fti6xDn5TF0","key":"test_secret"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$E6weMECLPKle/+GTDhl4WA$TkWtSNjd6j19BT0bYoz4HZ8ky/nAn//6S5rKDyPfhgI","key":"foo_secret"}],"status":"deleting","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "809"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:38 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 936d9e64-1907-4719-9ccd-148563f81810
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/0cc5f17a-65f6-44e2-be19-21e563ecbaeb
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"0cc5f17a-65f6-44e2-be19-21e563ecbaeb","name":"tf-func-optimistic-lederberg","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncoptimisticledezjooj5mt","registry_namespace_id":"ef6057c1-dccb-4344-b023-1a02888a9647","secret_environment_variables":[],"status":"ready"}'
-    headers:
-      Content-Length:
-      - "467"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:38 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6d2f5876-ce23-468c-8d55-78909fc67491
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/0cc5f17a-65f6-44e2-be19-21e563ecbaeb
-    method: DELETE
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"0cc5f17a-65f6-44e2-be19-21e563ecbaeb","name":"tf-func-optimistic-lederberg","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncoptimisticledezjooj5mt","registry_namespace_id":"ef6057c1-dccb-4344-b023-1a02888a9647","secret_environment_variables":[],"status":"deleting"}'
-    headers:
-      Content-Length:
-      - "470"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:38 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b3ff017a-c2e4-4271-ac47-9a8b64e21dcb
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/0cc5f17a-65f6-44e2-be19-21e563ecbaeb
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"0cc5f17a-65f6-44e2-be19-21e563ecbaeb","name":"tf-func-optimistic-lederberg","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncoptimisticledezjooj5mt","registry_namespace_id":"ef6057c1-dccb-4344-b023-1a02888a9647","secret_environment_variables":[],"status":"deleting"}'
-    headers:
-      Content-Length:
-      - "470"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:38 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5bd875dd-fd3b-465b-9b1f-e7c44004cd97
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/0cc5f17a-65f6-44e2-be19-21e563ecbaeb
-    method: GET
-  response:
-    body: '{"message":"Namespace was not found"}'
-    headers:
-      Content-Length:
-      - "37"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:43 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - de1163b6-12a0-4d95-b15a-84f0b2100d22
-    status: 404 Not Found
-    code: 404
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/525ffa28-ec28-4b97-9ea8-a576632f7e1e
-    method: DELETE
-  response:
-    body: '{"message":"Function was not found"}'
-    headers:
-      Content-Length:
-      - "36"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:43 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 40b05ad8-8d7a-47df-9570-53cb0998fbac
-    status: 404 Not Found
-    code: 404
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 147
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"name":"tf-func-tender-torvalds","environment_variables":{},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","secret_environment_variables":[]}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 373
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"c1c0c944-e794-47f1-aa6f-a615f262b68e","name":"tf-func-tender-torvalds","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
+        headers:
+            Content-Length:
+                - "373"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:19 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 93bd55a4-4002-4f37-bed2-05c1ab4162b9
+        status: 200 OK
+        code: 200
+        duration: 1.240083499s
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/c1c0c944-e794-47f1-aa6f-a615f262b68e
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 373
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"c1c0c944-e794-47f1-aa6f-a615f262b68e","name":"tf-func-tender-torvalds","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
+        headers:
+            Content-Length:
+                - "373"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:20 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 59245a17-4940-4363-a224-9ae3c1c9276c
+        status: 200 OK
+        code: 200
+        duration: 71.749446ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/c1c0c944-e794-47f1-aa6f-a615f262b68e
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 462
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"c1c0c944-e794-47f1-aa6f-a615f262b68e","name":"tf-func-tender-torvalds","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunctendertorvaldszifl1dcs","registry_namespace_id":"d6bd1d34-ffae-48eb-ae83-577b590687d8","secret_environment_variables":[],"status":"ready"}'
+        headers:
+            Content-Length:
+                - "462"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:25 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 0837f4ba-98ee-4ed4-b3a6-786c0aaf97e9
+        status: 200 OK
+        code: 200
+        duration: 64.404375ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/c1c0c944-e794-47f1-aa6f-a615f262b68e
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 462
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"c1c0c944-e794-47f1-aa6f-a615f262b68e","name":"tf-func-tender-torvalds","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunctendertorvaldszifl1dcs","registry_namespace_id":"d6bd1d34-ffae-48eb-ae83-577b590687d8","secret_environment_variables":[],"status":"ready"}'
+        headers:
+            Content-Length:
+                - "462"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:25 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 9760ff47-5961-4c40-a715-0c481e377439
+        status: 200 OK
+        code: 200
+        duration: 49.786087ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 354
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"name":"foobar","namespace_id":"c1c0c944-e794-47f1-aa6f-a615f262b68e","environment_variables":{"test":"test"},"min_scale":0,"max_scale":20,"runtime":"node22","memory_limit":256,"handler":"handler.handle","privacy":"private","secret_environment_variables":[{"key":"test_secret","value":"test_secret"}],"http_option":"enabled","sandbox":"unknown_sandbox"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 711
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffunctendertorvaldszifl1dcs-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"test":"test"},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"5b9b9c2d-fa31-418f-9904-14aac5a7c984","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"c1c0c944-e794-47f1-aa6f-a615f262b68e","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$mfBbtNvve4vk4GBtcwkAkQ$hHOfmX8YZu13Lolmok5xYJtK1KmssC3XcAQG6PWadjk","key":"test_secret"}],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "711"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:25 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 692dfd5d-e3eb-44c7-a3b6-9ff45c7e268b
+        status: 200 OK
+        code: 200
+        duration: 831.924728ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/5b9b9c2d-fa31-418f-9904-14aac5a7c984
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 711
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffunctendertorvaldszifl1dcs-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"test":"test"},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"5b9b9c2d-fa31-418f-9904-14aac5a7c984","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"c1c0c944-e794-47f1-aa6f-a615f262b68e","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$mfBbtNvve4vk4GBtcwkAkQ$hHOfmX8YZu13Lolmok5xYJtK1KmssC3XcAQG6PWadjk","key":"test_secret"}],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "711"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:26 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ab9f7f9e-ef14-4fea-a119-0feca01e12bd
+        status: 200 OK
+        code: 200
+        duration: 66.435761ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/5b9b9c2d-fa31-418f-9904-14aac5a7c984
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 711
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffunctendertorvaldszifl1dcs-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"test":"test"},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"5b9b9c2d-fa31-418f-9904-14aac5a7c984","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"c1c0c944-e794-47f1-aa6f-a615f262b68e","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$mfBbtNvve4vk4GBtcwkAkQ$hHOfmX8YZu13Lolmok5xYJtK1KmssC3XcAQG6PWadjk","key":"test_secret"}],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "711"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:26 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 2b641d3c-787a-4ed1-a2be-934a7e2b8b59
+        status: 200 OK
+        code: 200
+        duration: 71.967886ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/5b9b9c2d-fa31-418f-9904-14aac5a7c984
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 711
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffunctendertorvaldszifl1dcs-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"test":"test"},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"5b9b9c2d-fa31-418f-9904-14aac5a7c984","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"c1c0c944-e794-47f1-aa6f-a615f262b68e","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$mfBbtNvve4vk4GBtcwkAkQ$hHOfmX8YZu13Lolmok5xYJtK1KmssC3XcAQG6PWadjk","key":"test_secret"}],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "711"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:26 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 188ddb12-1ede-4fb7-8aa5-526f5d867f1f
+        status: 200 OK
+        code: 200
+        duration: 58.480073ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/c1c0c944-e794-47f1-aa6f-a615f262b68e
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 462
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"c1c0c944-e794-47f1-aa6f-a615f262b68e","name":"tf-func-tender-torvalds","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunctendertorvaldszifl1dcs","registry_namespace_id":"d6bd1d34-ffae-48eb-ae83-577b590687d8","secret_environment_variables":[],"status":"ready"}'
+        headers:
+            Content-Length:
+                - "462"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:26 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ca530f8f-136d-49ba-8378-10b0c3f64e19
+        status: 200 OK
+        code: 200
+        duration: 71.041446ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/5b9b9c2d-fa31-418f-9904-14aac5a7c984
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 711
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffunctendertorvaldszifl1dcs-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"test":"test"},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"5b9b9c2d-fa31-418f-9904-14aac5a7c984","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"c1c0c944-e794-47f1-aa6f-a615f262b68e","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$mfBbtNvve4vk4GBtcwkAkQ$hHOfmX8YZu13Lolmok5xYJtK1KmssC3XcAQG6PWadjk","key":"test_secret"}],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "711"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:26 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 088c4dbb-fd34-4904-bd90-eecf89cc40c2
+        status: 200 OK
+        code: 200
+        duration: 71.92712ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/c1c0c944-e794-47f1-aa6f-a615f262b68e
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 462
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"c1c0c944-e794-47f1-aa6f-a615f262b68e","name":"tf-func-tender-torvalds","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunctendertorvaldszifl1dcs","registry_namespace_id":"d6bd1d34-ffae-48eb-ae83-577b590687d8","secret_environment_variables":[],"status":"ready"}'
+        headers:
+            Content-Length:
+                - "462"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:26 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - eb68c115-0ae8-4938-b07d-f810437e2f5a
+        status: 200 OK
+        code: 200
+        duration: 65.46671ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/5b9b9c2d-fa31-418f-9904-14aac5a7c984
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 711
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffunctendertorvaldszifl1dcs-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"test":"test"},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"5b9b9c2d-fa31-418f-9904-14aac5a7c984","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"c1c0c944-e794-47f1-aa6f-a615f262b68e","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$mfBbtNvve4vk4GBtcwkAkQ$hHOfmX8YZu13Lolmok5xYJtK1KmssC3XcAQG6PWadjk","key":"test_secret"}],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "711"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:27 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e5a732e8-778c-499d-a839-d6952a33388a
+        status: 200 OK
+        code: 200
+        duration: 54.958977ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/5b9b9c2d-fa31-418f-9904-14aac5a7c984
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 711
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffunctendertorvaldszifl1dcs-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"test":"test"},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"5b9b9c2d-fa31-418f-9904-14aac5a7c984","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"c1c0c944-e794-47f1-aa6f-a615f262b68e","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$mfBbtNvve4vk4GBtcwkAkQ$hHOfmX8YZu13Lolmok5xYJtK1KmssC3XcAQG6PWadjk","key":"test_secret"}],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "711"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:27 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - edc290e2-fc4d-49c1-91b8-18d036c2ea8a
+        status: 200 OK
+        code: 200
+        duration: 72.438171ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 234
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"environment_variables":{"foo":"bar"},"runtime":"unknown_runtime","privacy":"unknown_privacy","secret_environment_variables":[{"key":"foo_secret","value":"bar_secret"}],"http_option":"unknown_http_option","sandbox":"unknown_sandbox"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/5b9b9c2d-fa31-418f-9904-14aac5a7c984
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 845
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffunctendertorvaldszifl1dcs-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"bar"},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"5b9b9c2d-fa31-418f-9904-14aac5a7c984","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"c1c0c944-e794-47f1-aa6f-a615f262b68e","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$mfBbtNvve4vk4GBtcwkAkQ$hHOfmX8YZu13Lolmok5xYJtK1KmssC3XcAQG6PWadjk","key":"test_secret"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$FlLYj4RAWGj8hQzb2DIKqQ$SeGLoqwg0kWIeSXwz/o8IyYsjgIOLLcj6c4iD93aRzw","key":"foo_secret"}],"status":"pending","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "845"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:27 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 2da79b2d-663c-4cef-a261-673fc6c2a313
+        status: 200 OK
+        code: 200
+        duration: 226.522611ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/5b9b9c2d-fa31-418f-9904-14aac5a7c984
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 845
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffunctendertorvaldszifl1dcs-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"bar"},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"5b9b9c2d-fa31-418f-9904-14aac5a7c984","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"c1c0c944-e794-47f1-aa6f-a615f262b68e","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$mfBbtNvve4vk4GBtcwkAkQ$hHOfmX8YZu13Lolmok5xYJtK1KmssC3XcAQG6PWadjk","key":"test_secret"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$FlLYj4RAWGj8hQzb2DIKqQ$SeGLoqwg0kWIeSXwz/o8IyYsjgIOLLcj6c4iD93aRzw","key":"foo_secret"}],"status":"pending","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "845"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:28 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 1f8d1c20-f338-4770-bda1-79073469a7d1
+        status: 200 OK
+        code: 200
+        duration: 61.065902ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/5b9b9c2d-fa31-418f-9904-14aac5a7c984
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 855
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffunctendertorvaldszifl1dcs-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"bar"},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"5b9b9c2d-fa31-418f-9904-14aac5a7c984","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"c1c0c944-e794-47f1-aa6f-a615f262b68e","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$mfBbtNvve4vk4GBtcwkAkQ$hHOfmX8YZu13Lolmok5xYJtK1KmssC3XcAQG6PWadjk","key":"test_secret"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$FlLYj4RAWGj8hQzb2DIKqQ$SeGLoqwg0kWIeSXwz/o8IyYsjgIOLLcj6c4iD93aRzw","key":"foo_secret"}],"status":"error","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "855"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:33 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 499625d4-8f08-47c9-a695-a217b5691ea8
+        status: 200 OK
+        code: 200
+        duration: 72.976812ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/5b9b9c2d-fa31-418f-9904-14aac5a7c984
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 855
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffunctendertorvaldszifl1dcs-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"bar"},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"5b9b9c2d-fa31-418f-9904-14aac5a7c984","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"c1c0c944-e794-47f1-aa6f-a615f262b68e","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$mfBbtNvve4vk4GBtcwkAkQ$hHOfmX8YZu13Lolmok5xYJtK1KmssC3XcAQG6PWadjk","key":"test_secret"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$FlLYj4RAWGj8hQzb2DIKqQ$SeGLoqwg0kWIeSXwz/o8IyYsjgIOLLcj6c4iD93aRzw","key":"foo_secret"}],"status":"error","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "855"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f00fcd59-5585-436a-a65f-d919e0246064
+        status: 200 OK
+        code: 200
+        duration: 63.200393ms
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/c1c0c944-e794-47f1-aa6f-a615f262b68e
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 462
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"c1c0c944-e794-47f1-aa6f-a615f262b68e","name":"tf-func-tender-torvalds","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunctendertorvaldszifl1dcs","registry_namespace_id":"d6bd1d34-ffae-48eb-ae83-577b590687d8","secret_environment_variables":[],"status":"ready"}'
+        headers:
+            Content-Length:
+                - "462"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b9653151-243b-4345-93fd-dd9addfdc9e2
+        status: 200 OK
+        code: 200
+        duration: 52.219229ms
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/5b9b9c2d-fa31-418f-9904-14aac5a7c984
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 855
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffunctendertorvaldszifl1dcs-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"bar"},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"5b9b9c2d-fa31-418f-9904-14aac5a7c984","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"c1c0c944-e794-47f1-aa6f-a615f262b68e","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$mfBbtNvve4vk4GBtcwkAkQ$hHOfmX8YZu13Lolmok5xYJtK1KmssC3XcAQG6PWadjk","key":"test_secret"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$FlLYj4RAWGj8hQzb2DIKqQ$SeGLoqwg0kWIeSXwz/o8IyYsjgIOLLcj6c4iD93aRzw","key":"foo_secret"}],"status":"error","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "855"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 73a06132-7273-4ec7-88aa-a7825a740c78
+        status: 200 OK
+        code: 200
+        duration: 63.43314ms
+    - id: 19
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/5b9b9c2d-fa31-418f-9904-14aac5a7c984
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 855
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffunctendertorvaldszifl1dcs-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"bar"},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"5b9b9c2d-fa31-418f-9904-14aac5a7c984","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"c1c0c944-e794-47f1-aa6f-a615f262b68e","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$mfBbtNvve4vk4GBtcwkAkQ$hHOfmX8YZu13Lolmok5xYJtK1KmssC3XcAQG6PWadjk","key":"test_secret"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$FlLYj4RAWGj8hQzb2DIKqQ$SeGLoqwg0kWIeSXwz/o8IyYsjgIOLLcj6c4iD93aRzw","key":"foo_secret"}],"status":"error","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "855"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3e62664c-fb8d-45c8-a6ad-d387a2163e44
+        status: 200 OK
+        code: 200
+        duration: 68.456128ms
+    - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/5b9b9c2d-fa31-418f-9904-14aac5a7c984
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 846
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffunctendertorvaldszifl1dcs-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"bar"},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"5b9b9c2d-fa31-418f-9904-14aac5a7c984","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"c1c0c944-e794-47f1-aa6f-a615f262b68e","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$mfBbtNvve4vk4GBtcwkAkQ$hHOfmX8YZu13Lolmok5xYJtK1KmssC3XcAQG6PWadjk","key":"test_secret"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$FlLYj4RAWGj8hQzb2DIKqQ$SeGLoqwg0kWIeSXwz/o8IyYsjgIOLLcj6c4iD93aRzw","key":"foo_secret"}],"status":"deleting","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "846"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 027cdfd3-e4ce-4e72-a8eb-a8923c954a91
+        status: 200 OK
+        code: 200
+        duration: 106.915051ms
+    - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/c1c0c944-e794-47f1-aa6f-a615f262b68e
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 462
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"c1c0c944-e794-47f1-aa6f-a615f262b68e","name":"tf-func-tender-torvalds","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunctendertorvaldszifl1dcs","registry_namespace_id":"d6bd1d34-ffae-48eb-ae83-577b590687d8","secret_environment_variables":[],"status":"ready"}'
+        headers:
+            Content-Length:
+                - "462"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 6047e22b-e6f0-4c9d-aead-35d801d1d0df
+        status: 200 OK
+        code: 200
+        duration: 51.097251ms
+    - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/c1c0c944-e794-47f1-aa6f-a615f262b68e
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 465
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"c1c0c944-e794-47f1-aa6f-a615f262b68e","name":"tf-func-tender-torvalds","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunctendertorvaldszifl1dcs","registry_namespace_id":"d6bd1d34-ffae-48eb-ae83-577b590687d8","secret_environment_variables":[],"status":"deleting"}'
+        headers:
+            Content-Length:
+                - "465"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b4379735-5477-4612-b2cf-d6cad0faa3eb
+        status: 200 OK
+        code: 200
+        duration: 253.249381ms
+    - id: 23
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/c1c0c944-e794-47f1-aa6f-a615f262b68e
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 465
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"c1c0c944-e794-47f1-aa6f-a615f262b68e","name":"tf-func-tender-torvalds","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunctendertorvaldszifl1dcs","registry_namespace_id":"d6bd1d34-ffae-48eb-ae83-577b590687d8","secret_environment_variables":[],"status":"deleting"}'
+        headers:
+            Content-Length:
+                - "465"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 36c6ca5e-830d-4de3-a5c9-6f726b2dc885
+        status: 200 OK
+        code: 200
+        duration: 59.169428ms
+    - id: 24
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/c1c0c944-e794-47f1-aa6f-a615f262b68e
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 37
+        uncompressed: false
+        body: '{"message":"Namespace was not found"}'
+        headers:
+            Content-Length:
+                - "37"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:40 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 05c3dce3-5c0c-46f8-91ca-21f3dc2efeca
+        status: 404 Not Found
+        code: 404
+        duration: 23.465441ms
+    - id: 25
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/5b9b9c2d-fa31-418f-9904-14aac5a7c984
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 36
+        uncompressed: false
+        body: '{"message":"Function was not found"}'
+        headers:
+            Content-Length:
+                - "36"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:40 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 22a2e830-ff11-4021-a664-c537022a79d6
+        status: 404 Not Found
+        code: 404
+        duration: 29.525498ms

--- a/internal/services/function/testdata/function-http-option.cassette.yaml
+++ b/internal/services/function/testdata/function-http-option.cassette.yaml
@@ -1,1524 +1,1677 @@
 ---
 version: 2
 interactions:
-- request:
-    body: '{"name":"tf-func-priceless-gauss","environment_variables":{},"project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","description":null,"secret_environment_variables":[]}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces
-    method: POST
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"86a56709-566d-4a59-967b-dd762e15a7b6","name":"tf-func-priceless-gauss","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "373"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:46:38 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - af222ae6-2ae7-4848-800f-8a92676ae14f
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/86a56709-566d-4a59-967b-dd762e15a7b6
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"86a56709-566d-4a59-967b-dd762e15a7b6","name":"tf-func-priceless-gauss","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "373"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:46:38 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9b6ce964-e312-4bb1-a155-edd79485ab20
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/86a56709-566d-4a59-967b-dd762e15a7b6
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"86a56709-566d-4a59-967b-dd762e15a7b6","name":"tf-func-priceless-gauss","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "373"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:46:43 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e25a6069-b6d4-4cea-84d4-21a656b375b3
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/86a56709-566d-4a59-967b-dd762e15a7b6
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"86a56709-566d-4a59-967b-dd762e15a7b6","name":"tf-func-priceless-gauss","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "373"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:46:48 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 66eacfc2-1c16-46d6-a8a0-622d1f4ee047
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/86a56709-566d-4a59-967b-dd762e15a7b6
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"86a56709-566d-4a59-967b-dd762e15a7b6","name":"tf-func-priceless-gauss","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "373"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:46:53 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 37130c3a-f5ad-4a07-95d2-31ebc891dc34
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/86a56709-566d-4a59-967b-dd762e15a7b6
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"86a56709-566d-4a59-967b-dd762e15a7b6","name":"tf-func-priceless-gauss","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "373"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:46:58 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 14f2b13a-f82a-49df-8569-f8152d9219b8
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/86a56709-566d-4a59-967b-dd762e15a7b6
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"86a56709-566d-4a59-967b-dd762e15a7b6","name":"tf-func-priceless-gauss","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "373"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d233dd74-f04a-42c1-b1e0-0bbadae16e05
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/86a56709-566d-4a59-967b-dd762e15a7b6
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"86a56709-566d-4a59-967b-dd762e15a7b6","name":"tf-func-priceless-gauss","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncpricelessgaussrxnpdycu","registry_namespace_id":"00e2499f-3294-410d-839e-257e0a6c3667","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "464"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:08 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 378b2459-3ea5-4b7d-b94f-6916d76b8bc5
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/86a56709-566d-4a59-967b-dd762e15a7b6
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"86a56709-566d-4a59-967b-dd762e15a7b6","name":"tf-func-priceless-gauss","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncpricelessgaussrxnpdycu","registry_namespace_id":"00e2499f-3294-410d-839e-257e0a6c3667","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "464"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d34a45d7-145d-4184-9f82-fea702863190
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/86a56709-566d-4a59-967b-dd762e15a7b6
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"86a56709-566d-4a59-967b-dd762e15a7b6","name":"tf-func-priceless-gauss","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncpricelessgaussrxnpdycu","registry_namespace_id":"00e2499f-3294-410d-839e-257e0a6c3667","secret_environment_variables":[],"status":"ready"}'
-    headers:
-      Content-Length:
-      - "462"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:18 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - fadde25e-432f-4c20-b418-751c49763e3f
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/86a56709-566d-4a59-967b-dd762e15a7b6
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"86a56709-566d-4a59-967b-dd762e15a7b6","name":"tf-func-priceless-gauss","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncpricelessgaussrxnpdycu","registry_namespace_id":"00e2499f-3294-410d-839e-257e0a6c3667","secret_environment_variables":[],"status":"ready"}'
-    headers:
-      Content-Length:
-      - "462"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:18 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 956405ed-b5bb-426e-b74f-c98d65a5d679
-    status: 200 OK
-    code: 200
-- request:
-    body: '{"name":"foobar","namespace_id":"86a56709-566d-4a59-967b-dd762e15a7b6","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"node14","memory_limit":128,"timeout":null,"handler":"handler.handle","privacy":"private","description":null,"secret_environment_variables":[],"http_option":"enabled"}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions
-    method: POST
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncpricelessgaussrxnpdycu-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"5682fd21-e3b6-473c-a2f0-eddf72df900e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"86a56709-566d-4a59-967b-dd762e15a7b6","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "525"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0dbbec49-aa3f-4872-b533-e0bbc024f934
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/5682fd21-e3b6-473c-a2f0-eddf72df900e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncpricelessgaussrxnpdycu-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"5682fd21-e3b6-473c-a2f0-eddf72df900e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"86a56709-566d-4a59-967b-dd762e15a7b6","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "525"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9f03fe32-4a4a-4075-a9b0-13ff701a3848
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/5682fd21-e3b6-473c-a2f0-eddf72df900e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncpricelessgaussrxnpdycu-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"5682fd21-e3b6-473c-a2f0-eddf72df900e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"86a56709-566d-4a59-967b-dd762e15a7b6","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "525"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8c96836b-f23b-4f4c-9fb8-6b47d6c13074
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/5682fd21-e3b6-473c-a2f0-eddf72df900e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncpricelessgaussrxnpdycu-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"5682fd21-e3b6-473c-a2f0-eddf72df900e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"86a56709-566d-4a59-967b-dd762e15a7b6","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "525"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 19b3653e-b30b-4607-b8b9-6bdf6d80c467
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/86a56709-566d-4a59-967b-dd762e15a7b6
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"86a56709-566d-4a59-967b-dd762e15a7b6","name":"tf-func-priceless-gauss","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncpricelessgaussrxnpdycu","registry_namespace_id":"00e2499f-3294-410d-839e-257e0a6c3667","secret_environment_variables":[],"status":"ready"}'
-    headers:
-      Content-Length:
-      - "462"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c81ae884-eeca-4dba-bc98-fc7ab1c39ca8
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/5682fd21-e3b6-473c-a2f0-eddf72df900e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncpricelessgaussrxnpdycu-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"5682fd21-e3b6-473c-a2f0-eddf72df900e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"86a56709-566d-4a59-967b-dd762e15a7b6","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "525"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e1358e75-8d7d-4ecd-8191-e6b32bea00c9
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/86a56709-566d-4a59-967b-dd762e15a7b6
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"86a56709-566d-4a59-967b-dd762e15a7b6","name":"tf-func-priceless-gauss","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncpricelessgaussrxnpdycu","registry_namespace_id":"00e2499f-3294-410d-839e-257e0a6c3667","secret_environment_variables":[],"status":"ready"}'
-    headers:
-      Content-Length:
-      - "462"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ae291d6f-6279-4aed-a7ba-7d1c2c877ccc
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/5682fd21-e3b6-473c-a2f0-eddf72df900e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncpricelessgaussrxnpdycu-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"5682fd21-e3b6-473c-a2f0-eddf72df900e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"86a56709-566d-4a59-967b-dd762e15a7b6","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "525"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b8691a2e-460a-4f88-961a-be1e8ec0582b
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/5682fd21-e3b6-473c-a2f0-eddf72df900e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncpricelessgaussrxnpdycu-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"5682fd21-e3b6-473c-a2f0-eddf72df900e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"86a56709-566d-4a59-967b-dd762e15a7b6","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "525"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:20 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 04d6cc5b-50b1-404f-9b8c-84d7a4152358
-    status: 200 OK
-    code: 200
-- request:
-    body: '{"environment_variables":null,"min_scale":null,"max_scale":null,"runtime":"unknown_runtime","memory_limit":null,"timeout":null,"redeploy":null,"handler":null,"privacy":"unknown_privacy","description":null,"secret_environment_variables":null,"http_option":"redirected"}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/5682fd21-e3b6-473c-a2f0-eddf72df900e
-    method: PATCH
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncpricelessgaussrxnpdycu-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"redirected","id":"5682fd21-e3b6-473c-a2f0-eddf72df900e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"86a56709-566d-4a59-967b-dd762e15a7b6","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "528"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:20 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c644d0bc-32cb-4948-9a0e-5ca77ab1482a
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/5682fd21-e3b6-473c-a2f0-eddf72df900e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncpricelessgaussrxnpdycu-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"redirected","id":"5682fd21-e3b6-473c-a2f0-eddf72df900e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"86a56709-566d-4a59-967b-dd762e15a7b6","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "528"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:21 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - cdb85f6d-f855-497f-b582-4373117a8e94
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/5682fd21-e3b6-473c-a2f0-eddf72df900e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncpricelessgaussrxnpdycu-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"redirected","id":"5682fd21-e3b6-473c-a2f0-eddf72df900e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"86a56709-566d-4a59-967b-dd762e15a7b6","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "528"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:26 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - caea5ccf-f763-4077-bc4b-f1c2b68a6b0f
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/5682fd21-e3b6-473c-a2f0-eddf72df900e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncpricelessgaussrxnpdycu-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"redirected","id":"5682fd21-e3b6-473c-a2f0-eddf72df900e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"86a56709-566d-4a59-967b-dd762e15a7b6","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "528"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:31 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 83d78136-6529-4ec8-ab90-7988e72e3ba9
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/5682fd21-e3b6-473c-a2f0-eddf72df900e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncpricelessgaussrxnpdycu-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"redirected","id":"5682fd21-e3b6-473c-a2f0-eddf72df900e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"86a56709-566d-4a59-967b-dd762e15a7b6","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "528"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:36 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 135d8834-2635-47b4-a5b0-9c1a4b4fa459
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/5682fd21-e3b6-473c-a2f0-eddf72df900e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncpricelessgaussrxnpdycu-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"an
-      error occurred during function source code build step","handler":"handler.handle","http_option":"redirected","id":"5682fd21-e3b6-473c-a2f0-eddf72df900e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"86a56709-566d-4a59-967b-dd762e15a7b6","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"error","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "580"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:41 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - abc0303c-64dd-4614-bca1-0dac8f6859cf
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/5682fd21-e3b6-473c-a2f0-eddf72df900e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncpricelessgaussrxnpdycu-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"an
-      error occurred during function source code build step","handler":"handler.handle","http_option":"redirected","id":"5682fd21-e3b6-473c-a2f0-eddf72df900e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"86a56709-566d-4a59-967b-dd762e15a7b6","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"error","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "580"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:41 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 95571437-89e2-4b3d-9f07-8106f889e089
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/86a56709-566d-4a59-967b-dd762e15a7b6
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"86a56709-566d-4a59-967b-dd762e15a7b6","name":"tf-func-priceless-gauss","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncpricelessgaussrxnpdycu","registry_namespace_id":"00e2499f-3294-410d-839e-257e0a6c3667","secret_environment_variables":[],"status":"ready"}'
-    headers:
-      Content-Length:
-      - "462"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:42 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 46aff57f-99f3-4ff6-a542-2bd01de168f4
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/5682fd21-e3b6-473c-a2f0-eddf72df900e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncpricelessgaussrxnpdycu-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"an
-      error occurred during function source code build step","handler":"handler.handle","http_option":"redirected","id":"5682fd21-e3b6-473c-a2f0-eddf72df900e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"86a56709-566d-4a59-967b-dd762e15a7b6","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"error","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "580"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:42 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 271881d0-2003-4cbe-bd8e-d40b6af8c657
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/86a56709-566d-4a59-967b-dd762e15a7b6
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"86a56709-566d-4a59-967b-dd762e15a7b6","name":"tf-func-priceless-gauss","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncpricelessgaussrxnpdycu","registry_namespace_id":"00e2499f-3294-410d-839e-257e0a6c3667","secret_environment_variables":[],"status":"ready"}'
-    headers:
-      Content-Length:
-      - "462"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:42 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - de9f95b2-2462-482a-8cf6-370f4a4061f1
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/5682fd21-e3b6-473c-a2f0-eddf72df900e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncpricelessgaussrxnpdycu-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"an
-      error occurred during function source code build step","handler":"handler.handle","http_option":"redirected","id":"5682fd21-e3b6-473c-a2f0-eddf72df900e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"86a56709-566d-4a59-967b-dd762e15a7b6","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"error","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "580"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:42 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6632a6d1-ca87-48e8-b059-615627d70e95
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/5682fd21-e3b6-473c-a2f0-eddf72df900e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncpricelessgaussrxnpdycu-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"an
-      error occurred during function source code build step","handler":"handler.handle","http_option":"redirected","id":"5682fd21-e3b6-473c-a2f0-eddf72df900e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"86a56709-566d-4a59-967b-dd762e15a7b6","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"error","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "580"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:43 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 101daac4-c143-4355-8971-f134791cd60f
-    status: 200 OK
-    code: 200
-- request:
-    body: '{"environment_variables":null,"min_scale":null,"max_scale":null,"runtime":"unknown_runtime","memory_limit":null,"timeout":null,"redeploy":null,"handler":null,"privacy":"unknown_privacy","description":null,"secret_environment_variables":null,"http_option":"enabled"}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/5682fd21-e3b6-473c-a2f0-eddf72df900e
-    method: PATCH
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncpricelessgaussrxnpdycu-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"5682fd21-e3b6-473c-a2f0-eddf72df900e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"86a56709-566d-4a59-967b-dd762e15a7b6","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "525"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:43 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c4001952-da36-4e03-9755-26f2cb1c8e7c
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/5682fd21-e3b6-473c-a2f0-eddf72df900e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncpricelessgaussrxnpdycu-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"5682fd21-e3b6-473c-a2f0-eddf72df900e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"86a56709-566d-4a59-967b-dd762e15a7b6","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "525"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:44 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e42b7688-9e3b-409c-af8a-4cd40eb52a81
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/5682fd21-e3b6-473c-a2f0-eddf72df900e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncpricelessgaussrxnpdycu-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"5682fd21-e3b6-473c-a2f0-eddf72df900e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"86a56709-566d-4a59-967b-dd762e15a7b6","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "525"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:49 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5b58e68d-aff0-424a-8fcc-5e4685f90e94
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/5682fd21-e3b6-473c-a2f0-eddf72df900e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncpricelessgaussrxnpdycu-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"5682fd21-e3b6-473c-a2f0-eddf72df900e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"86a56709-566d-4a59-967b-dd762e15a7b6","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "525"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:54 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 61c354f1-5c3f-440a-81e6-f8ef54faa4c7
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/5682fd21-e3b6-473c-a2f0-eddf72df900e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncpricelessgaussrxnpdycu-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"an
-      error occurred during function source code build step","handler":"handler.handle","http_option":"enabled","id":"5682fd21-e3b6-473c-a2f0-eddf72df900e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"86a56709-566d-4a59-967b-dd762e15a7b6","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"error","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "577"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:59 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 854d4ecc-71ff-4081-a97d-c1b8bb114dda
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/5682fd21-e3b6-473c-a2f0-eddf72df900e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncpricelessgaussrxnpdycu-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"an
-      error occurred during function source code build step","handler":"handler.handle","http_option":"enabled","id":"5682fd21-e3b6-473c-a2f0-eddf72df900e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"86a56709-566d-4a59-967b-dd762e15a7b6","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"error","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "577"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:59 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 078a0923-4d20-4664-affd-eeeef28c60ed
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/86a56709-566d-4a59-967b-dd762e15a7b6
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"86a56709-566d-4a59-967b-dd762e15a7b6","name":"tf-func-priceless-gauss","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncpricelessgaussrxnpdycu","registry_namespace_id":"00e2499f-3294-410d-839e-257e0a6c3667","secret_environment_variables":[],"status":"ready"}'
-    headers:
-      Content-Length:
-      - "462"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:48:00 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 159dbd92-a1cd-45b3-99b0-9b413f70e323
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/5682fd21-e3b6-473c-a2f0-eddf72df900e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncpricelessgaussrxnpdycu-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"an
-      error occurred during function source code build step","handler":"handler.handle","http_option":"enabled","id":"5682fd21-e3b6-473c-a2f0-eddf72df900e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"86a56709-566d-4a59-967b-dd762e15a7b6","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"error","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "577"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:48:00 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f2ebeffa-5991-4b9b-8627-cab22881c5aa
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/5682fd21-e3b6-473c-a2f0-eddf72df900e
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncpricelessgaussrxnpdycu-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"an
-      error occurred during function source code build step","handler":"handler.handle","http_option":"enabled","id":"5682fd21-e3b6-473c-a2f0-eddf72df900e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"86a56709-566d-4a59-967b-dd762e15a7b6","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"error","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "577"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:48:00 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3c7bc275-da7a-4371-bc91-3fb63cecb924
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/5682fd21-e3b6-473c-a2f0-eddf72df900e
-    method: DELETE
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncpricelessgaussrxnpdycu-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"5682fd21-e3b6-473c-a2f0-eddf72df900e","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"86a56709-566d-4a59-967b-dd762e15a7b6","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"deleting","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "526"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:48:00 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3cb8a42f-9afa-4f3c-b949-1f5cf9d488c6
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/86a56709-566d-4a59-967b-dd762e15a7b6
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"86a56709-566d-4a59-967b-dd762e15a7b6","name":"tf-func-priceless-gauss","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncpricelessgaussrxnpdycu","registry_namespace_id":"00e2499f-3294-410d-839e-257e0a6c3667","secret_environment_variables":[],"status":"ready"}'
-    headers:
-      Content-Length:
-      - "462"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:48:00 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - df6bebfd-7ca9-4829-a692-9c0964690738
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/86a56709-566d-4a59-967b-dd762e15a7b6
-    method: DELETE
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"86a56709-566d-4a59-967b-dd762e15a7b6","name":"tf-func-priceless-gauss","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncpricelessgaussrxnpdycu","registry_namespace_id":"00e2499f-3294-410d-839e-257e0a6c3667","secret_environment_variables":[],"status":"deleting"}'
-    headers:
-      Content-Length:
-      - "465"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:48:00 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e85d5164-2685-499a-bdb1-90993d3c0347
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/86a56709-566d-4a59-967b-dd762e15a7b6
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"86a56709-566d-4a59-967b-dd762e15a7b6","name":"tf-func-priceless-gauss","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncpricelessgaussrxnpdycu","registry_namespace_id":"00e2499f-3294-410d-839e-257e0a6c3667","secret_environment_variables":[],"status":"deleting"}'
-    headers:
-      Content-Length:
-      - "465"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:48:01 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 79230fde-0bb3-4bb2-8d31-b3d2c51d145c
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/86a56709-566d-4a59-967b-dd762e15a7b6
-    method: GET
-  response:
-    body: '{"message":"Namespace was not found"}'
-    headers:
-      Content-Length:
-      - "37"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:48:06 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f533cd06-bf98-44f8-91f8-e929352f827e
-    status: 404 Not Found
-    code: 404
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/5682fd21-e3b6-473c-a2f0-eddf72df900e
-    method: DELETE
-  response:
-    body: '{"message":"Function was not found"}'
-    headers:
-      Content-Length:
-      - "36"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:48:06 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 08b71e9d-a4e1-4377-bc56-c0a6eede81b2
-    status: 404 Not Found
-    code: 404
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 145
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"name":"tf-func-busy-bhaskara","environment_variables":{},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","secret_environment_variables":[]}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 371
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"2332d876-1040-4f72-ae9b-c56bd134e133","name":"tf-func-busy-bhaskara","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
+        headers:
+            Content-Length:
+                - "371"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:19 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 55a8c046-b10a-4466-8134-0f08cf74045e
+        status: 200 OK
+        code: 200
+        duration: 1.228127985s
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/2332d876-1040-4f72-ae9b-c56bd134e133
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 371
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"2332d876-1040-4f72-ae9b-c56bd134e133","name":"tf-func-busy-bhaskara","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
+        headers:
+            Content-Length:
+                - "371"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:20 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - d8456c3a-2305-4856-af4c-5e86ecc557a4
+        status: 200 OK
+        code: 200
+        duration: 65.504171ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/2332d876-1040-4f72-ae9b-c56bd134e133
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 458
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"2332d876-1040-4f72-ae9b-c56bd134e133","name":"tf-func-busy-bhaskara","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncbusybhaskaraa0fnicgs","registry_namespace_id":"4406b484-07a6-46fd-8041-bced8ebb01d2","secret_environment_variables":[],"status":"ready"}'
+        headers:
+            Content-Length:
+                - "458"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:25 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - a2a8aa68-29af-439a-a251-63748b1b6da3
+        status: 200 OK
+        code: 200
+        duration: 48.050576ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/2332d876-1040-4f72-ae9b-c56bd134e133
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 458
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"2332d876-1040-4f72-ae9b-c56bd134e133","name":"tf-func-busy-bhaskara","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncbusybhaskaraa0fnicgs","registry_namespace_id":"4406b484-07a6-46fd-8041-bced8ebb01d2","secret_environment_variables":[],"status":"ready"}'
+        headers:
+            Content-Length:
+                - "458"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:25 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - d4b18d72-510c-4db2-8d41-65b87336a7b8
+        status: 200 OK
+        code: 200
+        duration: 59.364985ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 298
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"name":"foobar","namespace_id":"2332d876-1040-4f72-ae9b-c56bd134e133","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"node22","memory_limit":256,"handler":"handler.handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 560
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncbusybhaskaraa0fnicgs-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"d59dca0e-d8e7-44b5-b0ca-fea62b5055b2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"2332d876-1040-4f72-ae9b-c56bd134e133","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "560"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:25 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 55f4e79c-5104-43c4-a0c8-0874a491c08e
+        status: 200 OK
+        code: 200
+        duration: 550.157946ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d59dca0e-d8e7-44b5-b0ca-fea62b5055b2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 560
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncbusybhaskaraa0fnicgs-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"d59dca0e-d8e7-44b5-b0ca-fea62b5055b2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"2332d876-1040-4f72-ae9b-c56bd134e133","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "560"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:25 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 1ee353ee-fbd8-4809-b6e8-abbeee43adf4
+        status: 200 OK
+        code: 200
+        duration: 144.182956ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d59dca0e-d8e7-44b5-b0ca-fea62b5055b2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 560
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncbusybhaskaraa0fnicgs-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"d59dca0e-d8e7-44b5-b0ca-fea62b5055b2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"2332d876-1040-4f72-ae9b-c56bd134e133","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "560"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:25 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 5ae3e74c-dd1f-4aa6-b204-3d28e57d61ee
+        status: 200 OK
+        code: 200
+        duration: 62.726963ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d59dca0e-d8e7-44b5-b0ca-fea62b5055b2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 560
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncbusybhaskaraa0fnicgs-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"d59dca0e-d8e7-44b5-b0ca-fea62b5055b2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"2332d876-1040-4f72-ae9b-c56bd134e133","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "560"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:26 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 9825d28b-54e5-4780-b93c-21a2e9524d0f
+        status: 200 OK
+        code: 200
+        duration: 67.048863ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/2332d876-1040-4f72-ae9b-c56bd134e133
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 458
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"2332d876-1040-4f72-ae9b-c56bd134e133","name":"tf-func-busy-bhaskara","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncbusybhaskaraa0fnicgs","registry_namespace_id":"4406b484-07a6-46fd-8041-bced8ebb01d2","secret_environment_variables":[],"status":"ready"}'
+        headers:
+            Content-Length:
+                - "458"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:26 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 6c55c2ba-7194-4e56-b878-45e002c8683e
+        status: 200 OK
+        code: 200
+        duration: 62.859331ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d59dca0e-d8e7-44b5-b0ca-fea62b5055b2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 560
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncbusybhaskaraa0fnicgs-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"d59dca0e-d8e7-44b5-b0ca-fea62b5055b2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"2332d876-1040-4f72-ae9b-c56bd134e133","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "560"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:26 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - a8cbfbf3-909b-4250-abba-83450f1afa1c
+        status: 200 OK
+        code: 200
+        duration: 60.877288ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/2332d876-1040-4f72-ae9b-c56bd134e133
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 458
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"2332d876-1040-4f72-ae9b-c56bd134e133","name":"tf-func-busy-bhaskara","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncbusybhaskaraa0fnicgs","registry_namespace_id":"4406b484-07a6-46fd-8041-bced8ebb01d2","secret_environment_variables":[],"status":"ready"}'
+        headers:
+            Content-Length:
+                - "458"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:26 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e11c1af5-b930-4946-abe5-c2f30a3d763c
+        status: 200 OK
+        code: 200
+        duration: 55.690131ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d59dca0e-d8e7-44b5-b0ca-fea62b5055b2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 560
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncbusybhaskaraa0fnicgs-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"d59dca0e-d8e7-44b5-b0ca-fea62b5055b2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"2332d876-1040-4f72-ae9b-c56bd134e133","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "560"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:26 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 96b50f42-4e45-4a24-9c30-789cfa582942
+        status: 200 OK
+        code: 200
+        duration: 62.239627ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d59dca0e-d8e7-44b5-b0ca-fea62b5055b2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 560
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncbusybhaskaraa0fnicgs-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"d59dca0e-d8e7-44b5-b0ca-fea62b5055b2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"2332d876-1040-4f72-ae9b-c56bd134e133","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "560"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:27 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - c9218c6e-e5ed-4c1a-be94-293e2c2cb351
+        status: 200 OK
+        code: 200
+        duration: 62.593552ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 148
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"runtime":"unknown_runtime","privacy":"unknown_privacy","secret_environment_variables":null,"http_option":"redirected","sandbox":"unknown_sandbox"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d59dca0e-d8e7-44b5-b0ca-fea62b5055b2
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 563
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncbusybhaskaraa0fnicgs-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"redirected","id":"d59dca0e-d8e7-44b5-b0ca-fea62b5055b2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"2332d876-1040-4f72-ae9b-c56bd134e133","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "563"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:27 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - aab269a6-36cd-4854-bb4d-0c33489e20df
+        status: 200 OK
+        code: 200
+        duration: 124.964656ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d59dca0e-d8e7-44b5-b0ca-fea62b5055b2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 563
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncbusybhaskaraa0fnicgs-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"redirected","id":"d59dca0e-d8e7-44b5-b0ca-fea62b5055b2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"2332d876-1040-4f72-ae9b-c56bd134e133","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "563"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:28 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - a6f0042e-2104-40c1-8d96-ee5adca9dfd5
+        status: 200 OK
+        code: 200
+        duration: 68.299563ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d59dca0e-d8e7-44b5-b0ca-fea62b5055b2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 573
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncbusybhaskaraa0fnicgs-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"redirected","id":"d59dca0e-d8e7-44b5-b0ca-fea62b5055b2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"2332d876-1040-4f72-ae9b-c56bd134e133","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"error","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "573"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:33 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 9f1c49ad-15ba-47da-ba36-c20c169bf312
+        status: 200 OK
+        code: 200
+        duration: 63.926446ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d59dca0e-d8e7-44b5-b0ca-fea62b5055b2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 573
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncbusybhaskaraa0fnicgs-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"redirected","id":"d59dca0e-d8e7-44b5-b0ca-fea62b5055b2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"2332d876-1040-4f72-ae9b-c56bd134e133","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"error","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "573"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:33 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - eeaed10c-4854-4c41-b61f-b543e0eb79eb
+        status: 200 OK
+        code: 200
+        duration: 70.350067ms
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/2332d876-1040-4f72-ae9b-c56bd134e133
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 458
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"2332d876-1040-4f72-ae9b-c56bd134e133","name":"tf-func-busy-bhaskara","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncbusybhaskaraa0fnicgs","registry_namespace_id":"4406b484-07a6-46fd-8041-bced8ebb01d2","secret_environment_variables":[],"status":"ready"}'
+        headers:
+            Content-Length:
+                - "458"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - de8f261b-3b4e-4974-a0ef-a42314c23fb3
+        status: 200 OK
+        code: 200
+        duration: 57.104138ms
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d59dca0e-d8e7-44b5-b0ca-fea62b5055b2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 573
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncbusybhaskaraa0fnicgs-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"redirected","id":"d59dca0e-d8e7-44b5-b0ca-fea62b5055b2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"2332d876-1040-4f72-ae9b-c56bd134e133","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"error","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "573"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 57dcce07-c74f-4c7c-9459-a429e380ceb9
+        status: 200 OK
+        code: 200
+        duration: 66.71181ms
+    - id: 19
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/2332d876-1040-4f72-ae9b-c56bd134e133
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 458
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"2332d876-1040-4f72-ae9b-c56bd134e133","name":"tf-func-busy-bhaskara","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncbusybhaskaraa0fnicgs","registry_namespace_id":"4406b484-07a6-46fd-8041-bced8ebb01d2","secret_environment_variables":[],"status":"ready"}'
+        headers:
+            Content-Length:
+                - "458"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e136e3eb-008c-44d5-ba50-9e487800319b
+        status: 200 OK
+        code: 200
+        duration: 58.678696ms
+    - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d59dca0e-d8e7-44b5-b0ca-fea62b5055b2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 573
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncbusybhaskaraa0fnicgs-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"redirected","id":"d59dca0e-d8e7-44b5-b0ca-fea62b5055b2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"2332d876-1040-4f72-ae9b-c56bd134e133","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"error","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "573"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 85955067-9ed7-47db-9f91-9140ab4ca9cb
+        status: 200 OK
+        code: 200
+        duration: 75.631069ms
+    - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d59dca0e-d8e7-44b5-b0ca-fea62b5055b2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 573
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncbusybhaskaraa0fnicgs-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"redirected","id":"d59dca0e-d8e7-44b5-b0ca-fea62b5055b2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"2332d876-1040-4f72-ae9b-c56bd134e133","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"error","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "573"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f7999d57-2ca3-493a-95ff-6c760249363d
+        status: 200 OK
+        code: 200
+        duration: 60.369093ms
+    - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 145
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"runtime":"unknown_runtime","privacy":"unknown_privacy","secret_environment_variables":null,"http_option":"enabled","sandbox":"unknown_sandbox"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d59dca0e-d8e7-44b5-b0ca-fea62b5055b2
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 560
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncbusybhaskaraa0fnicgs-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"d59dca0e-d8e7-44b5-b0ca-fea62b5055b2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"2332d876-1040-4f72-ae9b-c56bd134e133","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "560"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - fdc6d85b-1ceb-49d1-94bf-2bcadd06d67b
+        status: 200 OK
+        code: 200
+        duration: 71.200284ms
+    - id: 23
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d59dca0e-d8e7-44b5-b0ca-fea62b5055b2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 570
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncbusybhaskaraa0fnicgs-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"d59dca0e-d8e7-44b5-b0ca-fea62b5055b2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"2332d876-1040-4f72-ae9b-c56bd134e133","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"error","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "570"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:36 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 38e29def-5ff6-4cf1-893b-078369e7d7a8
+        status: 200 OK
+        code: 200
+        duration: 66.221939ms
+    - id: 24
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d59dca0e-d8e7-44b5-b0ca-fea62b5055b2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 570
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncbusybhaskaraa0fnicgs-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"d59dca0e-d8e7-44b5-b0ca-fea62b5055b2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"2332d876-1040-4f72-ae9b-c56bd134e133","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"error","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "570"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:36 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - a484e9a2-0952-4da2-8593-bde462633837
+        status: 200 OK
+        code: 200
+        duration: 71.043559ms
+    - id: 25
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/2332d876-1040-4f72-ae9b-c56bd134e133
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 458
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"2332d876-1040-4f72-ae9b-c56bd134e133","name":"tf-func-busy-bhaskara","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncbusybhaskaraa0fnicgs","registry_namespace_id":"4406b484-07a6-46fd-8041-bced8ebb01d2","secret_environment_variables":[],"status":"ready"}'
+        headers:
+            Content-Length:
+                - "458"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:36 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f175ab66-b286-443a-881e-886a738e0cee
+        status: 200 OK
+        code: 200
+        duration: 69.220574ms
+    - id: 26
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d59dca0e-d8e7-44b5-b0ca-fea62b5055b2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 570
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncbusybhaskaraa0fnicgs-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"d59dca0e-d8e7-44b5-b0ca-fea62b5055b2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"2332d876-1040-4f72-ae9b-c56bd134e133","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"error","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "570"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:36 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 516a1c37-8853-4293-afe7-bf0594774c44
+        status: 200 OK
+        code: 200
+        duration: 53.796873ms
+    - id: 27
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d59dca0e-d8e7-44b5-b0ca-fea62b5055b2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 570
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncbusybhaskaraa0fnicgs-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"d59dca0e-d8e7-44b5-b0ca-fea62b5055b2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"2332d876-1040-4f72-ae9b-c56bd134e133","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"error","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "570"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:37 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 7f481756-b56c-4753-8e77-398f84401173
+        status: 200 OK
+        code: 200
+        duration: 58.771641ms
+    - id: 28
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d59dca0e-d8e7-44b5-b0ca-fea62b5055b2
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 561
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncbusybhaskaraa0fnicgs-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"d59dca0e-d8e7-44b5-b0ca-fea62b5055b2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"2332d876-1040-4f72-ae9b-c56bd134e133","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"deleting","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "561"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:37 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 5a1a554f-0437-4635-9f4d-4d621f52de3c
+        status: 200 OK
+        code: 200
+        duration: 245.908617ms
+    - id: 29
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/2332d876-1040-4f72-ae9b-c56bd134e133
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 458
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"2332d876-1040-4f72-ae9b-c56bd134e133","name":"tf-func-busy-bhaskara","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncbusybhaskaraa0fnicgs","registry_namespace_id":"4406b484-07a6-46fd-8041-bced8ebb01d2","secret_environment_variables":[],"status":"ready"}'
+        headers:
+            Content-Length:
+                - "458"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:37 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 293e9cbc-31d3-4104-8c90-3be40969532c
+        status: 200 OK
+        code: 200
+        duration: 71.756199ms
+    - id: 30
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/2332d876-1040-4f72-ae9b-c56bd134e133
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 461
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"2332d876-1040-4f72-ae9b-c56bd134e133","name":"tf-func-busy-bhaskara","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncbusybhaskaraa0fnicgs","registry_namespace_id":"4406b484-07a6-46fd-8041-bced8ebb01d2","secret_environment_variables":[],"status":"deleting"}'
+        headers:
+            Content-Length:
+                - "461"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:37 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 5ad9d58a-210b-447a-9f78-0e019172c4ed
+        status: 200 OK
+        code: 200
+        duration: 337.591116ms
+    - id: 31
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/2332d876-1040-4f72-ae9b-c56bd134e133
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 460
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"2332d876-1040-4f72-ae9b-c56bd134e133","name":"tf-func-busy-bhaskara","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncbusybhaskaraa0fnicgs","registry_namespace_id":"4406b484-07a6-46fd-8041-bced8ebb01d2","secret_environment_variables":[],"status":"unknown"}'
+        headers:
+            Content-Length:
+                - "460"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:37 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - a5c930ef-c852-4d85-84be-bc3416c69d12
+        status: 200 OK
+        code: 200
+        duration: 66.928347ms
+    - id: 32
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/2332d876-1040-4f72-ae9b-c56bd134e133
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 37
+        uncompressed: false
+        body: '{"message":"Namespace was not found"}'
+        headers:
+            Content-Length:
+                - "37"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:42 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 4eecf2a9-1f84-4875-bcef-4609ee5c215c
+        status: 404 Not Found
+        code: 404
+        duration: 30.954824ms
+    - id: 33
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d59dca0e-d8e7-44b5-b0ca-fea62b5055b2
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 36
+        uncompressed: false
+        body: '{"message":"Function was not found"}'
+        headers:
+            Content-Length:
+                - "36"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:43 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 48260218-5c95-4258-891d-564e17f8d5d6
+        status: 404 Not Found
+        code: 404
+        duration: 22.631364ms

--- a/internal/services/function/testdata/function-no-name.cassette.yaml
+++ b/internal/services/function/testdata/function-no-name.cassette.yaml
@@ -1,935 +1,840 @@
 ---
 version: 2
 interactions:
-- request:
-    body: '{"name":"tf-func-ecstatic-jennings","environment_variables":{},"project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","description":null,"secret_environment_variables":[]}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces
-    method: POST
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"d3538d62-e383-4a70-a539-7fe1f3e8dbbe","name":"tf-func-ecstatic-jennings","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "375"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:46:38 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 87fd7db9-c706-4150-9532-8093f247232e
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d3538d62-e383-4a70-a539-7fe1f3e8dbbe
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"d3538d62-e383-4a70-a539-7fe1f3e8dbbe","name":"tf-func-ecstatic-jennings","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "375"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:46:38 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b1828d2e-305d-4560-88ed-25e93930483d
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d3538d62-e383-4a70-a539-7fe1f3e8dbbe
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"d3538d62-e383-4a70-a539-7fe1f3e8dbbe","name":"tf-func-ecstatic-jennings","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "375"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:46:43 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 477a599f-e6e6-408a-b227-f1b27635ef76
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d3538d62-e383-4a70-a539-7fe1f3e8dbbe
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"d3538d62-e383-4a70-a539-7fe1f3e8dbbe","name":"tf-func-ecstatic-jennings","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "375"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:46:48 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 28717c7d-fa3d-4b74-88c6-96928777f559
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d3538d62-e383-4a70-a539-7fe1f3e8dbbe
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"d3538d62-e383-4a70-a539-7fe1f3e8dbbe","name":"tf-func-ecstatic-jennings","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "375"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:46:53 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7000c2af-afe8-402a-bdfd-f94c26f0b3fc
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d3538d62-e383-4a70-a539-7fe1f3e8dbbe
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"d3538d62-e383-4a70-a539-7fe1f3e8dbbe","name":"tf-func-ecstatic-jennings","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "375"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:46:58 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a958bfd2-6d72-42ee-9bc9-49f04f98c8a7
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d3538d62-e383-4a70-a539-7fe1f3e8dbbe
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"d3538d62-e383-4a70-a539-7fe1f3e8dbbe","name":"tf-func-ecstatic-jennings","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "375"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 92655c7a-53d1-4f1c-89ac-ac64a93a902b
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d3538d62-e383-4a70-a539-7fe1f3e8dbbe
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"d3538d62-e383-4a70-a539-7fe1f3e8dbbe","name":"tf-func-ecstatic-jennings","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "375"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:08 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 126a42c5-c602-4288-aea8-ee14a9ebc390
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d3538d62-e383-4a70-a539-7fe1f3e8dbbe
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"d3538d62-e383-4a70-a539-7fe1f3e8dbbe","name":"tf-func-ecstatic-jennings","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "375"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c612ddfb-3f3c-4d36-a6d8-6f0b55383b7f
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d3538d62-e383-4a70-a539-7fe1f3e8dbbe
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"d3538d62-e383-4a70-a539-7fe1f3e8dbbe","name":"tf-func-ecstatic-jennings","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncecstaticjenniniqw2ujak","registry_namespace_id":"5d427822-8ff8-41ea-b252-39343a64e997","secret_environment_variables":[],"status":"ready"}'
-    headers:
-      Content-Length:
-      - "464"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:18 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7fe2ee87-d72c-4834-8904-89e2e9479518
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d3538d62-e383-4a70-a539-7fe1f3e8dbbe
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"d3538d62-e383-4a70-a539-7fe1f3e8dbbe","name":"tf-func-ecstatic-jennings","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncecstaticjenniniqw2ujak","registry_namespace_id":"5d427822-8ff8-41ea-b252-39343a64e997","secret_environment_variables":[],"status":"ready"}'
-    headers:
-      Content-Length:
-      - "464"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:18 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - eba41e2a-a5d7-4f06-84ce-3eba373cb870
-    status: 200 OK
-    code: 200
-- request:
-    body: '{"name":"tf-func-fervent-mayer","namespace_id":"d3538d62-e383-4a70-a539-7fe1f3e8dbbe","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"node14","memory_limit":128,"timeout":null,"handler":"handler.handle","privacy":"private","description":null,"secret_environment_variables":[],"http_option":"enabled"}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions
-    method: POST
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncecstaticjenniniqw2ujak-tf-func-fervent-mayer.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"d5e98aa1-2d1f-4a6c-8a56-1fbd351dc37a","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-func-fervent-mayer","namespace_id":"d3538d62-e383-4a70-a539-7fe1f3e8dbbe","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "555"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ea23e7d5-ff84-45e6-94da-b263506f1093
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d5e98aa1-2d1f-4a6c-8a56-1fbd351dc37a
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncecstaticjenniniqw2ujak-tf-func-fervent-mayer.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"d5e98aa1-2d1f-4a6c-8a56-1fbd351dc37a","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-func-fervent-mayer","namespace_id":"d3538d62-e383-4a70-a539-7fe1f3e8dbbe","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "555"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1bd77c3a-d838-452c-9025-21e5e21847b4
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d5e98aa1-2d1f-4a6c-8a56-1fbd351dc37a
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncecstaticjenniniqw2ujak-tf-func-fervent-mayer.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"d5e98aa1-2d1f-4a6c-8a56-1fbd351dc37a","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-func-fervent-mayer","namespace_id":"d3538d62-e383-4a70-a539-7fe1f3e8dbbe","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "555"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9b686f5a-ba14-4de5-ba12-e3c46fecd648
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d5e98aa1-2d1f-4a6c-8a56-1fbd351dc37a
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncecstaticjenniniqw2ujak-tf-func-fervent-mayer.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"d5e98aa1-2d1f-4a6c-8a56-1fbd351dc37a","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-func-fervent-mayer","namespace_id":"d3538d62-e383-4a70-a539-7fe1f3e8dbbe","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "555"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 42f4033c-a083-464e-a1ac-9b376b9a01dc
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d3538d62-e383-4a70-a539-7fe1f3e8dbbe
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"d3538d62-e383-4a70-a539-7fe1f3e8dbbe","name":"tf-func-ecstatic-jennings","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncecstaticjenniniqw2ujak","registry_namespace_id":"5d427822-8ff8-41ea-b252-39343a64e997","secret_environment_variables":[],"status":"ready"}'
-    headers:
-      Content-Length:
-      - "464"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ee4f0c41-22bc-449b-878d-2cefddbf8785
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d5e98aa1-2d1f-4a6c-8a56-1fbd351dc37a
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncecstaticjenniniqw2ujak-tf-func-fervent-mayer.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"d5e98aa1-2d1f-4a6c-8a56-1fbd351dc37a","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-func-fervent-mayer","namespace_id":"d3538d62-e383-4a70-a539-7fe1f3e8dbbe","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "555"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0adad8d9-10be-4b16-bda5-d64c93cb5742
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d5e98aa1-2d1f-4a6c-8a56-1fbd351dc37a
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncecstaticjenniniqw2ujak-tf-func-fervent-mayer.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"d5e98aa1-2d1f-4a6c-8a56-1fbd351dc37a","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-func-fervent-mayer","namespace_id":"d3538d62-e383-4a70-a539-7fe1f3e8dbbe","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "555"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:20 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ee53e15a-affe-471b-b97b-58d4aeffa719
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d5e98aa1-2d1f-4a6c-8a56-1fbd351dc37a
-    method: DELETE
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncecstaticjenniniqw2ujak-tf-func-fervent-mayer.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"d5e98aa1-2d1f-4a6c-8a56-1fbd351dc37a","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-func-fervent-mayer","namespace_id":"d3538d62-e383-4a70-a539-7fe1f3e8dbbe","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"deleting","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "556"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:20 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e388a045-5f3d-4d22-b88b-17838dc71b7c
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d3538d62-e383-4a70-a539-7fe1f3e8dbbe
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"d3538d62-e383-4a70-a539-7fe1f3e8dbbe","name":"tf-func-ecstatic-jennings","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncecstaticjenniniqw2ujak","registry_namespace_id":"5d427822-8ff8-41ea-b252-39343a64e997","secret_environment_variables":[],"status":"ready"}'
-    headers:
-      Content-Length:
-      - "464"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:20 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - aabc7a05-f14c-4e77-a6b9-543f4b95f589
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d3538d62-e383-4a70-a539-7fe1f3e8dbbe
-    method: DELETE
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"d3538d62-e383-4a70-a539-7fe1f3e8dbbe","name":"tf-func-ecstatic-jennings","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncecstaticjenniniqw2ujak","registry_namespace_id":"5d427822-8ff8-41ea-b252-39343a64e997","secret_environment_variables":[],"status":"deleting"}'
-    headers:
-      Content-Length:
-      - "467"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:20 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6b3eefe1-32bd-49b5-bb5b-15254efc0e28
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d3538d62-e383-4a70-a539-7fe1f3e8dbbe
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"d3538d62-e383-4a70-a539-7fe1f3e8dbbe","name":"tf-func-ecstatic-jennings","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncecstaticjenniniqw2ujak","registry_namespace_id":"5d427822-8ff8-41ea-b252-39343a64e997","secret_environment_variables":[],"status":"deleting"}'
-    headers:
-      Content-Length:
-      - "467"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:20 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f1b33a49-26bd-4dbc-9a65-0e39b6a21b60
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d3538d62-e383-4a70-a539-7fe1f3e8dbbe
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"d3538d62-e383-4a70-a539-7fe1f3e8dbbe","name":"tf-func-ecstatic-jennings","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncecstaticjenniniqw2ujak","registry_namespace_id":"5d427822-8ff8-41ea-b252-39343a64e997","secret_environment_variables":[],"status":"deleting"}'
-    headers:
-      Content-Length:
-      - "467"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:25 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7d60848c-69bf-4197-a0ad-72472fd96c77
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d3538d62-e383-4a70-a539-7fe1f3e8dbbe
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"d3538d62-e383-4a70-a539-7fe1f3e8dbbe","name":"tf-func-ecstatic-jennings","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncecstaticjenniniqw2ujak","registry_namespace_id":"5d427822-8ff8-41ea-b252-39343a64e997","secret_environment_variables":[],"status":"deleting"}'
-    headers:
-      Content-Length:
-      - "467"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:30 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 85863822-8fbe-4372-bf78-2e44a002d2d2
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d3538d62-e383-4a70-a539-7fe1f3e8dbbe
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"d3538d62-e383-4a70-a539-7fe1f3e8dbbe","name":"tf-func-ecstatic-jennings","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncecstaticjenniniqw2ujak","registry_namespace_id":"5d427822-8ff8-41ea-b252-39343a64e997","secret_environment_variables":[],"status":"deleting"}'
-    headers:
-      Content-Length:
-      - "467"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:35 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 537b4cdf-5b47-4404-a28c-ea004d7dcae7
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d3538d62-e383-4a70-a539-7fe1f3e8dbbe
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"d3538d62-e383-4a70-a539-7fe1f3e8dbbe","name":"tf-func-ecstatic-jennings","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncecstaticjenniniqw2ujak","registry_namespace_id":"5d427822-8ff8-41ea-b252-39343a64e997","secret_environment_variables":[],"status":"deleting"}'
-    headers:
-      Content-Length:
-      - "467"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:40 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 774d24f0-d5f5-463f-879e-b16483768c5e
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d3538d62-e383-4a70-a539-7fe1f3e8dbbe
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"d3538d62-e383-4a70-a539-7fe1f3e8dbbe","name":"tf-func-ecstatic-jennings","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncecstaticjenniniqw2ujak","registry_namespace_id":"5d427822-8ff8-41ea-b252-39343a64e997","secret_environment_variables":[],"status":"deleting"}'
-    headers:
-      Content-Length:
-      - "467"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:45 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 13edc3b8-f329-4ca4-993d-70cc2be94b6c
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d3538d62-e383-4a70-a539-7fe1f3e8dbbe
-    method: GET
-  response:
-    body: '{"message":"Namespace was not found"}'
-    headers:
-      Content-Length:
-      - "37"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:50 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a3681bf8-a0f5-43e5-9510-0ea8a6d2bcf6
-    status: 404 Not Found
-    code: 404
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d3538d62-e383-4a70-a539-7fe1f3e8dbbe
-    method: DELETE
-  response:
-    body: '{"message":"Namespace was not found"}'
-    headers:
-      Content-Length:
-      - "37"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:50 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d2a46f5c-1b49-471a-b32f-3dd54a33a7ba
-    status: 404 Not Found
-    code: 404
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 146
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"name":"tf-func-vigilant-kalam","environment_variables":{},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","secret_environment_variables":[]}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 372
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"4c0c44b6-752b-4ca9-9797-8f1129f2e306","name":"tf-func-vigilant-kalam","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
+        headers:
+            Content-Length:
+                - "372"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:19 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 53898636-c08e-4190-b21d-533b6505fa37
+        status: 200 OK
+        code: 200
+        duration: 1.219766264s
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/4c0c44b6-752b-4ca9-9797-8f1129f2e306
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 372
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"4c0c44b6-752b-4ca9-9797-8f1129f2e306","name":"tf-func-vigilant-kalam","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
+        headers:
+            Content-Length:
+                - "372"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:20 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 8eb57b6d-7ebe-49ba-b8cf-298309c1310a
+        status: 200 OK
+        code: 200
+        duration: 61.507782ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/4c0c44b6-752b-4ca9-9797-8f1129f2e306
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 460
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"4c0c44b6-752b-4ca9-9797-8f1129f2e306","name":"tf-func-vigilant-kalam","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncvigilantkalambpv74atz","registry_namespace_id":"39d0985b-b1df-4e6e-a6fa-df8a5552f3c8","secret_environment_variables":[],"status":"ready"}'
+        headers:
+            Content-Length:
+                - "460"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:25 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 4b2ad9bc-e654-47fc-8739-3f91904345d9
+        status: 200 OK
+        code: 200
+        duration: 55.257468ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/4c0c44b6-752b-4ca9-9797-8f1129f2e306
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 460
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"4c0c44b6-752b-4ca9-9797-8f1129f2e306","name":"tf-func-vigilant-kalam","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncvigilantkalambpv74atz","registry_namespace_id":"39d0985b-b1df-4e6e-a6fa-df8a5552f3c8","secret_environment_variables":[],"status":"ready"}'
+        headers:
+            Content-Length:
+                - "460"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:25 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 5674afda-f34a-49ed-9372-29117f3c92c6
+        status: 200 OK
+        code: 200
+        duration: 64.682417ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 311
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"name":"tf-func-nice-bhabha","namespace_id":"4c0c44b6-752b-4ca9-9797-8f1129f2e306","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"node22","memory_limit":256,"handler":"handler.handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 587
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncvigilantkalambpv74atz-tf-func-nice-bhabha.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"b1a4cb95-12b3-46df-85c1-e6af6bc6e7e3","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-nice-bhabha","namespace_id":"4c0c44b6-752b-4ca9-9797-8f1129f2e306","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "587"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:25 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 2c6d0e11-2459-4540-85cf-4223817d2e9b
+        status: 200 OK
+        code: 200
+        duration: 542.313205ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/b1a4cb95-12b3-46df-85c1-e6af6bc6e7e3
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 587
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncvigilantkalambpv74atz-tf-func-nice-bhabha.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"b1a4cb95-12b3-46df-85c1-e6af6bc6e7e3","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-nice-bhabha","namespace_id":"4c0c44b6-752b-4ca9-9797-8f1129f2e306","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "587"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:25 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 97129b6c-06d5-47d8-8b43-81954b040927
+        status: 200 OK
+        code: 200
+        duration: 70.92699ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/b1a4cb95-12b3-46df-85c1-e6af6bc6e7e3
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 587
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncvigilantkalambpv74atz-tf-func-nice-bhabha.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"b1a4cb95-12b3-46df-85c1-e6af6bc6e7e3","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-nice-bhabha","namespace_id":"4c0c44b6-752b-4ca9-9797-8f1129f2e306","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "587"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:25 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3b0d4aba-1073-406c-847d-a2b79c569cf8
+        status: 200 OK
+        code: 200
+        duration: 116.521842ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/b1a4cb95-12b3-46df-85c1-e6af6bc6e7e3
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 587
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncvigilantkalambpv74atz-tf-func-nice-bhabha.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"b1a4cb95-12b3-46df-85c1-e6af6bc6e7e3","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-nice-bhabha","namespace_id":"4c0c44b6-752b-4ca9-9797-8f1129f2e306","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "587"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:26 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 8b5ace93-e01f-455f-bdcb-32191aa3665d
+        status: 200 OK
+        code: 200
+        duration: 69.601871ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/4c0c44b6-752b-4ca9-9797-8f1129f2e306
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 460
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"4c0c44b6-752b-4ca9-9797-8f1129f2e306","name":"tf-func-vigilant-kalam","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncvigilantkalambpv74atz","registry_namespace_id":"39d0985b-b1df-4e6e-a6fa-df8a5552f3c8","secret_environment_variables":[],"status":"ready"}'
+        headers:
+            Content-Length:
+                - "460"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:26 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f86968e8-85aa-4d38-a361-9cda4f0127dd
+        status: 200 OK
+        code: 200
+        duration: 62.49173ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/b1a4cb95-12b3-46df-85c1-e6af6bc6e7e3
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 587
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncvigilantkalambpv74atz-tf-func-nice-bhabha.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"b1a4cb95-12b3-46df-85c1-e6af6bc6e7e3","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-nice-bhabha","namespace_id":"4c0c44b6-752b-4ca9-9797-8f1129f2e306","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "587"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:26 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 68b0af2e-b9f4-4151-8304-5ba6c5bcfb89
+        status: 200 OK
+        code: 200
+        duration: 59.105678ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/b1a4cb95-12b3-46df-85c1-e6af6bc6e7e3
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 587
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncvigilantkalambpv74atz-tf-func-nice-bhabha.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"b1a4cb95-12b3-46df-85c1-e6af6bc6e7e3","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-nice-bhabha","namespace_id":"4c0c44b6-752b-4ca9-9797-8f1129f2e306","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "587"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:26 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 07749648-38bf-4815-b5e3-970399cc535a
+        status: 200 OK
+        code: 200
+        duration: 70.324147ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/b1a4cb95-12b3-46df-85c1-e6af6bc6e7e3
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 588
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncvigilantkalambpv74atz-tf-func-nice-bhabha.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"b1a4cb95-12b3-46df-85c1-e6af6bc6e7e3","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-nice-bhabha","namespace_id":"4c0c44b6-752b-4ca9-9797-8f1129f2e306","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"deleting","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "588"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:27 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 2a6e0c94-ae5b-4b34-8de5-b8a3899cc0ff
+        status: 200 OK
+        code: 200
+        duration: 140.930375ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/4c0c44b6-752b-4ca9-9797-8f1129f2e306
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 460
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"4c0c44b6-752b-4ca9-9797-8f1129f2e306","name":"tf-func-vigilant-kalam","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncvigilantkalambpv74atz","registry_namespace_id":"39d0985b-b1df-4e6e-a6fa-df8a5552f3c8","secret_environment_variables":[],"status":"ready"}'
+        headers:
+            Content-Length:
+                - "460"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:27 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ce6b0977-6ef1-4623-9e6e-62c1df6847e8
+        status: 200 OK
+        code: 200
+        duration: 59.790285ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/4c0c44b6-752b-4ca9-9797-8f1129f2e306
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 463
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"4c0c44b6-752b-4ca9-9797-8f1129f2e306","name":"tf-func-vigilant-kalam","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncvigilantkalambpv74atz","registry_namespace_id":"39d0985b-b1df-4e6e-a6fa-df8a5552f3c8","secret_environment_variables":[],"status":"deleting"}'
+        headers:
+            Content-Length:
+                - "463"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:27 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 2f492d23-82f4-4b0b-819a-2fdd49963b35
+        status: 200 OK
+        code: 200
+        duration: 242.584821ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/4c0c44b6-752b-4ca9-9797-8f1129f2e306
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 463
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"4c0c44b6-752b-4ca9-9797-8f1129f2e306","name":"tf-func-vigilant-kalam","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncvigilantkalambpv74atz","registry_namespace_id":"39d0985b-b1df-4e6e-a6fa-df8a5552f3c8","secret_environment_variables":[],"status":"deleting"}'
+        headers:
+            Content-Length:
+                - "463"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:27 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 1d23fded-e2ba-4ae9-ae61-5dc6c73e66d9
+        status: 200 OK
+        code: 200
+        duration: 65.631861ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/4c0c44b6-752b-4ca9-9797-8f1129f2e306
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 37
+        uncompressed: false
+        body: '{"message":"Namespace was not found"}'
+        headers:
+            Content-Length:
+                - "37"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:32 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 0c259a38-a1ed-485a-90ee-4c83ffdc47bf
+        status: 404 Not Found
+        code: 404
+        duration: 27.640256ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/4c0c44b6-752b-4ca9-9797-8f1129f2e306
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 37
+        uncompressed: false
+        body: '{"message":"Namespace was not found"}'
+        headers:
+            Content-Length:
+                - "37"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:32 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 73c86a0e-3519-4730-92f3-049ecca7f531
+        status: 404 Not Found
+        code: 404
+        duration: 24.637454ms

--- a/internal/services/function/testdata/function-timeout.cassette.yaml
+++ b/internal/services/function/testdata/function-timeout.cassette.yaml
@@ -1,743 +1,1134 @@
 ---
 version: 2
 interactions:
-- request:
-    body: '{"name":"tf-func-distracted-poincare","environment_variables":{},"project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","description":null,"secret_environment_variables":[]}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces
-    method: POST
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"c7e1453d-e77c-483e-a250-ab7ba950d4ce","name":"tf-func-distracted-poincare","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "377"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:46:38 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 40aa9450-366a-45d1-829d-44503443f631
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/c7e1453d-e77c-483e-a250-ab7ba950d4ce
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"c7e1453d-e77c-483e-a250-ab7ba950d4ce","name":"tf-func-distracted-poincare","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "377"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:46:38 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c760cb29-6664-4120-afc7-049019608b94
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/c7e1453d-e77c-483e-a250-ab7ba950d4ce
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"c7e1453d-e77c-483e-a250-ab7ba950d4ce","name":"tf-func-distracted-poincare","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "377"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:46:43 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0e1d0ff4-2ac4-4e7c-a7f4-431b5282eb79
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/c7e1453d-e77c-483e-a250-ab7ba950d4ce
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"c7e1453d-e77c-483e-a250-ab7ba950d4ce","name":"tf-func-distracted-poincare","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncdistractedpoinrz0ih2jg","registry_namespace_id":"4b602f28-c69b-459a-8c36-9770582b1740","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "468"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:46:48 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 89134963-f4b7-4c2a-af21-2dbff0f34bf8
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/c7e1453d-e77c-483e-a250-ab7ba950d4ce
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"c7e1453d-e77c-483e-a250-ab7ba950d4ce","name":"tf-func-distracted-poincare","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncdistractedpoinrz0ih2jg","registry_namespace_id":"4b602f28-c69b-459a-8c36-9770582b1740","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "468"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:46:53 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2ffa811e-4068-4f1f-8cb6-1708b092da3f
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/c7e1453d-e77c-483e-a250-ab7ba950d4ce
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"c7e1453d-e77c-483e-a250-ab7ba950d4ce","name":"tf-func-distracted-poincare","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncdistractedpoinrz0ih2jg","registry_namespace_id":"4b602f28-c69b-459a-8c36-9770582b1740","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "468"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:46:58 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 016801ac-c2ff-45a3-9e51-e21629aee837
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/c7e1453d-e77c-483e-a250-ab7ba950d4ce
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"c7e1453d-e77c-483e-a250-ab7ba950d4ce","name":"tf-func-distracted-poincare","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncdistractedpoinrz0ih2jg","registry_namespace_id":"4b602f28-c69b-459a-8c36-9770582b1740","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "468"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f5309862-e947-4cee-bf12-2a219ab00440
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/c7e1453d-e77c-483e-a250-ab7ba950d4ce
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"c7e1453d-e77c-483e-a250-ab7ba950d4ce","name":"tf-func-distracted-poincare","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncdistractedpoinrz0ih2jg","registry_namespace_id":"4b602f28-c69b-459a-8c36-9770582b1740","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "468"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:08 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 028afb03-0621-4355-97ee-9e5c8ffaca2e
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/c7e1453d-e77c-483e-a250-ab7ba950d4ce
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"c7e1453d-e77c-483e-a250-ab7ba950d4ce","name":"tf-func-distracted-poincare","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncdistractedpoinrz0ih2jg","registry_namespace_id":"4b602f28-c69b-459a-8c36-9770582b1740","secret_environment_variables":[],"status":"ready"}'
-    headers:
-      Content-Length:
-      - "466"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b4ce6931-3f33-47be-8f38-cd2efbf37709
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/c7e1453d-e77c-483e-a250-ab7ba950d4ce
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"c7e1453d-e77c-483e-a250-ab7ba950d4ce","name":"tf-func-distracted-poincare","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncdistractedpoinrz0ih2jg","registry_namespace_id":"4b602f28-c69b-459a-8c36-9770582b1740","secret_environment_variables":[],"status":"ready"}'
-    headers:
-      Content-Length:
-      - "466"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a2e8980b-b97e-4040-9c83-a8f7c5840bbe
-    status: 200 OK
-    code: 200
-- request:
-    body: '{"name":"foobar","namespace_id":"c7e1453d-e77c-483e-a250-ab7ba950d4ce","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"node14","memory_limit":128,"timeout":"10.000000000s","handler":"handler.handle","privacy":"private","description":null,"secret_environment_variables":[],"http_option":"enabled"}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions
-    method: POST
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncdistractedpoinrz0ih2jg-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"cd358a70-45c5-48d9-9842-a712cc3b2099","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"c7e1453d-e77c-483e-a250-ab7ba950d4ce","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"10s"}'
-    headers:
-      Content-Length:
-      - "524"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 78470628-215a-4d7b-885f-c082d883f43a
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/cd358a70-45c5-48d9-9842-a712cc3b2099
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncdistractedpoinrz0ih2jg-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"cd358a70-45c5-48d9-9842-a712cc3b2099","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"c7e1453d-e77c-483e-a250-ab7ba950d4ce","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"10s"}'
-    headers:
-      Content-Length:
-      - "524"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5ac2e254-ea92-4a6f-b605-cda9ff5c0f2d
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/cd358a70-45c5-48d9-9842-a712cc3b2099
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncdistractedpoinrz0ih2jg-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"cd358a70-45c5-48d9-9842-a712cc3b2099","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"c7e1453d-e77c-483e-a250-ab7ba950d4ce","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"10s"}'
-    headers:
-      Content-Length:
-      - "524"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:14 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - efded6ac-9148-4e3a-8997-a1dea4482d73
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/cd358a70-45c5-48d9-9842-a712cc3b2099
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncdistractedpoinrz0ih2jg-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"cd358a70-45c5-48d9-9842-a712cc3b2099","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"c7e1453d-e77c-483e-a250-ab7ba950d4ce","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"10s"}'
-    headers:
-      Content-Length:
-      - "524"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:14 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8ee721bd-cacb-47fe-9d07-36082bf90e91
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/c7e1453d-e77c-483e-a250-ab7ba950d4ce
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"c7e1453d-e77c-483e-a250-ab7ba950d4ce","name":"tf-func-distracted-poincare","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncdistractedpoinrz0ih2jg","registry_namespace_id":"4b602f28-c69b-459a-8c36-9770582b1740","secret_environment_variables":[],"status":"ready"}'
-    headers:
-      Content-Length:
-      - "466"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:14 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 70a4bd8e-7b0b-48c1-892b-b1b0db76f156
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/cd358a70-45c5-48d9-9842-a712cc3b2099
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncdistractedpoinrz0ih2jg-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"cd358a70-45c5-48d9-9842-a712cc3b2099","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"c7e1453d-e77c-483e-a250-ab7ba950d4ce","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"10s"}'
-    headers:
-      Content-Length:
-      - "524"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:14 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5fd514f4-c647-4343-a1da-63c18eb1ed4d
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/cd358a70-45c5-48d9-9842-a712cc3b2099
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncdistractedpoinrz0ih2jg-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"cd358a70-45c5-48d9-9842-a712cc3b2099","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"c7e1453d-e77c-483e-a250-ab7ba950d4ce","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"10s"}'
-    headers:
-      Content-Length:
-      - "524"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:14 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 73d86940-367e-465e-a757-870cf5957370
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/cd358a70-45c5-48d9-9842-a712cc3b2099
-    method: DELETE
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffuncdistractedpoinrz0ih2jg-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"cd358a70-45c5-48d9-9842-a712cc3b2099","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"c7e1453d-e77c-483e-a250-ab7ba950d4ce","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"deleting","timeout":"10s"}'
-    headers:
-      Content-Length:
-      - "525"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:14 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - cb77055d-ed05-4e30-af2a-5b376ea610df
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/c7e1453d-e77c-483e-a250-ab7ba950d4ce
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"c7e1453d-e77c-483e-a250-ab7ba950d4ce","name":"tf-func-distracted-poincare","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncdistractedpoinrz0ih2jg","registry_namespace_id":"4b602f28-c69b-459a-8c36-9770582b1740","secret_environment_variables":[],"status":"ready"}'
-    headers:
-      Content-Length:
-      - "466"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:14 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e9e913a7-9fcf-489b-b66e-12a0841f87b2
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/c7e1453d-e77c-483e-a250-ab7ba950d4ce
-    method: DELETE
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"c7e1453d-e77c-483e-a250-ab7ba950d4ce","name":"tf-func-distracted-poincare","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncdistractedpoinrz0ih2jg","registry_namespace_id":"4b602f28-c69b-459a-8c36-9770582b1740","secret_environment_variables":[],"status":"deleting"}'
-    headers:
-      Content-Length:
-      - "469"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:15 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - be0ee1d0-ccdf-4719-bcef-22f99a3fca52
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/c7e1453d-e77c-483e-a250-ab7ba950d4ce
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"c7e1453d-e77c-483e-a250-ab7ba950d4ce","name":"tf-func-distracted-poincare","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncdistractedpoinrz0ih2jg","registry_namespace_id":"4b602f28-c69b-459a-8c36-9770582b1740","secret_environment_variables":[],"status":"deleting"}'
-    headers:
-      Content-Length:
-      - "469"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:15 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1118964e-28e9-4b17-8758-ca0a1fa38bdf
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/c7e1453d-e77c-483e-a250-ab7ba950d4ce
-    method: GET
-  response:
-    body: '{"message":"Namespace was not found"}'
-    headers:
-      Content-Length:
-      - "37"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:20 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7e92ccf4-037c-47b5-b737-03428a665939
-    status: 404 Not Found
-    code: 404
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/cd358a70-45c5-48d9-9842-a712cc3b2099
-    method: DELETE
-  response:
-    body: '{"message":"Function was not found"}'
-    headers:
-      Content-Length:
-      - "36"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:20 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - bf0ae71d-8b25-41a8-821f-b6137d77b147
-    status: 404 Not Found
-    code: 404
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 144
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"name":"tf-func-upbeat-fermi","environment_variables":{},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","secret_environment_variables":[]}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 370
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"39c4795d-a66a-4b4b-9457-05e9a26ba1f9","name":"tf-func-upbeat-fermi","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
+        headers:
+            Content-Length:
+                - "370"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:19 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 9d3bd2b2-ac37-45fa-84f8-a4db2e9310ee
+        status: 200 OK
+        code: 200
+        duration: 1.220991206s
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/39c4795d-a66a-4b4b-9457-05e9a26ba1f9
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 370
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"39c4795d-a66a-4b4b-9457-05e9a26ba1f9","name":"tf-func-upbeat-fermi","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
+        headers:
+            Content-Length:
+                - "370"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:20 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 339be897-f72c-4daa-8e94-808ffa754faf
+        status: 200 OK
+        code: 200
+        duration: 56.682565ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/39c4795d-a66a-4b4b-9457-05e9a26ba1f9
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 458
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"39c4795d-a66a-4b4b-9457-05e9a26ba1f9","name":"tf-func-upbeat-fermi","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncupbeatfermic7lqfeda","registry_namespace_id":"842cfbdb-9166-4a16-aad4-3dd49c9a99b5","secret_environment_variables":[],"status":"pending"}'
+        headers:
+            Content-Length:
+                - "458"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:25 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e331ea82-e2ca-453b-bd35-70b223575d8f
+        status: 200 OK
+        code: 200
+        duration: 75.904783ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/39c4795d-a66a-4b4b-9457-05e9a26ba1f9
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 458
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"39c4795d-a66a-4b4b-9457-05e9a26ba1f9","name":"tf-func-upbeat-fermi","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncupbeatfermic7lqfeda","registry_namespace_id":"842cfbdb-9166-4a16-aad4-3dd49c9a99b5","secret_environment_variables":[],"status":"pending"}'
+        headers:
+            Content-Length:
+                - "458"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:30 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f1daa5ac-2430-42d0-8a04-28bffb157672
+        status: 200 OK
+        code: 200
+        duration: 304.106641ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/39c4795d-a66a-4b4b-9457-05e9a26ba1f9
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 458
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"39c4795d-a66a-4b4b-9457-05e9a26ba1f9","name":"tf-func-upbeat-fermi","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncupbeatfermic7lqfeda","registry_namespace_id":"842cfbdb-9166-4a16-aad4-3dd49c9a99b5","secret_environment_variables":[],"status":"pending"}'
+        headers:
+            Content-Length:
+                - "458"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 8f2446db-f1bd-4415-91ab-5d2d4c53976f
+        status: 200 OK
+        code: 200
+        duration: 60.541676ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/39c4795d-a66a-4b4b-9457-05e9a26ba1f9
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 458
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"39c4795d-a66a-4b4b-9457-05e9a26ba1f9","name":"tf-func-upbeat-fermi","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncupbeatfermic7lqfeda","registry_namespace_id":"842cfbdb-9166-4a16-aad4-3dd49c9a99b5","secret_environment_variables":[],"status":"pending"}'
+        headers:
+            Content-Length:
+                - "458"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:40 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 23726ee5-c373-496c-84cf-f41e9a2c7f67
+        status: 200 OK
+        code: 200
+        duration: 65.888954ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/39c4795d-a66a-4b4b-9457-05e9a26ba1f9
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 458
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"39c4795d-a66a-4b4b-9457-05e9a26ba1f9","name":"tf-func-upbeat-fermi","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncupbeatfermic7lqfeda","registry_namespace_id":"842cfbdb-9166-4a16-aad4-3dd49c9a99b5","secret_environment_variables":[],"status":"pending"}'
+        headers:
+            Content-Length:
+                - "458"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:45 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 02a99ef6-561f-4da7-9751-5cb7afde48f9
+        status: 200 OK
+        code: 200
+        duration: 59.029364ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/39c4795d-a66a-4b4b-9457-05e9a26ba1f9
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 458
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"39c4795d-a66a-4b4b-9457-05e9a26ba1f9","name":"tf-func-upbeat-fermi","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncupbeatfermic7lqfeda","registry_namespace_id":"842cfbdb-9166-4a16-aad4-3dd49c9a99b5","secret_environment_variables":[],"status":"pending"}'
+        headers:
+            Content-Length:
+                - "458"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:50 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f970488d-c5cd-4525-ad57-aa6dcf88bce5
+        status: 200 OK
+        code: 200
+        duration: 56.379185ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/39c4795d-a66a-4b4b-9457-05e9a26ba1f9
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 456
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"39c4795d-a66a-4b4b-9457-05e9a26ba1f9","name":"tf-func-upbeat-fermi","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncupbeatfermic7lqfeda","registry_namespace_id":"842cfbdb-9166-4a16-aad4-3dd49c9a99b5","secret_environment_variables":[],"status":"ready"}'
+        headers:
+            Content-Length:
+                - "456"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:55 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f6c8b15f-9bde-4c8d-b154-e63197c99238
+        status: 200 OK
+        code: 200
+        duration: 54.862327ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/39c4795d-a66a-4b4b-9457-05e9a26ba1f9
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 456
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"39c4795d-a66a-4b4b-9457-05e9a26ba1f9","name":"tf-func-upbeat-fermi","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncupbeatfermic7lqfeda","registry_namespace_id":"842cfbdb-9166-4a16-aad4-3dd49c9a99b5","secret_environment_variables":[],"status":"ready"}'
+        headers:
+            Content-Length:
+                - "456"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:55 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 84e4899b-e703-448f-8298-eca6e0b389d4
+        status: 200 OK
+        code: 200
+        duration: 54.417261ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 324
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"name":"foobar","namespace_id":"39c4795d-a66a-4b4b-9457-05e9a26ba1f9","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"node22","memory_limit":256,"timeout":"10.000000000s","handler":"handler.handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 558
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncupbeatfermic7lqfeda-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"b11b342e-3efb-409e-a9ea-9e5ada559b46","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"39c4795d-a66a-4b4b-9457-05e9a26ba1f9","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"10s"}'
+        headers:
+            Content-Length:
+                - "558"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:56 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ca39cd52-a91b-4ed9-964d-5e032c3acad3
+        status: 200 OK
+        code: 200
+        duration: 438.288652ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/b11b342e-3efb-409e-a9ea-9e5ada559b46
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 558
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncupbeatfermic7lqfeda-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"b11b342e-3efb-409e-a9ea-9e5ada559b46","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"39c4795d-a66a-4b4b-9457-05e9a26ba1f9","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"10s"}'
+        headers:
+            Content-Length:
+                - "558"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:56 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b897ff89-472d-40e7-a2d4-57fc8a2cfa27
+        status: 200 OK
+        code: 200
+        duration: 71.475908ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/b11b342e-3efb-409e-a9ea-9e5ada559b46
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 558
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncupbeatfermic7lqfeda-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"b11b342e-3efb-409e-a9ea-9e5ada559b46","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"39c4795d-a66a-4b4b-9457-05e9a26ba1f9","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"10s"}'
+        headers:
+            Content-Length:
+                - "558"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:56 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 7c26c8d4-43f5-4c1e-a9ea-6f196489d8e0
+        status: 200 OK
+        code: 200
+        duration: 78.792476ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/b11b342e-3efb-409e-a9ea-9e5ada559b46
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 558
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncupbeatfermic7lqfeda-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"b11b342e-3efb-409e-a9ea-9e5ada559b46","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"39c4795d-a66a-4b4b-9457-05e9a26ba1f9","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"10s"}'
+        headers:
+            Content-Length:
+                - "558"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:56 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f5d1bf9b-e4a0-4c1b-8915-5fe977ab3dbb
+        status: 200 OK
+        code: 200
+        duration: 65.935155ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/39c4795d-a66a-4b4b-9457-05e9a26ba1f9
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 456
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"39c4795d-a66a-4b4b-9457-05e9a26ba1f9","name":"tf-func-upbeat-fermi","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncupbeatfermic7lqfeda","registry_namespace_id":"842cfbdb-9166-4a16-aad4-3dd49c9a99b5","secret_environment_variables":[],"status":"ready"}'
+        headers:
+            Content-Length:
+                - "456"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:56 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - bbeabc71-f06d-4025-99fb-b2476bb29a77
+        status: 200 OK
+        code: 200
+        duration: 56.548055ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/b11b342e-3efb-409e-a9ea-9e5ada559b46
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 558
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncupbeatfermic7lqfeda-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"b11b342e-3efb-409e-a9ea-9e5ada559b46","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"39c4795d-a66a-4b4b-9457-05e9a26ba1f9","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"10s"}'
+        headers:
+            Content-Length:
+                - "558"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:56 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - c8ab60cc-0e46-48f9-8646-a49c25b2dac5
+        status: 200 OK
+        code: 200
+        duration: 58.01421ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/b11b342e-3efb-409e-a9ea-9e5ada559b46
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 558
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncupbeatfermic7lqfeda-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"b11b342e-3efb-409e-a9ea-9e5ada559b46","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"39c4795d-a66a-4b4b-9457-05e9a26ba1f9","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"10s"}'
+        headers:
+            Content-Length:
+                - "558"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:57 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 941303ef-f019-4361-9c35-dcf8dd408507
+        status: 200 OK
+        code: 200
+        duration: 62.49989ms
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/b11b342e-3efb-409e-a9ea-9e5ada559b46
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 559
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncupbeatfermic7lqfeda-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"b11b342e-3efb-409e-a9ea-9e5ada559b46","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"39c4795d-a66a-4b4b-9457-05e9a26ba1f9","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"deleting","timeout":"10s"}'
+        headers:
+            Content-Length:
+                - "559"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:57 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - d2b09f78-8d75-4aaf-a693-25a4529dc887
+        status: 200 OK
+        code: 200
+        duration: 182.868005ms
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/39c4795d-a66a-4b4b-9457-05e9a26ba1f9
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 456
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"39c4795d-a66a-4b4b-9457-05e9a26ba1f9","name":"tf-func-upbeat-fermi","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncupbeatfermic7lqfeda","registry_namespace_id":"842cfbdb-9166-4a16-aad4-3dd49c9a99b5","secret_environment_variables":[],"status":"ready"}'
+        headers:
+            Content-Length:
+                - "456"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:57 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 8e2e0306-2bcd-4e1a-90a5-569384f22a10
+        status: 200 OK
+        code: 200
+        duration: 63.965143ms
+    - id: 19
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/39c4795d-a66a-4b4b-9457-05e9a26ba1f9
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 459
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"39c4795d-a66a-4b4b-9457-05e9a26ba1f9","name":"tf-func-upbeat-fermi","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncupbeatfermic7lqfeda","registry_namespace_id":"842cfbdb-9166-4a16-aad4-3dd49c9a99b5","secret_environment_variables":[],"status":"deleting"}'
+        headers:
+            Content-Length:
+                - "459"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:57 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - d08ba7b0-3b49-4299-84fc-44b4f87e5711
+        status: 200 OK
+        code: 200
+        duration: 243.742771ms
+    - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/39c4795d-a66a-4b4b-9457-05e9a26ba1f9
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 459
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"39c4795d-a66a-4b4b-9457-05e9a26ba1f9","name":"tf-func-upbeat-fermi","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncupbeatfermic7lqfeda","registry_namespace_id":"842cfbdb-9166-4a16-aad4-3dd49c9a99b5","secret_environment_variables":[],"status":"deleting"}'
+        headers:
+            Content-Length:
+                - "459"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:57 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e64f657f-7539-4808-841c-18a256ebdea0
+        status: 200 OK
+        code: 200
+        duration: 58.546561ms
+    - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/39c4795d-a66a-4b4b-9457-05e9a26ba1f9
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 37
+        uncompressed: false
+        body: '{"message":"Namespace was not found"}'
+        headers:
+            Content-Length:
+                - "37"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:25:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ba2834ef-421a-41ed-85a8-0a6a742fa217
+        status: 404 Not Found
+        code: 404
+        duration: 27.54325ms
+    - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/b11b342e-3efb-409e-a9ea-9e5ada559b46
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 36
+        uncompressed: false
+        body: '{"message":"Function was not found"}'
+        headers:
+            Content-Length:
+                - "36"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:25:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - cab5722b-fc27-442d-b17f-ca41643c79f1
+        status: 404 Not Found
+        code: 404
+        duration: 31.301462ms

--- a/internal/services/function/testdata/function-token-basic.cassette.yaml
+++ b/internal/services/function/testdata/function-token-basic.cassette.yaml
@@ -1,1007 +1,1334 @@
 ---
 version: 2
 interactions:
-- request:
-    body: '{"name":"test-function-token-ns","environment_variables":{},"project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","description":null,"secret_environment_variables":[]}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces
-    method: POST
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"9e8a7fd7-4ee3-4713-8fdd-10cd0fe172a3","name":"test-function-token-ns","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "372"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 12:53:12 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a8e271d8-7aaa-407d-a743-1a8536edb8a1
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/9e8a7fd7-4ee3-4713-8fdd-10cd0fe172a3
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"9e8a7fd7-4ee3-4713-8fdd-10cd0fe172a3","name":"test-function-token-ns","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "372"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 12:53:12 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 50f22608-7955-4e82-9410-088c29aa8f34
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/9e8a7fd7-4ee3-4713-8fdd-10cd0fe172a3
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"9e8a7fd7-4ee3-4713-8fdd-10cd0fe172a3","name":"test-function-token-ns","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "372"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 12:53:17 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4ec63b1a-1386-4b3f-afad-16b541de8dae
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/9e8a7fd7-4ee3-4713-8fdd-10cd0fe172a3
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"9e8a7fd7-4ee3-4713-8fdd-10cd0fe172a3","name":"test-function-token-ns","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "372"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 12:53:22 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 352e85fd-e8e4-4a4b-aeda-55c6ffb9cd29
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/9e8a7fd7-4ee3-4713-8fdd-10cd0fe172a3
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"9e8a7fd7-4ee3-4713-8fdd-10cd0fe172a3","name":"test-function-token-ns","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "372"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 12:53:27 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 50d3c22e-d40d-4a61-99b4-8f6fce9fcfbf
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/9e8a7fd7-4ee3-4713-8fdd-10cd0fe172a3
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"9e8a7fd7-4ee3-4713-8fdd-10cd0fe172a3","name":"test-function-token-ns","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "372"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 12:53:32 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 303f041d-c2c8-42f2-9836-51d45c58881c
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/9e8a7fd7-4ee3-4713-8fdd-10cd0fe172a3
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"9e8a7fd7-4ee3-4713-8fdd-10cd0fe172a3","name":"test-function-token-ns","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontokennskfwgpzjz","registry_namespace_id":"0e677101-24c0-4e6c-ab6e-9559be97b3aa","secret_environment_variables":[],"status":"ready"}'
-    headers:
-      Content-Length:
-      - "460"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 12:53:37 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 24f11a49-171b-4355-b3c9-b4dab9ae5950
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/9e8a7fd7-4ee3-4713-8fdd-10cd0fe172a3
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"9e8a7fd7-4ee3-4713-8fdd-10cd0fe172a3","name":"test-function-token-ns","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontokennskfwgpzjz","registry_namespace_id":"0e677101-24c0-4e6c-ab6e-9559be97b3aa","secret_environment_variables":[],"status":"ready"}'
-    headers:
-      Content-Length:
-      - "460"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 12:53:37 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3c015ea1-4756-40b0-9508-221ad8aed890
-    status: 200 OK
-    code: 200
-- request:
-    body: '{"namespace_id":"9e8a7fd7-4ee3-4713-8fdd-10cd0fe172a3","description":null,"expires_at":"2023-01-05T13:53:11+01:00"}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens
-    method: POST
-  response:
-    body: '{"description":"","expires_at":"2023-01-05T12:53:11Z","id":"d8582c3f-6113-4da5-b210-2d97ed508cfb","namespace_id":"9e8a7fd7-4ee3-4713-8fdd-10cd0fe172a3","public_key":"-----BEGIN
-      RSA PUBLIC KEY-----\nMIICCgKCAgEAwJM9Aba3r9xqzl86midauK4QGJDbTD7NeWVMuJoctaCkEKa3M25u\nztQXnCPwvjWZwUTW8KiB9z7TOAQkeMC/tpuL7VoLR+X0WvdYf64R5RuZiUTunQ/I\nnZ0RsKY+qvD8+AFwOR6ahACgBmaaAMA3zTp2IHOAV5QRC1L2xtrbt8bZ4D6x88dQ\n5m+kiVbH+xAmrbEf1aaRjxj0QfySicsAN/rKH+d9NuDYHpeKKZpr1ifyQ9jYjjyw\nQBA+8omxcri+fevaAFO7RPZwDmCe1hCD8nmb0trMTt3p/DtgcTA7t0JkVZiwBIEo\nZmG7Zd9LcVR8swQVbmbBJ2AEMdoluBUcORVVXSj03BU2dnUAWb3lvWcpGXMozT5X\nR8n/hZSA/Xe5MVZsXh2fShmzo7PIc31TMkRKYD9B9FODJBdrYw0XuSaQY08wBvJN\nOWfRPspN20AoSV/oMhWr4YudCuFZAoN8qVVYTYUWYjMrkEv+WwFtCUkUhgMP6wef\nS0Fbf0q3bSYw2Z+Uwwrv92Y48f5MBX+/nlEDZp27VRs7pnxvTekAeKA4jUHkAW7F\nl5/gvsFT/SmanC3nH10zUjzika9ILwW6oeFLtKoGszPTLJDfCEC1W6hT+51jmCeD\nEAwrObDYWEvTRCDeyZRtViKv1nbmt8rdy8JyuFMc9d4RfHBOsi7pCRkCAwEAAQ==\n-----END
-      RSA PUBLIC KEY-----\n","status":"creating","token":"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJhcHBsaWNhdGlvbl9jbGFpbSI6W3sibmFtZXNwYWNlX2lkIjoiOWU4YTdmZDctNGVlMy00NzEzLThmZGQtMTBjZDBmZTE3MmEzIiwiYXBwbGljYXRpb25faWQiOiIifV0sInZlcnNpb24iOjIsImF1ZCI6ImZ1bmN0aW9ucyIsImV4cCI6MTY3MjkyMzE5MSwianRpIjoiZDg1ODJjM2YtNjExMy00ZGE1LWIyMTAtMmQ5N2VkNTA4Y2ZiIiwiaWF0IjoxNjcyODM2ODE3LCJpc3MiOiJTQ0FMRVdBWSIsIm5iZiI6MTY3MjgzNjgxNywic3ViIjoidG9rZW4ifQ.GM2ZcfwUSgn2AqF_n_GDKDtUjfEn5sh7nMoCT0C5-YcY3pdy9vUSyMglZJMIk-LRbHHuJmEiOFcGis3CwHaq5l0A8fj_CbvC7SQ0aWHxkmCK_a4kaFRzaI--TTEf7l1Q7y6oNSQwPFQxLop2vDAHhz8tDmL-VdE9gkITpXrotMP5CksFx8aY55yg1l2iCzOZC1Vnbc8p9ZdfvHyse0sOEotCFiSLBsPeJBD0pyqNWYf5bj-eoETs6lKBGwuOm8dy1Nj3jCbDm5DvqL6yTYhkXWYb0RvSurszGQltRijSMezAq21up65JLlKGyxyIFdaQgs1Lxn-sZRkfkAL9NkjYD5njpK4T80boe0SNfD-hc6ODYZkCYV4clGoJG3FLSCT1FXe4N1lOUgMtWLrCJWtpbAx3Kjsm-l5pG_oJThAhjSZDA2QuBKIuRkPx9DorW_lvoNY7R-7Jrchs1JVCD9eQOhX6CoZ6tYVb8_zqWLuNwGNJ1UkGSk1q7dbbeWn1KMttx5mfZAVX-2N3L0cV-8zR-hTZmCUe5EZy4qLn3-jD7HU9ZgXSE99iXdsLAmjsz3R5Foy5HsqbEW747i97Gg7N1CAfmwyckXDRo59y-2f7ET7TGSOQ3_VRJC3xy9CuQZgNq8d3gdvFYYQCYj42OsnKiWui63Ad33S1E33WdBqyMG4"}'
-    headers:
-      Content-Length:
-      - "2050"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 12:53:37 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9bf1e06c-5b10-4118-baaa-1ad49cae0fad
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens/d8582c3f-6113-4da5-b210-2d97ed508cfb
-    method: GET
-  response:
-    body: '{"description":"","expires_at":"2023-01-05T12:53:11Z","id":"d8582c3f-6113-4da5-b210-2d97ed508cfb","namespace_id":"9e8a7fd7-4ee3-4713-8fdd-10cd0fe172a3","public_key":"","status":"creating","token":"\u003chidden\u003e"}'
-    headers:
-      Content-Length:
-      - "217"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 12:53:38 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - fb167035-823f-449e-9560-0030f11deb32
-    status: 200 OK
-    code: 200
-- request:
-    body: '{"name":"tf-func-crazy-spence","namespace_id":"9e8a7fd7-4ee3-4713-8fdd-10cd0fe172a3","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"node14","memory_limit":128,"timeout":null,"handler":"handler.handle","privacy":"private","description":null,"secret_environment_variables":[],"http_option":"enabled"}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions
-    method: POST
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"testfunctiontokennskfwgpzjz-tf-func-crazy-spence.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"6fc08a84-02bc-47a6-b637-9aa9b6323d1b","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-func-crazy-spence","namespace_id":"9e8a7fd7-4ee3-4713-8fdd-10cd0fe172a3","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "552"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 12:53:38 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b206cc35-5c0e-4383-ac19-64dbaf06d03c
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/6fc08a84-02bc-47a6-b637-9aa9b6323d1b
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"testfunctiontokennskfwgpzjz-tf-func-crazy-spence.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"6fc08a84-02bc-47a6-b637-9aa9b6323d1b","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-func-crazy-spence","namespace_id":"9e8a7fd7-4ee3-4713-8fdd-10cd0fe172a3","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "552"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 12:53:38 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 10d1a3c1-5c05-49a4-9f91-0167a4b93ed6
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/6fc08a84-02bc-47a6-b637-9aa9b6323d1b
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"testfunctiontokennskfwgpzjz-tf-func-crazy-spence.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"6fc08a84-02bc-47a6-b637-9aa9b6323d1b","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-func-crazy-spence","namespace_id":"9e8a7fd7-4ee3-4713-8fdd-10cd0fe172a3","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "552"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 12:53:38 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - cb241e7d-688c-4a1b-8c9b-e1bb87b9aa77
-    status: 200 OK
-    code: 200
-- request:
-    body: '{"function_id":"6fc08a84-02bc-47a6-b637-9aa9b6323d1b","description":null,"expires_at":null}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens
-    method: POST
-  response:
-    body: '{"description":"","expires_at":null,"function_id":"6fc08a84-02bc-47a6-b637-9aa9b6323d1b","id":"eb3c32a0-136c-4050-8c2f-feba73f279e2","public_key":"-----BEGIN
-      RSA PUBLIC KEY-----\nMIICCgKCAgEAwJM9Aba3r9xqzl86midauK4QGJDbTD7NeWVMuJoctaCkEKa3M25u\nztQXnCPwvjWZwUTW8KiB9z7TOAQkeMC/tpuL7VoLR+X0WvdYf64R5RuZiUTunQ/I\nnZ0RsKY+qvD8+AFwOR6ahACgBmaaAMA3zTp2IHOAV5QRC1L2xtrbt8bZ4D6x88dQ\n5m+kiVbH+xAmrbEf1aaRjxj0QfySicsAN/rKH+d9NuDYHpeKKZpr1ifyQ9jYjjyw\nQBA+8omxcri+fevaAFO7RPZwDmCe1hCD8nmb0trMTt3p/DtgcTA7t0JkVZiwBIEo\nZmG7Zd9LcVR8swQVbmbBJ2AEMdoluBUcORVVXSj03BU2dnUAWb3lvWcpGXMozT5X\nR8n/hZSA/Xe5MVZsXh2fShmzo7PIc31TMkRKYD9B9FODJBdrYw0XuSaQY08wBvJN\nOWfRPspN20AoSV/oMhWr4YudCuFZAoN8qVVYTYUWYjMrkEv+WwFtCUkUhgMP6wef\nS0Fbf0q3bSYw2Z+Uwwrv92Y48f5MBX+/nlEDZp27VRs7pnxvTekAeKA4jUHkAW7F\nl5/gvsFT/SmanC3nH10zUjzika9ILwW6oeFLtKoGszPTLJDfCEC1W6hT+51jmCeD\nEAwrObDYWEvTRCDeyZRtViKv1nbmt8rdy8JyuFMc9d4RfHBOsi7pCRkCAwEAAQ==\n-----END
-      RSA PUBLIC KEY-----\n","status":"creating","token":"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJhcHBsaWNhdGlvbl9jbGFpbSI6W3sibmFtZXNwYWNlX2lkIjoiIiwiYXBwbGljYXRpb25faWQiOiI2ZmMwOGE4NC0wMmJjLTQ3YTYtYjYzNy05YWE5YjYzMjNkMWIifV0sInZlcnNpb24iOjIsImF1ZCI6ImZ1bmN0aW9ucyIsImp0aSI6ImViM2MzMmEwLTEzNmMtNDA1MC04YzJmLWZlYmE3M2YyNzllMiIsImlhdCI6MTY3MjgzNjgxOCwiaXNzIjoiU0NBTEVXQVkiLCJuYmYiOjE2NzI4MzY4MTgsInN1YiI6InRva2VuIn0.MlLyhesas__3TIHgOyTj-EbgsZUb3pOnK9Rv0_XHCeeCA_QIeHIwS1dShJSHoRlBFWZ-rSiF01SYV7Qx9MhAtSKpXksGZpKZICxrTAgNzxsnYGfxVPDr8eYIpS0PvoSDrMygHn5TwE3IkJxJUKc3Z04f3JC4gDEghUUTffAvhZItOctdWQadaX_x2wIDQS_5ERGZ2xS3PF40kN3Scowr1ovqiM-teqLW4qJqva7K_qhKGxWEYBN5pu6e7eonkJkQdDkSXaXTnBAeupUMf5x6OsB1ujxY7h2ek6UHSZm8qPC9_HxYmHKFnmNzo4RcSA51lYhrs459wH_FW_pN0yOyBpJHuUGhwPqARbw0Q5WXKKW3ktucGhnS_R-jkmyuIFyF1WViVs-rHWtkZxhrfqMrpRdfjWVqPEOhlZd72_yhbK-_sA_EbbdGFZ1vNm5c-xT39CQBX2LEhOeD7TNrYRK6pH9C0s3es7WEwXxjklsDfbfmKd8oVm5INOcmAV3zYkzoDNj9Uqd5Z6eXyslra-3xJXrJEVHaabkgOsm5dvXXUbDb76GmgkVKy0au57M4CmEFxkhscv9PVhOkNd_e66VH_UWuJMBGBoTFO987NR-WEsE7rgod1-LtTtL-1swly5g_bfr-JjNHtShpCvIT9WGncdNIzM70EJqbBt99aRP-f28"}'
-    headers:
-      Content-Length:
-      - "2008"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 12:53:38 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c4ad1751-0105-4bb4-ab26-65651a0a1535
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens/eb3c32a0-136c-4050-8c2f-feba73f279e2
-    method: GET
-  response:
-    body: '{"description":"","expires_at":null,"function_id":"6fc08a84-02bc-47a6-b637-9aa9b6323d1b","id":"eb3c32a0-136c-4050-8c2f-feba73f279e2","public_key":"","status":"creating","token":"\u003chidden\u003e"}'
-    headers:
-      Content-Length:
-      - "198"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 12:53:38 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5880d6c5-9026-4b31-8842-232ee081068f
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens/d8582c3f-6113-4da5-b210-2d97ed508cfb
-    method: GET
-  response:
-    body: '{"description":"","expires_at":"2023-01-05T12:53:11Z","id":"d8582c3f-6113-4da5-b210-2d97ed508cfb","namespace_id":"9e8a7fd7-4ee3-4713-8fdd-10cd0fe172a3","public_key":"","status":"ready","token":"\u003chidden\u003e"}'
-    headers:
-      Content-Length:
-      - "214"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 12:53:38 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1ce7619f-a3aa-41d2-8fd0-3297614b69db
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens/eb3c32a0-136c-4050-8c2f-feba73f279e2
-    method: GET
-  response:
-    body: '{"description":"","expires_at":null,"function_id":"6fc08a84-02bc-47a6-b637-9aa9b6323d1b","id":"eb3c32a0-136c-4050-8c2f-feba73f279e2","public_key":"","status":"ready","token":"\u003chidden\u003e"}'
-    headers:
-      Content-Length:
-      - "195"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 12:53:38 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e1625f0b-6663-48ab-99cf-a84d44ba006b
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/9e8a7fd7-4ee3-4713-8fdd-10cd0fe172a3
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"9e8a7fd7-4ee3-4713-8fdd-10cd0fe172a3","name":"test-function-token-ns","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontokennskfwgpzjz","registry_namespace_id":"0e677101-24c0-4e6c-ab6e-9559be97b3aa","secret_environment_variables":[],"status":"ready"}'
-    headers:
-      Content-Length:
-      - "460"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 12:53:38 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9801b8f4-a475-4d75-abe5-f0796be89d1e
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/6fc08a84-02bc-47a6-b637-9aa9b6323d1b
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"testfunctiontokennskfwgpzjz-tf-func-crazy-spence.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"6fc08a84-02bc-47a6-b637-9aa9b6323d1b","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-func-crazy-spence","namespace_id":"9e8a7fd7-4ee3-4713-8fdd-10cd0fe172a3","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "552"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 12:53:38 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6bd8e27d-cb0c-4ff2-add7-66a22c4a3cb5
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens/d8582c3f-6113-4da5-b210-2d97ed508cfb
-    method: GET
-  response:
-    body: '{"description":"","expires_at":"2023-01-05T12:53:11Z","id":"d8582c3f-6113-4da5-b210-2d97ed508cfb","namespace_id":"9e8a7fd7-4ee3-4713-8fdd-10cd0fe172a3","public_key":"","status":"ready","token":"\u003chidden\u003e"}'
-    headers:
-      Content-Length:
-      - "214"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 12:53:38 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9b260d98-065b-4b1f-8e47-6d9fe60fe406
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens/eb3c32a0-136c-4050-8c2f-feba73f279e2
-    method: GET
-  response:
-    body: '{"description":"","expires_at":null,"function_id":"6fc08a84-02bc-47a6-b637-9aa9b6323d1b","id":"eb3c32a0-136c-4050-8c2f-feba73f279e2","public_key":"","status":"ready","token":"\u003chidden\u003e"}'
-    headers:
-      Content-Length:
-      - "195"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 12:53:38 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7f040ffd-a8c3-4583-98bc-0eb8f30c6c9f
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/tokens/d8582c3f-6113-4da5-b210-2d97ed508cfb
-    method: DELETE
-  response:
-    body: '{"description":"","expires_at":"2023-01-05T12:53:11Z","id":"d8582c3f-6113-4da5-b210-2d97ed508cfb","namespace_id":"9e8a7fd7-4ee3-4713-8fdd-10cd0fe172a3","public_key":"","status":"deleting","token":""}'
-    headers:
-      Content-Length:
-      - "199"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 12:53:39 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6e325993-551b-4664-b8e5-11e50a633ea4
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/tokens/eb3c32a0-136c-4050-8c2f-feba73f279e2
-    method: DELETE
-  response:
-    body: '{"container_id":"6fc08a84-02bc-47a6-b637-9aa9b6323d1b","description":"","expires_at":null,"id":"eb3c32a0-136c-4050-8c2f-feba73f279e2","public_key":"","status":"deleting","token":""}'
-    headers:
-      Content-Length:
-      - "181"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 12:53:39 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 71ea95dc-8d96-43de-9e62-7e25e1bb0cd8
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/6fc08a84-02bc-47a6-b637-9aa9b6323d1b
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"testfunctiontokennskfwgpzjz-tf-func-crazy-spence.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"6fc08a84-02bc-47a6-b637-9aa9b6323d1b","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-func-crazy-spence","namespace_id":"9e8a7fd7-4ee3-4713-8fdd-10cd0fe172a3","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "552"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 12:53:39 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c672455e-15a2-4205-9fe5-ab0dff2f7cba
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/6fc08a84-02bc-47a6-b637-9aa9b6323d1b
-    method: DELETE
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"testfunctiontokennskfwgpzjz-tf-func-crazy-spence.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"6fc08a84-02bc-47a6-b637-9aa9b6323d1b","max_scale":20,"memory_limit":128,"min_scale":0,"name":"tf-func-crazy-spence","namespace_id":"9e8a7fd7-4ee3-4713-8fdd-10cd0fe172a3","privacy":"private","region":"fr-par","runtime":"node14","runtime_message":"","secret_environment_variables":[],"status":"deleting","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "553"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 12:53:39 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6bef15d0-5ef3-41c1-84d3-cc0a6c1260c1
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/9e8a7fd7-4ee3-4713-8fdd-10cd0fe172a3
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"9e8a7fd7-4ee3-4713-8fdd-10cd0fe172a3","name":"test-function-token-ns","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontokennskfwgpzjz","registry_namespace_id":"0e677101-24c0-4e6c-ab6e-9559be97b3aa","secret_environment_variables":[],"status":"ready"}'
-    headers:
-      Content-Length:
-      - "460"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 12:53:39 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c73166b6-640c-47d6-91d8-8b22fafa853f
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/9e8a7fd7-4ee3-4713-8fdd-10cd0fe172a3
-    method: DELETE
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"9e8a7fd7-4ee3-4713-8fdd-10cd0fe172a3","name":"test-function-token-ns","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontokennskfwgpzjz","registry_namespace_id":"0e677101-24c0-4e6c-ab6e-9559be97b3aa","secret_environment_variables":[],"status":"deleting"}'
-    headers:
-      Content-Length:
-      - "463"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 12:53:39 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e649c74d-f7d9-4317-9553-7ce7b82efc57
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/9e8a7fd7-4ee3-4713-8fdd-10cd0fe172a3
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"9e8a7fd7-4ee3-4713-8fdd-10cd0fe172a3","name":"test-function-token-ns","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontokennskfwgpzjz","registry_namespace_id":"0e677101-24c0-4e6c-ab6e-9559be97b3aa","secret_environment_variables":[],"status":"deleting"}'
-    headers:
-      Content-Length:
-      - "463"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 12:53:39 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d529b9d8-fa76-4d70-8a6d-cee23f24f8cb
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/9e8a7fd7-4ee3-4713-8fdd-10cd0fe172a3
-    method: GET
-  response:
-    body: '{"message":"Namespace was not found"}'
-    headers:
-      Content-Length:
-      - "37"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 12:53:44 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a0f93f54-f563-4d62-b952-bf7633b1bb26
-    status: 404 Not Found
-    code: 404
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens/eb3c32a0-136c-4050-8c2f-feba73f279e2
-    method: DELETE
-  response:
-    body: '{"message":"Token was not found"}'
-    headers:
-      Content-Length:
-      - "33"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 12:53:44 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - fd42702d-bc16-44a8-90c9-c2d60eb78eba
-    status: 404 Not Found
-    code: 404
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens/d8582c3f-6113-4da5-b210-2d97ed508cfb
-    method: DELETE
-  response:
-    body: '{"message":"Token was not found"}'
-    headers:
-      Content-Length:
-      - "33"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 12:53:44 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c7c4f57e-99d6-4416-9c46-8e907de6125a
-    status: 404 Not Found
-    code: 404
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 146
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"name":"test-function-token-ns","environment_variables":{},"project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","secret_environment_variables":[]}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 372
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"7c8c7642-c31d-43c4-9824-eebbfeae7297","name":"test-function-token-ns","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
+        headers:
+            Content-Length:
+                - "372"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:59:54 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 683d1065-e03b-41c9-8f44-9c00c4f9c09c
+        status: 200 OK
+        code: 200
+        duration: 496.246215ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7c8c7642-c31d-43c4-9824-eebbfeae7297
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 372
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"7c8c7642-c31d-43c4-9824-eebbfeae7297","name":"test-function-token-ns","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
+        headers:
+            Content-Length:
+                - "372"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:59:54 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - d18a0565-1598-4103-9701-d33933506b37
+        status: 200 OK
+        code: 200
+        duration: 51.109138ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7c8c7642-c31d-43c4-9824-eebbfeae7297
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 460
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"7c8c7642-c31d-43c4-9824-eebbfeae7297","name":"test-function-token-ns","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontokennszegozlyr","registry_namespace_id":"73752c5a-cc99-4649-aca8-8a9a54e56520","secret_environment_variables":[],"status":"ready"}'
+        headers:
+            Content-Length:
+                - "460"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:59:59 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 99d20ace-f3d4-43b2-be0f-a992228d3905
+        status: 200 OK
+        code: 200
+        duration: 57.055398ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7c8c7642-c31d-43c4-9824-eebbfeae7297
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 460
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"7c8c7642-c31d-43c4-9824-eebbfeae7297","name":"test-function-token-ns","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontokennszegozlyr","registry_namespace_id":"73752c5a-cc99-4649-aca8-8a9a54e56520","secret_environment_variables":[],"status":"ready"}'
+        headers:
+            Content-Length:
+                - "460"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:59:59 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - af028854-2945-4962-9c03-2a892b6782ea
+        status: 200 OK
+        code: 200
+        duration: 36.038171ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 96
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"namespace_id":"7c8c7642-c31d-43c4-9824-eebbfeae7297","expires_at":"2024-07-06T10:59:52+02:00"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2050
+        uncompressed: false
+        body: '{"description":"","expires_at":"2024-07-06T08:59:52Z","id":"25cd9426-0e10-4d9f-a177-ad4c4b8c759f","namespace_id":"7c8c7642-c31d-43c4-9824-eebbfeae7297","public_key":"-----BEGIN RSA PUBLIC KEY-----\nMIICCgKCAgEAyWUv4jLpKSgt5MkHQ+OqCcH+f8vrFI11Q4AUwWPS0qEHPgXsao5Z\npipBbhLvMjHLdrv3DDSq2cAumsHI7YRzAS1Wem0cS2RbiNGkQg7Echu22fa+r64b\nV5PHfEQfdeRk7iDOdTlMAtxc1wJsiy5UDWBtmcNX8rS5AiCHd1CgIW+JZm1597dR\nd1QXS+lCMtuFv2TEy7ciroEKwejGF2MZT1eHz+KEL0LO29h0KVR07VH3XVjeFjjl\nr2T2t1tRco14d2njtKYL/pDgVqVAzn4YZCN0F1ncC7iF8tK0b4rG/iVG3cGMrZjh\nJPFdiYYM4tGx2KN15SKX5KLo1dWVP7xPUgnk1Olzhg98DUju6K3V3iorqeDFVaCf\nh+i/TMhdY5pUjpLWgqZRTtneWSCyY8OugKS77jkNGWqSWQ56VcaVt7JvQRuTzfwK\nKKU8kCJnscZKaz9SMec+ZBpubMSyPIonADTKAzG7RaCftwgMRdanjD7YG+ERkhWr\n0AjdReajZ0RllAfXDzwqE94PHjVv9wmTRaoJ8vi9bslfdVAWO892OIxo9pXw93+g\nxjbh1Z7ocDXF3PY3g8+YsUlIsZ+/XCQF5l/oTV38Z0WaWUrsi18PolDLvNDZdzYY\ncUjpVDUlcUDPzUgv0UGwvjJ6j9qZBzUxZTyAU5R/cET1Yi/9xh3s5ssCAwEAAQ==\n-----END RSA PUBLIC KEY-----\n","status":"creating","token":"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJhcHBsaWNhdGlvbl9jbGFpbSI6W3sibmFtZXNwYWNlX2lkIjoiN2M4Yzc2NDItYzMxZC00M2M0LTk4MjQtZWViYmZlYWU3Mjk3IiwiYXBwbGljYXRpb25faWQiOiIifV0sInZlcnNpb24iOjIsImF1ZCI6ImZ1bmN0aW9ucyIsImV4cCI6MTcyMDI1NjM5MiwianRpIjoiMjVjZDk0MjYtMGUxMC00ZDlmLWExNzctYWQ0YzRiOGM3NTlmIiwiaWF0IjoxNzIwMTY5OTk5LCJpc3MiOiJTQ0FMRVdBWSIsIm5iZiI6MTcyMDE2OTk5OSwic3ViIjoidG9rZW4ifQ.M_-qqxjmOGN5ZN2nYQyPAVvDwc5NOouIv-7YXh7FxutOOHJV8X8w-i8lqMdrYLXPcD4dq4dE5Z05fcu8rxfczQnj2Hao5UElbyoECSAs03mTRW0Xy8pP2SDw10oN9PMb5AKiYx_Au0jbcX4iKtn81uKl_BnfGzyf1HhUbpIz1PcR1C6H0h3eyU7Dfba1AGiSzevyFMpvuimnLIzKToiW9b3N9dersLGOR2Y7tYc-xGh3xl00FKJ5Zo2U5FUYB8BXLEqaKPikEE4SdVmGhtOKwo_5H_AJS3iKSCXijPd4YrzgCa3Iarj-1Qem8AgWs6xgm2ON9mWSFLzc1_EXgmaUgURb5mkC5Zr5IP1CGLzgu8vh32-GKy2vICVh9vy7whNEkXpUG672Az6BjjFuCUYnYu4YHu_NgOGjJeQb1dXXrYXlpobZnN4LEWG3b2A-lLVzceQjh27GjNkma-pE52-daakplfoAQUmS4ZlUXmFMswZpDVoY5KSXyLnAvor0o2cQBupAOijIPIf5bpe3128Cwfjdb5vkfPDVdSO_vT8vHCoiv3KrmaJLKkQmkLsnwMv6bKjrVQjoE3rxlW23wuk33n3E8jJtVRj1f-ReuLpdUQjcb3-3RFiek3fJRlvRCgoIoaxw4HzTBBVeyiF_5-Vsg_-Path8jTrTzvsy4rpwF4s"}'
+        headers:
+            Content-Length:
+                - "2050"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:59:59 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - eba6ae19-a84a-408d-86f5-a594282c0287
+        status: 200 OK
+        code: 200
+        duration: 113.443131ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens/25cd9426-0e10-4d9f-a177-ad4c4b8c759f
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 207
+        uncompressed: false
+        body: '{"description":"","expires_at":"2024-07-06T08:59:52Z","id":"25cd9426-0e10-4d9f-a177-ad4c4b8c759f","namespace_id":"7c8c7642-c31d-43c4-9824-eebbfeae7297","public_key":"","status":"creating","token":"\u003chidden\u003e"}'
+        headers:
+            Content-Length:
+                - "207"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:59:59 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 1c170c5c-137c-4722-aa21-71e5435f20d9
+        status: 200 OK
+        code: 200
+        duration: 40.185198ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 314
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"name":"tf-func-tender-hermann","namespace_id":"7c8c7642-c31d-43c4-9824-eebbfeae7297","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"node22","memory_limit":256,"handler":"handler.handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 593
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"testfunctiontokennszegozlyr-tf-func-tender-hermann.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"9bd788f6-4d37-458b-bc5c-4bea510d538f","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-tender-hermann","namespace_id":"7c8c7642-c31d-43c4-9824-eebbfeae7297","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "593"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:59:59 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 32c191d4-1e45-4e0b-a9c3-b2360e5139df
+        status: 200 OK
+        code: 200
+        duration: 211.016433ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/9bd788f6-4d37-458b-bc5c-4bea510d538f
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 593
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"testfunctiontokennszegozlyr-tf-func-tender-hermann.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"9bd788f6-4d37-458b-bc5c-4bea510d538f","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-tender-hermann","namespace_id":"7c8c7642-c31d-43c4-9824-eebbfeae7297","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "593"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:59:59 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 38b42511-f436-4035-8e91-fa0b5cd5fb25
+        status: 200 OK
+        code: 200
+        duration: 38.69755ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/9bd788f6-4d37-458b-bc5c-4bea510d538f
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 593
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"testfunctiontokennszegozlyr-tf-func-tender-hermann.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"9bd788f6-4d37-458b-bc5c-4bea510d538f","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-tender-hermann","namespace_id":"7c8c7642-c31d-43c4-9824-eebbfeae7297","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "593"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:59:59 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 8a41303c-5104-4933-87b9-ed6d4dc7546a
+        status: 200 OK
+        code: 200
+        duration: 41.938586ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 54
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"function_id":"9bd788f6-4d37-458b-bc5c-4bea510d538f"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2008
+        uncompressed: false
+        body: '{"description":"","expires_at":null,"function_id":"9bd788f6-4d37-458b-bc5c-4bea510d538f","id":"77064e79-7855-414b-a066-ae90adb7b7c1","public_key":"-----BEGIN RSA PUBLIC KEY-----\nMIICCgKCAgEAyWUv4jLpKSgt5MkHQ+OqCcH+f8vrFI11Q4AUwWPS0qEHPgXsao5Z\npipBbhLvMjHLdrv3DDSq2cAumsHI7YRzAS1Wem0cS2RbiNGkQg7Echu22fa+r64b\nV5PHfEQfdeRk7iDOdTlMAtxc1wJsiy5UDWBtmcNX8rS5AiCHd1CgIW+JZm1597dR\nd1QXS+lCMtuFv2TEy7ciroEKwejGF2MZT1eHz+KEL0LO29h0KVR07VH3XVjeFjjl\nr2T2t1tRco14d2njtKYL/pDgVqVAzn4YZCN0F1ncC7iF8tK0b4rG/iVG3cGMrZjh\nJPFdiYYM4tGx2KN15SKX5KLo1dWVP7xPUgnk1Olzhg98DUju6K3V3iorqeDFVaCf\nh+i/TMhdY5pUjpLWgqZRTtneWSCyY8OugKS77jkNGWqSWQ56VcaVt7JvQRuTzfwK\nKKU8kCJnscZKaz9SMec+ZBpubMSyPIonADTKAzG7RaCftwgMRdanjD7YG+ERkhWr\n0AjdReajZ0RllAfXDzwqE94PHjVv9wmTRaoJ8vi9bslfdVAWO892OIxo9pXw93+g\nxjbh1Z7ocDXF3PY3g8+YsUlIsZ+/XCQF5l/oTV38Z0WaWUrsi18PolDLvNDZdzYY\ncUjpVDUlcUDPzUgv0UGwvjJ6j9qZBzUxZTyAU5R/cET1Yi/9xh3s5ssCAwEAAQ==\n-----END RSA PUBLIC KEY-----\n","status":"creating","token":"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJhcHBsaWNhdGlvbl9jbGFpbSI6W3sibmFtZXNwYWNlX2lkIjoiIiwiYXBwbGljYXRpb25faWQiOiI5YmQ3ODhmNi00ZDM3LTQ1OGItYmM1Yy00YmVhNTEwZDUzOGYifV0sInZlcnNpb24iOjIsImF1ZCI6ImZ1bmN0aW9ucyIsImp0aSI6Ijc3MDY0ZTc5LTc4NTUtNDE0Yi1hMDY2LWFlOTBhZGI3YjdjMSIsImlhdCI6MTcyMDE2OTk5OSwiaXNzIjoiU0NBTEVXQVkiLCJuYmYiOjE3MjAxNjk5OTksInN1YiI6InRva2VuIn0.dmDrwTtVr4wnmZE0YGVErQu7todtn0hGu1MemmwPDpm0d0PGQc-JGq92m14NUedgvPCGDBfElRRgiHYxcr2FTzTPYIyH4sH31iLK3322gcVJnrC3PEy4Ev0qvorzHvIQxcAn4bgfwBjJS-uZ2Y7lSg34sq4VUNmGOa4KtkkQXDMEUlrhRmO_2xMj3P8941UU8VBJJ5bgQw6IHxvhbH9PTav07fIgXCp9Ps_MBqTuVvn_nlUp65OgR9dXYnO1K4B_RNJA1ZX9Vp0PE8fUTKyGDH_uki9PQKVS7_S7378LKtupRPrEJyZqJ83vLdDzeBIIiA66Scb6F2Qf6mx7FPyNIDfXFo77EIORVMXaehJR5Cl8htvwIs_w7XW1Q66HdHCZwSisM42XG40g-6VDl5eAgd0xRJ6KCSbm3MNyGDHwcnS_u6nTupFAuuhcuKK-xu6AXusB_hg2uFmhD-2d55LufxHkJg1IAKUAyyafGZITYuOfbtlU7KmqYrQy_wIZCh_1R06E6rNjheQ9uhPbupobTY3LHisMBV5LdfMc5RtjfUdeKnZNWkPHEaZF7igBpWQpBj_KPiFWmYdVpQXCqpH3jZMXgqAwWSILMwWW-0msOKpX2cMTIBdy1yNeZmaxh5f3Cq2n5ZVnuAD9GwWr9a91DvgyTwpJkwy89CNLAFHxyQM"}'
+        headers:
+            Content-Length:
+                - "2008"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:59:59 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 49f1cf66-4c9c-42f7-a984-26c9b47099fb
+        status: 200 OK
+        code: 200
+        duration: 171.162759ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens/77064e79-7855-414b-a066-ae90adb7b7c1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 185
+        uncompressed: false
+        body: '{"description":"","expires_at":null,"function_id":"9bd788f6-4d37-458b-bc5c-4bea510d538f","id":"77064e79-7855-414b-a066-ae90adb7b7c1","public_key":"","status":"ready","token":"\u003chidden\u003e"}'
+        headers:
+            Content-Length:
+                - "185"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:59:59 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 14f4aa8f-f839-4919-80e4-7e8fbd83db34
+        status: 200 OK
+        code: 200
+        duration: 60.637774ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens/25cd9426-0e10-4d9f-a177-ad4c4b8c759f
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 204
+        uncompressed: false
+        body: '{"description":"","expires_at":"2024-07-06T08:59:52Z","id":"25cd9426-0e10-4d9f-a177-ad4c4b8c759f","namespace_id":"7c8c7642-c31d-43c4-9824-eebbfeae7297","public_key":"","status":"ready","token":"\u003chidden\u003e"}'
+        headers:
+            Content-Length:
+                - "204"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 09:00:00 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 5fb4b563-1623-45e4-8a78-12798f716562
+        status: 200 OK
+        code: 200
+        duration: 41.614065ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens/77064e79-7855-414b-a066-ae90adb7b7c1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 185
+        uncompressed: false
+        body: '{"description":"","expires_at":null,"function_id":"9bd788f6-4d37-458b-bc5c-4bea510d538f","id":"77064e79-7855-414b-a066-ae90adb7b7c1","public_key":"","status":"ready","token":"\u003chidden\u003e"}'
+        headers:
+            Content-Length:
+                - "185"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 09:00:00 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - d54e7acd-3632-4da6-ba70-d7e758f25990
+        status: 200 OK
+        code: 200
+        duration: 44.360589ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7c8c7642-c31d-43c4-9824-eebbfeae7297
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 460
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"7c8c7642-c31d-43c4-9824-eebbfeae7297","name":"test-function-token-ns","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontokennszegozlyr","registry_namespace_id":"73752c5a-cc99-4649-aca8-8a9a54e56520","secret_environment_variables":[],"status":"ready"}'
+        headers:
+            Content-Length:
+                - "460"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 09:00:00 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - af3d8da0-a6a1-4cc2-80e5-6272d98746dd
+        status: 200 OK
+        code: 200
+        duration: 37.714032ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens/25cd9426-0e10-4d9f-a177-ad4c4b8c759f
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 204
+        uncompressed: false
+        body: '{"description":"","expires_at":"2024-07-06T08:59:52Z","id":"25cd9426-0e10-4d9f-a177-ad4c4b8c759f","namespace_id":"7c8c7642-c31d-43c4-9824-eebbfeae7297","public_key":"","status":"ready","token":"\u003chidden\u003e"}'
+        headers:
+            Content-Length:
+                - "204"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 09:00:00 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 91787d64-d6d0-4d01-8ef6-940f0ac31d19
+        status: 200 OK
+        code: 200
+        duration: 42.656294ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/9bd788f6-4d37-458b-bc5c-4bea510d538f
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 593
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"testfunctiontokennszegozlyr-tf-func-tender-hermann.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"9bd788f6-4d37-458b-bc5c-4bea510d538f","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-tender-hermann","namespace_id":"7c8c7642-c31d-43c4-9824-eebbfeae7297","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "593"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 09:00:00 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f048cbca-4be7-4eb5-b44e-024ae7adc0c3
+        status: 200 OK
+        code: 200
+        duration: 43.199186ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens/77064e79-7855-414b-a066-ae90adb7b7c1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 185
+        uncompressed: false
+        body: '{"description":"","expires_at":null,"function_id":"9bd788f6-4d37-458b-bc5c-4bea510d538f","id":"77064e79-7855-414b-a066-ae90adb7b7c1","public_key":"","status":"ready","token":"\u003chidden\u003e"}'
+        headers:
+            Content-Length:
+                - "185"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 09:00:00 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 079ae925-872c-46e7-ad87-9df877e7742d
+        status: 200 OK
+        code: 200
+        duration: 51.099971ms
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/tokens/25cd9426-0e10-4d9f-a177-ad4c4b8c759f
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 37
+        uncompressed: false
+        body: '{"message":"Container was not found"}'
+        headers:
+            Content-Length:
+                - "37"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 09:00:01 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e3040837-33b1-4f40-aa24-0bcf7684db54
+        status: 404 Not Found
+        code: 404
+        duration: 31.445876ms
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/tokens/77064e79-7855-414b-a066-ae90adb7b7c1
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 37
+        uncompressed: false
+        body: '{"message":"Container was not found"}'
+        headers:
+            Content-Length:
+                - "37"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 09:00:01 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - c9b918d6-99a3-4bd5-a6ad-e820e93d6dc0
+        status: 404 Not Found
+        code: 404
+        duration: 49.024698ms
+    - id: 19
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/9bd788f6-4d37-458b-bc5c-4bea510d538f
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 593
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"testfunctiontokennszegozlyr-tf-func-tender-hermann.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"9bd788f6-4d37-458b-bc5c-4bea510d538f","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-tender-hermann","namespace_id":"7c8c7642-c31d-43c4-9824-eebbfeae7297","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "593"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 09:00:01 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 11da1b24-80b2-4a62-8fcf-0f89e59c4233
+        status: 200 OK
+        code: 200
+        duration: 47.928157ms
+    - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/9bd788f6-4d37-458b-bc5c-4bea510d538f
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 594
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"testfunctiontokennszegozlyr-tf-func-tender-hermann.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"9bd788f6-4d37-458b-bc5c-4bea510d538f","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-tender-hermann","namespace_id":"7c8c7642-c31d-43c4-9824-eebbfeae7297","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"deleting","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "594"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 09:00:01 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ec0212bc-88e9-4c12-a91a-288106de933d
+        status: 200 OK
+        code: 200
+        duration: 113.820099ms
+    - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7c8c7642-c31d-43c4-9824-eebbfeae7297
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 460
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"7c8c7642-c31d-43c4-9824-eebbfeae7297","name":"test-function-token-ns","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontokennszegozlyr","registry_namespace_id":"73752c5a-cc99-4649-aca8-8a9a54e56520","secret_environment_variables":[],"status":"ready"}'
+        headers:
+            Content-Length:
+                - "460"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 09:00:01 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - c6e5d5ef-9c6d-4f58-bc48-8a750eb41589
+        status: 200 OK
+        code: 200
+        duration: 41.50519ms
+    - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7c8c7642-c31d-43c4-9824-eebbfeae7297
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 463
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"7c8c7642-c31d-43c4-9824-eebbfeae7297","name":"test-function-token-ns","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontokennszegozlyr","registry_namespace_id":"73752c5a-cc99-4649-aca8-8a9a54e56520","secret_environment_variables":[],"status":"deleting"}'
+        headers:
+            Content-Length:
+                - "463"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 09:00:01 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - c48df74c-3584-4d18-b17b-6d59e079c18a
+        status: 200 OK
+        code: 200
+        duration: 202.822476ms
+    - id: 23
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7c8c7642-c31d-43c4-9824-eebbfeae7297
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 463
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"7c8c7642-c31d-43c4-9824-eebbfeae7297","name":"test-function-token-ns","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontokennszegozlyr","registry_namespace_id":"73752c5a-cc99-4649-aca8-8a9a54e56520","secret_environment_variables":[],"status":"deleting"}'
+        headers:
+            Content-Length:
+                - "463"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 09:00:01 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - cfc6bdcb-d3ee-46dc-bf68-56ff5c331b21
+        status: 200 OK
+        code: 200
+        duration: 37.884833ms
+    - id: 24
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7c8c7642-c31d-43c4-9824-eebbfeae7297
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 37
+        uncompressed: false
+        body: '{"message":"Namespace was not found"}'
+        headers:
+            Content-Length:
+                - "37"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 09:00:06 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 698ebf60-0086-44a6-877e-05785d760729
+        status: 404 Not Found
+        code: 404
+        duration: 27.330388ms
+    - id: 25
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens/77064e79-7855-414b-a066-ae90adb7b7c1
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 33
+        uncompressed: false
+        body: '{"message":"Token was not found"}'
+        headers:
+            Content-Length:
+                - "33"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 09:00:06 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 8f00beba-5d28-41dc-9b17-fa84ce83fc51
+        status: 404 Not Found
+        code: 404
+        duration: 35.022491ms
+    - id: 26
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens/25cd9426-0e10-4d9f-a177-ad4c4b8c759f
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 33
+        uncompressed: false
+        body: '{"message":"Token was not found"}'
+        headers:
+            Content-Length:
+                - "33"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 09:00:06 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 7ef7fed9-bd69-446d-842a-7125b53affe3
+        status: 404 Not Found
+        code: 404
+        duration: 24.023129ms

--- a/internal/services/function/testdata/function-trigger-nats.cassette.yaml
+++ b/internal/services/function/testdata/function-trigger-nats.cassette.yaml
@@ -1,1257 +1,2361 @@
 ---
 version: 2
 interactions:
-- request:
-    body: '{"name":"test-function-trigger-sqs","environment_variables":{},"project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","description":null,"secret_environment_variables":[]}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces
-    method: POST
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"d812e96c-2994-41f5-a3ec-757c9f08ad1d","name":"test-function-trigger-sqs","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "386"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 12:54:00 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2b2c8244-9a48-46d1-b524-7c216589e9c3
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d812e96c-2994-41f5-a3ec-757c9f08ad1d
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"d812e96c-2994-41f5-a3ec-757c9f08ad1d","name":"test-function-trigger-sqs","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "386"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 12:54:00 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c0b620f8-5f9e-4721-a32e-1e9f7337f631
-    status: 200 OK
-    code: 200
-- request:
-    body: '{"name":"tf-nats-account-funny-maxwell","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b"}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/nats-accounts
-    method: POST
-  response:
-    body: '{"created_at":"2023-10-19T12:53:59.878367165Z","endpoint":"nats://nats.mnq.fr-par.scaleway.com:4222","id":"ADVJUIDXQ6VQMD576NIQ7FZDFY4DIC4F53IAEMOAWBLW2V2DCKPXXT4D","name":"tf-nats-account-funny-maxwell","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","updated_at":"2023-10-19T12:53:59.878367165Z"}'
-    headers:
-      Content-Length:
-      - "326"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 12:54:00 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0b990fe4-d358-40f2-a8c5-c01062654fb3
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/nats-accounts/ADVJUIDXQ6VQMD576NIQ7FZDFY4DIC4F53IAEMOAWBLW2V2DCKPXXT4D
-    method: GET
-  response:
-    body: '{"created_at":"2023-10-19T12:53:59.878367Z","endpoint":"nats://nats.mnq.fr-par.scaleway.com:4222","id":"ADVJUIDXQ6VQMD576NIQ7FZDFY4DIC4F53IAEMOAWBLW2V2DCKPXXT4D","name":"tf-nats-account-funny-maxwell","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","updated_at":"2023-10-19T12:53:59.878367Z"}'
-    headers:
-      Content-Length:
-      - "320"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 12:54:00 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8a6d3f9f-5cad-4885-98eb-36954aca3746
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d812e96c-2994-41f5-a3ec-757c9f08ad1d
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"d812e96c-2994-41f5-a3ec-757c9f08ad1d","name":"test-function-trigger-sqs","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggers8tep2nfz","registry_namespace_id":"1e31385e-5833-47ac-aa5a-6e35c831572e","secret_environment_variables":[],"status":"ready"}'
-    headers:
-      Content-Length:
-      - "475"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 12:54:05 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6029d60f-3ab1-435e-aec3-c801adbc7e07
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d812e96c-2994-41f5-a3ec-757c9f08ad1d
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"d812e96c-2994-41f5-a3ec-757c9f08ad1d","name":"test-function-trigger-sqs","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggers8tep2nfz","registry_namespace_id":"1e31385e-5833-47ac-aa5a-6e35c831572e","secret_environment_variables":[],"status":"ready"}'
-    headers:
-      Content-Length:
-      - "475"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 12:54:05 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0103df86-3266-4701-a917-78c5f11ea0dc
-    status: 200 OK
-    code: 200
-- request:
-    body: '{"name":"test-function-trigger-sqs","namespace_id":"d812e96c-2994-41f5-a3ec-757c9f08ad1d","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"node20","memory_limit":128,"timeout":null,"handler":"handler.handle","privacy":"private","description":null,"secret_environment_variables":[],"http_option":"enabled"}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions
-    method: POST
-  response:
-    body: '{"build_message":null,"cpu_limit":70,"description":"","domain_name":"testfunctiontriggers8tep2nfz-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"575dd83f-5694-41c7-995e-123baf1de4ee","max_scale":20,"memory_limit":128,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"d812e96c-2994-41f5-a3ec-757c9f08ad1d","privacy":"private","region":"fr-par","runtime":"node20","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "604"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 12:54:05 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6f0935a8-7c31-4c09-a23c-15ff0326724e
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/575dd83f-5694-41c7-995e-123baf1de4ee
-    method: GET
-  response:
-    body: '{"build_message":null,"cpu_limit":70,"description":"","domain_name":"testfunctiontriggers8tep2nfz-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"575dd83f-5694-41c7-995e-123baf1de4ee","max_scale":20,"memory_limit":128,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"d812e96c-2994-41f5-a3ec-757c9f08ad1d","privacy":"private","region":"fr-par","runtime":"node20","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "604"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 12:54:06 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e066a4a4-85f3-4ef2-ab7d-aa1535e0ef65
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/575dd83f-5694-41c7-995e-123baf1de4ee
-    method: GET
-  response:
-    body: '{"build_message":null,"cpu_limit":70,"description":"","domain_name":"testfunctiontriggers8tep2nfz-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"575dd83f-5694-41c7-995e-123baf1de4ee","max_scale":20,"memory_limit":128,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"d812e96c-2994-41f5-a3ec-757c9f08ad1d","privacy":"private","region":"fr-par","runtime":"node20","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "604"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 12:54:06 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 71b4cb97-bd40-4d58-8f33-7524dd64d0a3
-    status: 200 OK
-    code: 200
-- request:
-    body: '{"name":"test-function-trigger-nats","description":null,"function_id":"575dd83f-5694-41c7-995e-123baf1de4ee","scw_nats_config":{"subject":"TestSubject","mnq_project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","mnq_region":"fr-par","mnq_nats_account_id":"ADVJUIDXQ6VQMD576NIQ7FZDFY4DIC4F53IAEMOAWBLW2V2DCKPXXT4D"}}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers
-    method: POST
-  response:
-    body: '{"description":"","error_message":null,"function_id":"575dd83f-5694-41c7-995e-123baf1de4ee","id":"dc6904d5-421c-4f94-92d7-25c2feb95f8c","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":null,"mnq_namespace_id":"","mnq_nats_account_id":"ADVJUIDXQ6VQMD576NIQ7FZDFY4DIC4F53IAEMOAWBLW2V2DCKPXXT4D","mnq_project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","mnq_region":"fr-par","subject":"TestSubject"},"status":"creating"}'
-    headers:
-      Content-Length:
-      - "478"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 12:54:06 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 060ea3ca-6637-445b-9b33-ddc53b115ddc
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/dc6904d5-421c-4f94-92d7-25c2feb95f8c
-    method: GET
-  response:
-    body: '{"description":"","error_message":null,"function_id":"575dd83f-5694-41c7-995e-123baf1de4ee","id":"dc6904d5-421c-4f94-92d7-25c2feb95f8c","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":null,"mnq_namespace_id":"","mnq_nats_account_id":"ADVJUIDXQ6VQMD576NIQ7FZDFY4DIC4F53IAEMOAWBLW2V2DCKPXXT4D","mnq_project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","mnq_region":"fr-par","subject":"TestSubject"},"status":"creating"}'
-    headers:
-      Content-Length:
-      - "478"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 12:54:06 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e4d5850a-fce3-4e3b-a6c6-35f94f20dcc0
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/dc6904d5-421c-4f94-92d7-25c2feb95f8c
-    method: GET
-  response:
-    body: '{"description":"","error_message":null,"function_id":"575dd83f-5694-41c7-995e-123baf1de4ee","id":"dc6904d5-421c-4f94-92d7-25c2feb95f8c","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":"cd21c6af-4d21-44da-83f3-403ae9a5cdae","mnq_namespace_id":"","mnq_nats_account_id":"ADVJUIDXQ6VQMD576NIQ7FZDFY4DIC4F53IAEMOAWBLW2V2DCKPXXT4D","mnq_project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","mnq_region":"fr-par","subject":"TestSubject"},"status":"ready"}'
-    headers:
-      Content-Length:
-      - "509"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 12:54:11 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e22bca56-df86-4947-aa09-37510e90f8b3
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/dc6904d5-421c-4f94-92d7-25c2feb95f8c
-    method: GET
-  response:
-    body: '{"description":"","error_message":null,"function_id":"575dd83f-5694-41c7-995e-123baf1de4ee","id":"dc6904d5-421c-4f94-92d7-25c2feb95f8c","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":"cd21c6af-4d21-44da-83f3-403ae9a5cdae","mnq_namespace_id":"","mnq_nats_account_id":"ADVJUIDXQ6VQMD576NIQ7FZDFY4DIC4F53IAEMOAWBLW2V2DCKPXXT4D","mnq_project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","mnq_region":"fr-par","subject":"TestSubject"},"status":"ready"}'
-    headers:
-      Content-Length:
-      - "509"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 12:54:11 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d7ffd2db-d994-4547-b53c-6f719189254d
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/dc6904d5-421c-4f94-92d7-25c2feb95f8c
-    method: GET
-  response:
-    body: '{"description":"","error_message":null,"function_id":"575dd83f-5694-41c7-995e-123baf1de4ee","id":"dc6904d5-421c-4f94-92d7-25c2feb95f8c","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":"cd21c6af-4d21-44da-83f3-403ae9a5cdae","mnq_namespace_id":"","mnq_nats_account_id":"ADVJUIDXQ6VQMD576NIQ7FZDFY4DIC4F53IAEMOAWBLW2V2DCKPXXT4D","mnq_project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","mnq_region":"fr-par","subject":"TestSubject"},"status":"ready"}'
-    headers:
-      Content-Length:
-      - "509"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 12:54:11 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d6f72655-07be-4671-b4a4-7c7ff340e1e7
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/dc6904d5-421c-4f94-92d7-25c2feb95f8c
-    method: GET
-  response:
-    body: '{"description":"","error_message":null,"function_id":"575dd83f-5694-41c7-995e-123baf1de4ee","id":"dc6904d5-421c-4f94-92d7-25c2feb95f8c","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":"cd21c6af-4d21-44da-83f3-403ae9a5cdae","mnq_namespace_id":"","mnq_nats_account_id":"ADVJUIDXQ6VQMD576NIQ7FZDFY4DIC4F53IAEMOAWBLW2V2DCKPXXT4D","mnq_project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","mnq_region":"fr-par","subject":"TestSubject"},"status":"ready"}'
-    headers:
-      Content-Length:
-      - "509"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 12:54:11 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 740c6952-0982-42b4-9edf-c32b7f022bcc
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d812e96c-2994-41f5-a3ec-757c9f08ad1d
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"d812e96c-2994-41f5-a3ec-757c9f08ad1d","name":"test-function-trigger-sqs","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggers8tep2nfz","registry_namespace_id":"1e31385e-5833-47ac-aa5a-6e35c831572e","secret_environment_variables":[],"status":"ready"}'
-    headers:
-      Content-Length:
-      - "475"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 12:54:12 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4365d502-172f-4a74-ab51-4dccd35f8478
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/nats-accounts/ADVJUIDXQ6VQMD576NIQ7FZDFY4DIC4F53IAEMOAWBLW2V2DCKPXXT4D
-    method: GET
-  response:
-    body: '{"created_at":"2023-10-19T12:53:59.878367Z","endpoint":"nats://nats.mnq.fr-par.scaleway.com:4222","id":"ADVJUIDXQ6VQMD576NIQ7FZDFY4DIC4F53IAEMOAWBLW2V2DCKPXXT4D","name":"tf-nats-account-funny-maxwell","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","updated_at":"2023-10-19T12:53:59.878367Z"}'
-    headers:
-      Content-Length:
-      - "320"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 12:54:12 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d000b14d-3191-4ae6-a8b1-216ea77cbdb8
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/575dd83f-5694-41c7-995e-123baf1de4ee
-    method: GET
-  response:
-    body: '{"build_message":null,"cpu_limit":70,"description":"","domain_name":"testfunctiontriggers8tep2nfz-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"575dd83f-5694-41c7-995e-123baf1de4ee","max_scale":20,"memory_limit":128,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"d812e96c-2994-41f5-a3ec-757c9f08ad1d","privacy":"private","region":"fr-par","runtime":"node20","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "604"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 12:54:12 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 57555a29-e426-415a-88a2-e578b3c04981
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/dc6904d5-421c-4f94-92d7-25c2feb95f8c
-    method: GET
-  response:
-    body: '{"description":"","error_message":null,"function_id":"575dd83f-5694-41c7-995e-123baf1de4ee","id":"dc6904d5-421c-4f94-92d7-25c2feb95f8c","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":"cd21c6af-4d21-44da-83f3-403ae9a5cdae","mnq_namespace_id":"","mnq_nats_account_id":"ADVJUIDXQ6VQMD576NIQ7FZDFY4DIC4F53IAEMOAWBLW2V2DCKPXXT4D","mnq_project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","mnq_region":"fr-par","subject":"TestSubject"},"status":"ready"}'
-    headers:
-      Content-Length:
-      - "509"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 12:54:12 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 712d2923-a106-4f52-a55b-1fb49a054e9f
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/nats-accounts/ADVJUIDXQ6VQMD576NIQ7FZDFY4DIC4F53IAEMOAWBLW2V2DCKPXXT4D
-    method: GET
-  response:
-    body: '{"created_at":"2023-10-19T12:53:59.878367Z","endpoint":"nats://nats.mnq.fr-par.scaleway.com:4222","id":"ADVJUIDXQ6VQMD576NIQ7FZDFY4DIC4F53IAEMOAWBLW2V2DCKPXXT4D","name":"tf-nats-account-funny-maxwell","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","updated_at":"2023-10-19T12:53:59.878367Z"}'
-    headers:
-      Content-Length:
-      - "320"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 12:54:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f02d13b2-5c87-4da3-8a1b-13ab6ab51018
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d812e96c-2994-41f5-a3ec-757c9f08ad1d
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"d812e96c-2994-41f5-a3ec-757c9f08ad1d","name":"test-function-trigger-sqs","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggers8tep2nfz","registry_namespace_id":"1e31385e-5833-47ac-aa5a-6e35c831572e","secret_environment_variables":[],"status":"ready"}'
-    headers:
-      Content-Length:
-      - "475"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 12:54:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 97821b75-d1ed-4334-a240-f4cb7487c9b8
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/575dd83f-5694-41c7-995e-123baf1de4ee
-    method: GET
-  response:
-    body: '{"build_message":null,"cpu_limit":70,"description":"","domain_name":"testfunctiontriggers8tep2nfz-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"575dd83f-5694-41c7-995e-123baf1de4ee","max_scale":20,"memory_limit":128,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"d812e96c-2994-41f5-a3ec-757c9f08ad1d","privacy":"private","region":"fr-par","runtime":"node20","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "604"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 12:54:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5d7c1234-6ac2-48c0-9635-3804719cbdd2
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/dc6904d5-421c-4f94-92d7-25c2feb95f8c
-    method: GET
-  response:
-    body: '{"description":"","error_message":null,"function_id":"575dd83f-5694-41c7-995e-123baf1de4ee","id":"dc6904d5-421c-4f94-92d7-25c2feb95f8c","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":"cd21c6af-4d21-44da-83f3-403ae9a5cdae","mnq_namespace_id":"","mnq_nats_account_id":"ADVJUIDXQ6VQMD576NIQ7FZDFY4DIC4F53IAEMOAWBLW2V2DCKPXXT4D","mnq_project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","mnq_region":"fr-par","subject":"TestSubject"},"status":"ready"}'
-    headers:
-      Content-Length:
-      - "509"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 12:54:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 65fd3bca-84fb-4468-bd51-58dd1fd07b59
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/nats-accounts/ADVJUIDXQ6VQMD576NIQ7FZDFY4DIC4F53IAEMOAWBLW2V2DCKPXXT4D
-    method: GET
-  response:
-    body: '{"created_at":"2023-10-19T12:53:59.878367Z","endpoint":"nats://nats.mnq.fr-par.scaleway.com:4222","id":"ADVJUIDXQ6VQMD576NIQ7FZDFY4DIC4F53IAEMOAWBLW2V2DCKPXXT4D","name":"tf-nats-account-funny-maxwell","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","updated_at":"2023-10-19T12:53:59.878367Z"}'
-    headers:
-      Content-Length:
-      - "320"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 12:54:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3ff4d391-a38e-46b3-b2f2-d5b0a87b0656
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d812e96c-2994-41f5-a3ec-757c9f08ad1d
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"d812e96c-2994-41f5-a3ec-757c9f08ad1d","name":"test-function-trigger-sqs","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggers8tep2nfz","registry_namespace_id":"1e31385e-5833-47ac-aa5a-6e35c831572e","secret_environment_variables":[],"status":"ready"}'
-    headers:
-      Content-Length:
-      - "475"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 12:54:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 947c27fb-c4be-472c-a938-4b9bc77b8cc4
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/575dd83f-5694-41c7-995e-123baf1de4ee
-    method: GET
-  response:
-    body: '{"build_message":null,"cpu_limit":70,"description":"","domain_name":"testfunctiontriggers8tep2nfz-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"575dd83f-5694-41c7-995e-123baf1de4ee","max_scale":20,"memory_limit":128,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"d812e96c-2994-41f5-a3ec-757c9f08ad1d","privacy":"private","region":"fr-par","runtime":"node20","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "604"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 12:54:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 26f355f2-141c-4f4f-ae86-6acf19ceb2ab
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/dc6904d5-421c-4f94-92d7-25c2feb95f8c
-    method: GET
-  response:
-    body: '{"description":"","error_message":null,"function_id":"575dd83f-5694-41c7-995e-123baf1de4ee","id":"dc6904d5-421c-4f94-92d7-25c2feb95f8c","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":"cd21c6af-4d21-44da-83f3-403ae9a5cdae","mnq_namespace_id":"","mnq_nats_account_id":"ADVJUIDXQ6VQMD576NIQ7FZDFY4DIC4F53IAEMOAWBLW2V2DCKPXXT4D","mnq_project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","mnq_region":"fr-par","subject":"TestSubject"},"status":"ready"}'
-    headers:
-      Content-Length:
-      - "509"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 12:54:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f950f745-766c-4e05-9b68-b089003ce282
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/dc6904d5-421c-4f94-92d7-25c2feb95f8c
-    method: GET
-  response:
-    body: '{"description":"","error_message":null,"function_id":"575dd83f-5694-41c7-995e-123baf1de4ee","id":"dc6904d5-421c-4f94-92d7-25c2feb95f8c","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":"cd21c6af-4d21-44da-83f3-403ae9a5cdae","mnq_namespace_id":"","mnq_nats_account_id":"ADVJUIDXQ6VQMD576NIQ7FZDFY4DIC4F53IAEMOAWBLW2V2DCKPXXT4D","mnq_project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","mnq_region":"fr-par","subject":"TestSubject"},"status":"ready"}'
-    headers:
-      Content-Length:
-      - "509"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 12:54:14 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9ec78319-5696-49a2-b43e-67b136572b7e
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/dc6904d5-421c-4f94-92d7-25c2feb95f8c
-    method: DELETE
-  response:
-    body: '{"description":"","error_message":null,"function_id":"575dd83f-5694-41c7-995e-123baf1de4ee","id":"dc6904d5-421c-4f94-92d7-25c2feb95f8c","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":"cd21c6af-4d21-44da-83f3-403ae9a5cdae","mnq_namespace_id":"","mnq_nats_account_id":"ADVJUIDXQ6VQMD576NIQ7FZDFY4DIC4F53IAEMOAWBLW2V2DCKPXXT4D","mnq_project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","mnq_region":"fr-par","subject":"TestSubject"},"status":"deleting"}'
-    headers:
-      Content-Length:
-      - "512"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 12:54:14 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c826b5d6-a626-4fa8-bfbe-c520815cd140
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/dc6904d5-421c-4f94-92d7-25c2feb95f8c
-    method: GET
-  response:
-    body: '{"description":"","error_message":null,"function_id":"575dd83f-5694-41c7-995e-123baf1de4ee","id":"dc6904d5-421c-4f94-92d7-25c2feb95f8c","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":"cd21c6af-4d21-44da-83f3-403ae9a5cdae","mnq_namespace_id":"","mnq_nats_account_id":"ADVJUIDXQ6VQMD576NIQ7FZDFY4DIC4F53IAEMOAWBLW2V2DCKPXXT4D","mnq_project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","mnq_region":"fr-par","subject":"TestSubject"},"status":"deleting"}'
-    headers:
-      Content-Length:
-      - "512"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 12:54:14 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d211ce91-14e8-46e9-84d1-fca95147df10
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/dc6904d5-421c-4f94-92d7-25c2feb95f8c
-    method: GET
-  response:
-    body: '{"message":"trigger does not exist"}'
-    headers:
-      Content-Length:
-      - "36"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 12:54:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2b8f98f2-d844-4b63-8ca7-9e9c070c8aae
-    status: 404 Not Found
-    code: 404
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/575dd83f-5694-41c7-995e-123baf1de4ee
-    method: GET
-  response:
-    body: '{"build_message":null,"cpu_limit":70,"description":"","domain_name":"testfunctiontriggers8tep2nfz-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"575dd83f-5694-41c7-995e-123baf1de4ee","max_scale":20,"memory_limit":128,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"d812e96c-2994-41f5-a3ec-757c9f08ad1d","privacy":"private","region":"fr-par","runtime":"node20","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "604"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 12:54:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 753a4873-0b09-4170-b443-55a048c5d5a2
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/575dd83f-5694-41c7-995e-123baf1de4ee
-    method: DELETE
-  response:
-    body: '{"build_message":null,"cpu_limit":70,"description":"","domain_name":"testfunctiontriggers8tep2nfz-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"575dd83f-5694-41c7-995e-123baf1de4ee","max_scale":20,"memory_limit":128,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"d812e96c-2994-41f5-a3ec-757c9f08ad1d","privacy":"private","region":"fr-par","runtime":"node20","runtime_message":"","secret_environment_variables":[],"status":"deleting","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "605"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 12:54:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 88f614c5-223f-4b31-88ca-3ad93112715e
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d812e96c-2994-41f5-a3ec-757c9f08ad1d
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"d812e96c-2994-41f5-a3ec-757c9f08ad1d","name":"test-function-trigger-sqs","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggers8tep2nfz","registry_namespace_id":"1e31385e-5833-47ac-aa5a-6e35c831572e","secret_environment_variables":[],"status":"ready"}'
-    headers:
-      Content-Length:
-      - "475"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 12:54:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7327fd8c-006c-4c83-bdf4-2ca3c5f3f55b
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d812e96c-2994-41f5-a3ec-757c9f08ad1d
-    method: DELETE
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"d812e96c-2994-41f5-a3ec-757c9f08ad1d","name":"test-function-trigger-sqs","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggers8tep2nfz","registry_namespace_id":"1e31385e-5833-47ac-aa5a-6e35c831572e","secret_environment_variables":[],"status":"deleting"}'
-    headers:
-      Content-Length:
-      - "478"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 12:54:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 024b07fc-c4d8-4d8f-8da3-658f7baa2504
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d812e96c-2994-41f5-a3ec-757c9f08ad1d
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"d812e96c-2994-41f5-a3ec-757c9f08ad1d","name":"test-function-trigger-sqs","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggers8tep2nfz","registry_namespace_id":"1e31385e-5833-47ac-aa5a-6e35c831572e","secret_environment_variables":[],"status":"deleting"}'
-    headers:
-      Content-Length:
-      - "478"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 12:54:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3f74ce0f-586f-49d3-862c-8740f0d15f0b
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/nats-accounts/ADVJUIDXQ6VQMD576NIQ7FZDFY4DIC4F53IAEMOAWBLW2V2DCKPXXT4D
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 12:54:20 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6f60773a-c2b6-466b-9d8e-c4f00f849a04
-    status: 204 No Content
-    code: 204
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d812e96c-2994-41f5-a3ec-757c9f08ad1d
-    method: GET
-  response:
-    body: '{"message":"Namespace was not found"}'
-    headers:
-      Content-Length:
-      - "37"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 12:54:24 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - fccfb186-43d1-4898-9d4e-c22fb52b52a0
-    status: 404 Not Found
-    code: 404
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/dc6904d5-421c-4f94-92d7-25c2feb95f8c
-    method: DELETE
-  response:
-    body: '{"message":"trigger does not exist: could not find trigger with id dc6904d5-421c-4f94-92d7-25c2feb95f8c"}'
-    headers:
-      Content-Length:
-      - "105"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 12:54:24 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f1a53bf4-2989-4fe9-beda-07415cb39903
-    status: 404 Not Found
-    code: 404
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 90
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"name":"tf-nats-account-sad-faraday","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/nats-accounts
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 318
+        uncompressed: false
+        body: '{"created_at":"2024-07-05T08:50:32.852316484Z","endpoint":"nats://nats.mnq.fr-par.scaleway.com:4222","id":"AA3NA65BFWAVKDBVNPVXFUGSITWAY7TO3YWR46LAVPSIUZU7UCKRDB5W","name":"tf-nats-account-sad-faraday","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","updated_at":"2024-07-05T08:50:32.852316484Z"}'
+        headers:
+            Content-Length:
+                - "318"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:50:32 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 25c01f9a-be25-4e1e-9af4-871defaf84fd
+        status: 200 OK
+        code: 200
+        duration: 201.580695ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/nats-accounts/AA3NA65BFWAVKDBVNPVXFUGSITWAY7TO3YWR46LAVPSIUZU7UCKRDB5W
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 312
+        uncompressed: false
+        body: '{"created_at":"2024-07-05T08:50:32.852316Z","endpoint":"nats://nats.mnq.fr-par.scaleway.com:4222","id":"AA3NA65BFWAVKDBVNPVXFUGSITWAY7TO3YWR46LAVPSIUZU7UCKRDB5W","name":"tf-nats-account-sad-faraday","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","updated_at":"2024-07-05T08:50:32.852316Z"}'
+        headers:
+            Content-Length:
+                - "312"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:50:32 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 59023559-cb78-4606-9fd0-95d8df0e9c0c
+        status: 200 OK
+        code: 200
+        duration: 35.133228ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 149
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"name":"test-function-trigger-sqs","environment_variables":{},"project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","secret_environment_variables":[]}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 375
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"76111182-9825-41b7-a3c2-3b423caf470a","name":"test-function-trigger-sqs","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
+        headers:
+            Content-Length:
+                - "375"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:50:33 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 50fbdbf1-eba1-4337-b5bb-c76e9ba3e6ea
+        status: 200 OK
+        code: 200
+        duration: 449.727706ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/76111182-9825-41b7-a3c2-3b423caf470a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 375
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"76111182-9825-41b7-a3c2-3b423caf470a","name":"test-function-trigger-sqs","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
+        headers:
+            Content-Length:
+                - "375"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:50:33 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 6b4bc413-6f2a-447a-ac1c-b4abc6bcf2f5
+        status: 200 OK
+        code: 200
+        duration: 48.928095ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/76111182-9825-41b7-a3c2-3b423caf470a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 464
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"76111182-9825-41b7-a3c2-3b423caf470a","name":"test-function-trigger-sqs","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggersmoeymike","registry_namespace_id":"b68555d2-9e6a-415c-98f2-71af5f983d84","secret_environment_variables":[],"status":"ready"}'
+        headers:
+            Content-Length:
+                - "464"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:50:38 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f815ecef-da0e-40b2-8bd5-5e29d8e80a04
+        status: 200 OK
+        code: 200
+        duration: 47.479061ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/76111182-9825-41b7-a3c2-3b423caf470a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 464
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"76111182-9825-41b7-a3c2-3b423caf470a","name":"test-function-trigger-sqs","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggersmoeymike","registry_namespace_id":"b68555d2-9e6a-415c-98f2-71af5f983d84","secret_environment_variables":[],"status":"ready"}'
+        headers:
+            Content-Length:
+                - "464"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:50:38 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 7b3b0989-404f-4932-a433-e4961bd6e94a
+        status: 200 OK
+        code: 200
+        duration: 61.43412ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 317
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"name":"test-function-trigger-sqs","namespace_id":"76111182-9825-41b7-a3c2-3b423caf470a","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"node22","memory_limit":256,"handler":"handler.handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 600
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"testfunctiontriggersmoeymike-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"24390cea-180e-47c1-8cf4-cd71c7d2f2db","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"76111182-9825-41b7-a3c2-3b423caf470a","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "600"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:50:38 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - be16d781-f8df-4eee-9963-d38c43c398ea
+        status: 200 OK
+        code: 200
+        duration: 256.318584ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/24390cea-180e-47c1-8cf4-cd71c7d2f2db
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 600
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"testfunctiontriggersmoeymike-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"24390cea-180e-47c1-8cf4-cd71c7d2f2db","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"76111182-9825-41b7-a3c2-3b423caf470a","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "600"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:50:38 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 59ce1e06-d6f2-44d2-80e6-39bf89b6feb0
+        status: 200 OK
+        code: 200
+        duration: 55.385066ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/24390cea-180e-47c1-8cf4-cd71c7d2f2db
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 600
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"testfunctiontriggersmoeymike-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"24390cea-180e-47c1-8cf4-cd71c7d2f2db","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"76111182-9825-41b7-a3c2-3b423caf470a","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "600"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:50:38 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 9c6c4954-9474-4e65-8b0d-1b1068e43c7b
+        status: 200 OK
+        code: 200
+        duration: 40.205425ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 293
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"name":"test-function-trigger-nats","function_id":"24390cea-180e-47c1-8cf4-cd71c7d2f2db","scw_nats_config":{"subject":"TestSubject","mnq_nats_account_id":"AA3NA65BFWAVKDBVNPVXFUGSITWAY7TO3YWR46LAVPSIUZU7UCKRDB5W","mnq_project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","mnq_region":"fr-par"}}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 444
+        uncompressed: false
+        body: '{"description":"","error_message":null,"function_id":"24390cea-180e-47c1-8cf4-cd71c7d2f2db","id":"1dc01607-a88d-40de-ad18-f6b2232ce5ac","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":null,"mnq_nats_account_id":"AA3NA65BFWAVKDBVNPVXFUGSITWAY7TO3YWR46LAVPSIUZU7UCKRDB5W","mnq_project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","mnq_region":"fr-par","subject":"TestSubject"},"status":"creating"}'
+        headers:
+            Content-Length:
+                - "444"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:50:38 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 2ceb8292-99be-42b9-99ab-7901e4013676
+        status: 200 OK
+        code: 200
+        duration: 201.352055ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/1dc01607-a88d-40de-ad18-f6b2232ce5ac
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 444
+        uncompressed: false
+        body: '{"description":"","error_message":null,"function_id":"24390cea-180e-47c1-8cf4-cd71c7d2f2db","id":"1dc01607-a88d-40de-ad18-f6b2232ce5ac","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":null,"mnq_nats_account_id":"AA3NA65BFWAVKDBVNPVXFUGSITWAY7TO3YWR46LAVPSIUZU7UCKRDB5W","mnq_project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","mnq_region":"fr-par","subject":"TestSubject"},"status":"creating"}'
+        headers:
+            Content-Length:
+                - "444"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:50:38 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 11855d25-5727-4ebe-91c2-440b92e2b80c
+        status: 200 OK
+        code: 200
+        duration: 51.800887ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/1dc01607-a88d-40de-ad18-f6b2232ce5ac
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 478
+        uncompressed: false
+        body: '{"description":"","error_message":null,"function_id":"24390cea-180e-47c1-8cf4-cd71c7d2f2db","id":"1dc01607-a88d-40de-ad18-f6b2232ce5ac","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":"b70daba0-fd6f-4e65-b6fc-8cfc94ea2b83","mnq_nats_account_id":"AA3NA65BFWAVKDBVNPVXFUGSITWAY7TO3YWR46LAVPSIUZU7UCKRDB5W","mnq_project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","mnq_region":"fr-par","subject":"TestSubject"},"status":"creating"}'
+        headers:
+            Content-Length:
+                - "478"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:50:43 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 9740ffc3-15a1-486f-ba3f-02176b38163f
+        status: 200 OK
+        code: 200
+        duration: 50.846573ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/1dc01607-a88d-40de-ad18-f6b2232ce5ac
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 478
+        uncompressed: false
+        body: '{"description":"","error_message":null,"function_id":"24390cea-180e-47c1-8cf4-cd71c7d2f2db","id":"1dc01607-a88d-40de-ad18-f6b2232ce5ac","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":"b70daba0-fd6f-4e65-b6fc-8cfc94ea2b83","mnq_nats_account_id":"AA3NA65BFWAVKDBVNPVXFUGSITWAY7TO3YWR46LAVPSIUZU7UCKRDB5W","mnq_project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","mnq_region":"fr-par","subject":"TestSubject"},"status":"creating"}'
+        headers:
+            Content-Length:
+                - "478"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:50:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ad987384-c48d-4823-a138-16ef9c0de270
+        status: 200 OK
+        code: 200
+        duration: 64.341947ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/1dc01607-a88d-40de-ad18-f6b2232ce5ac
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 475
+        uncompressed: false
+        body: '{"description":"","error_message":null,"function_id":"24390cea-180e-47c1-8cf4-cd71c7d2f2db","id":"1dc01607-a88d-40de-ad18-f6b2232ce5ac","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":"b70daba0-fd6f-4e65-b6fc-8cfc94ea2b83","mnq_nats_account_id":"AA3NA65BFWAVKDBVNPVXFUGSITWAY7TO3YWR46LAVPSIUZU7UCKRDB5W","mnq_project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","mnq_region":"fr-par","subject":"TestSubject"},"status":"ready"}'
+        headers:
+            Content-Length:
+                - "475"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:50:54 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 1d625851-c8a3-4f8b-b686-8b179d01a5a1
+        status: 200 OK
+        code: 200
+        duration: 62.117054ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/1dc01607-a88d-40de-ad18-f6b2232ce5ac
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 475
+        uncompressed: false
+        body: '{"description":"","error_message":null,"function_id":"24390cea-180e-47c1-8cf4-cd71c7d2f2db","id":"1dc01607-a88d-40de-ad18-f6b2232ce5ac","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":"b70daba0-fd6f-4e65-b6fc-8cfc94ea2b83","mnq_nats_account_id":"AA3NA65BFWAVKDBVNPVXFUGSITWAY7TO3YWR46LAVPSIUZU7UCKRDB5W","mnq_project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","mnq_region":"fr-par","subject":"TestSubject"},"status":"ready"}'
+        headers:
+            Content-Length:
+                - "475"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:50:54 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 12a07940-6033-44cd-bb08-b40356444c28
+        status: 200 OK
+        code: 200
+        duration: 48.159541ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/1dc01607-a88d-40de-ad18-f6b2232ce5ac
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 475
+        uncompressed: false
+        body: '{"description":"","error_message":null,"function_id":"24390cea-180e-47c1-8cf4-cd71c7d2f2db","id":"1dc01607-a88d-40de-ad18-f6b2232ce5ac","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":"b70daba0-fd6f-4e65-b6fc-8cfc94ea2b83","mnq_nats_account_id":"AA3NA65BFWAVKDBVNPVXFUGSITWAY7TO3YWR46LAVPSIUZU7UCKRDB5W","mnq_project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","mnq_region":"fr-par","subject":"TestSubject"},"status":"ready"}'
+        headers:
+            Content-Length:
+                - "475"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:50:54 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 5ddad9a1-29d2-47b0-9237-9288962ab58d
+        status: 200 OK
+        code: 200
+        duration: 51.860228ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/1dc01607-a88d-40de-ad18-f6b2232ce5ac
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 475
+        uncompressed: false
+        body: '{"description":"","error_message":null,"function_id":"24390cea-180e-47c1-8cf4-cd71c7d2f2db","id":"1dc01607-a88d-40de-ad18-f6b2232ce5ac","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":"b70daba0-fd6f-4e65-b6fc-8cfc94ea2b83","mnq_nats_account_id":"AA3NA65BFWAVKDBVNPVXFUGSITWAY7TO3YWR46LAVPSIUZU7UCKRDB5W","mnq_project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","mnq_region":"fr-par","subject":"TestSubject"},"status":"ready"}'
+        headers:
+            Content-Length:
+                - "475"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:50:54 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 90daed52-f452-467c-87e7-45c9c92df81d
+        status: 200 OK
+        code: 200
+        duration: 52.816296ms
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/nats-accounts/AA3NA65BFWAVKDBVNPVXFUGSITWAY7TO3YWR46LAVPSIUZU7UCKRDB5W
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 312
+        uncompressed: false
+        body: '{"created_at":"2024-07-05T08:50:32.852316Z","endpoint":"nats://nats.mnq.fr-par.scaleway.com:4222","id":"AA3NA65BFWAVKDBVNPVXFUGSITWAY7TO3YWR46LAVPSIUZU7UCKRDB5W","name":"tf-nats-account-sad-faraday","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","updated_at":"2024-07-05T08:50:32.852316Z"}'
+        headers:
+            Content-Length:
+                - "312"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:50:54 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 348230f1-d01b-4ae9-b173-37343657dfd5
+        status: 200 OK
+        code: 200
+        duration: 41.370636ms
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/76111182-9825-41b7-a3c2-3b423caf470a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 464
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"76111182-9825-41b7-a3c2-3b423caf470a","name":"test-function-trigger-sqs","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggersmoeymike","registry_namespace_id":"b68555d2-9e6a-415c-98f2-71af5f983d84","secret_environment_variables":[],"status":"ready"}'
+        headers:
+            Content-Length:
+                - "464"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:50:54 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - fa21641b-f051-4093-b039-2398e515e5a4
+        status: 200 OK
+        code: 200
+        duration: 57.001926ms
+    - id: 19
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/24390cea-180e-47c1-8cf4-cd71c7d2f2db
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 600
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"testfunctiontriggersmoeymike-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"24390cea-180e-47c1-8cf4-cd71c7d2f2db","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"76111182-9825-41b7-a3c2-3b423caf470a","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "600"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:50:54 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - be4e10cb-a61e-45e5-8948-75e427ca1f9c
+        status: 200 OK
+        code: 200
+        duration: 42.398047ms
+    - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/1dc01607-a88d-40de-ad18-f6b2232ce5ac
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 475
+        uncompressed: false
+        body: '{"description":"","error_message":null,"function_id":"24390cea-180e-47c1-8cf4-cd71c7d2f2db","id":"1dc01607-a88d-40de-ad18-f6b2232ce5ac","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":"b70daba0-fd6f-4e65-b6fc-8cfc94ea2b83","mnq_nats_account_id":"AA3NA65BFWAVKDBVNPVXFUGSITWAY7TO3YWR46LAVPSIUZU7UCKRDB5W","mnq_project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","mnq_region":"fr-par","subject":"TestSubject"},"status":"ready"}'
+        headers:
+            Content-Length:
+                - "475"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:50:54 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 2bf397bb-2e17-4e66-8c9e-29cdf5da7a20
+        status: 200 OK
+        code: 200
+        duration: 47.563009ms
+    - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/nats-accounts/AA3NA65BFWAVKDBVNPVXFUGSITWAY7TO3YWR46LAVPSIUZU7UCKRDB5W
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 312
+        uncompressed: false
+        body: '{"created_at":"2024-07-05T08:50:32.852316Z","endpoint":"nats://nats.mnq.fr-par.scaleway.com:4222","id":"AA3NA65BFWAVKDBVNPVXFUGSITWAY7TO3YWR46LAVPSIUZU7UCKRDB5W","name":"tf-nats-account-sad-faraday","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","updated_at":"2024-07-05T08:50:32.852316Z"}'
+        headers:
+            Content-Length:
+                - "312"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:50:55 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 32bf5fc5-bec7-4539-a928-8fce9593714d
+        status: 200 OK
+        code: 200
+        duration: 37.294201ms
+    - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/76111182-9825-41b7-a3c2-3b423caf470a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 464
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"76111182-9825-41b7-a3c2-3b423caf470a","name":"test-function-trigger-sqs","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggersmoeymike","registry_namespace_id":"b68555d2-9e6a-415c-98f2-71af5f983d84","secret_environment_variables":[],"status":"ready"}'
+        headers:
+            Content-Length:
+                - "464"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:50:55 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 196db484-5aff-4c6c-907e-c969a631b91b
+        status: 200 OK
+        code: 200
+        duration: 38.189836ms
+    - id: 23
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/24390cea-180e-47c1-8cf4-cd71c7d2f2db
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 600
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"testfunctiontriggersmoeymike-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"24390cea-180e-47c1-8cf4-cd71c7d2f2db","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"76111182-9825-41b7-a3c2-3b423caf470a","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "600"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:50:55 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 9c9f41a2-d682-462c-a7c4-526ae7b6e8f7
+        status: 200 OK
+        code: 200
+        duration: 47.542671ms
+    - id: 24
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/1dc01607-a88d-40de-ad18-f6b2232ce5ac
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 475
+        uncompressed: false
+        body: '{"description":"","error_message":null,"function_id":"24390cea-180e-47c1-8cf4-cd71c7d2f2db","id":"1dc01607-a88d-40de-ad18-f6b2232ce5ac","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":"b70daba0-fd6f-4e65-b6fc-8cfc94ea2b83","mnq_nats_account_id":"AA3NA65BFWAVKDBVNPVXFUGSITWAY7TO3YWR46LAVPSIUZU7UCKRDB5W","mnq_project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","mnq_region":"fr-par","subject":"TestSubject"},"status":"ready"}'
+        headers:
+            Content-Length:
+                - "475"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:50:55 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ea7f9287-ec14-473a-b2dd-9932c0f0cc82
+        status: 200 OK
+        code: 200
+        duration: 58.281973ms
+    - id: 25
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/nats-accounts/AA3NA65BFWAVKDBVNPVXFUGSITWAY7TO3YWR46LAVPSIUZU7UCKRDB5W
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 312
+        uncompressed: false
+        body: '{"created_at":"2024-07-05T08:50:32.852316Z","endpoint":"nats://nats.mnq.fr-par.scaleway.com:4222","id":"AA3NA65BFWAVKDBVNPVXFUGSITWAY7TO3YWR46LAVPSIUZU7UCKRDB5W","name":"tf-nats-account-sad-faraday","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","updated_at":"2024-07-05T08:50:32.852316Z"}'
+        headers:
+            Content-Length:
+                - "312"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:50:55 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e239e897-cfad-480f-8e7a-e88e8c9739d3
+        status: 200 OK
+        code: 200
+        duration: 33.774875ms
+    - id: 26
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/76111182-9825-41b7-a3c2-3b423caf470a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 464
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"76111182-9825-41b7-a3c2-3b423caf470a","name":"test-function-trigger-sqs","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggersmoeymike","registry_namespace_id":"b68555d2-9e6a-415c-98f2-71af5f983d84","secret_environment_variables":[],"status":"ready"}'
+        headers:
+            Content-Length:
+                - "464"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:50:55 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e1f7f73b-225f-4652-add9-c9b9e6b50f7e
+        status: 200 OK
+        code: 200
+        duration: 38.28291ms
+    - id: 27
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/24390cea-180e-47c1-8cf4-cd71c7d2f2db
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 600
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"testfunctiontriggersmoeymike-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"24390cea-180e-47c1-8cf4-cd71c7d2f2db","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"76111182-9825-41b7-a3c2-3b423caf470a","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "600"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:50:55 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 186985ac-5bc5-4d4a-8251-0cb3fbbb01d5
+        status: 200 OK
+        code: 200
+        duration: 41.849717ms
+    - id: 28
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/1dc01607-a88d-40de-ad18-f6b2232ce5ac
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 475
+        uncompressed: false
+        body: '{"description":"","error_message":null,"function_id":"24390cea-180e-47c1-8cf4-cd71c7d2f2db","id":"1dc01607-a88d-40de-ad18-f6b2232ce5ac","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":"b70daba0-fd6f-4e65-b6fc-8cfc94ea2b83","mnq_nats_account_id":"AA3NA65BFWAVKDBVNPVXFUGSITWAY7TO3YWR46LAVPSIUZU7UCKRDB5W","mnq_project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","mnq_region":"fr-par","subject":"TestSubject"},"status":"ready"}'
+        headers:
+            Content-Length:
+                - "475"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:50:55 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 632da905-5cbc-4141-8460-cc8a28a13f2e
+        status: 200 OK
+        code: 200
+        duration: 53.85589ms
+    - id: 29
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/1dc01607-a88d-40de-ad18-f6b2232ce5ac
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 475
+        uncompressed: false
+        body: '{"description":"","error_message":null,"function_id":"24390cea-180e-47c1-8cf4-cd71c7d2f2db","id":"1dc01607-a88d-40de-ad18-f6b2232ce5ac","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":"b70daba0-fd6f-4e65-b6fc-8cfc94ea2b83","mnq_nats_account_id":"AA3NA65BFWAVKDBVNPVXFUGSITWAY7TO3YWR46LAVPSIUZU7UCKRDB5W","mnq_project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","mnq_region":"fr-par","subject":"TestSubject"},"status":"ready"}'
+        headers:
+            Content-Length:
+                - "475"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:50:56 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 9cabaa5f-f2a6-45eb-9e4e-c9d16f6e8f8e
+        status: 200 OK
+        code: 200
+        duration: 54.035419ms
+    - id: 30
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/1dc01607-a88d-40de-ad18-f6b2232ce5ac
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 478
+        uncompressed: false
+        body: '{"description":"","error_message":null,"function_id":"24390cea-180e-47c1-8cf4-cd71c7d2f2db","id":"1dc01607-a88d-40de-ad18-f6b2232ce5ac","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":"b70daba0-fd6f-4e65-b6fc-8cfc94ea2b83","mnq_nats_account_id":"AA3NA65BFWAVKDBVNPVXFUGSITWAY7TO3YWR46LAVPSIUZU7UCKRDB5W","mnq_project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","mnq_region":"fr-par","subject":"TestSubject"},"status":"deleting"}'
+        headers:
+            Content-Length:
+                - "478"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:50:56 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 9f4b0d40-a67f-4161-9957-a437d39f9808
+        status: 200 OK
+        code: 200
+        duration: 84.025918ms
+    - id: 31
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/1dc01607-a88d-40de-ad18-f6b2232ce5ac
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 478
+        uncompressed: false
+        body: '{"description":"","error_message":null,"function_id":"24390cea-180e-47c1-8cf4-cd71c7d2f2db","id":"1dc01607-a88d-40de-ad18-f6b2232ce5ac","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":"b70daba0-fd6f-4e65-b6fc-8cfc94ea2b83","mnq_nats_account_id":"AA3NA65BFWAVKDBVNPVXFUGSITWAY7TO3YWR46LAVPSIUZU7UCKRDB5W","mnq_project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","mnq_region":"fr-par","subject":"TestSubject"},"status":"deleting"}'
+        headers:
+            Content-Length:
+                - "478"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:50:56 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 7915cc39-bf8d-4297-b2a0-4e679ba35924
+        status: 200 OK
+        code: 200
+        duration: 53.86629ms
+    - id: 32
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/1dc01607-a88d-40de-ad18-f6b2232ce5ac
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 478
+        uncompressed: false
+        body: '{"description":"","error_message":null,"function_id":"24390cea-180e-47c1-8cf4-cd71c7d2f2db","id":"1dc01607-a88d-40de-ad18-f6b2232ce5ac","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":"b70daba0-fd6f-4e65-b6fc-8cfc94ea2b83","mnq_nats_account_id":"AA3NA65BFWAVKDBVNPVXFUGSITWAY7TO3YWR46LAVPSIUZU7UCKRDB5W","mnq_project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","mnq_region":"fr-par","subject":"TestSubject"},"status":"deleting"}'
+        headers:
+            Content-Length:
+                - "478"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:51:01 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 180d4f5f-ee6a-4c84-82fe-e27509634acd
+        status: 200 OK
+        code: 200
+        duration: 71.621564ms
+    - id: 33
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/1dc01607-a88d-40de-ad18-f6b2232ce5ac
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 478
+        uncompressed: false
+        body: '{"description":"","error_message":null,"function_id":"24390cea-180e-47c1-8cf4-cd71c7d2f2db","id":"1dc01607-a88d-40de-ad18-f6b2232ce5ac","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":"b70daba0-fd6f-4e65-b6fc-8cfc94ea2b83","mnq_nats_account_id":"AA3NA65BFWAVKDBVNPVXFUGSITWAY7TO3YWR46LAVPSIUZU7UCKRDB5W","mnq_project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","mnq_region":"fr-par","subject":"TestSubject"},"status":"deleting"}'
+        headers:
+            Content-Length:
+                - "478"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:51:06 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - a3d9217a-afb7-4d5b-99f5-79da44781ea3
+        status: 200 OK
+        code: 200
+        duration: 48.36695ms
+    - id: 34
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/1dc01607-a88d-40de-ad18-f6b2232ce5ac
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 36
+        uncompressed: false
+        body: '{"message":"trigger does not exist"}'
+        headers:
+            Content-Length:
+                - "36"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:51:11 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 9c3f9787-813d-4dea-88d0-1ad884e25393
+        status: 404 Not Found
+        code: 404
+        duration: 30.933471ms
+    - id: 35
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/24390cea-180e-47c1-8cf4-cd71c7d2f2db
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 600
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"testfunctiontriggersmoeymike-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"24390cea-180e-47c1-8cf4-cd71c7d2f2db","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"76111182-9825-41b7-a3c2-3b423caf470a","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "600"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:51:11 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f278db22-c737-45c2-9a05-2296592a7a3e
+        status: 200 OK
+        code: 200
+        duration: 50.437353ms
+    - id: 36
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/24390cea-180e-47c1-8cf4-cd71c7d2f2db
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 601
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"testfunctiontriggersmoeymike-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"24390cea-180e-47c1-8cf4-cd71c7d2f2db","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"76111182-9825-41b7-a3c2-3b423caf470a","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"deleting","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "601"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:51:11 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - db1406ac-b96c-44d8-8a96-70d4e2ad9969
+        status: 200 OK
+        code: 200
+        duration: 82.427372ms
+    - id: 37
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/nats-accounts/AA3NA65BFWAVKDBVNPVXFUGSITWAY7TO3YWR46LAVPSIUZU7UCKRDB5W
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:51:11 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 810e252a-2c40-49c9-be26-5b524c439727
+        status: 204 No Content
+        code: 204
+        duration: 143.878302ms
+    - id: 38
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/76111182-9825-41b7-a3c2-3b423caf470a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 464
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"76111182-9825-41b7-a3c2-3b423caf470a","name":"test-function-trigger-sqs","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggersmoeymike","registry_namespace_id":"b68555d2-9e6a-415c-98f2-71af5f983d84","secret_environment_variables":[],"status":"ready"}'
+        headers:
+            Content-Length:
+                - "464"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:51:12 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 4bf73085-8646-45b6-a61f-dae8a76c4861
+        status: 200 OK
+        code: 200
+        duration: 39.838014ms
+    - id: 39
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/76111182-9825-41b7-a3c2-3b423caf470a
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 467
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"76111182-9825-41b7-a3c2-3b423caf470a","name":"test-function-trigger-sqs","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggersmoeymike","registry_namespace_id":"b68555d2-9e6a-415c-98f2-71af5f983d84","secret_environment_variables":[],"status":"deleting"}'
+        headers:
+            Content-Length:
+                - "467"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:51:12 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 9ef45afc-bb04-4d8f-86e0-685d57ea46c7
+        status: 200 OK
+        code: 200
+        duration: 234.133572ms
+    - id: 40
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/76111182-9825-41b7-a3c2-3b423caf470a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 467
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"76111182-9825-41b7-a3c2-3b423caf470a","name":"test-function-trigger-sqs","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggersmoeymike","registry_namespace_id":"b68555d2-9e6a-415c-98f2-71af5f983d84","secret_environment_variables":[],"status":"deleting"}'
+        headers:
+            Content-Length:
+                - "467"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:51:12 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 354a3d79-28eb-4d93-bfc9-320d7fc819af
+        status: 200 OK
+        code: 200
+        duration: 35.575029ms
+    - id: 41
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/76111182-9825-41b7-a3c2-3b423caf470a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 467
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"76111182-9825-41b7-a3c2-3b423caf470a","name":"test-function-trigger-sqs","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggersmoeymike","registry_namespace_id":"b68555d2-9e6a-415c-98f2-71af5f983d84","secret_environment_variables":[],"status":"deleting"}'
+        headers:
+            Content-Length:
+                - "467"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:51:17 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 6b3765a3-ed2c-41e1-90b4-da8a85ff1c3d
+        status: 200 OK
+        code: 200
+        duration: 43.577915ms
+    - id: 42
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/76111182-9825-41b7-a3c2-3b423caf470a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 467
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"76111182-9825-41b7-a3c2-3b423caf470a","name":"test-function-trigger-sqs","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggersmoeymike","registry_namespace_id":"b68555d2-9e6a-415c-98f2-71af5f983d84","secret_environment_variables":[],"status":"deleting"}'
+        headers:
+            Content-Length:
+                - "467"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:51:22 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 2343cf7d-492b-4cad-98f2-04d2a2999032
+        status: 200 OK
+        code: 200
+        duration: 41.389091ms
+    - id: 43
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/76111182-9825-41b7-a3c2-3b423caf470a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 467
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"76111182-9825-41b7-a3c2-3b423caf470a","name":"test-function-trigger-sqs","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggersmoeymike","registry_namespace_id":"b68555d2-9e6a-415c-98f2-71af5f983d84","secret_environment_variables":[],"status":"deleting"}'
+        headers:
+            Content-Length:
+                - "467"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:51:27 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - fd18a39f-50f6-4319-933f-3b5e334b786e
+        status: 200 OK
+        code: 200
+        duration: 65.187376ms
+    - id: 44
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/76111182-9825-41b7-a3c2-3b423caf470a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 467
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"76111182-9825-41b7-a3c2-3b423caf470a","name":"test-function-trigger-sqs","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggersmoeymike","registry_namespace_id":"b68555d2-9e6a-415c-98f2-71af5f983d84","secret_environment_variables":[],"status":"deleting"}'
+        headers:
+            Content-Length:
+                - "467"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:51:32 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - def45330-015e-40d1-a89e-260f2e638df7
+        status: 200 OK
+        code: 200
+        duration: 41.998477ms
+    - id: 45
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/76111182-9825-41b7-a3c2-3b423caf470a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 467
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"76111182-9825-41b7-a3c2-3b423caf470a","name":"test-function-trigger-sqs","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggersmoeymike","registry_namespace_id":"b68555d2-9e6a-415c-98f2-71af5f983d84","secret_environment_variables":[],"status":"deleting"}'
+        headers:
+            Content-Length:
+                - "467"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:51:37 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 0a6caace-264b-4b95-b0ea-d310de85ebe9
+        status: 200 OK
+        code: 200
+        duration: 43.198032ms
+    - id: 46
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/76111182-9825-41b7-a3c2-3b423caf470a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 37
+        uncompressed: false
+        body: '{"message":"Namespace was not found"}'
+        headers:
+            Content-Length:
+                - "37"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:51:42 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b77a9ff5-4702-4052-814b-a97e7c23d06f
+        status: 404 Not Found
+        code: 404
+        duration: 44.270669ms
+    - id: 47
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/1dc01607-a88d-40de-ad18-f6b2232ce5ac
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 105
+        uncompressed: false
+        body: '{"message":"trigger does not exist: could not find trigger with id 1dc01607-a88d-40de-ad18-f6b2232ce5ac"}'
+        headers:
+            Content-Length:
+                - "105"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:51:42 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 6c2c202a-5df2-41d5-91f3-e8c66b184f69
+        status: 404 Not Found
+        code: 404
+        duration: 32.551734ms

--- a/internal/services/function/testdata/function-trigger-sqs.cassette.yaml
+++ b/internal/services/function/testdata/function-trigger-sqs.cassette.yaml
@@ -1,2220 +1,3372 @@
 ---
 version: 2
 interactions:
-- request:
-    body: '{"name":"tf_tests_function_trigger_sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","description":""}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/account/v3/projects
-    method: POST
-  response:
-    body: '{"created_at":"2023-12-21T10:02:07.257271Z","description":"","id":"13fe8a26-d3d4-4e16-baae-78c340a727d9","name":"tf_tests_function_trigger_sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","updated_at":"2023-12-21T10:02:07.257271Z"}'
-    headers:
-      Content-Length:
-      - "244"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 21 Dec 2023 10:02:07 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2051fb35-1dcc-470b-a595-2256d9d242ea
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/account/v3/projects/13fe8a26-d3d4-4e16-baae-78c340a727d9
-    method: GET
-  response:
-    body: '{"created_at":"2023-12-21T10:02:07.257271Z","description":"","id":"13fe8a26-d3d4-4e16-baae-78c340a727d9","name":"tf_tests_function_trigger_sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","updated_at":"2023-12-21T10:02:07.257271Z"}'
-    headers:
-      Content-Length:
-      - "244"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 21 Dec 2023 10:02:07 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6155322b-f1ed-4319-b7b8-0d06912252af
-    status: 200 OK
-    code: 200
-- request:
-    body: '{"project_id":"13fe8a26-d3d4-4e16-baae-78c340a727d9"}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/activate-sqs
-    method: POST
-  response:
-    body: '{"created_at":"2023-12-21T10:02:07.712412450Z","project_id":"13fe8a26-d3d4-4e16-baae-78c340a727d9","region":"fr-par","sqs_endpoint_url":"https://sqs.mnq.fr-par.scaleway.com","status":"enabled","updated_at":"2023-12-21T10:02:07.712412450Z"}'
-    headers:
-      Content-Length:
-      - "239"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 21 Dec 2023 10:02:07 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a35d2d80-540d-4c2c-a90d-43651a901b15
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-info?project_id=13fe8a26-d3d4-4e16-baae-78c340a727d9
-    method: GET
-  response:
-    body: '{"created_at":"2023-12-21T10:02:07.712412Z","project_id":"13fe8a26-d3d4-4e16-baae-78c340a727d9","region":"fr-par","sqs_endpoint_url":"https://sqs.mnq.fr-par.scaleway.com","status":"enabled","updated_at":"2023-12-21T10:02:07.712412Z"}'
-    headers:
-      Content-Length:
-      - "233"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 21 Dec 2023 10:02:07 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 41b826cb-4e14-48a2-9a03-c79f5bab9de5
-    status: 200 OK
-    code: 200
-- request:
-    body: '{"name":"test-function-trigger-sqs","environment_variables":{},"project_id":"13fe8a26-d3d4-4e16-baae-78c340a727d9","secret_environment_variables":[]}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces
-    method: POST
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"be45f46f-5382-4d16-9c01-32c0afaec57b","name":"test-function-trigger-sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"13fe8a26-d3d4-4e16-baae-78c340a727d9","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "375"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 21 Dec 2023 10:02:08 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a00d3713-f009-473e-bb3d-7abdd851b70d
-    status: 200 OK
-    code: 200
-- request:
-    body: '{"project_id":"13fe8a26-d3d4-4e16-baae-78c340a727d9","name":"tf-sqs-credentials-busy-blackburn","permissions":{"can_publish":true,"can_receive":true,"can_manage":true}}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-credentials
-    method: POST
-  response:
-    body: '{"access_key":"teCCZUDBXIXO1NasGcYg","created_at":"2023-12-21T10:02:08.058390715Z","id":"8819a419-851f-4477-ba08-c8bbf15ac248","name":"tf-sqs-credentials-busy-blackburn","permissions":{"can_manage":true,"can_publish":true,"can_receive":true},"project_id":"13fe8a26-d3d4-4e16-baae-78c340a727d9","region":"fr-par","secret_checksum":"7be2934f8242850010e11048889a25a0b2665d4b","secret_key":"00000000-0000-0000-0000-000000000000","updated_at":null}'
-    headers:
-      Content-Length:
-      - "471"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 21 Dec 2023 10:02:08 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f25cc1c3-59f2-4f93-b934-9815005b0bc5
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/be45f46f-5382-4d16-9c01-32c0afaec57b
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"be45f46f-5382-4d16-9c01-32c0afaec57b","name":"test-function-trigger-sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"13fe8a26-d3d4-4e16-baae-78c340a727d9","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "375"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 21 Dec 2023 10:02:08 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d3b8f709-7d46-4ada-8b25-f1fbc6153420
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-credentials/8819a419-851f-4477-ba08-c8bbf15ac248
-    method: GET
-  response:
-    body: '{"access_key":"teCCZUDBXIXO1NasGcYg","created_at":"2023-12-21T10:02:08.058390Z","id":"8819a419-851f-4477-ba08-c8bbf15ac248","name":"tf-sqs-credentials-busy-blackburn","permissions":{"can_manage":true,"can_publish":true,"can_receive":true},"project_id":"13fe8a26-d3d4-4e16-baae-78c340a727d9","region":"fr-par","secret_checksum":"7be2934f8242850010e11048889a25a0b2665d4b","secret_key":"00000000-0000-0000-0000-000000000000","updated_at":null}'
-    headers:
-      Content-Length:
-      - "404"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 21 Dec 2023 10:02:08 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 01dccdb9-f119-4907-8577-9264667fe475
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-info?project_id=13fe8a26-d3d4-4e16-baae-78c340a727d9
-    method: GET
-  response:
-    body: '{"created_at":"2023-12-21T10:02:07.712412Z","project_id":"13fe8a26-d3d4-4e16-baae-78c340a727d9","region":"fr-par","sqs_endpoint_url":"https://sqs.mnq.fr-par.scaleway.com","status":"enabled","updated_at":"2023-12-21T10:02:07.712412Z"}'
-    headers:
-      Content-Length:
-      - "233"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 21 Dec 2023 10:02:08 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - bacbd9d2-e82f-4802-a913-45abb370c9f1
-    status: 200 OK
-    code: 200
-- request:
-    body: '{"Attributes":{"MaximumMessageSize":"262144","MessageRetentionPeriod":"345600","VisibilityTimeout":"30"},"QueueName":"TestQueue"}'
-    form: {}
-    headers:
-      Content-Length:
-      - "129"
-      Content-Type:
-      - application/x-amz-json-1.0
-      User-Agent:
-      - aws-sdk-go/1.49.6 (go1.21.1; linux; amd64)
-      X-Amz-Date:
-      - 20231221T100208Z
-      X-Amz-Target:
-      - AmazonSQS.CreateQueue
-    url: https://sqs.mnq.fr-par.scaleway.com/
-    method: POST
-  response:
-    body: '{"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-13fe8a26-d3d4-4e16-baae-78c340a727d9/TestQueue"}'
-    headers:
-      Content-Length:
-      - "105"
-      Content-Type:
-      - application/x-amz-json-1.0; charset=utf-8
-      Date:
-      - Thu, 21 Dec 2023 10:02:09 GMT
-      X-Amzn-Requestid:
-      - tx3c6c4532-194a-4868-a065-d056d9676b19
-    status: 200 OK
-    code: 200
-- request:
-    body: '{"QueueName":"TestQueue"}'
-    form: {}
-    headers:
-      Content-Length:
-      - "25"
-      Content-Type:
-      - application/x-amz-json-1.0
-      User-Agent:
-      - aws-sdk-go/1.49.6 (go1.21.1; linux; amd64)
-      X-Amz-Date:
-      - 20231221T100209Z
-      X-Amz-Target:
-      - AmazonSQS.GetQueueUrl
-    url: https://sqs.mnq.fr-par.scaleway.com/
-    method: POST
-  response:
-    body: '{"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-13fe8a26-d3d4-4e16-baae-78c340a727d9/TestQueue"}'
-    headers:
-      Content-Length:
-      - "105"
-      Content-Type:
-      - application/x-amz-json-1.0; charset=utf-8
-      Date:
-      - Thu, 21 Dec 2023 10:02:09 GMT
-      X-Amzn-Requestid:
-      - tx7171d80e-0849-46fe-9aa9-23c6e5d67585
-    status: 200 OK
-    code: 200
-- request:
-    body: '{"AttributeNames":["ReceiveMessageWaitTimeSeconds","VisibilityTimeout","MaximumMessageSize","MessageRetentionPeriod","FifoQueue","ContentBasedDeduplication"],"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-13fe8a26-d3d4-4e16-baae-78c340a727d9/TestQueue"}'
-    form: {}
-    headers:
-      Content-Length:
-      - "262"
-      Content-Type:
-      - application/x-amz-json-1.0
-      User-Agent:
-      - aws-sdk-go/1.49.6 (go1.21.1; linux; amd64)
-      X-Amz-Date:
-      - 20231221T100209Z
-      X-Amz-Target:
-      - AmazonSQS.GetQueueAttributes
-    url: https://sqs.mnq.fr-par.scaleway.com/
-    method: POST
-  response:
-    body: '{"Attributes":{"MaximumMessageSize":"262144","MessageRetentionPeriod":"345600","ReceiveMessageWaitTimeSeconds":"0","VisibilityTimeout":"30"}}'
-    headers:
-      Content-Length:
-      - "141"
-      Content-Type:
-      - application/x-amz-json-1.0; charset=utf-8
-      Date:
-      - Thu, 21 Dec 2023 10:02:10 GMT
-      X-Amzn-Requestid:
-      - tx0345e8b4-fbac-4436-b81e-414e581de50c
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/be45f46f-5382-4d16-9c01-32c0afaec57b
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"be45f46f-5382-4d16-9c01-32c0afaec57b","name":"test-function-trigger-sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"13fe8a26-d3d4-4e16-baae-78c340a727d9","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggerswlzcd1pg","registry_namespace_id":"403a9fa1-9296-4d2e-aa5e-35eaa9cd642a","secret_environment_variables":[],"status":"ready"}'
-    headers:
-      Content-Length:
-      - "464"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 21 Dec 2023 10:02:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3ca3d03a-583b-467d-ae40-fc83420fb98d
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/be45f46f-5382-4d16-9c01-32c0afaec57b
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"be45f46f-5382-4d16-9c01-32c0afaec57b","name":"test-function-trigger-sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"13fe8a26-d3d4-4e16-baae-78c340a727d9","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggerswlzcd1pg","registry_namespace_id":"403a9fa1-9296-4d2e-aa5e-35eaa9cd642a","secret_environment_variables":[],"status":"ready"}'
-    headers:
-      Content-Length:
-      - "464"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 21 Dec 2023 10:02:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a72a9d52-71d9-4ad2-91ce-91ee18c6feb7
-    status: 200 OK
-    code: 200
-- request:
-    body: '{"name":"test-function-trigger-sqs","namespace_id":"be45f46f-5382-4d16-9c01-32c0afaec57b","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"node20","memory_limit":128,"handler":"handler.handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled"}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions
-    method: POST
-  response:
-    body: '{"build_message":null,"cpu_limit":70,"description":"","domain_name":"testfunctiontriggerswlzcd1pg-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"84ef5ae3-1601-4857-92d3-8efc96575279","max_scale":20,"memory_limit":128,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"be45f46f-5382-4d16-9c01-32c0afaec57b","privacy":"private","region":"fr-par","runtime":"node20","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "584"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 21 Dec 2023 10:02:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5399de0a-8985-4415-a45d-456a4371435e
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/84ef5ae3-1601-4857-92d3-8efc96575279
-    method: GET
-  response:
-    body: '{"build_message":null,"cpu_limit":70,"description":"","domain_name":"testfunctiontriggerswlzcd1pg-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"84ef5ae3-1601-4857-92d3-8efc96575279","max_scale":20,"memory_limit":128,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"be45f46f-5382-4d16-9c01-32c0afaec57b","privacy":"private","region":"fr-par","runtime":"node20","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "584"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 21 Dec 2023 10:02:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 14ab3353-614c-4a27-91c6-0ec61e02cbf3
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/84ef5ae3-1601-4857-92d3-8efc96575279
-    method: GET
-  response:
-    body: '{"build_message":null,"cpu_limit":70,"description":"","domain_name":"testfunctiontriggerswlzcd1pg-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"84ef5ae3-1601-4857-92d3-8efc96575279","max_scale":20,"memory_limit":128,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"be45f46f-5382-4d16-9c01-32c0afaec57b","privacy":"private","region":"fr-par","runtime":"node20","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "584"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 21 Dec 2023 10:02:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c38baa74-f1ec-45e4-ab7d-99abfdb0e77b
-    status: 200 OK
-    code: 200
-- request:
-    body: '{"name":"test-function-trigger-sqs","function_id":"84ef5ae3-1601-4857-92d3-8efc96575279","scw_sqs_config":{"queue":"TestQueue","mnq_project_id":"13fe8a26-d3d4-4e16-baae-78c340a727d9","mnq_region":"fr-par"}}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers
-    method: POST
-  response:
-    body: '{"description":"","error_message":null,"function_id":"84ef5ae3-1601-4857-92d3-8efc96575279","id":"90e1b238-7a46-420d-8bd5-fc3f73803a0d","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":null,"mnq_namespace_id":"","mnq_project_id":"13fe8a26-d3d4-4e16-baae-78c340a727d9","mnq_region":"fr-par","queue":"TestQueue"},"status":"creating"}'
-    headers:
-      Content-Length:
-      - "378"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 21 Dec 2023 10:02:14 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7090dd51-9ad7-4d94-a98e-b71111e23d69
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/90e1b238-7a46-420d-8bd5-fc3f73803a0d
-    method: GET
-  response:
-    body: '{"description":"","error_message":null,"function_id":"84ef5ae3-1601-4857-92d3-8efc96575279","id":"90e1b238-7a46-420d-8bd5-fc3f73803a0d","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":null,"mnq_namespace_id":"","mnq_project_id":"13fe8a26-d3d4-4e16-baae-78c340a727d9","mnq_region":"fr-par","queue":"TestQueue"},"status":"creating"}'
-    headers:
-      Content-Length:
-      - "378"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 21 Dec 2023 10:02:14 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d4f616ed-3d5d-44d5-bf25-80e94dfa021f
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/90e1b238-7a46-420d-8bd5-fc3f73803a0d
-    method: GET
-  response:
-    body: '{"description":"","error_message":null,"function_id":"84ef5ae3-1601-4857-92d3-8efc96575279","id":"90e1b238-7a46-420d-8bd5-fc3f73803a0d","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"9e7d26bd-a27f-4a65-9d6c-ed2c35b922cb","mnq_namespace_id":"","mnq_project_id":"13fe8a26-d3d4-4e16-baae-78c340a727d9","mnq_region":"fr-par","queue":"TestQueue"},"status":"creating"}'
-    headers:
-      Content-Length:
-      - "412"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 21 Dec 2023 10:02:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 13281c50-1767-4314-8f98-259830cc106c
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/90e1b238-7a46-420d-8bd5-fc3f73803a0d
-    method: GET
-  response:
-    body: '{"description":"","error_message":null,"function_id":"84ef5ae3-1601-4857-92d3-8efc96575279","id":"90e1b238-7a46-420d-8bd5-fc3f73803a0d","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"9e7d26bd-a27f-4a65-9d6c-ed2c35b922cb","mnq_namespace_id":"","mnq_project_id":"13fe8a26-d3d4-4e16-baae-78c340a727d9","mnq_region":"fr-par","queue":"TestQueue"},"status":"creating"}'
-    headers:
-      Content-Length:
-      - "412"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 21 Dec 2023 10:02:24 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1f050bf7-5872-4d74-a314-5a9f55a7be07
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/90e1b238-7a46-420d-8bd5-fc3f73803a0d
-    method: GET
-  response:
-    body: '{"description":"","error_message":null,"function_id":"84ef5ae3-1601-4857-92d3-8efc96575279","id":"90e1b238-7a46-420d-8bd5-fc3f73803a0d","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"9e7d26bd-a27f-4a65-9d6c-ed2c35b922cb","mnq_namespace_id":"","mnq_project_id":"13fe8a26-d3d4-4e16-baae-78c340a727d9","mnq_region":"fr-par","queue":"TestQueue"},"status":"creating"}'
-    headers:
-      Content-Length:
-      - "412"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 21 Dec 2023 10:02:29 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3a603271-9729-4431-92c0-0e4245fb473b
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/90e1b238-7a46-420d-8bd5-fc3f73803a0d
-    method: GET
-  response:
-    body: '{"description":"","error_message":null,"function_id":"84ef5ae3-1601-4857-92d3-8efc96575279","id":"90e1b238-7a46-420d-8bd5-fc3f73803a0d","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"9e7d26bd-a27f-4a65-9d6c-ed2c35b922cb","mnq_namespace_id":"","mnq_project_id":"13fe8a26-d3d4-4e16-baae-78c340a727d9","mnq_region":"fr-par","queue":"TestQueue"},"status":"ready"}'
-    headers:
-      Content-Length:
-      - "409"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 21 Dec 2023 10:02:34 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f8772e35-822b-496a-9870-18949e90173e
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/90e1b238-7a46-420d-8bd5-fc3f73803a0d
-    method: GET
-  response:
-    body: '{"description":"","error_message":null,"function_id":"84ef5ae3-1601-4857-92d3-8efc96575279","id":"90e1b238-7a46-420d-8bd5-fc3f73803a0d","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"9e7d26bd-a27f-4a65-9d6c-ed2c35b922cb","mnq_namespace_id":"","mnq_project_id":"13fe8a26-d3d4-4e16-baae-78c340a727d9","mnq_region":"fr-par","queue":"TestQueue"},"status":"ready"}'
-    headers:
-      Content-Length:
-      - "409"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 21 Dec 2023 10:02:34 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a1d81388-3b87-46db-9ced-48a1a5acfb4e
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/90e1b238-7a46-420d-8bd5-fc3f73803a0d
-    method: GET
-  response:
-    body: '{"description":"","error_message":null,"function_id":"84ef5ae3-1601-4857-92d3-8efc96575279","id":"90e1b238-7a46-420d-8bd5-fc3f73803a0d","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"9e7d26bd-a27f-4a65-9d6c-ed2c35b922cb","mnq_namespace_id":"","mnq_project_id":"13fe8a26-d3d4-4e16-baae-78c340a727d9","mnq_region":"fr-par","queue":"TestQueue"},"status":"ready"}'
-    headers:
-      Content-Length:
-      - "409"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 21 Dec 2023 10:02:35 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - bc6257b2-6fb1-4a24-9e55-e0a481a99cf1
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/90e1b238-7a46-420d-8bd5-fc3f73803a0d
-    method: GET
-  response:
-    body: '{"description":"","error_message":null,"function_id":"84ef5ae3-1601-4857-92d3-8efc96575279","id":"90e1b238-7a46-420d-8bd5-fc3f73803a0d","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"9e7d26bd-a27f-4a65-9d6c-ed2c35b922cb","mnq_namespace_id":"","mnq_project_id":"13fe8a26-d3d4-4e16-baae-78c340a727d9","mnq_region":"fr-par","queue":"TestQueue"},"status":"ready"}'
-    headers:
-      Content-Length:
-      - "409"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 21 Dec 2023 10:02:35 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 813c0133-96e9-4e7c-9505-73482ea68965
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/account/v3/projects/13fe8a26-d3d4-4e16-baae-78c340a727d9
-    method: GET
-  response:
-    body: '{"created_at":"2023-12-21T10:02:07.257271Z","description":"","id":"13fe8a26-d3d4-4e16-baae-78c340a727d9","name":"tf_tests_function_trigger_sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","updated_at":"2023-12-21T10:02:07.257271Z"}'
-    headers:
-      Content-Length:
-      - "244"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 21 Dec 2023 10:02:37 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 00ef5e64-8a02-4b76-9100-a385b51ce9ae
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/be45f46f-5382-4d16-9c01-32c0afaec57b
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"be45f46f-5382-4d16-9c01-32c0afaec57b","name":"test-function-trigger-sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"13fe8a26-d3d4-4e16-baae-78c340a727d9","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggerswlzcd1pg","registry_namespace_id":"403a9fa1-9296-4d2e-aa5e-35eaa9cd642a","secret_environment_variables":[],"status":"ready"}'
-    headers:
-      Content-Length:
-      - "464"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 21 Dec 2023 10:02:37 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4d5f99a9-cea2-4955-8492-52c1811ce38c
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-info?project_id=13fe8a26-d3d4-4e16-baae-78c340a727d9
-    method: GET
-  response:
-    body: '{"created_at":"2023-12-21T10:02:07.712412Z","project_id":"13fe8a26-d3d4-4e16-baae-78c340a727d9","region":"fr-par","sqs_endpoint_url":"https://sqs.mnq.fr-par.scaleway.com","status":"enabled","updated_at":"2023-12-21T10:02:07.712412Z"}'
-    headers:
-      Content-Length:
-      - "233"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 21 Dec 2023 10:02:37 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 278d7e61-a8a7-49f0-90bc-0e8b37c29689
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-credentials/8819a419-851f-4477-ba08-c8bbf15ac248
-    method: GET
-  response:
-    body: '{"access_key":"teCCZUDBXIXO1NasGcYg","created_at":"2023-12-21T10:02:08.058390Z","id":"8819a419-851f-4477-ba08-c8bbf15ac248","name":"tf-sqs-credentials-busy-blackburn","permissions":{"can_manage":true,"can_publish":true,"can_receive":true},"project_id":"13fe8a26-d3d4-4e16-baae-78c340a727d9","region":"fr-par","secret_checksum":"7be2934f8242850010e11048889a25a0b2665d4b","secret_key":"00000000-0000-0000-0000-000000000000","updated_at":null}'
-    headers:
-      Content-Length:
-      - "404"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 21 Dec 2023 10:02:37 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ab3267ce-2617-413f-bb45-06ba97857ad3
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/84ef5ae3-1601-4857-92d3-8efc96575279
-    method: GET
-  response:
-    body: '{"build_message":null,"cpu_limit":70,"description":"","domain_name":"testfunctiontriggerswlzcd1pg-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"84ef5ae3-1601-4857-92d3-8efc96575279","max_scale":20,"memory_limit":128,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"be45f46f-5382-4d16-9c01-32c0afaec57b","privacy":"private","region":"fr-par","runtime":"node20","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "584"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 21 Dec 2023 10:02:38 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 61e65e03-dc5a-4fb4-9549-6bc15374fef9
-    status: 200 OK
-    code: 200
-- request:
-    body: '{"QueueName":"TestQueue"}'
-    form: {}
-    headers:
-      Content-Length:
-      - "25"
-      Content-Type:
-      - application/x-amz-json-1.0
-      User-Agent:
-      - aws-sdk-go/1.49.6 (go1.21.1; linux; amd64)
-      X-Amz-Date:
-      - 20231221T100238Z
-      X-Amz-Target:
-      - AmazonSQS.GetQueueUrl
-    url: https://sqs.mnq.fr-par.scaleway.com/
-    method: POST
-  response:
-    body: '{"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-13fe8a26-d3d4-4e16-baae-78c340a727d9/TestQueue"}'
-    headers:
-      Content-Length:
-      - "105"
-      Content-Type:
-      - application/x-amz-json-1.0; charset=utf-8
-      Date:
-      - Thu, 21 Dec 2023 10:02:38 GMT
-      X-Amzn-Requestid:
-      - tx1706b384-5994-4411-b79c-4dde2557a0c1
-    status: 200 OK
-    code: 200
-- request:
-    body: '{"AttributeNames":["MessageRetentionPeriod","FifoQueue","ContentBasedDeduplication","ReceiveMessageWaitTimeSeconds","VisibilityTimeout","MaximumMessageSize"],"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-13fe8a26-d3d4-4e16-baae-78c340a727d9/TestQueue"}'
-    form: {}
-    headers:
-      Content-Length:
-      - "262"
-      Content-Type:
-      - application/x-amz-json-1.0
-      User-Agent:
-      - aws-sdk-go/1.49.6 (go1.21.1; linux; amd64)
-      X-Amz-Date:
-      - 20231221T100238Z
-      X-Amz-Target:
-      - AmazonSQS.GetQueueAttributes
-    url: https://sqs.mnq.fr-par.scaleway.com/
-    method: POST
-  response:
-    body: '{"Attributes":{"MaximumMessageSize":"262144","MessageRetentionPeriod":"345600","ReceiveMessageWaitTimeSeconds":"0","VisibilityTimeout":"30"}}'
-    headers:
-      Content-Length:
-      - "141"
-      Content-Type:
-      - application/x-amz-json-1.0; charset=utf-8
-      Date:
-      - Thu, 21 Dec 2023 10:02:38 GMT
-      X-Amzn-Requestid:
-      - tx8ce7999b-3ae6-42bb-aa26-fb700f8344bd
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/90e1b238-7a46-420d-8bd5-fc3f73803a0d
-    method: GET
-  response:
-    body: '{"description":"","error_message":null,"function_id":"84ef5ae3-1601-4857-92d3-8efc96575279","id":"90e1b238-7a46-420d-8bd5-fc3f73803a0d","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"9e7d26bd-a27f-4a65-9d6c-ed2c35b922cb","mnq_namespace_id":"","mnq_project_id":"13fe8a26-d3d4-4e16-baae-78c340a727d9","mnq_region":"fr-par","queue":"TestQueue"},"status":"ready"}'
-    headers:
-      Content-Length:
-      - "409"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 21 Dec 2023 10:02:38 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a6f2eae8-ef45-406d-94ee-8b70988c79fd
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/account/v3/projects/13fe8a26-d3d4-4e16-baae-78c340a727d9
-    method: GET
-  response:
-    body: '{"created_at":"2023-12-21T10:02:07.257271Z","description":"","id":"13fe8a26-d3d4-4e16-baae-78c340a727d9","name":"tf_tests_function_trigger_sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","updated_at":"2023-12-21T10:02:07.257271Z"}'
-    headers:
-      Content-Length:
-      - "244"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 21 Dec 2023 10:02:40 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6ad754a1-6046-45d7-83f1-e75077d7a025
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/be45f46f-5382-4d16-9c01-32c0afaec57b
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"be45f46f-5382-4d16-9c01-32c0afaec57b","name":"test-function-trigger-sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"13fe8a26-d3d4-4e16-baae-78c340a727d9","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggerswlzcd1pg","registry_namespace_id":"403a9fa1-9296-4d2e-aa5e-35eaa9cd642a","secret_environment_variables":[],"status":"ready"}'
-    headers:
-      Content-Length:
-      - "464"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 21 Dec 2023 10:02:41 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8b0e1eac-5ee5-4712-b506-85feabdeb2a4
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-info?project_id=13fe8a26-d3d4-4e16-baae-78c340a727d9
-    method: GET
-  response:
-    body: '{"created_at":"2023-12-21T10:02:07.712412Z","project_id":"13fe8a26-d3d4-4e16-baae-78c340a727d9","region":"fr-par","sqs_endpoint_url":"https://sqs.mnq.fr-par.scaleway.com","status":"enabled","updated_at":"2023-12-21T10:02:07.712412Z"}'
-    headers:
-      Content-Length:
-      - "233"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 21 Dec 2023 10:02:41 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c3671e73-83e4-47de-a4f6-d73bc658988a
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/84ef5ae3-1601-4857-92d3-8efc96575279
-    method: GET
-  response:
-    body: '{"build_message":null,"cpu_limit":70,"description":"","domain_name":"testfunctiontriggerswlzcd1pg-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"84ef5ae3-1601-4857-92d3-8efc96575279","max_scale":20,"memory_limit":128,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"be45f46f-5382-4d16-9c01-32c0afaec57b","privacy":"private","region":"fr-par","runtime":"node20","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "584"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 21 Dec 2023 10:02:41 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6ce6123d-f217-450c-a897-3ea3de8299ce
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-credentials/8819a419-851f-4477-ba08-c8bbf15ac248
-    method: GET
-  response:
-    body: '{"access_key":"teCCZUDBXIXO1NasGcYg","created_at":"2023-12-21T10:02:08.058390Z","id":"8819a419-851f-4477-ba08-c8bbf15ac248","name":"tf-sqs-credentials-busy-blackburn","permissions":{"can_manage":true,"can_publish":true,"can_receive":true},"project_id":"13fe8a26-d3d4-4e16-baae-78c340a727d9","region":"fr-par","secret_checksum":"7be2934f8242850010e11048889a25a0b2665d4b","secret_key":"00000000-0000-0000-0000-000000000000","updated_at":null}'
-    headers:
-      Content-Length:
-      - "404"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 21 Dec 2023 10:02:41 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5719592e-021d-41eb-82e0-0302e4dca062
-    status: 200 OK
-    code: 200
-- request:
-    body: '{"QueueName":"TestQueue"}'
-    form: {}
-    headers:
-      Content-Length:
-      - "25"
-      Content-Type:
-      - application/x-amz-json-1.0
-      User-Agent:
-      - aws-sdk-go/1.49.6 (go1.21.1; linux; amd64)
-      X-Amz-Date:
-      - 20231221T100241Z
-      X-Amz-Target:
-      - AmazonSQS.GetQueueUrl
-    url: https://sqs.mnq.fr-par.scaleway.com/
-    method: POST
-  response:
-    body: '{"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-13fe8a26-d3d4-4e16-baae-78c340a727d9/TestQueue"}'
-    headers:
-      Content-Length:
-      - "105"
-      Content-Type:
-      - application/x-amz-json-1.0; charset=utf-8
-      Date:
-      - Thu, 21 Dec 2023 10:02:41 GMT
-      X-Amzn-Requestid:
-      - tx85d00363-66e4-4abb-b017-77b4bc15ae82
-    status: 200 OK
-    code: 200
-- request:
-    body: '{"AttributeNames":["VisibilityTimeout","MaximumMessageSize","MessageRetentionPeriod","FifoQueue","ContentBasedDeduplication","ReceiveMessageWaitTimeSeconds"],"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-13fe8a26-d3d4-4e16-baae-78c340a727d9/TestQueue"}'
-    form: {}
-    headers:
-      Content-Length:
-      - "262"
-      Content-Type:
-      - application/x-amz-json-1.0
-      User-Agent:
-      - aws-sdk-go/1.49.6 (go1.21.1; linux; amd64)
-      X-Amz-Date:
-      - 20231221T100241Z
-      X-Amz-Target:
-      - AmazonSQS.GetQueueAttributes
-    url: https://sqs.mnq.fr-par.scaleway.com/
-    method: POST
-  response:
-    body: '{"Attributes":{"MaximumMessageSize":"262144","MessageRetentionPeriod":"345600","ReceiveMessageWaitTimeSeconds":"0","VisibilityTimeout":"30"}}'
-    headers:
-      Content-Length:
-      - "141"
-      Content-Type:
-      - application/x-amz-json-1.0; charset=utf-8
-      Date:
-      - Thu, 21 Dec 2023 10:02:41 GMT
-      X-Amzn-Requestid:
-      - txbc667593-2935-46d7-8266-6f860dbdb97a
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/90e1b238-7a46-420d-8bd5-fc3f73803a0d
-    method: GET
-  response:
-    body: '{"description":"","error_message":null,"function_id":"84ef5ae3-1601-4857-92d3-8efc96575279","id":"90e1b238-7a46-420d-8bd5-fc3f73803a0d","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"9e7d26bd-a27f-4a65-9d6c-ed2c35b922cb","mnq_namespace_id":"","mnq_project_id":"13fe8a26-d3d4-4e16-baae-78c340a727d9","mnq_region":"fr-par","queue":"TestQueue"},"status":"ready"}'
-    headers:
-      Content-Length:
-      - "409"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 21 Dec 2023 10:02:41 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b8a2b6ac-1c81-4dc3-8cd7-06abe23c41fa
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/account/v3/projects/13fe8a26-d3d4-4e16-baae-78c340a727d9
-    method: GET
-  response:
-    body: '{"created_at":"2023-12-21T10:02:07.257271Z","description":"","id":"13fe8a26-d3d4-4e16-baae-78c340a727d9","name":"tf_tests_function_trigger_sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","updated_at":"2023-12-21T10:02:07.257271Z"}'
-    headers:
-      Content-Length:
-      - "244"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 21 Dec 2023 10:02:44 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9cad940c-a083-4661-8a64-ff9d0f4df8e6
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-info?project_id=13fe8a26-d3d4-4e16-baae-78c340a727d9
-    method: GET
-  response:
-    body: '{"created_at":"2023-12-21T10:02:07.712412Z","project_id":"13fe8a26-d3d4-4e16-baae-78c340a727d9","region":"fr-par","sqs_endpoint_url":"https://sqs.mnq.fr-par.scaleway.com","status":"enabled","updated_at":"2023-12-21T10:02:07.712412Z"}'
-    headers:
-      Content-Length:
-      - "233"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 21 Dec 2023 10:02:44 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f8944e19-8594-4b74-b0a1-0e7d8d58c110
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/be45f46f-5382-4d16-9c01-32c0afaec57b
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"be45f46f-5382-4d16-9c01-32c0afaec57b","name":"test-function-trigger-sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"13fe8a26-d3d4-4e16-baae-78c340a727d9","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggerswlzcd1pg","registry_namespace_id":"403a9fa1-9296-4d2e-aa5e-35eaa9cd642a","secret_environment_variables":[],"status":"ready"}'
-    headers:
-      Content-Length:
-      - "464"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 21 Dec 2023 10:02:44 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 06678ff9-a37f-49b1-a05b-d84664e46638
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-credentials/8819a419-851f-4477-ba08-c8bbf15ac248
-    method: GET
-  response:
-    body: '{"access_key":"teCCZUDBXIXO1NasGcYg","created_at":"2023-12-21T10:02:08.058390Z","id":"8819a419-851f-4477-ba08-c8bbf15ac248","name":"tf-sqs-credentials-busy-blackburn","permissions":{"can_manage":true,"can_publish":true,"can_receive":true},"project_id":"13fe8a26-d3d4-4e16-baae-78c340a727d9","region":"fr-par","secret_checksum":"7be2934f8242850010e11048889a25a0b2665d4b","secret_key":"00000000-0000-0000-0000-000000000000","updated_at":null}'
-    headers:
-      Content-Length:
-      - "404"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 21 Dec 2023 10:02:44 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 24226e88-c6f9-4042-9498-7c9220465ec1
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/84ef5ae3-1601-4857-92d3-8efc96575279
-    method: GET
-  response:
-    body: '{"build_message":null,"cpu_limit":70,"description":"","domain_name":"testfunctiontriggerswlzcd1pg-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"84ef5ae3-1601-4857-92d3-8efc96575279","max_scale":20,"memory_limit":128,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"be45f46f-5382-4d16-9c01-32c0afaec57b","privacy":"private","region":"fr-par","runtime":"node20","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "584"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 21 Dec 2023 10:02:44 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c269df6a-1b05-426e-8767-e3376278a9c0
-    status: 200 OK
-    code: 200
-- request:
-    body: '{"QueueName":"TestQueue"}'
-    form: {}
-    headers:
-      Content-Length:
-      - "25"
-      Content-Type:
-      - application/x-amz-json-1.0
-      User-Agent:
-      - aws-sdk-go/1.49.6 (go1.21.1; linux; amd64)
-      X-Amz-Date:
-      - 20231221T100244Z
-      X-Amz-Target:
-      - AmazonSQS.GetQueueUrl
-    url: https://sqs.mnq.fr-par.scaleway.com/
-    method: POST
-  response:
-    body: '{"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-13fe8a26-d3d4-4e16-baae-78c340a727d9/TestQueue"}'
-    headers:
-      Content-Length:
-      - "105"
-      Content-Type:
-      - application/x-amz-json-1.0; charset=utf-8
-      Date:
-      - Thu, 21 Dec 2023 10:02:44 GMT
-      X-Amzn-Requestid:
-      - tx73a6f604-8d44-4e62-8c55-83099dd10440
-    status: 200 OK
-    code: 200
-- request:
-    body: '{"AttributeNames":["MaximumMessageSize","MessageRetentionPeriod","FifoQueue","ContentBasedDeduplication","ReceiveMessageWaitTimeSeconds","VisibilityTimeout"],"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-13fe8a26-d3d4-4e16-baae-78c340a727d9/TestQueue"}'
-    form: {}
-    headers:
-      Content-Length:
-      - "262"
-      Content-Type:
-      - application/x-amz-json-1.0
-      User-Agent:
-      - aws-sdk-go/1.49.6 (go1.21.1; linux; amd64)
-      X-Amz-Date:
-      - 20231221T100244Z
-      X-Amz-Target:
-      - AmazonSQS.GetQueueAttributes
-    url: https://sqs.mnq.fr-par.scaleway.com/
-    method: POST
-  response:
-    body: '{"Attributes":{"MaximumMessageSize":"262144","MessageRetentionPeriod":"345600","ReceiveMessageWaitTimeSeconds":"0","VisibilityTimeout":"30"}}'
-    headers:
-      Content-Length:
-      - "141"
-      Content-Type:
-      - application/x-amz-json-1.0; charset=utf-8
-      Date:
-      - Thu, 21 Dec 2023 10:02:44 GMT
-      X-Amzn-Requestid:
-      - txe9b6cf5b-98b5-4377-b07e-37cfa3c26058
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/90e1b238-7a46-420d-8bd5-fc3f73803a0d
-    method: GET
-  response:
-    body: '{"description":"","error_message":null,"function_id":"84ef5ae3-1601-4857-92d3-8efc96575279","id":"90e1b238-7a46-420d-8bd5-fc3f73803a0d","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"9e7d26bd-a27f-4a65-9d6c-ed2c35b922cb","mnq_namespace_id":"","mnq_project_id":"13fe8a26-d3d4-4e16-baae-78c340a727d9","mnq_region":"fr-par","queue":"TestQueue"},"status":"ready"}'
-    headers:
-      Content-Length:
-      - "409"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 21 Dec 2023 10:02:44 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7f228cde-2051-40b2-b7e8-cc0f6f0e67e3
-    status: 200 OK
-    code: 200
-- request:
-    body: '{"QueueName":"TestQueue"}'
-    form: {}
-    headers:
-      Content-Length:
-      - "25"
-      Content-Type:
-      - application/x-amz-json-1.0
-      User-Agent:
-      - aws-sdk-go/1.49.6 (go1.21.1; linux; amd64)
-      X-Amz-Date:
-      - 20231221T100248Z
-      X-Amz-Target:
-      - AmazonSQS.GetQueueUrl
-    url: https://sqs.mnq.fr-par.scaleway.com/
-    method: POST
-  response:
-    body: '{"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-13fe8a26-d3d4-4e16-baae-78c340a727d9/TestQueue"}'
-    headers:
-      Content-Length:
-      - "105"
-      Content-Type:
-      - application/x-amz-json-1.0; charset=utf-8
-      Date:
-      - Thu, 21 Dec 2023 10:02:48 GMT
-      X-Amzn-Requestid:
-      - tx7f1837bc-19c6-400f-ac6d-8de974bbe8c3
-    status: 200 OK
-    code: 200
-- request:
-    body: '{"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-13fe8a26-d3d4-4e16-baae-78c340a727d9/TestQueue"}'
-    form: {}
-    headers:
-      Content-Length:
-      - "105"
-      Content-Type:
-      - application/x-amz-json-1.0
-      User-Agent:
-      - aws-sdk-go/1.49.6 (go1.21.1; linux; amd64)
-      X-Amz-Date:
-      - 20231221T100248Z
-      X-Amz-Target:
-      - AmazonSQS.DeleteQueue
-    url: https://sqs.mnq.fr-par.scaleway.com/
-    method: POST
-  response:
-    body: ""
-    headers:
-      Content-Length:
-      - "0"
-      Content-Type:
-      - application/x-amz-json-1.0; charset=utf-8
-      Date:
-      - Thu, 21 Dec 2023 10:02:48 GMT
-      X-Amzn-Requestid:
-      - tx04fd307e-29e4-45e8-ab72-3d68ca01afbc
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/90e1b238-7a46-420d-8bd5-fc3f73803a0d
-    method: GET
-  response:
-    body: '{"description":"","error_message":null,"function_id":"84ef5ae3-1601-4857-92d3-8efc96575279","id":"90e1b238-7a46-420d-8bd5-fc3f73803a0d","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"9e7d26bd-a27f-4a65-9d6c-ed2c35b922cb","mnq_namespace_id":"","mnq_project_id":"13fe8a26-d3d4-4e16-baae-78c340a727d9","mnq_region":"fr-par","queue":"TestQueue"},"status":"ready"}'
-    headers:
-      Content-Length:
-      - "409"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 21 Dec 2023 10:02:48 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - df21502e-18ad-4fcc-9891-1bc5e2fb930b
-    status: 200 OK
-    code: 200
-- request:
-    body: '{"QueueName":"TestQueue"}'
-    form: {}
-    headers:
-      Content-Length:
-      - "25"
-      Content-Type:
-      - application/x-amz-json-1.0
-      User-Agent:
-      - aws-sdk-go/1.49.6 (go1.21.1; linux; amd64)
-      X-Amz-Date:
-      - 20231221T100248Z
-      X-Amz-Target:
-      - AmazonSQS.GetQueueUrl
-    url: https://sqs.mnq.fr-par.scaleway.com/
-    method: POST
-  response:
-    body: '{"__type":"com.scaleway.sqs#AWS.SimpleQueueService.NonExistentQueue","message":"Queue
-      \"TestQueue\" does not exist."}'
-    headers:
-      Content-Length:
-      - "117"
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Thu, 21 Dec 2023 10:02:48 GMT
-      X-Amzn-Query-Error:
-      - AWS.SimpleQueueService.NonExistentQueue;Sender
-      X-Amzn-Requestid:
-      - txee1129a3-a764-4903-85b7-c669cbc2ea05
-    status: 400 Bad Request
-    code: 400
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-credentials/8819a419-851f-4477-ba08-c8bbf15ac248
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 21 Dec 2023 10:02:48 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e8e7769d-d322-451e-ad57-75727dcab572
-    status: 204 No Content
-    code: 204
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/90e1b238-7a46-420d-8bd5-fc3f73803a0d
-    method: DELETE
-  response:
-    body: '{"description":"","error_message":null,"function_id":"84ef5ae3-1601-4857-92d3-8efc96575279","id":"90e1b238-7a46-420d-8bd5-fc3f73803a0d","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"9e7d26bd-a27f-4a65-9d6c-ed2c35b922cb","mnq_namespace_id":"","mnq_project_id":"13fe8a26-d3d4-4e16-baae-78c340a727d9","mnq_region":"fr-par","queue":"TestQueue"},"status":"deleting"}'
-    headers:
-      Content-Length:
-      - "412"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 21 Dec 2023 10:02:48 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 70445d27-0608-4ce1-b7c7-90e17d04a498
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/90e1b238-7a46-420d-8bd5-fc3f73803a0d
-    method: GET
-  response:
-    body: '{"description":"","error_message":null,"function_id":"84ef5ae3-1601-4857-92d3-8efc96575279","id":"90e1b238-7a46-420d-8bd5-fc3f73803a0d","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"9e7d26bd-a27f-4a65-9d6c-ed2c35b922cb","mnq_namespace_id":"","mnq_project_id":"13fe8a26-d3d4-4e16-baae-78c340a727d9","mnq_region":"fr-par","queue":"TestQueue"},"status":"deleting"}'
-    headers:
-      Content-Length:
-      - "412"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 21 Dec 2023 10:02:48 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 574438c0-8714-42a9-986e-beb26612399c
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/90e1b238-7a46-420d-8bd5-fc3f73803a0d
-    method: GET
-  response:
-    body: '{"description":"","error_message":null,"function_id":"84ef5ae3-1601-4857-92d3-8efc96575279","id":"90e1b238-7a46-420d-8bd5-fc3f73803a0d","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"9e7d26bd-a27f-4a65-9d6c-ed2c35b922cb","mnq_namespace_id":"","mnq_project_id":"13fe8a26-d3d4-4e16-baae-78c340a727d9","mnq_region":"fr-par","queue":"TestQueue"},"status":"deleting"}'
-    headers:
-      Content-Length:
-      - "412"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 21 Dec 2023 10:02:53 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ee86cc1a-fcb2-4551-a944-7d6998e88aa4
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/90e1b238-7a46-420d-8bd5-fc3f73803a0d
-    method: GET
-  response:
-    body: '{"description":"","error_message":null,"function_id":"84ef5ae3-1601-4857-92d3-8efc96575279","id":"90e1b238-7a46-420d-8bd5-fc3f73803a0d","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"9e7d26bd-a27f-4a65-9d6c-ed2c35b922cb","mnq_namespace_id":"","mnq_project_id":"13fe8a26-d3d4-4e16-baae-78c340a727d9","mnq_region":"fr-par","queue":"TestQueue"},"status":"deleting"}'
-    headers:
-      Content-Length:
-      - "412"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 21 Dec 2023 10:02:58 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 52b154ea-1550-4eb6-850e-7c9172198c9d
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/90e1b238-7a46-420d-8bd5-fc3f73803a0d
-    method: GET
-  response:
-    body: '{"message":"trigger does not exist"}'
-    headers:
-      Content-Length:
-      - "36"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 21 Dec 2023 10:03:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - dbcac36c-677b-4d30-85f7-f745aece08e0
-    status: 404 Not Found
-    code: 404
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-info?project_id=13fe8a26-d3d4-4e16-baae-78c340a727d9
-    method: GET
-  response:
-    body: '{"created_at":"2023-12-21T10:02:07.712412Z","project_id":"13fe8a26-d3d4-4e16-baae-78c340a727d9","region":"fr-par","sqs_endpoint_url":"https://sqs.mnq.fr-par.scaleway.com","status":"enabled","updated_at":"2023-12-21T10:02:07.712412Z"}'
-    headers:
-      Content-Length:
-      - "233"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 21 Dec 2023 10:03:04 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 14a5e054-51a3-4a5b-9446-84ac986ff8eb
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/84ef5ae3-1601-4857-92d3-8efc96575279
-    method: GET
-  response:
-    body: '{"build_message":null,"cpu_limit":70,"description":"","domain_name":"testfunctiontriggerswlzcd1pg-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"84ef5ae3-1601-4857-92d3-8efc96575279","max_scale":20,"memory_limit":128,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"be45f46f-5382-4d16-9c01-32c0afaec57b","privacy":"private","region":"fr-par","runtime":"node20","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "584"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 21 Dec 2023 10:03:04 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 614bbbba-2ae5-474a-999e-ae887fdec24d
-    status: 200 OK
-    code: 200
-- request:
-    body: '{"project_id":"13fe8a26-d3d4-4e16-baae-78c340a727d9"}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/deactivate-sqs
-    method: POST
-  response:
-    body: '{"created_at":null,"project_id":"13fe8a26-d3d4-4e16-baae-78c340a727d9","region":"fr-par","sqs_endpoint_url":"https://sqs.mnq.fr-par.scaleway.com","status":"disabled","updated_at":null}'
-    headers:
-      Content-Length:
-      - "184"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 21 Dec 2023 10:03:04 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5b596fdf-832b-45a0-917d-e0987724269f
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/84ef5ae3-1601-4857-92d3-8efc96575279
-    method: DELETE
-  response:
-    body: '{"build_message":null,"cpu_limit":70,"description":"","domain_name":"testfunctiontriggerswlzcd1pg-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"84ef5ae3-1601-4857-92d3-8efc96575279","max_scale":20,"memory_limit":128,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"be45f46f-5382-4d16-9c01-32c0afaec57b","privacy":"private","region":"fr-par","runtime":"node20","runtime_message":"","secret_environment_variables":[],"status":"deleting","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "585"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 21 Dec 2023 10:03:04 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2952e22b-3e9c-4f63-b942-910eb4eac599
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/be45f46f-5382-4d16-9c01-32c0afaec57b
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"be45f46f-5382-4d16-9c01-32c0afaec57b","name":"test-function-trigger-sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"13fe8a26-d3d4-4e16-baae-78c340a727d9","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggerswlzcd1pg","registry_namespace_id":"403a9fa1-9296-4d2e-aa5e-35eaa9cd642a","secret_environment_variables":[],"status":"ready"}'
-    headers:
-      Content-Length:
-      - "464"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 21 Dec 2023 10:03:04 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 66270820-4a80-4583-8aea-6e92d801220d
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/be45f46f-5382-4d16-9c01-32c0afaec57b
-    method: DELETE
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"be45f46f-5382-4d16-9c01-32c0afaec57b","name":"test-function-trigger-sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"13fe8a26-d3d4-4e16-baae-78c340a727d9","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggerswlzcd1pg","registry_namespace_id":"403a9fa1-9296-4d2e-aa5e-35eaa9cd642a","secret_environment_variables":[],"status":"deleting"}'
-    headers:
-      Content-Length:
-      - "467"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 21 Dec 2023 10:03:04 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 66893ca1-7f5c-47de-b9c5-70603322ea72
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/be45f46f-5382-4d16-9c01-32c0afaec57b
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"be45f46f-5382-4d16-9c01-32c0afaec57b","name":"test-function-trigger-sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"13fe8a26-d3d4-4e16-baae-78c340a727d9","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggerswlzcd1pg","registry_namespace_id":"403a9fa1-9296-4d2e-aa5e-35eaa9cd642a","secret_environment_variables":[],"status":"deleting"}'
-    headers:
-      Content-Length:
-      - "467"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 21 Dec 2023 10:03:04 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a07fc07a-79d4-4924-8ba3-3e8d3e18f30f
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/be45f46f-5382-4d16-9c01-32c0afaec57b
-    method: GET
-  response:
-    body: '{"message":"Namespace was not found"}'
-    headers:
-      Content-Length:
-      - "37"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 21 Dec 2023 10:03:09 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 935d1201-6f6e-4002-943b-30210807b5c7
-    status: 404 Not Found
-    code: 404
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/account/v3/projects/13fe8a26-d3d4-4e16-baae-78c340a727d9
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 21 Dec 2023 10:03:10 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6dbbdd2a-c446-4a1e-9ef4-4a8e6445f977
-    status: 204 No Content
-    code: 204
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/90e1b238-7a46-420d-8bd5-fc3f73803a0d
-    method: DELETE
-  response:
-    body: '{"message":"trigger does not exist: could not find trigger with id 90e1b238-7a46-420d-8bd5-fc3f73803a0d"}'
-    headers:
-      Content-Length:
-      - "105"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 21 Dec 2023 10:03:10 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 617b2623-76f7-49eb-9293-3392404eff20
-    status: 404 Not Found
-    code: 404
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 114
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"name":"tf_tests_function_trigger_sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","description":""}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/account/v3/projects
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 244
+        uncompressed: false
+        body: '{"created_at":"2024-07-05T08:55:17.361975Z","description":"","id":"6772ce94-5880-4b12-93c3-5cc023cc1d0d","name":"tf_tests_function_trigger_sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","updated_at":"2024-07-05T08:55:17.361975Z"}'
+        headers:
+            Content-Length:
+                - "244"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:55:17 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 415c71f4-d551-47c0-8fd9-e0a8c000af8e
+        status: 200 OK
+        code: 200
+        duration: 446.089513ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/account/v3/projects/6772ce94-5880-4b12-93c3-5cc023cc1d0d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 244
+        uncompressed: false
+        body: '{"created_at":"2024-07-05T08:55:17.361975Z","description":"","id":"6772ce94-5880-4b12-93c3-5cc023cc1d0d","name":"tf_tests_function_trigger_sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","updated_at":"2024-07-05T08:55:17.361975Z"}'
+        headers:
+            Content-Length:
+                - "244"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:55:17 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 9dc61d61-6fa8-4bdf-aa88-79a9bb09339d
+        status: 200 OK
+        code: 200
+        duration: 107.92097ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 53
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"project_id":"6772ce94-5880-4b12-93c3-5cc023cc1d0d"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/activate-sqs
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 239
+        uncompressed: false
+        body: '{"created_at":"2024-07-05T08:55:17.784228054Z","project_id":"6772ce94-5880-4b12-93c3-5cc023cc1d0d","region":"fr-par","sqs_endpoint_url":"https://sqs.mnq.fr-par.scaleway.com","status":"enabled","updated_at":"2024-07-05T08:55:17.784228054Z"}'
+        headers:
+            Content-Length:
+                - "239"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:55:17 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3c3e90e5-c672-4a1a-8361-f7ed0ada9502
+        status: 200 OK
+        code: 200
+        duration: 105.877427ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-info?project_id=6772ce94-5880-4b12-93c3-5cc023cc1d0d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 233
+        uncompressed: false
+        body: '{"created_at":"2024-07-05T08:55:17.784228Z","project_id":"6772ce94-5880-4b12-93c3-5cc023cc1d0d","region":"fr-par","sqs_endpoint_url":"https://sqs.mnq.fr-par.scaleway.com","status":"enabled","updated_at":"2024-07-05T08:55:17.784228Z"}'
+        headers:
+            Content-Length:
+                - "233"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:55:17 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 2ea22257-ce93-4339-ae20-e812a731764a
+        status: 200 OK
+        code: 200
+        duration: 60.965766ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 170
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"project_id":"6772ce94-5880-4b12-93c3-5cc023cc1d0d","name":"tf-sqs-credentials-heuristic-banzai","permissions":{"can_publish":true,"can_receive":true,"can_manage":true}}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-credentials
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 473
+        uncompressed: false
+        body: '{"access_key":"dlYs0iXWGLbyg0NvrbSK","created_at":"2024-07-05T08:55:17.962801680Z","id":"a5106479-81d4-4c48-b882-b973b38cffda","name":"tf-sqs-credentials-heuristic-banzai","permissions":{"can_manage":true,"can_publish":true,"can_receive":true},"project_id":"6772ce94-5880-4b12-93c3-5cc023cc1d0d","region":"fr-par","secret_checksum":"9bf7bd00cb0fd488bd1e81144bf61445ea1d2680","secret_key":"00000000-0000-0000-0000-000000000000","updated_at":null}'
+        headers:
+            Content-Length:
+                - "473"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:55:17 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - c552fb1e-acf4-4cd8-a6a1-4d2bd3526ddc
+        status: 200 OK
+        code: 200
+        duration: 74.203585ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-credentials/a5106479-81d4-4c48-b882-b973b38cffda
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 406
+        uncompressed: false
+        body: '{"access_key":"dlYs0iXWGLbyg0NvrbSK","created_at":"2024-07-05T08:55:17.962801Z","id":"a5106479-81d4-4c48-b882-b973b38cffda","name":"tf-sqs-credentials-heuristic-banzai","permissions":{"can_manage":true,"can_publish":true,"can_receive":true},"project_id":"6772ce94-5880-4b12-93c3-5cc023cc1d0d","region":"fr-par","secret_checksum":"9bf7bd00cb0fd488bd1e81144bf61445ea1d2680","secret_key":"00000000-0000-0000-0000-000000000000","updated_at":null}'
+        headers:
+            Content-Length:
+                - "406"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:55:18 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 76cd5f52-82cb-45be-b915-288484678c69
+        status: 200 OK
+        code: 200
+        duration: 59.606611ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 149
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"name":"test-function-trigger-sqs","environment_variables":{},"project_id":"6772ce94-5880-4b12-93c3-5cc023cc1d0d","secret_environment_variables":[]}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 375
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"7afb1378-b581-4b20-a2ef-728b4880a639","name":"test-function-trigger-sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"6772ce94-5880-4b12-93c3-5cc023cc1d0d","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
+        headers:
+            Content-Length:
+                - "375"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:55:18 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - feafebf4-bcc2-4fea-9ace-d0925f7938d5
+        status: 200 OK
+        code: 200
+        duration: 315.513218ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-info?project_id=6772ce94-5880-4b12-93c3-5cc023cc1d0d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 233
+        uncompressed: false
+        body: '{"created_at":"2024-07-05T08:55:17.784228Z","project_id":"6772ce94-5880-4b12-93c3-5cc023cc1d0d","region":"fr-par","sqs_endpoint_url":"https://sqs.mnq.fr-par.scaleway.com","status":"enabled","updated_at":"2024-07-05T08:55:17.784228Z"}'
+        headers:
+            Content-Length:
+                - "233"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:55:18 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3fa8fbf0-5ad6-4a8b-91c0-bf38bfecc693
+        status: 200 OK
+        code: 200
+        duration: 46.919957ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7afb1378-b581-4b20-a2ef-728b4880a639
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 375
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"7afb1378-b581-4b20-a2ef-728b4880a639","name":"test-function-trigger-sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"6772ce94-5880-4b12-93c3-5cc023cc1d0d","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
+        headers:
+            Content-Length:
+                - "375"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:55:18 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 44cb8672-54d5-4313-b5c1-36e04c491778
+        status: 200 OK
+        code: 200
+        duration: 60.837725ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 129
+        transfer_encoding: []
+        trailer: {}
+        host: sqs.mnq.fr-par.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"Attributes":{"MaximumMessageSize":"262144","MessageRetentionPeriod":"345600","VisibilityTimeout":"30"},"QueueName":"TestQueue"}'
+        form: {}
+        headers:
+            Content-Length:
+                - "129"
+            Content-Type:
+                - application/x-amz-json-1.0
+            User-Agent:
+                - aws-sdk-go/1.54.12 (go1.22.2; linux; amd64)
+            X-Amz-Date:
+                - 20240705T085518Z
+            X-Amz-Target:
+                - AmazonSQS.CreateQueue
+        url: https://sqs.mnq.fr-par.scaleway.com/
+        method: POST
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        transfer_encoding: []
+        trailer: {}
+        content_length: 105
+        uncompressed: false
+        body: '{"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-6772ce94-5880-4b12-93c3-5cc023cc1d0d/TestQueue"}'
+        headers:
+            Content-Length:
+                - "105"
+            Content-Type:
+                - application/x-amz-json-1.0; charset=utf-8
+            Date:
+                - Fri, 05 Jul 2024 08:55:18 GMT
+            X-Amzn-Requestid:
+                - tx7b0e019d-84c9-4625-bfa0-4a0915096d1c
+        status: 200 OK
+        code: 200
+        duration: 952.561705ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 25
+        transfer_encoding: []
+        trailer: {}
+        host: sqs.mnq.fr-par.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"QueueName":"TestQueue"}'
+        form: {}
+        headers:
+            Content-Length:
+                - "25"
+            Content-Type:
+                - application/x-amz-json-1.0
+            User-Agent:
+                - aws-sdk-go/1.54.12 (go1.22.2; linux; amd64)
+            X-Amz-Date:
+                - 20240705T085519Z
+            X-Amz-Target:
+                - AmazonSQS.GetQueueUrl
+        url: https://sqs.mnq.fr-par.scaleway.com/
+        method: POST
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        transfer_encoding: []
+        trailer: {}
+        content_length: 105
+        uncompressed: false
+        body: '{"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-6772ce94-5880-4b12-93c3-5cc023cc1d0d/TestQueue"}'
+        headers:
+            Content-Length:
+                - "105"
+            Content-Type:
+                - application/x-amz-json-1.0; charset=utf-8
+            Date:
+                - Fri, 05 Jul 2024 08:55:19 GMT
+            X-Amzn-Requestid:
+                - txf508985d-6c00-4f5b-9cfe-01cbb28baf25
+        status: 200 OK
+        code: 200
+        duration: 28.138596ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 262
+        transfer_encoding: []
+        trailer: {}
+        host: sqs.mnq.fr-par.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"AttributeNames":["MaximumMessageSize","MessageRetentionPeriod","FifoQueue","ContentBasedDeduplication","ReceiveMessageWaitTimeSeconds","VisibilityTimeout"],"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-6772ce94-5880-4b12-93c3-5cc023cc1d0d/TestQueue"}'
+        form: {}
+        headers:
+            Content-Length:
+                - "262"
+            Content-Type:
+                - application/x-amz-json-1.0
+            User-Agent:
+                - aws-sdk-go/1.54.12 (go1.22.2; linux; amd64)
+            X-Amz-Date:
+                - 20240705T085519Z
+            X-Amz-Target:
+                - AmazonSQS.GetQueueAttributes
+        url: https://sqs.mnq.fr-par.scaleway.com/
+        method: POST
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        transfer_encoding: []
+        trailer: {}
+        content_length: 141
+        uncompressed: false
+        body: '{"Attributes":{"MaximumMessageSize":"262144","MessageRetentionPeriod":"345600","ReceiveMessageWaitTimeSeconds":"0","VisibilityTimeout":"30"}}'
+        headers:
+            Content-Length:
+                - "141"
+            Content-Type:
+                - application/x-amz-json-1.0; charset=utf-8
+            Date:
+                - Fri, 05 Jul 2024 08:55:19 GMT
+            X-Amzn-Requestid:
+                - txaf1df908-bf73-46e9-8354-ff3879c35af9
+        status: 200 OK
+        code: 200
+        duration: 23.371212ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7afb1378-b581-4b20-a2ef-728b4880a639
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 464
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"7afb1378-b581-4b20-a2ef-728b4880a639","name":"test-function-trigger-sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"6772ce94-5880-4b12-93c3-5cc023cc1d0d","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggers92ysz3ef","registry_namespace_id":"121e1254-08b2-4cdb-a4ec-8c2943a42cf7","secret_environment_variables":[],"status":"ready"}'
+        headers:
+            Content-Length:
+                - "464"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:55:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - a14b099f-8f00-4d03-aff0-4908c329bcaa
+        status: 200 OK
+        code: 200
+        duration: 57.347713ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7afb1378-b581-4b20-a2ef-728b4880a639
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 464
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"7afb1378-b581-4b20-a2ef-728b4880a639","name":"test-function-trigger-sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"6772ce94-5880-4b12-93c3-5cc023cc1d0d","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggers92ysz3ef","registry_namespace_id":"121e1254-08b2-4cdb-a4ec-8c2943a42cf7","secret_environment_variables":[],"status":"ready"}'
+        headers:
+            Content-Length:
+                - "464"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:55:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b3300df3-ced5-4c76-a3d5-b648ab98db41
+        status: 200 OK
+        code: 200
+        duration: 57.435739ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 317
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"name":"test-function-trigger-sqs","namespace_id":"7afb1378-b581-4b20-a2ef-728b4880a639","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"node22","memory_limit":256,"handler":"handler.handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 600
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"testfunctiontriggers92ysz3ef-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"a0daf564-a5ac-4efd-b92e-b3362f267f77","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"7afb1378-b581-4b20-a2ef-728b4880a639","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "600"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:55:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 4f40274a-46f8-4dbe-9e41-8ada493ff177
+        status: 200 OK
+        code: 200
+        duration: 248.931392ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/a0daf564-a5ac-4efd-b92e-b3362f267f77
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 600
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"testfunctiontriggers92ysz3ef-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"a0daf564-a5ac-4efd-b92e-b3362f267f77","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"7afb1378-b581-4b20-a2ef-728b4880a639","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "600"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:55:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - a990da25-23a6-4dbf-87ca-cbe8d94bc188
+        status: 200 OK
+        code: 200
+        duration: 66.803792ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/a0daf564-a5ac-4efd-b92e-b3362f267f77
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 600
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"testfunctiontriggers92ysz3ef-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"a0daf564-a5ac-4efd-b92e-b3362f267f77","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"7afb1378-b581-4b20-a2ef-728b4880a639","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "600"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:55:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 6ffcfa4c-6e02-49c2-9f59-6277774bb7b7
+        status: 200 OK
+        code: 200
+        duration: 81.84375ms
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 206
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"name":"test-function-trigger-sqs","function_id":"a0daf564-a5ac-4efd-b92e-b3362f267f77","scw_sqs_config":{"queue":"TestQueue","mnq_project_id":"6772ce94-5880-4b12-93c3-5cc023cc1d0d","mnq_region":"fr-par"}}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 356
+        uncompressed: false
+        body: '{"description":"","error_message":null,"function_id":"a0daf564-a5ac-4efd-b92e-b3362f267f77","id":"f8cd86ed-8ced-414b-a383-7b97934ffd8b","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":null,"mnq_project_id":"6772ce94-5880-4b12-93c3-5cc023cc1d0d","mnq_region":"fr-par","queue":"TestQueue"},"status":"creating"}'
+        headers:
+            Content-Length:
+                - "356"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:55:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 46261a3a-1345-41bd-b0e3-75e4ae748076
+        status: 200 OK
+        code: 200
+        duration: 222.321953ms
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/f8cd86ed-8ced-414b-a383-7b97934ffd8b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 356
+        uncompressed: false
+        body: '{"description":"","error_message":null,"function_id":"a0daf564-a5ac-4efd-b92e-b3362f267f77","id":"f8cd86ed-8ced-414b-a383-7b97934ffd8b","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":null,"mnq_project_id":"6772ce94-5880-4b12-93c3-5cc023cc1d0d","mnq_region":"fr-par","queue":"TestQueue"},"status":"creating"}'
+        headers:
+            Content-Length:
+                - "356"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:55:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f7fe2167-3e95-4bdc-9c34-db9c621474f4
+        status: 200 OK
+        code: 200
+        duration: 83.32261ms
+    - id: 19
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/f8cd86ed-8ced-414b-a383-7b97934ffd8b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 390
+        uncompressed: false
+        body: '{"description":"","error_message":null,"function_id":"a0daf564-a5ac-4efd-b92e-b3362f267f77","id":"f8cd86ed-8ced-414b-a383-7b97934ffd8b","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"61efab41-1f7f-47a3-8848-6d411e416d49","mnq_project_id":"6772ce94-5880-4b12-93c3-5cc023cc1d0d","mnq_region":"fr-par","queue":"TestQueue"},"status":"creating"}'
+        headers:
+            Content-Length:
+                - "390"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:55:29 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 0fb818ff-ed47-44f6-8d03-fd40b034e016
+        status: 200 OK
+        code: 200
+        duration: 63.087475ms
+    - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/f8cd86ed-8ced-414b-a383-7b97934ffd8b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 390
+        uncompressed: false
+        body: '{"description":"","error_message":null,"function_id":"a0daf564-a5ac-4efd-b92e-b3362f267f77","id":"f8cd86ed-8ced-414b-a383-7b97934ffd8b","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"61efab41-1f7f-47a3-8848-6d411e416d49","mnq_project_id":"6772ce94-5880-4b12-93c3-5cc023cc1d0d","mnq_region":"fr-par","queue":"TestQueue"},"status":"creating"}'
+        headers:
+            Content-Length:
+                - "390"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:55:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 0907e2fe-3544-426e-80c7-753dca5cc6c5
+        status: 200 OK
+        code: 200
+        duration: 85.11477ms
+    - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/f8cd86ed-8ced-414b-a383-7b97934ffd8b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 387
+        uncompressed: false
+        body: '{"description":"","error_message":null,"function_id":"a0daf564-a5ac-4efd-b92e-b3362f267f77","id":"f8cd86ed-8ced-414b-a383-7b97934ffd8b","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"61efab41-1f7f-47a3-8848-6d411e416d49","mnq_project_id":"6772ce94-5880-4b12-93c3-5cc023cc1d0d","mnq_region":"fr-par","queue":"TestQueue"},"status":"ready"}'
+        headers:
+            Content-Length:
+                - "387"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:55:39 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - d4d649b4-4d4a-4897-8382-c86f61e31a2a
+        status: 200 OK
+        code: 200
+        duration: 103.013533ms
+    - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/f8cd86ed-8ced-414b-a383-7b97934ffd8b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 387
+        uncompressed: false
+        body: '{"description":"","error_message":null,"function_id":"a0daf564-a5ac-4efd-b92e-b3362f267f77","id":"f8cd86ed-8ced-414b-a383-7b97934ffd8b","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"61efab41-1f7f-47a3-8848-6d411e416d49","mnq_project_id":"6772ce94-5880-4b12-93c3-5cc023cc1d0d","mnq_region":"fr-par","queue":"TestQueue"},"status":"ready"}'
+        headers:
+            Content-Length:
+                - "387"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:55:39 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - bd69df10-f5d3-469a-af64-20667311f2b9
+        status: 200 OK
+        code: 200
+        duration: 87.309877ms
+    - id: 23
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/f8cd86ed-8ced-414b-a383-7b97934ffd8b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 387
+        uncompressed: false
+        body: '{"description":"","error_message":null,"function_id":"a0daf564-a5ac-4efd-b92e-b3362f267f77","id":"f8cd86ed-8ced-414b-a383-7b97934ffd8b","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"61efab41-1f7f-47a3-8848-6d411e416d49","mnq_project_id":"6772ce94-5880-4b12-93c3-5cc023cc1d0d","mnq_region":"fr-par","queue":"TestQueue"},"status":"ready"}'
+        headers:
+            Content-Length:
+                - "387"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:55:39 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f98e2d44-538a-402d-a5e1-0706383cb64a
+        status: 200 OK
+        code: 200
+        duration: 88.682909ms
+    - id: 24
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/f8cd86ed-8ced-414b-a383-7b97934ffd8b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 387
+        uncompressed: false
+        body: '{"description":"","error_message":null,"function_id":"a0daf564-a5ac-4efd-b92e-b3362f267f77","id":"f8cd86ed-8ced-414b-a383-7b97934ffd8b","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"61efab41-1f7f-47a3-8848-6d411e416d49","mnq_project_id":"6772ce94-5880-4b12-93c3-5cc023cc1d0d","mnq_region":"fr-par","queue":"TestQueue"},"status":"ready"}'
+        headers:
+            Content-Length:
+                - "387"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:55:39 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 9dad538d-54a7-4ef9-bcb3-2e87632556fb
+        status: 200 OK
+        code: 200
+        duration: 65.812098ms
+    - id: 25
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/account/v3/projects/6772ce94-5880-4b12-93c3-5cc023cc1d0d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 244
+        uncompressed: false
+        body: '{"created_at":"2024-07-05T08:55:17.361975Z","description":"","id":"6772ce94-5880-4b12-93c3-5cc023cc1d0d","name":"tf_tests_function_trigger_sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","updated_at":"2024-07-05T08:55:17.361975Z"}'
+        headers:
+            Content-Length:
+                - "244"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:55:40 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 97b6399a-f479-4601-8ab3-470658df4613
+        status: 200 OK
+        code: 200
+        duration: 94.165808ms
+    - id: 26
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-info?project_id=6772ce94-5880-4b12-93c3-5cc023cc1d0d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 233
+        uncompressed: false
+        body: '{"created_at":"2024-07-05T08:55:17.784228Z","project_id":"6772ce94-5880-4b12-93c3-5cc023cc1d0d","region":"fr-par","sqs_endpoint_url":"https://sqs.mnq.fr-par.scaleway.com","status":"enabled","updated_at":"2024-07-05T08:55:17.784228Z"}'
+        headers:
+            Content-Length:
+                - "233"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:55:40 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - eeed0d87-5998-4294-956b-49ad14715a48
+        status: 200 OK
+        code: 200
+        duration: 49.329618ms
+    - id: 27
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7afb1378-b581-4b20-a2ef-728b4880a639
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 464
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"7afb1378-b581-4b20-a2ef-728b4880a639","name":"test-function-trigger-sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"6772ce94-5880-4b12-93c3-5cc023cc1d0d","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggers92ysz3ef","registry_namespace_id":"121e1254-08b2-4cdb-a4ec-8c2943a42cf7","secret_environment_variables":[],"status":"ready"}'
+        headers:
+            Content-Length:
+                - "464"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:55:40 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ba215185-8da9-4f6e-b129-64baf292a4ac
+        status: 200 OK
+        code: 200
+        duration: 61.625707ms
+    - id: 28
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-credentials/a5106479-81d4-4c48-b882-b973b38cffda
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 406
+        uncompressed: false
+        body: '{"access_key":"dlYs0iXWGLbyg0NvrbSK","created_at":"2024-07-05T08:55:17.962801Z","id":"a5106479-81d4-4c48-b882-b973b38cffda","name":"tf-sqs-credentials-heuristic-banzai","permissions":{"can_manage":true,"can_publish":true,"can_receive":true},"project_id":"6772ce94-5880-4b12-93c3-5cc023cc1d0d","region":"fr-par","secret_checksum":"9bf7bd00cb0fd488bd1e81144bf61445ea1d2680","secret_key":"00000000-0000-0000-0000-000000000000","updated_at":null}'
+        headers:
+            Content-Length:
+                - "406"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:55:40 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e9841af7-8029-4b46-8489-cc164fbc1502
+        status: 200 OK
+        code: 200
+        duration: 57.838796ms
+    - id: 29
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 25
+        transfer_encoding: []
+        trailer: {}
+        host: sqs.mnq.fr-par.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"QueueName":"TestQueue"}'
+        form: {}
+        headers:
+            Content-Length:
+                - "25"
+            Content-Type:
+                - application/x-amz-json-1.0
+            User-Agent:
+                - aws-sdk-go/1.54.12 (go1.22.2; linux; amd64)
+            X-Amz-Date:
+                - 20240705T085540Z
+            X-Amz-Target:
+                - AmazonSQS.GetQueueUrl
+        url: https://sqs.mnq.fr-par.scaleway.com/
+        method: POST
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        transfer_encoding: []
+        trailer: {}
+        content_length: 105
+        uncompressed: false
+        body: '{"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-6772ce94-5880-4b12-93c3-5cc023cc1d0d/TestQueue"}'
+        headers:
+            Content-Length:
+                - "105"
+            Content-Type:
+                - application/x-amz-json-1.0; charset=utf-8
+            Date:
+                - Fri, 05 Jul 2024 08:55:40 GMT
+            X-Amzn-Requestid:
+                - txc8230a3d-2183-4c60-8372-ad2f78678e96
+        status: 200 OK
+        code: 200
+        duration: 17.914102ms
+    - id: 30
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/a0daf564-a5ac-4efd-b92e-b3362f267f77
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 600
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"testfunctiontriggers92ysz3ef-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"a0daf564-a5ac-4efd-b92e-b3362f267f77","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"7afb1378-b581-4b20-a2ef-728b4880a639","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "600"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:55:40 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 76efc888-ded3-4ebe-aedc-e11133817f2a
+        status: 200 OK
+        code: 200
+        duration: 78.216991ms
+    - id: 31
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 262
+        transfer_encoding: []
+        trailer: {}
+        host: sqs.mnq.fr-par.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"AttributeNames":["MaximumMessageSize","MessageRetentionPeriod","FifoQueue","ContentBasedDeduplication","ReceiveMessageWaitTimeSeconds","VisibilityTimeout"],"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-6772ce94-5880-4b12-93c3-5cc023cc1d0d/TestQueue"}'
+        form: {}
+        headers:
+            Content-Length:
+                - "262"
+            Content-Type:
+                - application/x-amz-json-1.0
+            User-Agent:
+                - aws-sdk-go/1.54.12 (go1.22.2; linux; amd64)
+            X-Amz-Date:
+                - 20240705T085540Z
+            X-Amz-Target:
+                - AmazonSQS.GetQueueAttributes
+        url: https://sqs.mnq.fr-par.scaleway.com/
+        method: POST
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        transfer_encoding: []
+        trailer: {}
+        content_length: 141
+        uncompressed: false
+        body: '{"Attributes":{"MaximumMessageSize":"262144","MessageRetentionPeriod":"345600","ReceiveMessageWaitTimeSeconds":"0","VisibilityTimeout":"30"}}'
+        headers:
+            Content-Length:
+                - "141"
+            Content-Type:
+                - application/x-amz-json-1.0; charset=utf-8
+            Date:
+                - Fri, 05 Jul 2024 08:55:40 GMT
+            X-Amzn-Requestid:
+                - tx5790d4b9-a536-42f6-a538-c4358c91caa1
+        status: 200 OK
+        code: 200
+        duration: 21.149995ms
+    - id: 32
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/f8cd86ed-8ced-414b-a383-7b97934ffd8b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 387
+        uncompressed: false
+        body: '{"description":"","error_message":null,"function_id":"a0daf564-a5ac-4efd-b92e-b3362f267f77","id":"f8cd86ed-8ced-414b-a383-7b97934ffd8b","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"61efab41-1f7f-47a3-8848-6d411e416d49","mnq_project_id":"6772ce94-5880-4b12-93c3-5cc023cc1d0d","mnq_region":"fr-par","queue":"TestQueue"},"status":"ready"}'
+        headers:
+            Content-Length:
+                - "387"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:55:40 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 127978f1-b656-4ff8-b456-659060d24a4c
+        status: 200 OK
+        code: 200
+        duration: 63.501032ms
+    - id: 33
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/account/v3/projects/6772ce94-5880-4b12-93c3-5cc023cc1d0d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 244
+        uncompressed: false
+        body: '{"created_at":"2024-07-05T08:55:17.361975Z","description":"","id":"6772ce94-5880-4b12-93c3-5cc023cc1d0d","name":"tf_tests_function_trigger_sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","updated_at":"2024-07-05T08:55:17.361975Z"}'
+        headers:
+            Content-Length:
+                - "244"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:55:40 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 07244f07-6268-4b3a-accc-c29ab3e0374e
+        status: 200 OK
+        code: 200
+        duration: 74.827649ms
+    - id: 34
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7afb1378-b581-4b20-a2ef-728b4880a639
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 464
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"7afb1378-b581-4b20-a2ef-728b4880a639","name":"test-function-trigger-sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"6772ce94-5880-4b12-93c3-5cc023cc1d0d","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggers92ysz3ef","registry_namespace_id":"121e1254-08b2-4cdb-a4ec-8c2943a42cf7","secret_environment_variables":[],"status":"ready"}'
+        headers:
+            Content-Length:
+                - "464"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:55:40 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - a818a3c1-a9dc-4b46-9e89-9e06d76a438c
+        status: 200 OK
+        code: 200
+        duration: 55.6068ms
+    - id: 35
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-info?project_id=6772ce94-5880-4b12-93c3-5cc023cc1d0d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 233
+        uncompressed: false
+        body: '{"created_at":"2024-07-05T08:55:17.784228Z","project_id":"6772ce94-5880-4b12-93c3-5cc023cc1d0d","region":"fr-par","sqs_endpoint_url":"https://sqs.mnq.fr-par.scaleway.com","status":"enabled","updated_at":"2024-07-05T08:55:17.784228Z"}'
+        headers:
+            Content-Length:
+                - "233"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:55:40 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 467e462d-8b73-4585-8d56-1eafc1247b66
+        status: 200 OK
+        code: 200
+        duration: 59.122561ms
+    - id: 36
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/a0daf564-a5ac-4efd-b92e-b3362f267f77
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 600
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"testfunctiontriggers92ysz3ef-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"a0daf564-a5ac-4efd-b92e-b3362f267f77","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"7afb1378-b581-4b20-a2ef-728b4880a639","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "600"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:55:41 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 7b3c3669-246c-4541-8a25-214e2e705d91
+        status: 200 OK
+        code: 200
+        duration: 63.499359ms
+    - id: 37
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-credentials/a5106479-81d4-4c48-b882-b973b38cffda
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 406
+        uncompressed: false
+        body: '{"access_key":"dlYs0iXWGLbyg0NvrbSK","created_at":"2024-07-05T08:55:17.962801Z","id":"a5106479-81d4-4c48-b882-b973b38cffda","name":"tf-sqs-credentials-heuristic-banzai","permissions":{"can_manage":true,"can_publish":true,"can_receive":true},"project_id":"6772ce94-5880-4b12-93c3-5cc023cc1d0d","region":"fr-par","secret_checksum":"9bf7bd00cb0fd488bd1e81144bf61445ea1d2680","secret_key":"00000000-0000-0000-0000-000000000000","updated_at":null}'
+        headers:
+            Content-Length:
+                - "406"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:55:41 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f9ad89fb-d473-42cd-a545-e9edddcf4098
+        status: 200 OK
+        code: 200
+        duration: 66.674469ms
+    - id: 38
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 25
+        transfer_encoding: []
+        trailer: {}
+        host: sqs.mnq.fr-par.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"QueueName":"TestQueue"}'
+        form: {}
+        headers:
+            Content-Length:
+                - "25"
+            Content-Type:
+                - application/x-amz-json-1.0
+            User-Agent:
+                - aws-sdk-go/1.54.12 (go1.22.2; linux; amd64)
+            X-Amz-Date:
+                - 20240705T085541Z
+            X-Amz-Target:
+                - AmazonSQS.GetQueueUrl
+        url: https://sqs.mnq.fr-par.scaleway.com/
+        method: POST
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        transfer_encoding: []
+        trailer: {}
+        content_length: 105
+        uncompressed: false
+        body: '{"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-6772ce94-5880-4b12-93c3-5cc023cc1d0d/TestQueue"}'
+        headers:
+            Content-Length:
+                - "105"
+            Content-Type:
+                - application/x-amz-json-1.0; charset=utf-8
+            Date:
+                - Fri, 05 Jul 2024 08:55:41 GMT
+            X-Amzn-Requestid:
+                - txb9bb61f4-fbb4-4ea7-909e-3de8fcfe2b8e
+        status: 200 OK
+        code: 200
+        duration: 20.017626ms
+    - id: 39
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 262
+        transfer_encoding: []
+        trailer: {}
+        host: sqs.mnq.fr-par.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"AttributeNames":["MaximumMessageSize","MessageRetentionPeriod","FifoQueue","ContentBasedDeduplication","ReceiveMessageWaitTimeSeconds","VisibilityTimeout"],"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-6772ce94-5880-4b12-93c3-5cc023cc1d0d/TestQueue"}'
+        form: {}
+        headers:
+            Content-Length:
+                - "262"
+            Content-Type:
+                - application/x-amz-json-1.0
+            User-Agent:
+                - aws-sdk-go/1.54.12 (go1.22.2; linux; amd64)
+            X-Amz-Date:
+                - 20240705T085541Z
+            X-Amz-Target:
+                - AmazonSQS.GetQueueAttributes
+        url: https://sqs.mnq.fr-par.scaleway.com/
+        method: POST
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        transfer_encoding: []
+        trailer: {}
+        content_length: 141
+        uncompressed: false
+        body: '{"Attributes":{"MaximumMessageSize":"262144","MessageRetentionPeriod":"345600","ReceiveMessageWaitTimeSeconds":"0","VisibilityTimeout":"30"}}'
+        headers:
+            Content-Length:
+                - "141"
+            Content-Type:
+                - application/x-amz-json-1.0; charset=utf-8
+            Date:
+                - Fri, 05 Jul 2024 08:55:41 GMT
+            X-Amzn-Requestid:
+                - tx4e6bdd3b-7c9c-41ab-9532-2c6d6997d32e
+        status: 200 OK
+        code: 200
+        duration: 22.500425ms
+    - id: 40
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/f8cd86ed-8ced-414b-a383-7b97934ffd8b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 387
+        uncompressed: false
+        body: '{"description":"","error_message":null,"function_id":"a0daf564-a5ac-4efd-b92e-b3362f267f77","id":"f8cd86ed-8ced-414b-a383-7b97934ffd8b","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"61efab41-1f7f-47a3-8848-6d411e416d49","mnq_project_id":"6772ce94-5880-4b12-93c3-5cc023cc1d0d","mnq_region":"fr-par","queue":"TestQueue"},"status":"ready"}'
+        headers:
+            Content-Length:
+                - "387"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:55:41 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 7d2b9aee-127b-436f-9da3-cdeb458d764c
+        status: 200 OK
+        code: 200
+        duration: 71.911365ms
+    - id: 41
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/account/v3/projects/6772ce94-5880-4b12-93c3-5cc023cc1d0d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 244
+        uncompressed: false
+        body: '{"created_at":"2024-07-05T08:55:17.361975Z","description":"","id":"6772ce94-5880-4b12-93c3-5cc023cc1d0d","name":"tf_tests_function_trigger_sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","updated_at":"2024-07-05T08:55:17.361975Z"}'
+        headers:
+            Content-Length:
+                - "244"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:55:41 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - a3151e2f-6b3d-4e4d-ba20-774dd0145923
+        status: 200 OK
+        code: 200
+        duration: 73.87113ms
+    - id: 42
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7afb1378-b581-4b20-a2ef-728b4880a639
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 464
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"7afb1378-b581-4b20-a2ef-728b4880a639","name":"test-function-trigger-sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"6772ce94-5880-4b12-93c3-5cc023cc1d0d","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggers92ysz3ef","registry_namespace_id":"121e1254-08b2-4cdb-a4ec-8c2943a42cf7","secret_environment_variables":[],"status":"ready"}'
+        headers:
+            Content-Length:
+                - "464"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:55:41 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 99407186-2ca6-4f23-bb2c-6cbab2f72405
+        status: 200 OK
+        code: 200
+        duration: 66.213383ms
+    - id: 43
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-info?project_id=6772ce94-5880-4b12-93c3-5cc023cc1d0d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 233
+        uncompressed: false
+        body: '{"created_at":"2024-07-05T08:55:17.784228Z","project_id":"6772ce94-5880-4b12-93c3-5cc023cc1d0d","region":"fr-par","sqs_endpoint_url":"https://sqs.mnq.fr-par.scaleway.com","status":"enabled","updated_at":"2024-07-05T08:55:17.784228Z"}'
+        headers:
+            Content-Length:
+                - "233"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:55:41 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - a7ced675-43d6-4c4c-95d6-e1c695daff74
+        status: 200 OK
+        code: 200
+        duration: 65.921003ms
+    - id: 44
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-credentials/a5106479-81d4-4c48-b882-b973b38cffda
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 406
+        uncompressed: false
+        body: '{"access_key":"dlYs0iXWGLbyg0NvrbSK","created_at":"2024-07-05T08:55:17.962801Z","id":"a5106479-81d4-4c48-b882-b973b38cffda","name":"tf-sqs-credentials-heuristic-banzai","permissions":{"can_manage":true,"can_publish":true,"can_receive":true},"project_id":"6772ce94-5880-4b12-93c3-5cc023cc1d0d","region":"fr-par","secret_checksum":"9bf7bd00cb0fd488bd1e81144bf61445ea1d2680","secret_key":"00000000-0000-0000-0000-000000000000","updated_at":null}'
+        headers:
+            Content-Length:
+                - "406"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:55:41 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b153c702-c3d5-4220-a41e-8dcd26065d0a
+        status: 200 OK
+        code: 200
+        duration: 59.858123ms
+    - id: 45
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/a0daf564-a5ac-4efd-b92e-b3362f267f77
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 600
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"testfunctiontriggers92ysz3ef-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"a0daf564-a5ac-4efd-b92e-b3362f267f77","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"7afb1378-b581-4b20-a2ef-728b4880a639","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "600"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:55:41 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 7ea927f7-d818-44ae-8b6d-396e8a18d8bd
+        status: 200 OK
+        code: 200
+        duration: 64.097935ms
+    - id: 46
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 25
+        transfer_encoding: []
+        trailer: {}
+        host: sqs.mnq.fr-par.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"QueueName":"TestQueue"}'
+        form: {}
+        headers:
+            Content-Length:
+                - "25"
+            Content-Type:
+                - application/x-amz-json-1.0
+            User-Agent:
+                - aws-sdk-go/1.54.12 (go1.22.2; linux; amd64)
+            X-Amz-Date:
+                - 20240705T085541Z
+            X-Amz-Target:
+                - AmazonSQS.GetQueueUrl
+        url: https://sqs.mnq.fr-par.scaleway.com/
+        method: POST
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        transfer_encoding: []
+        trailer: {}
+        content_length: 105
+        uncompressed: false
+        body: '{"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-6772ce94-5880-4b12-93c3-5cc023cc1d0d/TestQueue"}'
+        headers:
+            Content-Length:
+                - "105"
+            Content-Type:
+                - application/x-amz-json-1.0; charset=utf-8
+            Date:
+                - Fri, 05 Jul 2024 08:55:41 GMT
+            X-Amzn-Requestid:
+                - txa72e7d02-aeee-4ad4-aca6-039a7e774e5c
+        status: 200 OK
+        code: 200
+        duration: 24.385359ms
+    - id: 47
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 262
+        transfer_encoding: []
+        trailer: {}
+        host: sqs.mnq.fr-par.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"AttributeNames":["MaximumMessageSize","MessageRetentionPeriod","FifoQueue","ContentBasedDeduplication","ReceiveMessageWaitTimeSeconds","VisibilityTimeout"],"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-6772ce94-5880-4b12-93c3-5cc023cc1d0d/TestQueue"}'
+        form: {}
+        headers:
+            Content-Length:
+                - "262"
+            Content-Type:
+                - application/x-amz-json-1.0
+            User-Agent:
+                - aws-sdk-go/1.54.12 (go1.22.2; linux; amd64)
+            X-Amz-Date:
+                - 20240705T085541Z
+            X-Amz-Target:
+                - AmazonSQS.GetQueueAttributes
+        url: https://sqs.mnq.fr-par.scaleway.com/
+        method: POST
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        transfer_encoding: []
+        trailer: {}
+        content_length: 141
+        uncompressed: false
+        body: '{"Attributes":{"MaximumMessageSize":"262144","MessageRetentionPeriod":"345600","ReceiveMessageWaitTimeSeconds":"0","VisibilityTimeout":"30"}}'
+        headers:
+            Content-Length:
+                - "141"
+            Content-Type:
+                - application/x-amz-json-1.0; charset=utf-8
+            Date:
+                - Fri, 05 Jul 2024 08:55:41 GMT
+            X-Amzn-Requestid:
+                - txd0b3cc63-9e9c-47ce-8573-d64e7463bc98
+        status: 200 OK
+        code: 200
+        duration: 35.534722ms
+    - id: 48
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/f8cd86ed-8ced-414b-a383-7b97934ffd8b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 387
+        uncompressed: false
+        body: '{"description":"","error_message":null,"function_id":"a0daf564-a5ac-4efd-b92e-b3362f267f77","id":"f8cd86ed-8ced-414b-a383-7b97934ffd8b","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"61efab41-1f7f-47a3-8848-6d411e416d49","mnq_project_id":"6772ce94-5880-4b12-93c3-5cc023cc1d0d","mnq_region":"fr-par","queue":"TestQueue"},"status":"ready"}'
+        headers:
+            Content-Length:
+                - "387"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:55:41 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ad387fdf-fd2d-468f-beb6-6a74fbaf5f87
+        status: 200 OK
+        code: 200
+        duration: 84.341256ms
+    - id: 49
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 25
+        transfer_encoding: []
+        trailer: {}
+        host: sqs.mnq.fr-par.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"QueueName":"TestQueue"}'
+        form: {}
+        headers:
+            Content-Length:
+                - "25"
+            Content-Type:
+                - application/x-amz-json-1.0
+            User-Agent:
+                - aws-sdk-go/1.54.12 (go1.22.2; linux; amd64)
+            X-Amz-Date:
+                - 20240705T085542Z
+            X-Amz-Target:
+                - AmazonSQS.GetQueueUrl
+        url: https://sqs.mnq.fr-par.scaleway.com/
+        method: POST
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        transfer_encoding: []
+        trailer: {}
+        content_length: 105
+        uncompressed: false
+        body: '{"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-6772ce94-5880-4b12-93c3-5cc023cc1d0d/TestQueue"}'
+        headers:
+            Content-Length:
+                - "105"
+            Content-Type:
+                - application/x-amz-json-1.0; charset=utf-8
+            Date:
+                - Fri, 05 Jul 2024 08:55:42 GMT
+            X-Amzn-Requestid:
+                - tx3c096be8-99f1-46c0-a821-7d953b67f498
+        status: 200 OK
+        code: 200
+        duration: 23.109059ms
+    - id: 50
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/f8cd86ed-8ced-414b-a383-7b97934ffd8b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 387
+        uncompressed: false
+        body: '{"description":"","error_message":null,"function_id":"a0daf564-a5ac-4efd-b92e-b3362f267f77","id":"f8cd86ed-8ced-414b-a383-7b97934ffd8b","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"61efab41-1f7f-47a3-8848-6d411e416d49","mnq_project_id":"6772ce94-5880-4b12-93c3-5cc023cc1d0d","mnq_region":"fr-par","queue":"TestQueue"},"status":"ready"}'
+        headers:
+            Content-Length:
+                - "387"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:55:42 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b056b7f2-ab4d-4d51-92f5-aa390a539e50
+        status: 200 OK
+        code: 200
+        duration: 77.958165ms
+    - id: 51
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/f8cd86ed-8ced-414b-a383-7b97934ffd8b
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 390
+        uncompressed: false
+        body: '{"description":"","error_message":null,"function_id":"a0daf564-a5ac-4efd-b92e-b3362f267f77","id":"f8cd86ed-8ced-414b-a383-7b97934ffd8b","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"61efab41-1f7f-47a3-8848-6d411e416d49","mnq_project_id":"6772ce94-5880-4b12-93c3-5cc023cc1d0d","mnq_region":"fr-par","queue":"TestQueue"},"status":"deleting"}'
+        headers:
+            Content-Length:
+                - "390"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:55:42 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e4b6933e-2d3f-497c-9eac-afe6df31ecec
+        status: 200 OK
+        code: 200
+        duration: 120.206458ms
+    - id: 52
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 105
+        transfer_encoding: []
+        trailer: {}
+        host: sqs.mnq.fr-par.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-6772ce94-5880-4b12-93c3-5cc023cc1d0d/TestQueue"}'
+        form: {}
+        headers:
+            Content-Length:
+                - "105"
+            Content-Type:
+                - application/x-amz-json-1.0
+            User-Agent:
+                - aws-sdk-go/1.54.12 (go1.22.2; linux; amd64)
+            X-Amz-Date:
+                - 20240705T085542Z
+            X-Amz-Target:
+                - AmazonSQS.DeleteQueue
+        url: https://sqs.mnq.fr-par.scaleway.com/
+        method: POST
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Length:
+                - "0"
+            Content-Type:
+                - application/x-amz-json-1.0; charset=utf-8
+            Date:
+                - Fri, 05 Jul 2024 08:55:42 GMT
+            X-Amzn-Requestid:
+                - txf637edcc-f69d-4d6b-b3e3-0cb561a8bf50
+        status: 200 OK
+        code: 200
+        duration: 248.516963ms
+    - id: 53
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/f8cd86ed-8ced-414b-a383-7b97934ffd8b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 390
+        uncompressed: false
+        body: '{"description":"","error_message":null,"function_id":"a0daf564-a5ac-4efd-b92e-b3362f267f77","id":"f8cd86ed-8ced-414b-a383-7b97934ffd8b","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"61efab41-1f7f-47a3-8848-6d411e416d49","mnq_project_id":"6772ce94-5880-4b12-93c3-5cc023cc1d0d","mnq_region":"fr-par","queue":"TestQueue"},"status":"deleting"}'
+        headers:
+            Content-Length:
+                - "390"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:55:42 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e40bfe16-2133-4ba1-b7f1-0ffc3a457345
+        status: 200 OK
+        code: 200
+        duration: 84.782996ms
+    - id: 54
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 25
+        transfer_encoding: []
+        trailer: {}
+        host: sqs.mnq.fr-par.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"QueueName":"TestQueue"}'
+        form: {}
+        headers:
+            Content-Length:
+                - "25"
+            Content-Type:
+                - application/x-amz-json-1.0
+            User-Agent:
+                - aws-sdk-go/1.54.12 (go1.22.2; linux; amd64)
+            X-Amz-Date:
+                - 20240705T085542Z
+            X-Amz-Target:
+                - AmazonSQS.GetQueueUrl
+        url: https://sqs.mnq.fr-par.scaleway.com/
+        method: POST
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        transfer_encoding: []
+        trailer: {}
+        content_length: 96
+        uncompressed: false
+        body: '{"__type":"com.amazonaws.sqs#QueueDoesNotExist","message":"Queue \"TestQueue\" does not exist."}'
+        headers:
+            Content-Length:
+                - "96"
+            Content-Type:
+                - application/x-amz-json-1.0; charset=utf-8
+            Date:
+                - Fri, 05 Jul 2024 08:55:42 GMT
+            X-Amzn-Query-Error:
+                - AWS.SimpleQueueService.NonExistentQueue;Sender
+            X-Amzn-Requestid:
+                - tx65980c62-5385-4070-8e36-c199f1c21b1e
+        status: 404 Not Found
+        code: 404
+        duration: 37.062414ms
+    - id: 55
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-credentials/a5106479-81d4-4c48-b882-b973b38cffda
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:55:42 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - d23218ee-4d6c-4707-8173-6029c9536102
+        status: 204 No Content
+        code: 204
+        duration: 73.940671ms
+    - id: 56
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/f8cd86ed-8ced-414b-a383-7b97934ffd8b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 390
+        uncompressed: false
+        body: '{"description":"","error_message":null,"function_id":"a0daf564-a5ac-4efd-b92e-b3362f267f77","id":"f8cd86ed-8ced-414b-a383-7b97934ffd8b","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"61efab41-1f7f-47a3-8848-6d411e416d49","mnq_project_id":"6772ce94-5880-4b12-93c3-5cc023cc1d0d","mnq_region":"fr-par","queue":"TestQueue"},"status":"deleting"}'
+        headers:
+            Content-Length:
+                - "390"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:55:47 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 359e5913-9034-42fa-aa90-136b9589b726
+        status: 200 OK
+        code: 200
+        duration: 73.107054ms
+    - id: 57
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/f8cd86ed-8ced-414b-a383-7b97934ffd8b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 390
+        uncompressed: false
+        body: '{"description":"","error_message":null,"function_id":"a0daf564-a5ac-4efd-b92e-b3362f267f77","id":"f8cd86ed-8ced-414b-a383-7b97934ffd8b","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"61efab41-1f7f-47a3-8848-6d411e416d49","mnq_project_id":"6772ce94-5880-4b12-93c3-5cc023cc1d0d","mnq_region":"fr-par","queue":"TestQueue"},"status":"deleting"}'
+        headers:
+            Content-Length:
+                - "390"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:55:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - c5a16633-1de1-494a-abb9-bc312a4ff995
+        status: 200 OK
+        code: 200
+        duration: 69.810886ms
+    - id: 58
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/f8cd86ed-8ced-414b-a383-7b97934ffd8b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 36
+        uncompressed: false
+        body: '{"message":"trigger does not exist"}'
+        headers:
+            Content-Length:
+                - "36"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:55:57 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - c4388eae-de25-469b-91a6-df95c778f51e
+        status: 404 Not Found
+        code: 404
+        duration: 26.7002ms
+    - id: 59
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-info?project_id=6772ce94-5880-4b12-93c3-5cc023cc1d0d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 233
+        uncompressed: false
+        body: '{"created_at":"2024-07-05T08:55:17.784228Z","project_id":"6772ce94-5880-4b12-93c3-5cc023cc1d0d","region":"fr-par","sqs_endpoint_url":"https://sqs.mnq.fr-par.scaleway.com","status":"enabled","updated_at":"2024-07-05T08:55:17.784228Z"}'
+        headers:
+            Content-Length:
+                - "233"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:55:57 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - c35e5613-ce13-431b-b94a-5ca3e4a3e921
+        status: 200 OK
+        code: 200
+        duration: 47.041487ms
+    - id: 60
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/a0daf564-a5ac-4efd-b92e-b3362f267f77
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 600
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"testfunctiontriggers92ysz3ef-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"a0daf564-a5ac-4efd-b92e-b3362f267f77","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"7afb1378-b581-4b20-a2ef-728b4880a639","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "600"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:55:57 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 95cd40c5-4b1a-4274-8b86-a3acad231aec
+        status: 200 OK
+        code: 200
+        duration: 60.244431ms
+    - id: 61
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/a0daf564-a5ac-4efd-b92e-b3362f267f77
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 601
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"testfunctiontriggers92ysz3ef-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"a0daf564-a5ac-4efd-b92e-b3362f267f77","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"7afb1378-b581-4b20-a2ef-728b4880a639","privacy":"private","region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"deleting","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "601"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:55:57 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3a90860d-b973-45a7-b3f5-a5070ef2110f
+        status: 200 OK
+        code: 200
+        duration: 190.132842ms
+    - id: 62
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 53
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"project_id":"6772ce94-5880-4b12-93c3-5cc023cc1d0d"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/deactivate-sqs
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 184
+        uncompressed: false
+        body: '{"created_at":null,"project_id":"6772ce94-5880-4b12-93c3-5cc023cc1d0d","region":"fr-par","sqs_endpoint_url":"https://sqs.mnq.fr-par.scaleway.com","status":"disabled","updated_at":null}'
+        headers:
+            Content-Length:
+                - "184"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:55:57 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f965b6b1-e4cb-4c4e-bc6e-7b8f33f180af
+        status: 200 OK
+        code: 200
+        duration: 204.957344ms
+    - id: 63
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7afb1378-b581-4b20-a2ef-728b4880a639
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 464
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"7afb1378-b581-4b20-a2ef-728b4880a639","name":"test-function-trigger-sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"6772ce94-5880-4b12-93c3-5cc023cc1d0d","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggers92ysz3ef","registry_namespace_id":"121e1254-08b2-4cdb-a4ec-8c2943a42cf7","secret_environment_variables":[],"status":"ready"}'
+        headers:
+            Content-Length:
+                - "464"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:55:57 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - fedfcdf2-1cbb-4fdf-9a27-d06c4913d5e4
+        status: 200 OK
+        code: 200
+        duration: 51.939124ms
+    - id: 64
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7afb1378-b581-4b20-a2ef-728b4880a639
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 467
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"7afb1378-b581-4b20-a2ef-728b4880a639","name":"test-function-trigger-sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"6772ce94-5880-4b12-93c3-5cc023cc1d0d","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggers92ysz3ef","registry_namespace_id":"121e1254-08b2-4cdb-a4ec-8c2943a42cf7","secret_environment_variables":[],"status":"deleting"}'
+        headers:
+            Content-Length:
+                - "467"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:55:58 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - bd188951-2304-4a84-bcd0-498bf7aa8a31
+        status: 200 OK
+        code: 200
+        duration: 144.730508ms
+    - id: 65
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7afb1378-b581-4b20-a2ef-728b4880a639
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 467
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"7afb1378-b581-4b20-a2ef-728b4880a639","name":"test-function-trigger-sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"6772ce94-5880-4b12-93c3-5cc023cc1d0d","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggers92ysz3ef","registry_namespace_id":"121e1254-08b2-4cdb-a4ec-8c2943a42cf7","secret_environment_variables":[],"status":"deleting"}'
+        headers:
+            Content-Length:
+                - "467"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:55:58 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 57d2323b-496d-4c8d-8cbc-358e8a8a88dc
+        status: 200 OK
+        code: 200
+        duration: 66.88735ms
+    - id: 66
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7afb1378-b581-4b20-a2ef-728b4880a639
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 37
+        uncompressed: false
+        body: '{"message":"Namespace was not found"}'
+        headers:
+            Content-Length:
+                - "37"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:56:03 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - d823cf7c-f380-431c-a56e-67c8e1cde2cc
+        status: 404 Not Found
+        code: 404
+        duration: 22.883554ms
+    - id: 67
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/account/v3/projects/6772ce94-5880-4b12-93c3-5cc023cc1d0d
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:56:04 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 48642f8c-f93b-4350-b96e-612aefa15a2e
+        status: 204 No Content
+        code: 204
+        duration: 1.395048947s
+    - id: 68
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/f8cd86ed-8ced-414b-a383-7b97934ffd8b
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 105
+        uncompressed: false
+        body: '{"message":"trigger does not exist: could not find trigger with id f8cd86ed-8ced-414b-a383-7b97934ffd8b"}'
+        headers:
+            Content-Length:
+                - "105"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:56:04 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 7c282964-d6d3-4260-a2e6-d965eb0fed8d
+        status: 404 Not Found
+        code: 404
+        duration: 23.937236ms

--- a/internal/services/function/testdata/function-upload.cassette.yaml
+++ b/internal/services/function/testdata/function-upload.cassette.yaml
@@ -1,821 +1,1247 @@
 ---
 version: 2
 interactions:
-- request:
-    body: '{"name":"tf-func-zen-kare","environment_variables":{},"project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","description":null,"secret_environment_variables":[]}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces
-    method: POST
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"cae81d3c-7c09-4039-845a-a0f7a955fabd","name":"tf-func-zen-kare","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "366"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:46:38 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a21cb9ef-e2ed-4ffa-b0fe-93092aef4425
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/cae81d3c-7c09-4039-845a-a0f7a955fabd
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"cae81d3c-7c09-4039-845a-a0f7a955fabd","name":"tf-func-zen-kare","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "366"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:46:38 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 59746caf-0fe9-45d0-a886-0a334a33d236
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/cae81d3c-7c09-4039-845a-a0f7a955fabd
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"cae81d3c-7c09-4039-845a-a0f7a955fabd","name":"tf-func-zen-kare","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "366"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:46:43 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8c226acd-3d31-48db-a5b4-a122bd798613
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/cae81d3c-7c09-4039-845a-a0f7a955fabd
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"cae81d3c-7c09-4039-845a-a0f7a955fabd","name":"tf-func-zen-kare","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "366"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:46:48 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8578ff5d-e28c-4be0-bb9f-3a40f1cb78d9
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/cae81d3c-7c09-4039-845a-a0f7a955fabd
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"cae81d3c-7c09-4039-845a-a0f7a955fabd","name":"tf-func-zen-kare","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "366"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:46:53 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 09a02599-0581-43d7-b2cc-18aad5f9818c
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/cae81d3c-7c09-4039-845a-a0f7a955fabd
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"cae81d3c-7c09-4039-845a-a0f7a955fabd","name":"tf-func-zen-kare","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "366"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:46:58 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f85b8034-d0a1-4b99-b02a-ec1e4754009e
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/cae81d3c-7c09-4039-845a-a0f7a955fabd
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"cae81d3c-7c09-4039-845a-a0f7a955fabd","name":"tf-func-zen-kare","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "366"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - fc7d55c6-d3a2-4d5b-ad51-d94a0870b8da
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/cae81d3c-7c09-4039-845a-a0f7a955fabd
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"cae81d3c-7c09-4039-845a-a0f7a955fabd","name":"tf-func-zen-kare","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
-    headers:
-      Content-Length:
-      - "366"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:08 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f1c5aa24-6cbc-4f55-b6cf-9ee33904af34
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/cae81d3c-7c09-4039-845a-a0f7a955fabd
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"cae81d3c-7c09-4039-845a-a0f7a955fabd","name":"tf-func-zen-kare","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunczenkarernnmxsjz","registry_namespace_id":"0da8968e-4981-4055-8730-31d34c28f0cd","secret_environment_variables":[],"status":"ready"}'
-    headers:
-      Content-Length:
-      - "448"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - fa1ce8d3-a21c-499d-b3bb-092e116b0c99
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/cae81d3c-7c09-4039-845a-a0f7a955fabd
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"cae81d3c-7c09-4039-845a-a0f7a955fabd","name":"tf-func-zen-kare","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunczenkarernnmxsjz","registry_namespace_id":"0da8968e-4981-4055-8730-31d34c28f0cd","secret_environment_variables":[],"status":"ready"}'
-    headers:
-      Content-Length:
-      - "448"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c6b9997c-7b52-4c7b-949a-1dfe1ef731ed
-    status: 200 OK
-    code: 200
-- request:
-    body: '{"name":"foobar","namespace_id":"cae81d3c-7c09-4039-845a-a0f7a955fabd","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"go118","memory_limit":128,"timeout":null,"handler":"Handle","privacy":"private","description":null,"secret_environment_variables":[],"http_option":"enabled"}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions
-    method: POST
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffunczenkarernnmxsjz-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"c3507561-d796-4d77-8215-e33ddf89ac62","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"cae81d3c-7c09-4039-845a-a0f7a955fabd","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "509"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f1afe3af-a353-49e0-bfc1-82cd68d034c0
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/c3507561-d796-4d77-8215-e33ddf89ac62/upload-url?content_length=780
-    method: GET
-  response:
-    body: '{"headers":{"content-length":["780"],"content-type":["application/octet-stream"]},"url":"https://s3.fr-par.scw.cloud/scw-database-srvless-prod/uploads/function-c3507561-d796-4d77-8215-e33ddf89ac62.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256\u0026X-Amz-Credential=SCW6Z6VKJVG81FQZVB14%2F20230104%2Ffr-par%2Fs3%2Faws4_request\u0026X-Amz-Date=20230104T104714Z\u0026X-Amz-Expires=3600\u0026X-Amz-SignedHeaders=content-length%3Bcontent-type%3Bhost\u0026X-Amz-Signature=773b5d7d1937b5ffc99ca542682e7fd4c1ff7f961e9aaa9f359319ec9436b294"}'
-    headers:
-      Content-Length:
-      - "523"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:14 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1261a359-3ad1-41af-9265-1f459015dcbe
-    status: 200 OK
-    code: 200
-- request:
-    body: !!binary |
-      UEsDBAoAAAAAAGZZzVTiYkURGgAAABoAAAAGABwAZ28ubW9kVVQJAAMw/6ZiYP+mYnV4Cw
-      ABBOgDAAAE6AMAAG1vZHVsZSBteWhhbmRsZXIKCmdvIDEuMTgKUEsDBAoAAAAAACuFzVQA
-      AAAAAAAAAAAAAAAGABwAZ28uc3VtVVQJAAOSTKdil0ynYnV4CwABBOgDAAAE6AMAAFBLAw
-      QUAAAACABFgs1U1odLbzABAADKAQAACgAcAGhhbmRsZXIuZ29VVAkAAyJHp2IlR6didXgL
-      AAEE6AMAAAToAwAARVCxTsMwEJ3jrzi8kKA02RgqdSkClYGFInVADCa5NAHHNudLo6rqv2
-      OnKUw+v3t3791zqvpWe4T+2AymEqLrnSWGVCQSTWXrzuzLL2+NDEDTc3wMctkyOykyIcoS
-      NsrUGmFxLfCAhkVcNyPpCJFfvKJ31njcUcdIORDczfjPgJ4zOImEZg4sV9Ar9+6ZgoWPzo
-      SJRlV4OgdSInv0PtiWS5A7vCUEpTXsra1lHtstKs3tMbSZBpwgM/SfSAGB+/A/i3+pdQ5I
-      FAXjocWLIt8qnV7bmUi6ZmLcrMB0OrpMxmI6YoOqRkqnK7asePDP0ahReot0QHokshQWBC
-      0eyFx0x2Iey4otciofbJgxvHg7OpQ5SOWc7irFnTWX6MOCEH3x5EIUnI45XEL5c7jOMnEW
-      v1BLAQIeAwoAAAAAAGZZzVTiYkURGgAAABoAAAAGABgAAAAAAAEAAACkgQAAAABnby5tb2
-      RVVAUAAzD/pmJ1eAsAAQToAwAABOgDAABQSwECHgMKAAAAAAArhc1UAAAAAAAAAAAAAAAA
-      BgAYAAAAAAAAAAAApIFaAAAAZ28uc3VtVVQFAAOSTKdidXgLAAEE6AMAAAToAwAAUEsBAh
-      4DFAAAAAgARYLNVNaHS28wAQAAygEAAAoAGAAAAAAAAQAAAKSBmgAAAGhhbmRsZXIuZ29V
-      VAUAAyJHp2J1eAsAAQToAwAABOgDAABQSwUGAAAAAAMAAwDoAAAADgIAAAAA
-    form: {}
-    headers:
-      Content-Length:
-      - "780"
-      Content-Type:
-      - application/octet-stream
-    url: https://s3.fr-par.scw.cloud/scw-database-srvless-prod/uploads/function-c3507561-d796-4d77-8215-e33ddf89ac62.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=SCW6Z6VKJVG81FQZVB14%2F20230104%2Ffr-par%2Fs3%2Faws4_request&X-Amz-Date=20230104T104714Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=content-length%3Bcontent-type%3Bhost&X-Amz-Signature=773b5d7d1937b5ffc99ca542682e7fd4c1ff7f961e9aaa9f359319ec9436b294
-    method: PUT
-  response:
-    body: ""
-    headers:
-      Content-Length:
-      - "0"
-      Content-Type:
-      - text/html; charset=UTF-8
-      Date:
-      - Wed, 04 Jan 2023 10:47:15 GMT
-      Etag:
-      - '"10633bf7a5ff211d8f3eee3856a28101"'
-      Last-Modified:
-      - Wed, 04 Jan 2023 10:47:14 GMT
-      X-Amz-Id-2:
-      - txd922a0d480d44018940df-0063b55932
-      X-Amz-Request-Id:
-      - txd922a0d480d44018940df-0063b55932
-      X-Amz-Version-Id:
-      - "1672829234701736"
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/c3507561-d796-4d77-8215-e33ddf89ac62
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffunczenkarernnmxsjz-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"c3507561-d796-4d77-8215-e33ddf89ac62","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"cae81d3c-7c09-4039-845a-a0f7a955fabd","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "509"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:15 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4071305e-61a5-42e2-bada-35a8baa94784
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/c3507561-d796-4d77-8215-e33ddf89ac62
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffunczenkarernnmxsjz-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"c3507561-d796-4d77-8215-e33ddf89ac62","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"cae81d3c-7c09-4039-845a-a0f7a955fabd","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "509"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:15 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8364f0c3-ebf8-4fbe-99c2-d855837cab96
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/c3507561-d796-4d77-8215-e33ddf89ac62
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffunczenkarernnmxsjz-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"c3507561-d796-4d77-8215-e33ddf89ac62","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"cae81d3c-7c09-4039-845a-a0f7a955fabd","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "509"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:15 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 387c5144-b9a3-4dc2-8691-eb6352c7a5b3
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/cae81d3c-7c09-4039-845a-a0f7a955fabd
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"cae81d3c-7c09-4039-845a-a0f7a955fabd","name":"tf-func-zen-kare","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunczenkarernnmxsjz","registry_namespace_id":"0da8968e-4981-4055-8730-31d34c28f0cd","secret_environment_variables":[],"status":"ready"}'
-    headers:
-      Content-Length:
-      - "448"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:15 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a35e1eb1-e067-4d90-b7a4-971bfb10d19c
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/c3507561-d796-4d77-8215-e33ddf89ac62
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffunczenkarernnmxsjz-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"c3507561-d796-4d77-8215-e33ddf89ac62","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"cae81d3c-7c09-4039-845a-a0f7a955fabd","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "509"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:15 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6d0c0305-2d7c-4d77-bd2e-ef4ec1b902c5
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/c3507561-d796-4d77-8215-e33ddf89ac62
-    method: GET
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffunczenkarernnmxsjz-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"c3507561-d796-4d77-8215-e33ddf89ac62","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"cae81d3c-7c09-4039-845a-a0f7a955fabd","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"created","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "509"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:15 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1303c327-a3ed-4ae8-bea1-59a82d9743bb
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/c3507561-d796-4d77-8215-e33ddf89ac62
-    method: DELETE
-  response:
-    body: '{"cpu_limit":70,"description":"","domain_name":"tffunczenkarernnmxsjz-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"c3507561-d796-4d77-8215-e33ddf89ac62","max_scale":20,"memory_limit":128,"min_scale":0,"name":"foobar","namespace_id":"cae81d3c-7c09-4039-845a-a0f7a955fabd","privacy":"private","region":"fr-par","runtime":"go118","runtime_message":"","secret_environment_variables":[],"status":"deleting","timeout":"300s"}'
-    headers:
-      Content-Length:
-      - "510"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:16 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 07ec779a-c7a1-41f5-a239-8c6227e7d24c
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/cae81d3c-7c09-4039-845a-a0f7a955fabd
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"cae81d3c-7c09-4039-845a-a0f7a955fabd","name":"tf-func-zen-kare","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunczenkarernnmxsjz","registry_namespace_id":"0da8968e-4981-4055-8730-31d34c28f0cd","secret_environment_variables":[],"status":"ready"}'
-    headers:
-      Content-Length:
-      - "448"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:16 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ca0fe526-1c7c-45be-b361-23cc7cf195e7
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/cae81d3c-7c09-4039-845a-a0f7a955fabd
-    method: DELETE
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"cae81d3c-7c09-4039-845a-a0f7a955fabd","name":"tf-func-zen-kare","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunczenkarernnmxsjz","registry_namespace_id":"0da8968e-4981-4055-8730-31d34c28f0cd","secret_environment_variables":[],"status":"deleting"}'
-    headers:
-      Content-Length:
-      - "451"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:16 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 24f05afb-3e32-423f-a65d-0671469e195c
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/cae81d3c-7c09-4039-845a-a0f7a955fabd
-    method: GET
-  response:
-    body: '{"description":"","environment_variables":{},"error_message":null,"id":"cae81d3c-7c09-4039-845a-a0f7a955fabd","name":"tf-func-zen-kare","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunczenkarernnmxsjz","registry_namespace_id":"0da8968e-4981-4055-8730-31d34c28f0cd","secret_environment_variables":[],"status":"deleting"}'
-    headers:
-      Content-Length:
-      - "451"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:16 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - fe952277-9e7d-4a45-a1c0-f9f440b13978
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/cae81d3c-7c09-4039-845a-a0f7a955fabd
-    method: GET
-  response:
-    body: '{"message":"Namespace was not found"}'
-    headers:
-      Content-Length:
-      - "37"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:21 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2582e385-4a9e-46b9-a659-923396fa3e07
-    status: 404 Not Found
-    code: 404
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/c3507561-d796-4d77-8215-e33ddf89ac62
-    method: DELETE
-  response:
-    body: '{"message":"Function was not found"}'
-    headers:
-      Content-Length:
-      - "36"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 10:47:21 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f635e721-a47d-4a74-a871-d9e44c61d750
-    status: 404 Not Found
-    code: 404
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 144
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"name":"tf-func-nice-murdock","environment_variables":{},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","secret_environment_variables":[]}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 370
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"22f1649d-6bea-4564-8203-4aed16dd260b","name":"tf-func-nice-murdock","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
+        headers:
+            Content-Length:
+                - "370"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:19 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 1f26c39c-d9d8-40e3-be22-50cb183e6ae0
+        status: 200 OK
+        code: 200
+        duration: 1.223062808s
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/22f1649d-6bea-4564-8203-4aed16dd260b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 370
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"22f1649d-6bea-4564-8203-4aed16dd260b","name":"tf-func-nice-murdock","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
+        headers:
+            Content-Length:
+                - "370"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:20 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e2962969-baa2-455e-b16f-5f9cf6f14297
+        status: 200 OK
+        code: 200
+        duration: 65.645276ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/22f1649d-6bea-4564-8203-4aed16dd260b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 458
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"22f1649d-6bea-4564-8203-4aed16dd260b","name":"tf-func-nice-murdock","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncnicemurdock8wlj100t","registry_namespace_id":"898fd355-a10d-436d-9dd0-375e69f8e720","secret_environment_variables":[],"status":"pending"}'
+        headers:
+            Content-Length:
+                - "458"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:25 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 4c0265be-5bd8-44fc-9b36-19dc43547742
+        status: 200 OK
+        code: 200
+        duration: 63.264292ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/22f1649d-6bea-4564-8203-4aed16dd260b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 458
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"22f1649d-6bea-4564-8203-4aed16dd260b","name":"tf-func-nice-murdock","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncnicemurdock8wlj100t","registry_namespace_id":"898fd355-a10d-436d-9dd0-375e69f8e720","secret_environment_variables":[],"status":"pending"}'
+        headers:
+            Content-Length:
+                - "458"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:30 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 09c3ba13-1447-4872-9aaa-593a3c39c0df
+        status: 200 OK
+        code: 200
+        duration: 311.731418ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/22f1649d-6bea-4564-8203-4aed16dd260b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 458
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"22f1649d-6bea-4564-8203-4aed16dd260b","name":"tf-func-nice-murdock","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncnicemurdock8wlj100t","registry_namespace_id":"898fd355-a10d-436d-9dd0-375e69f8e720","secret_environment_variables":[],"status":"pending"}'
+        headers:
+            Content-Length:
+                - "458"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3bf31a1b-3553-42a7-bd83-a7abf6872a70
+        status: 200 OK
+        code: 200
+        duration: 56.821487ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/22f1649d-6bea-4564-8203-4aed16dd260b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 458
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"22f1649d-6bea-4564-8203-4aed16dd260b","name":"tf-func-nice-murdock","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncnicemurdock8wlj100t","registry_namespace_id":"898fd355-a10d-436d-9dd0-375e69f8e720","secret_environment_variables":[],"status":"pending"}'
+        headers:
+            Content-Length:
+                - "458"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:40 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 9b6a3fda-f660-4531-bdb7-194b1ce075c0
+        status: 200 OK
+        code: 200
+        duration: 57.677254ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/22f1649d-6bea-4564-8203-4aed16dd260b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 458
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"22f1649d-6bea-4564-8203-4aed16dd260b","name":"tf-func-nice-murdock","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncnicemurdock8wlj100t","registry_namespace_id":"898fd355-a10d-436d-9dd0-375e69f8e720","secret_environment_variables":[],"status":"pending"}'
+        headers:
+            Content-Length:
+                - "458"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:45 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ecfaa772-de7c-47ab-ad14-117745d11a08
+        status: 200 OK
+        code: 200
+        duration: 64.999032ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/22f1649d-6bea-4564-8203-4aed16dd260b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 458
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"22f1649d-6bea-4564-8203-4aed16dd260b","name":"tf-func-nice-murdock","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncnicemurdock8wlj100t","registry_namespace_id":"898fd355-a10d-436d-9dd0-375e69f8e720","secret_environment_variables":[],"status":"pending"}'
+        headers:
+            Content-Length:
+                - "458"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:50 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - be432f67-5fed-4ff0-8bda-0f06a2a55181
+        status: 200 OK
+        code: 200
+        duration: 56.001415ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/22f1649d-6bea-4564-8203-4aed16dd260b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 456
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"22f1649d-6bea-4564-8203-4aed16dd260b","name":"tf-func-nice-murdock","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncnicemurdock8wlj100t","registry_namespace_id":"898fd355-a10d-436d-9dd0-375e69f8e720","secret_environment_variables":[],"status":"ready"}'
+        headers:
+            Content-Length:
+                - "456"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:55 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 988b879f-995d-485c-87c1-14ba461f42d7
+        status: 200 OK
+        code: 200
+        duration: 56.631312ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/22f1649d-6bea-4564-8203-4aed16dd260b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 456
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"22f1649d-6bea-4564-8203-4aed16dd260b","name":"tf-func-nice-murdock","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncnicemurdock8wlj100t","registry_namespace_id":"898fd355-a10d-436d-9dd0-375e69f8e720","secret_environment_variables":[],"status":"ready"}'
+        headers:
+            Content-Length:
+                - "456"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:55 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 2c623b0c-40a1-4a20-ba81-6c134c3343bd
+        status: 200 OK
+        code: 200
+        duration: 67.653274ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 289
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"name":"foobar","namespace_id":"22f1649d-6bea-4564-8203-4aed16dd260b","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"go122","memory_limit":256,"handler":"Handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 550
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncnicemurdock8wlj100t-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"ae6267ab-cd93-4253-8051-394f264c769a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"22f1649d-6bea-4564-8203-4aed16dd260b","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "550"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:56 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - c171ab87-3616-493e-af5a-447dd7cddabf
+        status: 200 OK
+        code: 200
+        duration: 431.072401ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/ae6267ab-cd93-4253-8051-394f264c769a/upload-url?content_length=780
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 510
+        uncompressed: false
+        body: '{"headers":{"content-length":["780"],"content-type":["application/octet-stream"]},"url":"https://s3.fr-par.scw.cloud/serverless-functions-code-prod-fr-par/uploads/function-ae6267ab-cd93-4253-8051-394f264c769a.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256\u0026X-Amz-Credential=SCW3S98HDC0MAE9CBTQ5%2F20240705%2Ffr-par%2Fs3%2Faws4_request\u0026X-Amz-Date=20240705T082456Z\u0026X-Amz-Expires=3600\u0026X-Amz-SignedHeaders=content-length%3Bcontent-type%3Bhost\u0026X-Amz-Signature=00ad94b095671a03ae3ad7e519ce99e0b900003c96b7dc829623f119508b8465"}'
+        headers:
+            Content-Length:
+                - "510"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:56 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 087db889-230d-4634-8385-66203528fad4
+        status: 200 OK
+        code: 200
+        duration: 71.052873ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 780
+        transfer_encoding: []
+        trailer: {}
+        host: s3.fr-par.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: !!binary |
+            UEsDBAoAAAAAAGZZzVTiYkURGgAAABoAAAAGABwAZ28ubW9kVVQJAAMw/6ZiYP+mYnV4Cw
+            ABBOgDAAAE6AMAAG1vZHVsZSBteWhhbmRsZXIKCmdvIDEuMTgKUEsDBAoAAAAAACuFzVQA
+            AAAAAAAAAAAAAAAGABwAZ28uc3VtVVQJAAOSTKdil0ynYnV4CwABBOgDAAAE6AMAAFBLAw
+            QUAAAACABFgs1U1odLbzABAADKAQAACgAcAGhhbmRsZXIuZ29VVAkAAyJHp2IlR6didXgL
+            AAEE6AMAAAToAwAARVCxTsMwEJ3jrzi8kKA02RgqdSkClYGFInVADCa5NAHHNudLo6rqv2
+            OnKUw+v3t3791zqvpWe4T+2AymEqLrnSWGVCQSTWXrzuzLL2+NDEDTc3wMctkyOykyIcoS
+            NsrUGmFxLfCAhkVcNyPpCJFfvKJ31njcUcdIORDczfjPgJ4zOImEZg4sV9Ar9+6ZgoWPzo
+            SJRlV4OgdSInv0PtiWS5A7vCUEpTXsra1lHtstKs3tMbSZBpwgM/SfSAGB+/A/i3+pdQ5I
+            FAXjocWLIt8qnV7bmUi6ZmLcrMB0OrpMxmI6YoOqRkqnK7asePDP0ahReot0QHokshQWBC
+            0eyFx0x2Iey4otciofbJgxvHg7OpQ5SOWc7irFnTWX6MOCEH3x5EIUnI45XEL5c7jOMnEW
+            v1BLAQIeAwoAAAAAAGZZzVTiYkURGgAAABoAAAAGABgAAAAAAAEAAACkgQAAAABnby5tb2
+            RVVAUAAzD/pmJ1eAsAAQToAwAABOgDAABQSwECHgMKAAAAAAArhc1UAAAAAAAAAAAAAAAA
+            BgAYAAAAAAAAAAAApIFaAAAAZ28uc3VtVVQFAAOSTKdidXgLAAEE6AMAAAToAwAAUEsBAh
+            4DFAAAAAgARYLNVNaHS28wAQAAygEAAAoAGAAAAAAAAQAAAKSBmgAAAGhhbmRsZXIuZ29V
+            VAUAAyJHp2J1eAsAAQToAwAABOgDAABQSwUGAAAAAAMAAwDoAAAADgIAAAAA
+        form: {}
+        headers:
+            Content-Length:
+                - "780"
+            Content-Type:
+                - application/octet-stream
+        url: https://s3.fr-par.scw.cloud/serverless-functions-code-prod-fr-par/uploads/function-ae6267ab-cd93-4253-8051-394f264c769a.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=SCW3S98HDC0MAE9CBTQ5%2F20240705%2Ffr-par%2Fs3%2Faws4_request&X-Amz-Date=20240705T082456Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=content-length%3Bcontent-type%3Bhost&X-Amz-Signature=00ad94b095671a03ae3ad7e519ce99e0b900003c96b7dc829623f119508b8465
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Length:
+                - "0"
+            Content-Type:
+                - text/html; charset=UTF-8
+            Date:
+                - Fri, 05 Jul 2024 08:24:56 GMT
+            Etag:
+                - '"10633bf7a5ff211d8f3eee3856a28101"'
+            Last-Modified:
+                - Fri, 05 Jul 2024 08:24:56 GMT
+            X-Amz-Id-2:
+                - tx30f76612743a42f8a6a02-006687add8
+            X-Amz-Request-Id:
+                - tx30f76612743a42f8a6a02-006687add8
+            X-Amz-Version-Id:
+                - "1720167896391977"
+        status: 200 OK
+        code: 200
+        duration: 355.982071ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/ae6267ab-cd93-4253-8051-394f264c769a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 550
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncnicemurdock8wlj100t-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"ae6267ab-cd93-4253-8051-394f264c769a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"22f1649d-6bea-4564-8203-4aed16dd260b","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "550"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:56 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - d9a1fa6a-196b-4dd4-a78d-61075109238a
+        status: 200 OK
+        code: 200
+        duration: 56.224297ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/ae6267ab-cd93-4253-8051-394f264c769a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 550
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncnicemurdock8wlj100t-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"ae6267ab-cd93-4253-8051-394f264c769a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"22f1649d-6bea-4564-8203-4aed16dd260b","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "550"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:56 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 8beda76d-1889-446e-bdad-a174407dbccb
+        status: 200 OK
+        code: 200
+        duration: 52.550192ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/ae6267ab-cd93-4253-8051-394f264c769a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 550
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncnicemurdock8wlj100t-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"ae6267ab-cd93-4253-8051-394f264c769a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"22f1649d-6bea-4564-8203-4aed16dd260b","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "550"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:56 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 8294429e-01a2-4f82-9848-66b30db7f6fa
+        status: 200 OK
+        code: 200
+        duration: 55.63541ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/22f1649d-6bea-4564-8203-4aed16dd260b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 456
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"22f1649d-6bea-4564-8203-4aed16dd260b","name":"tf-func-nice-murdock","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncnicemurdock8wlj100t","registry_namespace_id":"898fd355-a10d-436d-9dd0-375e69f8e720","secret_environment_variables":[],"status":"ready"}'
+        headers:
+            Content-Length:
+                - "456"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:57 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e6be157f-cdfa-4fb9-8599-e8f2cc4220cf
+        status: 200 OK
+        code: 200
+        duration: 61.242076ms
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/ae6267ab-cd93-4253-8051-394f264c769a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 550
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncnicemurdock8wlj100t-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"ae6267ab-cd93-4253-8051-394f264c769a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"22f1649d-6bea-4564-8203-4aed16dd260b","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "550"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:57 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 83f9ec94-e712-41d7-9060-eb8942f12388
+        status: 200 OK
+        code: 200
+        duration: 69.8646ms
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/ae6267ab-cd93-4253-8051-394f264c769a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 550
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncnicemurdock8wlj100t-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"ae6267ab-cd93-4253-8051-394f264c769a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"22f1649d-6bea-4564-8203-4aed16dd260b","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "550"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:57 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - a088f3f1-6115-4f81-936b-13bda9966c27
+        status: 200 OK
+        code: 200
+        duration: 68.999253ms
+    - id: 19
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/ae6267ab-cd93-4253-8051-394f264c769a
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 551
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"description":"","domain_name":"tffuncnicemurdock8wlj100t-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"ae6267ab-cd93-4253-8051-394f264c769a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"22f1649d-6bea-4564-8203-4aed16dd260b","privacy":"private","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"deleting","timeout":"300s"}'
+        headers:
+            Content-Length:
+                - "551"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:57 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 68010f90-5592-481d-b6ed-c264b9adcb2f
+        status: 200 OK
+        code: 200
+        duration: 110.575383ms
+    - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/22f1649d-6bea-4564-8203-4aed16dd260b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 456
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"22f1649d-6bea-4564-8203-4aed16dd260b","name":"tf-func-nice-murdock","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncnicemurdock8wlj100t","registry_namespace_id":"898fd355-a10d-436d-9dd0-375e69f8e720","secret_environment_variables":[],"status":"ready"}'
+        headers:
+            Content-Length:
+                - "456"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:57 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e4855762-ac3e-40a6-8ad5-983b252c08b0
+        status: 200 OK
+        code: 200
+        duration: 49.475304ms
+    - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/22f1649d-6bea-4564-8203-4aed16dd260b
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 459
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"22f1649d-6bea-4564-8203-4aed16dd260b","name":"tf-func-nice-murdock","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncnicemurdock8wlj100t","registry_namespace_id":"898fd355-a10d-436d-9dd0-375e69f8e720","secret_environment_variables":[],"status":"deleting"}'
+        headers:
+            Content-Length:
+                - "459"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:58 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 7d82c287-a259-4b08-84f8-64696343ea7d
+        status: 200 OK
+        code: 200
+        duration: 222.663449ms
+    - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/22f1649d-6bea-4564-8203-4aed16dd260b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 459
+        uncompressed: false
+        body: '{"description":"","environment_variables":{},"error_message":null,"id":"22f1649d-6bea-4564-8203-4aed16dd260b","name":"tf-func-nice-murdock","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncnicemurdock8wlj100t","registry_namespace_id":"898fd355-a10d-436d-9dd0-375e69f8e720","secret_environment_variables":[],"status":"deleting"}'
+        headers:
+            Content-Length:
+                - "459"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:24:58 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 5340fce8-3d18-4cbb-a213-882848548b66
+        status: 200 OK
+        code: 200
+        duration: 54.166339ms
+    - id: 23
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/22f1649d-6bea-4564-8203-4aed16dd260b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 37
+        uncompressed: false
+        body: '{"message":"Namespace was not found"}'
+        headers:
+            Content-Length:
+                - "37"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:25:03 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 43306d93-760f-4311-a871-c61af0c17618
+        status: 404 Not Found
+        code: 404
+        duration: 24.098135ms
+    - id: 24
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/ae6267ab-cd93-4253-8051-394f264c769a
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 36
+        uncompressed: false
+        body: '{"message":"Function was not found"}'
+        headers:
+            Content-Length:
+                - "36"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 05 Jul 2024 08:25:03 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 80be14fb-abaf-4d9c-8065-970ea820c66f
+        status: 404 Not Found
+        code: 404
+        duration: 21.95072ms

--- a/internal/services/function/token_test.go
+++ b/internal/services/function/token_test.go
@@ -18,7 +18,7 @@ func TestAccFunctionToken_Basic(t *testing.T) {
 	defer tt.Cleanup()
 	expiresAt := time.Now().Add(time.Hour * 24).Format(time.RFC3339)
 	if !*acctest.UpdateCassettes {
-		expiresAt = "2023-01-05T13:53:11+01:00"
+		expiresAt = "2024-07-06T10:59:52+02:00"
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -34,7 +34,7 @@ func TestAccFunctionToken_Basic(t *testing.T) {
 
 					resource scaleway_function main {
 						namespace_id = scaleway_function_namespace.main.id
-						runtime = "node14"
+						runtime = "node22"
 						privacy = "private"
 						handler = "handler.handle"
 					}

--- a/internal/services/function/trigger_test.go
+++ b/internal/services/function/trigger_test.go
@@ -29,7 +29,7 @@ func TestAccFunctionTrigger_SQS(t *testing.T) {
 					resource scaleway_function main {
 						name = "test-function-trigger-sqs"
 						namespace_id = scaleway_function_namespace.main.id
-						runtime = "node20"
+						runtime = "node22"
 						privacy = "private"
 						handler = "handler.handle"
 					}
@@ -100,7 +100,7 @@ func TestAccFunctionTrigger_Nats(t *testing.T) {
 					resource scaleway_function main {
 						name = "test-function-trigger-sqs"
 						namespace_id = scaleway_function_namespace.main.id
-						runtime = "node20"
+						runtime = "node22"
 						privacy = "private"
 						handler = "handler.handle"
 					}
@@ -160,7 +160,7 @@ func TestAccFunctionTrigger_Error(t *testing.T) {
 					resource scaleway_function main {
 						name = "test-function-trigger-error"
 						namespace_id = scaleway_function_namespace.main.id
-						runtime = "node14"
+						runtime = "node22"
 						privacy = "private"
 						handler = "handler.handle"
 					}


### PR DESCRIPTION
Bumps default `memory_limit` to align with the Scaleway Console