### PR TITLE
docs(iam): document using expires_at with time_rotating

### DIFF
--- a/docs/resources/iam_api_key.md
+++ b/docs/resources/iam_api_key.md
@@ -35,6 +35,19 @@ resource "scaleway_iam_api_key" "main" {
 }
 ```
 
+### With expiration
+
+```terraform
+resource "time_rotating" "rotate_after_a_year" {
+  rotation_years = 1
+}
+
+resource "scaleway_iam_api_key" "main" {
+  application_id = scaleway_iam_application.main.id
+  expires_at     = time_rotating.rotate_after_a_year.rotation_rfc3339
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:


### PR DESCRIPTION
This PR adds a doc item for `iam_api_key` to show the use of the `expires_at` parameter in combination with `time_rotating`

**Reasoning for Change:**
In my opinion, it could be interesting to document the proper usage of the `expires_at` parameter for API keys, as it's not super clear.

**Prefer Scaleway Documentation:**
In that case, it's a pretty Terraform-specific use case. On the console, the API creation modal uses the "duration" of the key as opposed to the `expires_at` parameter.

**Terraform Configuration Language Features:**
It's not ideal indeed to use a resource from a default provider, but in that case, it's the most proper way to use `expires_at`.

Feel free to close this PR if you disagree with the change.