### PR TITLE
fix(servers): fix plugin segfault when bootscript is null

### DIFF
--- a/internal/services/instance/servers_data_source.go
+++ b/internal/services/instance/servers_data_source.go
@@ -183,7 +183,9 @@ func DataSourceInstanceServersRead(ctx context.Context, d *schema.ResourceData, 
 		rawServer["zone"] = string(zone)
 		rawServer["name"] = server.Name
 		rawServer["boot_type"] = server.BootType
-		rawServer["bootscript_id"] = server.Bootscript.ID
+		if server.Bootscript != nil {
+			rawServer["bootscript_id"] = server.Bootscript.ID
+		}
 		rawServer["type"] = server.CommercialType
 		if len(server.Tags) > 0 {
 			rawServer["tags"] = server.Tags


### PR DESCRIPTION
Bootscript is deprecated cf https://www.scaleway.com/en/developers/api/instance/#path-instances-list-all-instances


![image](https://github.com/user-attachments/assets/f4e2dd65-6c9b-41ef-a9e0-1a28a5ab3627)

seems relative to https://www.scaleway.com/en/docs/compute/instances/troubleshooting/bootscript-eol/

It appears that Bootscript is no longer available on API response