### PR TITLE
tests(secret_version): datasource using latest revision

### DIFF
--- a/docs/data-sources/secret_version.md
+++ b/docs/data-sources/secret_version.md
@@ -57,7 +57,7 @@ The following arguments are supported:
 - `secret_name` - (Optional) The Name of Secret associated wit the secret version.
   Only one of `secret_id` and `secret_name` should be specified.
 
-- `revision` - The revision for this Secret Version.
+- `revision` - The revision for this Secret Version. Alternative values (ex: `latest`) can be found in [API documentation](https://www.scaleway.com/en/developers/api/secret-manager/#path-secret-versions-access-a-secrets-version-using-the-secrets-id)
 
 - `region` - (Defaults to [provider](../index.md#region) `region`) The [region](../guides/regions_and_zones.md#regions)
   in which the resource exists.

--- a/internal/services/secret/testdata/data-source-secret-version-basic.cassette.yaml
+++ b/internal/services/secret/testdata/data-source-secret-version-basic.cassette.yaml
@@ -1,1540 +1,2894 @@
 ---
 version: 2
 interactions:
-- request:
-    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"dataSourceSecretVersionBasic","tags":["devtools","provider","terraform"],"description":"secret
-      description","type":"unknown_type","protected":false}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets
-    method: POST
-  response:
-    body: '{"created_at":"2024-02-16T07:43:30.664726Z","description":"secret description","ephemeral_policy":null,"id":"9a9cc414-0b6f-46be-b48a-335423727b82","managed":false,"name":"dataSourceSecretVersionBasic","path":"/","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"region":"fr-par","status":"ready","tags":["devtools","provider","terraform"],"type":"opaque","updated_at":"2024-02-16T07:43:30.664726Z","version_count":0}'
-    headers:
-      Content-Length:
-      - "453"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 16 Feb 2024 07:43:30 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 713c2f64-1265-4eb7-81a5-5d84a860931c
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9a9cc414-0b6f-46be-b48a-335423727b82
-    method: GET
-  response:
-    body: '{"created_at":"2024-02-16T07:43:30.664726Z","description":"secret description","ephemeral_policy":null,"id":"9a9cc414-0b6f-46be-b48a-335423727b82","managed":false,"name":"dataSourceSecretVersionBasic","path":"/","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"region":"fr-par","status":"ready","tags":["devtools","provider","terraform"],"type":"opaque","updated_at":"2024-02-16T07:43:30.664726Z","version_count":0}'
-    headers:
-      Content-Length:
-      - "453"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 16 Feb 2024 07:43:30 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8338d732-325b-4da7-b06f-d4fcd2e6d59c
-    status: 200 OK
-    code: 200
-- request:
-    body: '{"data":"bXlfc3VwZXJfc2VjcmV0","description":"version1"}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9a9cc414-0b6f-46be-b48a-335423727b82/versions
-    method: POST
-  response:
-    body: '{"created_at":"2024-02-16T07:43:30.908272Z","description":"version1","ephemeral_properties":null,"latest":true,"revision":1,"secret_id":"9a9cc414-0b6f-46be-b48a-335423727b82","status":"enabled","updated_at":"2024-02-16T07:43:30.908272Z"}'
-    headers:
-      Content-Length:
-      - "244"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 16 Feb 2024 07:43:30 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f59b06e9-f8f0-485f-aea6-d6d25b42aa36
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9a9cc414-0b6f-46be-b48a-335423727b82/versions/1
-    method: GET
-  response:
-    body: '{"created_at":"2024-02-16T07:43:30.908272Z","description":"version1","ephemeral_properties":null,"latest":true,"revision":1,"secret_id":"9a9cc414-0b6f-46be-b48a-335423727b82","status":"enabled","updated_at":"2024-02-16T07:43:30.908272Z"}'
-    headers:
-      Content-Length:
-      - "244"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 16 Feb 2024 07:43:30 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5fb80d17-a785-4085-b776-96b1a923cb84
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9a9cc414-0b6f-46be-b48a-335423727b82
-    method: GET
-  response:
-    body: '{"created_at":"2024-02-16T07:43:30.664726Z","description":"secret description","ephemeral_policy":null,"id":"9a9cc414-0b6f-46be-b48a-335423727b82","managed":false,"name":"dataSourceSecretVersionBasic","path":"/","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"region":"fr-par","status":"ready","tags":["devtools","provider","terraform"],"type":"opaque","updated_at":"2024-02-16T07:43:30.664726Z","version_count":1}'
-    headers:
-      Content-Length:
-      - "453"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 16 Feb 2024 07:43:31 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 36a9e17c-3444-43b1-906e-438952198722
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9a9cc414-0b6f-46be-b48a-335423727b82/versions/1
-    method: GET
-  response:
-    body: '{"created_at":"2024-02-16T07:43:30.908272Z","description":"version1","ephemeral_properties":null,"latest":true,"revision":1,"secret_id":"9a9cc414-0b6f-46be-b48a-335423727b82","status":"enabled","updated_at":"2024-02-16T07:43:30.908272Z"}'
-    headers:
-      Content-Length:
-      - "244"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 16 Feb 2024 07:43:31 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 620d8af1-6021-4c6e-a7d3-49952e42af7b
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9a9cc414-0b6f-46be-b48a-335423727b82
-    method: GET
-  response:
-    body: '{"created_at":"2024-02-16T07:43:30.664726Z","description":"secret description","ephemeral_policy":null,"id":"9a9cc414-0b6f-46be-b48a-335423727b82","managed":false,"name":"dataSourceSecretVersionBasic","path":"/","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"region":"fr-par","status":"ready","tags":["devtools","provider","terraform"],"type":"opaque","updated_at":"2024-02-16T07:43:30.664726Z","version_count":1}'
-    headers:
-      Content-Length:
-      - "453"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 16 Feb 2024 07:43:31 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0b9c6f0a-4dfe-4a6b-862b-1e718e8ae61d
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9a9cc414-0b6f-46be-b48a-335423727b82/versions/1
-    method: GET
-  response:
-    body: '{"created_at":"2024-02-16T07:43:30.908272Z","description":"version1","ephemeral_properties":null,"latest":true,"revision":1,"secret_id":"9a9cc414-0b6f-46be-b48a-335423727b82","status":"enabled","updated_at":"2024-02-16T07:43:30.908272Z"}'
-    headers:
-      Content-Length:
-      - "244"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 16 Feb 2024 07:43:31 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a1b42257-5842-46ed-a79d-4a6de40c7405
-    status: 200 OK
-    code: 200
-- request:
-    body: '{"data":"bXlfc3VwZXJfc2VjcmV0X3Yy","description":"version2"}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9a9cc414-0b6f-46be-b48a-335423727b82/versions
-    method: POST
-  response:
-    body: '{"created_at":"2024-02-16T07:43:32.327630Z","description":"version2","ephemeral_properties":null,"latest":true,"revision":2,"secret_id":"9a9cc414-0b6f-46be-b48a-335423727b82","status":"enabled","updated_at":"2024-02-16T07:43:32.327630Z"}'
-    headers:
-      Content-Length:
-      - "244"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 16 Feb 2024 07:43:32 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c49cd4a2-e6bd-4928-a7a9-904b90020100
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9a9cc414-0b6f-46be-b48a-335423727b82/versions/2
-    method: GET
-  response:
-    body: '{"created_at":"2024-02-16T07:43:32.327630Z","description":"version2","ephemeral_properties":null,"latest":true,"revision":2,"secret_id":"9a9cc414-0b6f-46be-b48a-335423727b82","status":"enabled","updated_at":"2024-02-16T07:43:32.327630Z"}'
-    headers:
-      Content-Length:
-      - "244"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 16 Feb 2024 07:43:32 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 49a08ab4-878c-444e-9858-f8219388ffb6
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9a9cc414-0b6f-46be-b48a-335423727b82
-    method: GET
-  response:
-    body: '{"created_at":"2024-02-16T07:43:30.664726Z","description":"secret description","ephemeral_policy":null,"id":"9a9cc414-0b6f-46be-b48a-335423727b82","managed":false,"name":"dataSourceSecretVersionBasic","path":"/","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"region":"fr-par","status":"ready","tags":["devtools","provider","terraform"],"type":"opaque","updated_at":"2024-02-16T07:43:30.664726Z","version_count":2}'
-    headers:
-      Content-Length:
-      - "453"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 16 Feb 2024 07:43:32 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 21b800f3-d802-44e1-8bbc-b9970674a360
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9a9cc414-0b6f-46be-b48a-335423727b82/versions/1
-    method: GET
-  response:
-    body: '{"created_at":"2024-02-16T07:43:30.908272Z","description":"version1","ephemeral_properties":null,"latest":false,"revision":1,"secret_id":"9a9cc414-0b6f-46be-b48a-335423727b82","status":"enabled","updated_at":"2024-02-16T07:43:30.908272Z"}'
-    headers:
-      Content-Length:
-      - "245"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 16 Feb 2024 07:43:32 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 334a2a17-912c-4efb-bf07-33da8d20525a
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9a9cc414-0b6f-46be-b48a-335423727b82/versions/2
-    method: GET
-  response:
-    body: '{"created_at":"2024-02-16T07:43:32.327630Z","description":"version2","ephemeral_properties":null,"latest":true,"revision":2,"secret_id":"9a9cc414-0b6f-46be-b48a-335423727b82","status":"enabled","updated_at":"2024-02-16T07:43:32.327630Z"}'
-    headers:
-      Content-Length:
-      - "244"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 16 Feb 2024 07:43:32 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 508d9f33-1e60-4d37-8244-99a9a23e2e9a
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9a9cc414-0b6f-46be-b48a-335423727b82
-    method: GET
-  response:
-    body: '{"created_at":"2024-02-16T07:43:30.664726Z","description":"secret description","ephemeral_policy":null,"id":"9a9cc414-0b6f-46be-b48a-335423727b82","managed":false,"name":"dataSourceSecretVersionBasic","path":"/","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"region":"fr-par","status":"ready","tags":["devtools","provider","terraform"],"type":"opaque","updated_at":"2024-02-16T07:43:30.664726Z","version_count":2}'
-    headers:
-      Content-Length:
-      - "453"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 16 Feb 2024 07:43:33 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0b1a13be-9630-4b81-9a76-539d712990ca
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9a9cc414-0b6f-46be-b48a-335423727b82/versions/1
-    method: GET
-  response:
-    body: '{"created_at":"2024-02-16T07:43:30.908272Z","description":"version1","ephemeral_properties":null,"latest":false,"revision":1,"secret_id":"9a9cc414-0b6f-46be-b48a-335423727b82","status":"enabled","updated_at":"2024-02-16T07:43:30.908272Z"}'
-    headers:
-      Content-Length:
-      - "245"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 16 Feb 2024 07:43:33 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3fdc6d24-5c43-4b41-9a78-67271f17ee7b
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9a9cc414-0b6f-46be-b48a-335423727b82/versions/2
-    method: GET
-  response:
-    body: '{"created_at":"2024-02-16T07:43:32.327630Z","description":"version2","ephemeral_properties":null,"latest":true,"revision":2,"secret_id":"9a9cc414-0b6f-46be-b48a-335423727b82","status":"enabled","updated_at":"2024-02-16T07:43:32.327630Z"}'
-    headers:
-      Content-Length:
-      - "244"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 16 Feb 2024 07:43:33 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3caf9136-9997-489b-8590-aa448e4862ce
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9a9cc414-0b6f-46be-b48a-335423727b82/versions/1/access
-    method: GET
-  response:
-    body: '{"data":"bXlfc3VwZXJfc2VjcmV0","data_crc32":null,"revision":1,"secret_id":"9a9cc414-0b6f-46be-b48a-335423727b82"}'
-    headers:
-      Content-Length:
-      - "116"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 16 Feb 2024 07:43:33 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 64386df3-bdf7-4c17-9c46-603a08ec05c5
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9a9cc414-0b6f-46be-b48a-335423727b82/versions/2/access
-    method: GET
-  response:
-    body: '{"data":"bXlfc3VwZXJfc2VjcmV0X3Yy","data_crc32":null,"revision":2,"secret_id":"9a9cc414-0b6f-46be-b48a-335423727b82"}'
-    headers:
-      Content-Length:
-      - "120"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 16 Feb 2024 07:43:33 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 208cc3bb-d782-499d-9e93-a9368684f156
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9a9cc414-0b6f-46be-b48a-335423727b82/versions/1
-    method: GET
-  response:
-    body: '{"created_at":"2024-02-16T07:43:30.908272Z","description":"version1","ephemeral_properties":null,"latest":false,"revision":1,"secret_id":"9a9cc414-0b6f-46be-b48a-335423727b82","status":"enabled","updated_at":"2024-02-16T07:43:30.908272Z"}'
-    headers:
-      Content-Length:
-      - "245"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 16 Feb 2024 07:43:33 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ffa3aa78-e296-448f-b20a-a92ada2b7134
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9a9cc414-0b6f-46be-b48a-335423727b82/versions/2
-    method: GET
-  response:
-    body: '{"created_at":"2024-02-16T07:43:32.327630Z","description":"version2","ephemeral_properties":null,"latest":true,"revision":2,"secret_id":"9a9cc414-0b6f-46be-b48a-335423727b82","status":"enabled","updated_at":"2024-02-16T07:43:32.327630Z"}'
-    headers:
-      Content-Length:
-      - "244"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 16 Feb 2024 07:43:33 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c3d6188d-d1fa-4f84-9094-a44430f54402
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9a9cc414-0b6f-46be-b48a-335423727b82/versions/1/access
-    method: GET
-  response:
-    body: '{"data":"bXlfc3VwZXJfc2VjcmV0","data_crc32":null,"revision":1,"secret_id":"9a9cc414-0b6f-46be-b48a-335423727b82"}'
-    headers:
-      Content-Length:
-      - "116"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 16 Feb 2024 07:43:33 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 29a83627-7437-439c-bcab-6d146e60bad7
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9a9cc414-0b6f-46be-b48a-335423727b82/versions/2/access
-    method: GET
-  response:
-    body: '{"data":"bXlfc3VwZXJfc2VjcmV0X3Yy","data_crc32":null,"revision":2,"secret_id":"9a9cc414-0b6f-46be-b48a-335423727b82"}'
-    headers:
-      Content-Length:
-      - "120"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 16 Feb 2024 07:43:33 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0617e888-8110-4c16-b0e8-442b03da13e0
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9a9cc414-0b6f-46be-b48a-335423727b82/versions/2
-    method: GET
-  response:
-    body: '{"created_at":"2024-02-16T07:43:32.327630Z","description":"version2","ephemeral_properties":null,"latest":true,"revision":2,"secret_id":"9a9cc414-0b6f-46be-b48a-335423727b82","status":"enabled","updated_at":"2024-02-16T07:43:32.327630Z"}'
-    headers:
-      Content-Length:
-      - "244"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 16 Feb 2024 07:43:33 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e3deb685-914d-4509-81ef-f1118287a5c5
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9a9cc414-0b6f-46be-b48a-335423727b82/versions/1
-    method: GET
-  response:
-    body: '{"created_at":"2024-02-16T07:43:30.908272Z","description":"version1","ephemeral_properties":null,"latest":false,"revision":1,"secret_id":"9a9cc414-0b6f-46be-b48a-335423727b82","status":"enabled","updated_at":"2024-02-16T07:43:30.908272Z"}'
-    headers:
-      Content-Length:
-      - "245"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 16 Feb 2024 07:43:33 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f3be1492-f94e-49f0-b6ca-77fe6a688454
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9a9cc414-0b6f-46be-b48a-335423727b82/versions/1
-    method: GET
-  response:
-    body: '{"created_at":"2024-02-16T07:43:30.908272Z","description":"version1","ephemeral_properties":null,"latest":false,"revision":1,"secret_id":"9a9cc414-0b6f-46be-b48a-335423727b82","status":"enabled","updated_at":"2024-02-16T07:43:30.908272Z"}'
-    headers:
-      Content-Length:
-      - "245"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 16 Feb 2024 07:43:33 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 426aafae-3dc3-48cb-b684-c60338835ad8
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9a9cc414-0b6f-46be-b48a-335423727b82/versions/2
-    method: GET
-  response:
-    body: '{"created_at":"2024-02-16T07:43:32.327630Z","description":"version2","ephemeral_properties":null,"latest":true,"revision":2,"secret_id":"9a9cc414-0b6f-46be-b48a-335423727b82","status":"enabled","updated_at":"2024-02-16T07:43:32.327630Z"}'
-    headers:
-      Content-Length:
-      - "244"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 16 Feb 2024 07:43:34 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9857ab01-89f5-4a15-8cbf-d653cf3a0d78
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9a9cc414-0b6f-46be-b48a-335423727b82/versions/1/access
-    method: GET
-  response:
-    body: '{"data":"bXlfc3VwZXJfc2VjcmV0","data_crc32":null,"revision":1,"secret_id":"9a9cc414-0b6f-46be-b48a-335423727b82"}'
-    headers:
-      Content-Length:
-      - "116"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 16 Feb 2024 07:43:34 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d2cba5d7-39a3-42b4-a093-60272e1a8d3b
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9a9cc414-0b6f-46be-b48a-335423727b82/versions/2/access
-    method: GET
-  response:
-    body: '{"data":"bXlfc3VwZXJfc2VjcmV0X3Yy","data_crc32":null,"revision":2,"secret_id":"9a9cc414-0b6f-46be-b48a-335423727b82"}'
-    headers:
-      Content-Length:
-      - "120"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 16 Feb 2024 07:43:34 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 28717760-b1f5-4b4b-9631-3d9fb9b25511
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9a9cc414-0b6f-46be-b48a-335423727b82/versions/1
-    method: GET
-  response:
-    body: '{"created_at":"2024-02-16T07:43:30.908272Z","description":"version1","ephemeral_properties":null,"latest":false,"revision":1,"secret_id":"9a9cc414-0b6f-46be-b48a-335423727b82","status":"enabled","updated_at":"2024-02-16T07:43:30.908272Z"}'
-    headers:
-      Content-Length:
-      - "245"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 16 Feb 2024 07:43:34 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0b90760b-6891-4622-964e-f6954ef4c246
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9a9cc414-0b6f-46be-b48a-335423727b82/versions/2
-    method: GET
-  response:
-    body: '{"created_at":"2024-02-16T07:43:32.327630Z","description":"version2","ephemeral_properties":null,"latest":true,"revision":2,"secret_id":"9a9cc414-0b6f-46be-b48a-335423727b82","status":"enabled","updated_at":"2024-02-16T07:43:32.327630Z"}'
-    headers:
-      Content-Length:
-      - "244"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 16 Feb 2024 07:43:34 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8bf6d1ab-320a-4497-8753-2b63aa35784e
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9a9cc414-0b6f-46be-b48a-335423727b82
-    method: GET
-  response:
-    body: '{"created_at":"2024-02-16T07:43:30.664726Z","description":"secret description","ephemeral_policy":null,"id":"9a9cc414-0b6f-46be-b48a-335423727b82","managed":false,"name":"dataSourceSecretVersionBasic","path":"/","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"region":"fr-par","status":"ready","tags":["devtools","provider","terraform"],"type":"opaque","updated_at":"2024-02-16T07:43:30.664726Z","version_count":2}'
-    headers:
-      Content-Length:
-      - "453"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 16 Feb 2024 07:43:34 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 829d15a8-ffbc-47b5-97ea-e0c3c3f9bf90
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9a9cc414-0b6f-46be-b48a-335423727b82/versions/2
-    method: GET
-  response:
-    body: '{"created_at":"2024-02-16T07:43:32.327630Z","description":"version2","ephemeral_properties":null,"latest":true,"revision":2,"secret_id":"9a9cc414-0b6f-46be-b48a-335423727b82","status":"enabled","updated_at":"2024-02-16T07:43:32.327630Z"}'
-    headers:
-      Content-Length:
-      - "244"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 16 Feb 2024 07:43:34 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 96c77675-f07c-43f7-bc08-ca1364b1f907
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9a9cc414-0b6f-46be-b48a-335423727b82/versions/1
-    method: GET
-  response:
-    body: '{"created_at":"2024-02-16T07:43:30.908272Z","description":"version1","ephemeral_properties":null,"latest":false,"revision":1,"secret_id":"9a9cc414-0b6f-46be-b48a-335423727b82","status":"enabled","updated_at":"2024-02-16T07:43:30.908272Z"}'
-    headers:
-      Content-Length:
-      - "245"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 16 Feb 2024 07:43:34 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8d97de63-cade-4169-a5b6-d7bfbea41a6b
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9a9cc414-0b6f-46be-b48a-335423727b82/versions/2/access
-    method: GET
-  response:
-    body: '{"data":"bXlfc3VwZXJfc2VjcmV0X3Yy","data_crc32":null,"revision":2,"secret_id":"9a9cc414-0b6f-46be-b48a-335423727b82"}'
-    headers:
-      Content-Length:
-      - "120"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 16 Feb 2024 07:43:34 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b6ce06dc-d299-4c6d-b45d-c3d111253d48
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9a9cc414-0b6f-46be-b48a-335423727b82/versions/1/access
-    method: GET
-  response:
-    body: '{"data":"bXlfc3VwZXJfc2VjcmV0","data_crc32":null,"revision":1,"secret_id":"9a9cc414-0b6f-46be-b48a-335423727b82"}'
-    headers:
-      Content-Length:
-      - "116"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 16 Feb 2024 07:43:34 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e1730cbc-c75d-44f8-a720-20418b37d15b
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9a9cc414-0b6f-46be-b48a-335423727b82/versions/2
-    method: GET
-  response:
-    body: '{"created_at":"2024-02-16T07:43:32.327630Z","description":"version2","ephemeral_properties":null,"latest":true,"revision":2,"secret_id":"9a9cc414-0b6f-46be-b48a-335423727b82","status":"enabled","updated_at":"2024-02-16T07:43:32.327630Z"}'
-    headers:
-      Content-Length:
-      - "244"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 16 Feb 2024 07:43:34 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b30491dd-efc1-4e4e-9b83-c1972b1771dc
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9a9cc414-0b6f-46be-b48a-335423727b82/versions/1
-    method: GET
-  response:
-    body: '{"created_at":"2024-02-16T07:43:30.908272Z","description":"version1","ephemeral_properties":null,"latest":false,"revision":1,"secret_id":"9a9cc414-0b6f-46be-b48a-335423727b82","status":"enabled","updated_at":"2024-02-16T07:43:30.908272Z"}'
-    headers:
-      Content-Length:
-      - "245"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 16 Feb 2024 07:43:34 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8e405564-d4be-43e1-8863-7cb2ef1f5309
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9a9cc414-0b6f-46be-b48a-335423727b82/versions/1/access
-    method: GET
-  response:
-    body: '{"data":"bXlfc3VwZXJfc2VjcmV0","data_crc32":null,"revision":1,"secret_id":"9a9cc414-0b6f-46be-b48a-335423727b82"}'
-    headers:
-      Content-Length:
-      - "116"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 16 Feb 2024 07:43:34 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 99c77cad-9089-46cf-964b-69a33c376039
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9a9cc414-0b6f-46be-b48a-335423727b82/versions/2/access
-    method: GET
-  response:
-    body: '{"data":"bXlfc3VwZXJfc2VjcmV0X3Yy","data_crc32":null,"revision":2,"secret_id":"9a9cc414-0b6f-46be-b48a-335423727b82"}'
-    headers:
-      Content-Length:
-      - "120"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 16 Feb 2024 07:43:34 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4a3ba348-20e2-4b3c-9a25-bbb23ed56103
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9a9cc414-0b6f-46be-b48a-335423727b82/versions/1
-    method: GET
-  response:
-    body: '{"created_at":"2024-02-16T07:43:30.908272Z","description":"version1","ephemeral_properties":null,"latest":false,"revision":1,"secret_id":"9a9cc414-0b6f-46be-b48a-335423727b82","status":"enabled","updated_at":"2024-02-16T07:43:30.908272Z"}'
-    headers:
-      Content-Length:
-      - "245"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 16 Feb 2024 07:43:35 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 491f43df-fa52-4ba1-ac29-0a2150c413c2
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9a9cc414-0b6f-46be-b48a-335423727b82/versions/2
-    method: GET
-  response:
-    body: '{"created_at":"2024-02-16T07:43:32.327630Z","description":"version2","ephemeral_properties":null,"latest":true,"revision":2,"secret_id":"9a9cc414-0b6f-46be-b48a-335423727b82","status":"enabled","updated_at":"2024-02-16T07:43:32.327630Z"}'
-    headers:
-      Content-Length:
-      - "244"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 16 Feb 2024 07:43:35 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4498ae9b-1c3b-445a-81e3-93ba229d2f59
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9a9cc414-0b6f-46be-b48a-335423727b82/versions/1
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 16 Feb 2024 07:43:35 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 11a37419-f787-499d-be37-f85d2530bf88
-    status: 204 No Content
-    code: 204
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9a9cc414-0b6f-46be-b48a-335423727b82/versions/2
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 16 Feb 2024 07:43:35 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4df8c1ef-e2c1-4b76-92b5-c6d813d387e9
-    status: 204 No Content
-    code: 204
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9a9cc414-0b6f-46be-b48a-335423727b82
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 16 Feb 2024 07:43:35 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - df7e2f99-7512-49fe-863b-fc7014fe5b4d
-    status: 204 No Content
-    code: 204
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9a9cc414-0b6f-46be-b48a-335423727b82/versions/1
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"secret","resource_id":"9a9cc414-0b6f-46be-b48a-335423727b82","type":"not_found"}'
-    headers:
-      Content-Length:
-      - "127"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 16 Feb 2024 07:43:35 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1855524d-b5ad-4a94-aecb-0d13b984d34a
-    status: 404 Not Found
-    code: 404
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9a9cc414-0b6f-46be-b48a-335423727b82/versions/2
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"secret","resource_id":"9a9cc414-0b6f-46be-b48a-335423727b82","type":"not_found"}'
-    headers:
-      Content-Length:
-      - "127"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 16 Feb 2024 07:43:35 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - bd75739b-43cf-41b5-80c2-2a70393bf6e2
-    status: 404 Not Found
-    code: 404
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9a9cc414-0b6f-46be-b48a-335423727b82/versions/1
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"secret","resource_id":"9a9cc414-0b6f-46be-b48a-335423727b82","type":"not_found"}'
-    headers:
-      Content-Length:
-      - "127"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 16 Feb 2024 07:43:35 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7ad833f9-7964-47f9-b0af-690acd53a3e8
-    status: 404 Not Found
-    code: 404
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9a9cc414-0b6f-46be-b48a-335423727b82/versions/2
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"secret","resource_id":"9a9cc414-0b6f-46be-b48a-335423727b82","type":"not_found"}'
-    headers:
-      Content-Length:
-      - "127"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 16 Feb 2024 07:43:35 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - dc9f7139-0c5d-4313-9568-7280625ed580
-    status: 404 Not Found
-    code: 404
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 220
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","name":"dataSourceSecretVersionBasic","tags":["devtools","provider","terraform"],"description":"secret description","type":"unknown_type","path":"/","protected":false}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 453
+        uncompressed: false
+        body: '{"created_at":"2024-08-07T13:05:33.128948Z","description":"secret description","ephemeral_policy":null,"id":"c84471f6-a738-4ccf-9d0a-e126c7b0311d","managed":false,"name":"dataSourceSecretVersionBasic","path":"/","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"region":"fr-par","status":"ready","tags":["devtools","provider","terraform"],"type":"opaque","updated_at":"2024-08-07T13:05:33.128948Z","version_count":0}'
+        headers:
+            Content-Length:
+                - "453"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:33 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - cca100fb-e859-4b11-87a5-a4905c41e74a
+        status: 200 OK
+        code: 200
+        duration: 143.152688ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c84471f6-a738-4ccf-9d0a-e126c7b0311d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 453
+        uncompressed: false
+        body: '{"created_at":"2024-08-07T13:05:33.128948Z","description":"secret description","ephemeral_policy":null,"id":"c84471f6-a738-4ccf-9d0a-e126c7b0311d","managed":false,"name":"dataSourceSecretVersionBasic","path":"/","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"region":"fr-par","status":"ready","tags":["devtools","provider","terraform"],"type":"opaque","updated_at":"2024-08-07T13:05:33.128948Z","version_count":0}'
+        headers:
+            Content-Length:
+                - "453"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:33 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 7ba12b1c-8d4b-47ff-978e-ff24f93a4c11
+        status: 200 OK
+        code: 200
+        duration: 46.090118ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 56
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"data":"bXlfc3VwZXJfc2VjcmV0","description":"version1"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c84471f6-a738-4ccf-9d0a-e126c7b0311d/versions
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 244
+        uncompressed: false
+        body: '{"created_at":"2024-08-07T13:05:33.339448Z","description":"version1","ephemeral_properties":null,"latest":true,"revision":1,"secret_id":"c84471f6-a738-4ccf-9d0a-e126c7b0311d","status":"enabled","updated_at":"2024-08-07T13:05:33.339448Z"}'
+        headers:
+            Content-Length:
+                - "244"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:33 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3d1292b2-e43e-4cb9-965d-530fd35b1d3e
+        status: 200 OK
+        code: 200
+        duration: 239.742367ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c84471f6-a738-4ccf-9d0a-e126c7b0311d/versions/1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 244
+        uncompressed: false
+        body: '{"created_at":"2024-08-07T13:05:33.339448Z","description":"version1","ephemeral_properties":null,"latest":true,"revision":1,"secret_id":"c84471f6-a738-4ccf-9d0a-e126c7b0311d","status":"enabled","updated_at":"2024-08-07T13:05:33.339448Z"}'
+        headers:
+            Content-Length:
+                - "244"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:33 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 79fee71e-8507-42ee-8950-b84c1f1c4ddf
+        status: 200 OK
+        code: 200
+        duration: 37.334227ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c84471f6-a738-4ccf-9d0a-e126c7b0311d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 453
+        uncompressed: false
+        body: '{"created_at":"2024-08-07T13:05:33.128948Z","description":"secret description","ephemeral_policy":null,"id":"c84471f6-a738-4ccf-9d0a-e126c7b0311d","managed":false,"name":"dataSourceSecretVersionBasic","path":"/","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"region":"fr-par","status":"ready","tags":["devtools","provider","terraform"],"type":"opaque","updated_at":"2024-08-07T13:05:33.128948Z","version_count":1}'
+        headers:
+            Content-Length:
+                - "453"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:33 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 9d2bbb45-4020-4f9c-917e-b796ac014b6d
+        status: 200 OK
+        code: 200
+        duration: 59.765855ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c84471f6-a738-4ccf-9d0a-e126c7b0311d/versions/1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 244
+        uncompressed: false
+        body: '{"created_at":"2024-08-07T13:05:33.339448Z","description":"version1","ephemeral_properties":null,"latest":true,"revision":1,"secret_id":"c84471f6-a738-4ccf-9d0a-e126c7b0311d","status":"enabled","updated_at":"2024-08-07T13:05:33.339448Z"}'
+        headers:
+            Content-Length:
+                - "244"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:33 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3c4389cb-e29b-4738-a188-5b657b8b1cd1
+        status: 200 OK
+        code: 200
+        duration: 53.11068ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c84471f6-a738-4ccf-9d0a-e126c7b0311d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 453
+        uncompressed: false
+        body: '{"created_at":"2024-08-07T13:05:33.128948Z","description":"secret description","ephemeral_policy":null,"id":"c84471f6-a738-4ccf-9d0a-e126c7b0311d","managed":false,"name":"dataSourceSecretVersionBasic","path":"/","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"region":"fr-par","status":"ready","tags":["devtools","provider","terraform"],"type":"opaque","updated_at":"2024-08-07T13:05:33.128948Z","version_count":1}'
+        headers:
+            Content-Length:
+                - "453"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3a04180f-b993-4196-95b7-ce908fdb203c
+        status: 200 OK
+        code: 200
+        duration: 27.35962ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c84471f6-a738-4ccf-9d0a-e126c7b0311d/versions/1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 244
+        uncompressed: false
+        body: '{"created_at":"2024-08-07T13:05:33.339448Z","description":"version1","ephemeral_properties":null,"latest":true,"revision":1,"secret_id":"c84471f6-a738-4ccf-9d0a-e126c7b0311d","status":"enabled","updated_at":"2024-08-07T13:05:33.339448Z"}'
+        headers:
+            Content-Length:
+                - "244"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ec4f4425-821a-425b-a1e6-3af1e5aeca3f
+        status: 200 OK
+        code: 200
+        duration: 51.268541ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 60
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"data":"bXlfc3VwZXJfc2VjcmV0X3Yy","description":"version2"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c84471f6-a738-4ccf-9d0a-e126c7b0311d/versions
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 244
+        uncompressed: false
+        body: '{"created_at":"2024-08-07T13:05:34.854587Z","description":"version2","ephemeral_properties":null,"latest":true,"revision":2,"secret_id":"c84471f6-a738-4ccf-9d0a-e126c7b0311d","status":"enabled","updated_at":"2024-08-07T13:05:34.854587Z"}'
+        headers:
+            Content-Length:
+                - "244"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 6bbd1b34-172e-44a6-9e0d-e150c0135b37
+        status: 200 OK
+        code: 200
+        duration: 296.644259ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c84471f6-a738-4ccf-9d0a-e126c7b0311d/versions/2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 244
+        uncompressed: false
+        body: '{"created_at":"2024-08-07T13:05:34.854587Z","description":"version2","ephemeral_properties":null,"latest":true,"revision":2,"secret_id":"c84471f6-a738-4ccf-9d0a-e126c7b0311d","status":"enabled","updated_at":"2024-08-07T13:05:34.854587Z"}'
+        headers:
+            Content-Length:
+                - "244"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - cfd358de-0119-452b-946b-f2a3984f35a8
+        status: 200 OK
+        code: 200
+        duration: 48.600596ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c84471f6-a738-4ccf-9d0a-e126c7b0311d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 453
+        uncompressed: false
+        body: '{"created_at":"2024-08-07T13:05:33.128948Z","description":"secret description","ephemeral_policy":null,"id":"c84471f6-a738-4ccf-9d0a-e126c7b0311d","managed":false,"name":"dataSourceSecretVersionBasic","path":"/","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"region":"fr-par","status":"ready","tags":["devtools","provider","terraform"],"type":"opaque","updated_at":"2024-08-07T13:05:33.128948Z","version_count":2}'
+        headers:
+            Content-Length:
+                - "453"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 604a46a1-be12-42ed-83a0-c616a8e36c1a
+        status: 200 OK
+        code: 200
+        duration: 43.306044ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c84471f6-a738-4ccf-9d0a-e126c7b0311d/versions/2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 244
+        uncompressed: false
+        body: '{"created_at":"2024-08-07T13:05:34.854587Z","description":"version2","ephemeral_properties":null,"latest":true,"revision":2,"secret_id":"c84471f6-a738-4ccf-9d0a-e126c7b0311d","status":"enabled","updated_at":"2024-08-07T13:05:34.854587Z"}'
+        headers:
+            Content-Length:
+                - "244"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 4615948a-9606-4607-9c8e-1dd59dac91a3
+        status: 200 OK
+        code: 200
+        duration: 23.181872ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c84471f6-a738-4ccf-9d0a-e126c7b0311d/versions/1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 245
+        uncompressed: false
+        body: '{"created_at":"2024-08-07T13:05:33.339448Z","description":"version1","ephemeral_properties":null,"latest":false,"revision":1,"secret_id":"c84471f6-a738-4ccf-9d0a-e126c7b0311d","status":"enabled","updated_at":"2024-08-07T13:05:33.339448Z"}'
+        headers:
+            Content-Length:
+                - "245"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ae46c0c1-dde2-4119-96d7-c42dd3154d04
+        status: 200 OK
+        code: 200
+        duration: 46.427143ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c84471f6-a738-4ccf-9d0a-e126c7b0311d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 453
+        uncompressed: false
+        body: '{"created_at":"2024-08-07T13:05:33.128948Z","description":"secret description","ephemeral_policy":null,"id":"c84471f6-a738-4ccf-9d0a-e126c7b0311d","managed":false,"name":"dataSourceSecretVersionBasic","path":"/","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"region":"fr-par","status":"ready","tags":["devtools","provider","terraform"],"type":"opaque","updated_at":"2024-08-07T13:05:33.128948Z","version_count":2}'
+        headers:
+            Content-Length:
+                - "453"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - eb94cb33-dcb2-4959-a8bd-adfc21e0f35e
+        status: 200 OK
+        code: 200
+        duration: 21.682438ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c84471f6-a738-4ccf-9d0a-e126c7b0311d/versions/1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 245
+        uncompressed: false
+        body: '{"created_at":"2024-08-07T13:05:33.339448Z","description":"version1","ephemeral_properties":null,"latest":false,"revision":1,"secret_id":"c84471f6-a738-4ccf-9d0a-e126c7b0311d","status":"enabled","updated_at":"2024-08-07T13:05:33.339448Z"}'
+        headers:
+            Content-Length:
+                - "245"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 77e7bb1c-2b90-41e8-b16f-3531c6d8e378
+        status: 200 OK
+        code: 200
+        duration: 27.931457ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c84471f6-a738-4ccf-9d0a-e126c7b0311d/versions/2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 244
+        uncompressed: false
+        body: '{"created_at":"2024-08-07T13:05:34.854587Z","description":"version2","ephemeral_properties":null,"latest":true,"revision":2,"secret_id":"c84471f6-a738-4ccf-9d0a-e126c7b0311d","status":"enabled","updated_at":"2024-08-07T13:05:34.854587Z"}'
+        headers:
+            Content-Length:
+                - "244"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 5a505631-9201-48f1-b3f2-c0dd50b7cb63
+        status: 200 OK
+        code: 200
+        duration: 29.384704ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c84471f6-a738-4ccf-9d0a-e126c7b0311d/versions/latest/access
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 137
+        uncompressed: false
+        body: '{"data":"bXlfc3VwZXJfc2VjcmV0X3Yy","data_crc32":null,"revision":2,"secret_id":"c84471f6-a738-4ccf-9d0a-e126c7b0311d","type":"opaque"}'
+        headers:
+            Content-Length:
+                - "137"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ee564fec-8607-447b-8a35-a60255a83785
+        status: 200 OK
+        code: 200
+        duration: 72.980013ms
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c84471f6-a738-4ccf-9d0a-e126c7b0311d/versions/2/access
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 137
+        uncompressed: false
+        body: '{"data":"bXlfc3VwZXJfc2VjcmV0X3Yy","data_crc32":null,"revision":2,"secret_id":"c84471f6-a738-4ccf-9d0a-e126c7b0311d","type":"opaque"}'
+        headers:
+            Content-Length:
+                - "137"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - eeee72d7-e78a-4eed-87cd-8b174697e034
+        status: 200 OK
+        code: 200
+        duration: 79.376661ms
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c84471f6-a738-4ccf-9d0a-e126c7b0311d/versions/2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 244
+        uncompressed: false
+        body: '{"created_at":"2024-08-07T13:05:34.854587Z","description":"version2","ephemeral_properties":null,"latest":true,"revision":2,"secret_id":"c84471f6-a738-4ccf-9d0a-e126c7b0311d","status":"enabled","updated_at":"2024-08-07T13:05:34.854587Z"}'
+        headers:
+            Content-Length:
+                - "244"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 708f2038-7d1e-4b63-83a8-1c23ab937138
+        status: 200 OK
+        code: 200
+        duration: 31.643548ms
+    - id: 19
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c84471f6-a738-4ccf-9d0a-e126c7b0311d/versions/2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 244
+        uncompressed: false
+        body: '{"created_at":"2024-08-07T13:05:34.854587Z","description":"version2","ephemeral_properties":null,"latest":true,"revision":2,"secret_id":"c84471f6-a738-4ccf-9d0a-e126c7b0311d","status":"enabled","updated_at":"2024-08-07T13:05:34.854587Z"}'
+        headers:
+            Content-Length:
+                - "244"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 5881ad39-8c42-4336-a840-848c50522ab6
+        status: 200 OK
+        code: 200
+        duration: 31.788531ms
+    - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c84471f6-a738-4ccf-9d0a-e126c7b0311d/versions/1/access
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 133
+        uncompressed: false
+        body: '{"data":"bXlfc3VwZXJfc2VjcmV0","data_crc32":null,"revision":1,"secret_id":"c84471f6-a738-4ccf-9d0a-e126c7b0311d","type":"opaque"}'
+        headers:
+            Content-Length:
+                - "133"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 95d28ba0-00ac-41ec-a432-f99f1b9d28df
+        status: 200 OK
+        code: 200
+        duration: 112.376293ms
+    - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c84471f6-a738-4ccf-9d0a-e126c7b0311d/versions/1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 245
+        uncompressed: false
+        body: '{"created_at":"2024-08-07T13:05:33.339448Z","description":"version1","ephemeral_properties":null,"latest":false,"revision":1,"secret_id":"c84471f6-a738-4ccf-9d0a-e126c7b0311d","status":"enabled","updated_at":"2024-08-07T13:05:33.339448Z"}'
+        headers:
+            Content-Length:
+                - "245"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 10b68021-3d5f-43fe-955d-54065d767af7
+        status: 200 OK
+        code: 200
+        duration: 21.501186ms
+    - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c84471f6-a738-4ccf-9d0a-e126c7b0311d/versions/latest/access
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 137
+        uncompressed: false
+        body: '{"data":"bXlfc3VwZXJfc2VjcmV0X3Yy","data_crc32":null,"revision":2,"secret_id":"c84471f6-a738-4ccf-9d0a-e126c7b0311d","type":"opaque"}'
+        headers:
+            Content-Length:
+                - "137"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:36 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ca2d6935-8e7c-4d82-8f62-374a3179a49a
+        status: 200 OK
+        code: 200
+        duration: 63.761871ms
+    - id: 23
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c84471f6-a738-4ccf-9d0a-e126c7b0311d/versions/1/access
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 133
+        uncompressed: false
+        body: '{"data":"bXlfc3VwZXJfc2VjcmV0","data_crc32":null,"revision":1,"secret_id":"c84471f6-a738-4ccf-9d0a-e126c7b0311d","type":"opaque"}'
+        headers:
+            Content-Length:
+                - "133"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:36 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e52c2333-564e-4ec3-ad74-46195654a7c9
+        status: 200 OK
+        code: 200
+        duration: 63.810903ms
+    - id: 24
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c84471f6-a738-4ccf-9d0a-e126c7b0311d/versions/2/access
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 137
+        uncompressed: false
+        body: '{"data":"bXlfc3VwZXJfc2VjcmV0X3Yy","data_crc32":null,"revision":2,"secret_id":"c84471f6-a738-4ccf-9d0a-e126c7b0311d","type":"opaque"}'
+        headers:
+            Content-Length:
+                - "137"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:36 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 7bf66536-8ca1-474a-8247-0aafa9f00607
+        status: 200 OK
+        code: 200
+        duration: 63.812036ms
+    - id: 25
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c84471f6-a738-4ccf-9d0a-e126c7b0311d/versions/2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 244
+        uncompressed: false
+        body: '{"created_at":"2024-08-07T13:05:34.854587Z","description":"version2","ephemeral_properties":null,"latest":true,"revision":2,"secret_id":"c84471f6-a738-4ccf-9d0a-e126c7b0311d","status":"enabled","updated_at":"2024-08-07T13:05:34.854587Z"}'
+        headers:
+            Content-Length:
+                - "244"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:36 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 12b61001-07f9-4dae-983f-45c9c3a02fc0
+        status: 200 OK
+        code: 200
+        duration: 26.812159ms
+    - id: 26
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c84471f6-a738-4ccf-9d0a-e126c7b0311d/versions/2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 244
+        uncompressed: false
+        body: '{"created_at":"2024-08-07T13:05:34.854587Z","description":"version2","ephemeral_properties":null,"latest":true,"revision":2,"secret_id":"c84471f6-a738-4ccf-9d0a-e126c7b0311d","status":"enabled","updated_at":"2024-08-07T13:05:34.854587Z"}'
+        headers:
+            Content-Length:
+                - "244"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:36 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - d79d68f0-a2b5-45ac-9e2a-eadb198d2291
+        status: 200 OK
+        code: 200
+        duration: 32.170832ms
+    - id: 27
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c84471f6-a738-4ccf-9d0a-e126c7b0311d/versions/1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 245
+        uncompressed: false
+        body: '{"created_at":"2024-08-07T13:05:33.339448Z","description":"version1","ephemeral_properties":null,"latest":false,"revision":1,"secret_id":"c84471f6-a738-4ccf-9d0a-e126c7b0311d","status":"enabled","updated_at":"2024-08-07T13:05:33.339448Z"}'
+        headers:
+            Content-Length:
+                - "245"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:36 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - db596ee9-c194-44bb-bad8-5090c63cec51
+        status: 200 OK
+        code: 200
+        duration: 39.459108ms
+    - id: 28
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c84471f6-a738-4ccf-9d0a-e126c7b0311d/versions/1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 245
+        uncompressed: false
+        body: '{"created_at":"2024-08-07T13:05:33.339448Z","description":"version1","ephemeral_properties":null,"latest":false,"revision":1,"secret_id":"c84471f6-a738-4ccf-9d0a-e126c7b0311d","status":"enabled","updated_at":"2024-08-07T13:05:33.339448Z"}'
+        headers:
+            Content-Length:
+                - "245"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:36 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 5d295b08-2d40-4cac-b409-9857057eea57
+        status: 200 OK
+        code: 200
+        duration: 21.071426ms
+    - id: 29
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c84471f6-a738-4ccf-9d0a-e126c7b0311d/versions/2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 244
+        uncompressed: false
+        body: '{"created_at":"2024-08-07T13:05:34.854587Z","description":"version2","ephemeral_properties":null,"latest":true,"revision":2,"secret_id":"c84471f6-a738-4ccf-9d0a-e126c7b0311d","status":"enabled","updated_at":"2024-08-07T13:05:34.854587Z"}'
+        headers:
+            Content-Length:
+                - "244"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:36 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 560e8cae-010a-4083-b9cf-0cf05dde6299
+        status: 200 OK
+        code: 200
+        duration: 49.742607ms
+    - id: 30
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c84471f6-a738-4ccf-9d0a-e126c7b0311d/versions/1/access
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 133
+        uncompressed: false
+        body: '{"data":"bXlfc3VwZXJfc2VjcmV0","data_crc32":null,"revision":1,"secret_id":"c84471f6-a738-4ccf-9d0a-e126c7b0311d","type":"opaque"}'
+        headers:
+            Content-Length:
+                - "133"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:36 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 8441b156-c615-4b3b-9120-d1f6c8fb84da
+        status: 200 OK
+        code: 200
+        duration: 52.314531ms
+    - id: 31
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c84471f6-a738-4ccf-9d0a-e126c7b0311d/versions/latest/access
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 137
+        uncompressed: false
+        body: '{"data":"bXlfc3VwZXJfc2VjcmV0X3Yy","data_crc32":null,"revision":2,"secret_id":"c84471f6-a738-4ccf-9d0a-e126c7b0311d","type":"opaque"}'
+        headers:
+            Content-Length:
+                - "137"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:36 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - c00ae58a-d56e-498b-9bce-723a8f987c28
+        status: 200 OK
+        code: 200
+        duration: 62.503622ms
+    - id: 32
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c84471f6-a738-4ccf-9d0a-e126c7b0311d/versions/2/access
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 137
+        uncompressed: false
+        body: '{"data":"bXlfc3VwZXJfc2VjcmV0X3Yy","data_crc32":null,"revision":2,"secret_id":"c84471f6-a738-4ccf-9d0a-e126c7b0311d","type":"opaque"}'
+        headers:
+            Content-Length:
+                - "137"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:36 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b5f92d5f-a896-4bb1-87ca-79ca99ac9406
+        status: 200 OK
+        code: 200
+        duration: 68.035591ms
+    - id: 33
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c84471f6-a738-4ccf-9d0a-e126c7b0311d/versions/1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 245
+        uncompressed: false
+        body: '{"created_at":"2024-08-07T13:05:33.339448Z","description":"version1","ephemeral_properties":null,"latest":false,"revision":1,"secret_id":"c84471f6-a738-4ccf-9d0a-e126c7b0311d","status":"enabled","updated_at":"2024-08-07T13:05:33.339448Z"}'
+        headers:
+            Content-Length:
+                - "245"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:36 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 6062b680-54ad-44f0-8b45-91dd5c058407
+        status: 200 OK
+        code: 200
+        duration: 29.990105ms
+    - id: 34
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c84471f6-a738-4ccf-9d0a-e126c7b0311d/versions/2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 244
+        uncompressed: false
+        body: '{"created_at":"2024-08-07T13:05:34.854587Z","description":"version2","ephemeral_properties":null,"latest":true,"revision":2,"secret_id":"c84471f6-a738-4ccf-9d0a-e126c7b0311d","status":"enabled","updated_at":"2024-08-07T13:05:34.854587Z"}'
+        headers:
+            Content-Length:
+                - "244"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:36 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 0bca6ae7-132d-492c-81e4-a258a7c39178
+        status: 200 OK
+        code: 200
+        duration: 17.888592ms
+    - id: 35
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c84471f6-a738-4ccf-9d0a-e126c7b0311d/versions/2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 244
+        uncompressed: false
+        body: '{"created_at":"2024-08-07T13:05:34.854587Z","description":"version2","ephemeral_properties":null,"latest":true,"revision":2,"secret_id":"c84471f6-a738-4ccf-9d0a-e126c7b0311d","status":"enabled","updated_at":"2024-08-07T13:05:34.854587Z"}'
+        headers:
+            Content-Length:
+                - "244"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:36 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 9a1703ca-ce09-4d4c-a4d6-b00920d7cec3
+        status: 200 OK
+        code: 200
+        duration: 44.664292ms
+    - id: 36
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c84471f6-a738-4ccf-9d0a-e126c7b0311d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 453
+        uncompressed: false
+        body: '{"created_at":"2024-08-07T13:05:33.128948Z","description":"secret description","ephemeral_policy":null,"id":"c84471f6-a738-4ccf-9d0a-e126c7b0311d","managed":false,"name":"dataSourceSecretVersionBasic","path":"/","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"region":"fr-par","status":"ready","tags":["devtools","provider","terraform"],"type":"opaque","updated_at":"2024-08-07T13:05:33.128948Z","version_count":2}'
+        headers:
+            Content-Length:
+                - "453"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:36 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ff71d6db-7b7b-4d27-989a-9e3e3f110d71
+        status: 200 OK
+        code: 200
+        duration: 23.575784ms
+    - id: 37
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c84471f6-a738-4ccf-9d0a-e126c7b0311d/versions/2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 244
+        uncompressed: false
+        body: '{"created_at":"2024-08-07T13:05:34.854587Z","description":"version2","ephemeral_properties":null,"latest":true,"revision":2,"secret_id":"c84471f6-a738-4ccf-9d0a-e126c7b0311d","status":"enabled","updated_at":"2024-08-07T13:05:34.854587Z"}'
+        headers:
+            Content-Length:
+                - "244"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:37 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - cd9974b8-ff90-4db3-af61-c4c14f1b5c55
+        status: 200 OK
+        code: 200
+        duration: 24.233051ms
+    - id: 38
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c84471f6-a738-4ccf-9d0a-e126c7b0311d/versions/1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 245
+        uncompressed: false
+        body: '{"created_at":"2024-08-07T13:05:33.339448Z","description":"version1","ephemeral_properties":null,"latest":false,"revision":1,"secret_id":"c84471f6-a738-4ccf-9d0a-e126c7b0311d","status":"enabled","updated_at":"2024-08-07T13:05:33.339448Z"}'
+        headers:
+            Content-Length:
+                - "245"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:37 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 5fe95f82-9c63-4840-b8fc-4387cdac6be7
+        status: 200 OK
+        code: 200
+        duration: 27.363728ms
+    - id: 39
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c84471f6-a738-4ccf-9d0a-e126c7b0311d/versions/1/access
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 133
+        uncompressed: false
+        body: '{"data":"bXlfc3VwZXJfc2VjcmV0","data_crc32":null,"revision":1,"secret_id":"c84471f6-a738-4ccf-9d0a-e126c7b0311d","type":"opaque"}'
+        headers:
+            Content-Length:
+                - "133"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:37 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - bbc486b7-7303-474c-8291-9c77e689b30d
+        status: 200 OK
+        code: 200
+        duration: 96.513576ms
+    - id: 40
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c84471f6-a738-4ccf-9d0a-e126c7b0311d/versions/2/access
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 137
+        uncompressed: false
+        body: '{"data":"bXlfc3VwZXJfc2VjcmV0X3Yy","data_crc32":null,"revision":2,"secret_id":"c84471f6-a738-4ccf-9d0a-e126c7b0311d","type":"opaque"}'
+        headers:
+            Content-Length:
+                - "137"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:37 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 69b0eabb-a128-4993-bd09-89119e7b3249
+        status: 200 OK
+        code: 200
+        duration: 98.204351ms
+    - id: 41
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c84471f6-a738-4ccf-9d0a-e126c7b0311d/versions/latest/access
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 137
+        uncompressed: false
+        body: '{"data":"bXlfc3VwZXJfc2VjcmV0X3Yy","data_crc32":null,"revision":2,"secret_id":"c84471f6-a738-4ccf-9d0a-e126c7b0311d","type":"opaque"}'
+        headers:
+            Content-Length:
+                - "137"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:37 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - fe10ad27-4e6d-40b7-832f-a87119a518db
+        status: 200 OK
+        code: 200
+        duration: 102.360058ms
+    - id: 42
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c84471f6-a738-4ccf-9d0a-e126c7b0311d/versions/1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 245
+        uncompressed: false
+        body: '{"created_at":"2024-08-07T13:05:33.339448Z","description":"version1","ephemeral_properties":null,"latest":false,"revision":1,"secret_id":"c84471f6-a738-4ccf-9d0a-e126c7b0311d","status":"enabled","updated_at":"2024-08-07T13:05:33.339448Z"}'
+        headers:
+            Content-Length:
+                - "245"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:37 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - de26ad26-079e-4332-bdf6-e6141ed60d98
+        status: 200 OK
+        code: 200
+        duration: 25.143136ms
+    - id: 43
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c84471f6-a738-4ccf-9d0a-e126c7b0311d/versions/2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 244
+        uncompressed: false
+        body: '{"created_at":"2024-08-07T13:05:34.854587Z","description":"version2","ephemeral_properties":null,"latest":true,"revision":2,"secret_id":"c84471f6-a738-4ccf-9d0a-e126c7b0311d","status":"enabled","updated_at":"2024-08-07T13:05:34.854587Z"}'
+        headers:
+            Content-Length:
+                - "244"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:37 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - dd33874e-5d89-4e87-949b-cf4246bf351e
+        status: 200 OK
+        code: 200
+        duration: 30.0515ms
+    - id: 44
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c84471f6-a738-4ccf-9d0a-e126c7b0311d/versions/2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 244
+        uncompressed: false
+        body: '{"created_at":"2024-08-07T13:05:34.854587Z","description":"version2","ephemeral_properties":null,"latest":true,"revision":2,"secret_id":"c84471f6-a738-4ccf-9d0a-e126c7b0311d","status":"enabled","updated_at":"2024-08-07T13:05:34.854587Z"}'
+        headers:
+            Content-Length:
+                - "244"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:37 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 62d79ed0-bbed-46a0-abdf-0be3f1f0f35d
+        status: 200 OK
+        code: 200
+        duration: 25.870174ms
+    - id: 45
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c84471f6-a738-4ccf-9d0a-e126c7b0311d/versions/latest/access
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 137
+        uncompressed: false
+        body: '{"data":"bXlfc3VwZXJfc2VjcmV0X3Yy","data_crc32":null,"revision":2,"secret_id":"c84471f6-a738-4ccf-9d0a-e126c7b0311d","type":"opaque"}'
+        headers:
+            Content-Length:
+                - "137"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:37 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - fa7f6daf-4e9f-480b-848b-00bd90cb6309
+        status: 200 OK
+        code: 200
+        duration: 61.738761ms
+    - id: 46
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c84471f6-a738-4ccf-9d0a-e126c7b0311d/versions/1/access
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 133
+        uncompressed: false
+        body: '{"data":"bXlfc3VwZXJfc2VjcmV0","data_crc32":null,"revision":1,"secret_id":"c84471f6-a738-4ccf-9d0a-e126c7b0311d","type":"opaque"}'
+        headers:
+            Content-Length:
+                - "133"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:37 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e3a74f70-ac90-4111-a51c-11fb2e40b03b
+        status: 200 OK
+        code: 200
+        duration: 73.464866ms
+    - id: 47
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c84471f6-a738-4ccf-9d0a-e126c7b0311d/versions/2/access
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 137
+        uncompressed: false
+        body: '{"data":"bXlfc3VwZXJfc2VjcmV0X3Yy","data_crc32":null,"revision":2,"secret_id":"c84471f6-a738-4ccf-9d0a-e126c7b0311d","type":"opaque"}'
+        headers:
+            Content-Length:
+                - "137"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:37 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 004c24a3-4727-4fc6-bbb2-d60d833922b7
+        status: 200 OK
+        code: 200
+        duration: 88.468193ms
+    - id: 48
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c84471f6-a738-4ccf-9d0a-e126c7b0311d/versions/2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 244
+        uncompressed: false
+        body: '{"created_at":"2024-08-07T13:05:34.854587Z","description":"version2","ephemeral_properties":null,"latest":true,"revision":2,"secret_id":"c84471f6-a738-4ccf-9d0a-e126c7b0311d","status":"enabled","updated_at":"2024-08-07T13:05:34.854587Z"}'
+        headers:
+            Content-Length:
+                - "244"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:37 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b0eb272d-73ea-4a90-9fe2-125737e09cd7
+        status: 200 OK
+        code: 200
+        duration: 28.025625ms
+    - id: 49
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c84471f6-a738-4ccf-9d0a-e126c7b0311d/versions/1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 245
+        uncompressed: false
+        body: '{"created_at":"2024-08-07T13:05:33.339448Z","description":"version1","ephemeral_properties":null,"latest":false,"revision":1,"secret_id":"c84471f6-a738-4ccf-9d0a-e126c7b0311d","status":"enabled","updated_at":"2024-08-07T13:05:33.339448Z"}'
+        headers:
+            Content-Length:
+                - "245"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:37 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - a78b99ab-501c-438e-953e-06dbe313cdd4
+        status: 200 OK
+        code: 200
+        duration: 27.413983ms
+    - id: 50
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c84471f6-a738-4ccf-9d0a-e126c7b0311d/versions/2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 244
+        uncompressed: false
+        body: '{"created_at":"2024-08-07T13:05:34.854587Z","description":"version2","ephemeral_properties":null,"latest":true,"revision":2,"secret_id":"c84471f6-a738-4ccf-9d0a-e126c7b0311d","status":"enabled","updated_at":"2024-08-07T13:05:34.854587Z"}'
+        headers:
+            Content-Length:
+                - "244"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:37 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 22054adf-b01e-4cc7-abea-e18372ac5cf0
+        status: 200 OK
+        code: 200
+        duration: 36.304367ms
+    - id: 51
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c84471f6-a738-4ccf-9d0a-e126c7b0311d/versions/2
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:37 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 142da72f-cd79-451f-ad24-cfac5cfed598
+        status: 204 No Content
+        code: 204
+        duration: 72.386315ms
+    - id: 52
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c84471f6-a738-4ccf-9d0a-e126c7b0311d/versions/1
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:37 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - c0a4f549-7e3f-44bd-a00f-1b1cc4b5b11b
+        status: 204 No Content
+        code: 204
+        duration: 98.604635ms
+    - id: 53
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c84471f6-a738-4ccf-9d0a-e126c7b0311d
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:37 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e7eedc65-2cf3-4e60-aec1-310e56c93e38
+        status: 204 No Content
+        code: 204
+        duration: 66.016247ms
+    - id: 54
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c84471f6-a738-4ccf-9d0a-e126c7b0311d/versions/1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 127
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"secret","resource_id":"c84471f6-a738-4ccf-9d0a-e126c7b0311d","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "127"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:37 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 02111719-92fa-4d47-b5df-0e1c399b918c
+        status: 404 Not Found
+        code: 404
+        duration: 24.159552ms
+    - id: 55
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c84471f6-a738-4ccf-9d0a-e126c7b0311d/versions/2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 127
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"secret","resource_id":"c84471f6-a738-4ccf-9d0a-e126c7b0311d","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "127"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:37 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 18fab790-9bf8-48df-b6d5-ea5683d0c090
+        status: 404 Not Found
+        code: 404
+        duration: 23.720867ms
+    - id: 56
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c84471f6-a738-4ccf-9d0a-e126c7b0311d/versions/2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 127
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"secret","resource_id":"c84471f6-a738-4ccf-9d0a-e126c7b0311d","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "127"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:37 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 10cab5d8-8d72-4434-88e2-2ddb5625457d
+        status: 404 Not Found
+        code: 404
+        duration: 18.91746ms
+    - id: 57
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c84471f6-a738-4ccf-9d0a-e126c7b0311d/versions/1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 127
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"secret","resource_id":"c84471f6-a738-4ccf-9d0a-e126c7b0311d","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "127"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:37 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 0a50296a-ec6a-486d-819e-f62104dd61c9
+        status: 404 Not Found
+        code: 404
+        duration: 20.394291ms
+    - id: 58
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c84471f6-a738-4ccf-9d0a-e126c7b0311d/versions/2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 127
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"secret","resource_id":"c84471f6-a738-4ccf-9d0a-e126c7b0311d","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "127"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:37 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - d0dbd85a-0015-422c-b148-a2fc29fb656f
+        status: 404 Not Found
+        code: 404
+        duration: 20.914271ms

--- a/internal/services/secret/testdata/data-source-secret-version-by-name-secret.cassette.yaml
+++ b/internal/services/secret/testdata/data-source-secret-version-by-name-secret.cassette.yaml
@@ -1,963 +1,2257 @@
 ---
 version: 2
 interactions:
-- request:
-    body: '{"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","name":"dataSourceSecretVersionByNameSecret","tags":["devtools","provider","terraform"],"type":"unknown_type","path":"/","protected":false}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.1; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests Crossplane
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets
-    method: POST
-  response:
-    body: '{"created_at":"2024-03-26T08:11:38.177920Z","description":"","ephemeral_policy":null,"id":"324b271b-b085-4cff-8a70-83939846d12c","managed":false,"name":"dataSourceSecretVersionByNameSecret","path":"/","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"region":"fr-par","status":"ready","tags":["devtools","provider","terraform"],"type":"opaque","updated_at":"2024-03-26T08:11:38.177920Z","version_count":0}'
-    headers:
-      Content-Length:
-      - "442"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 26 Mar 2024 08:11:38 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 227e6657-8e6e-442b-a43f-b35cf5f70ed8
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.1; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests Crossplane
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/324b271b-b085-4cff-8a70-83939846d12c
-    method: GET
-  response:
-    body: '{"created_at":"2024-03-26T08:11:38.177920Z","description":"","ephemeral_policy":null,"id":"324b271b-b085-4cff-8a70-83939846d12c","managed":false,"name":"dataSourceSecretVersionByNameSecret","path":"/","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"region":"fr-par","status":"ready","tags":["devtools","provider","terraform"],"type":"opaque","updated_at":"2024-03-26T08:11:38.177920Z","version_count":0}'
-    headers:
-      Content-Length:
-      - "442"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 26 Mar 2024 08:11:38 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c40c73f6-aec9-4d48-b7ed-6f039614b49f
-    status: 200 OK
-    code: 200
-- request:
-    body: '{"data":"bXlfc3VwZXJfc2VjcmV0","description":"version1"}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.1; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests Crossplane
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/324b271b-b085-4cff-8a70-83939846d12c/versions
-    method: POST
-  response:
-    body: '{"created_at":"2024-03-26T08:11:38.415254Z","description":"version1","ephemeral_properties":null,"latest":true,"revision":1,"secret_id":"324b271b-b085-4cff-8a70-83939846d12c","status":"enabled","updated_at":"2024-03-26T08:11:38.415254Z"}'
-    headers:
-      Content-Length:
-      - "244"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 26 Mar 2024 08:11:38 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5fde69ef-2715-4d3b-aac1-d7d6a78f9c23
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.1; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests Crossplane
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/324b271b-b085-4cff-8a70-83939846d12c/versions/1
-    method: GET
-  response:
-    body: '{"created_at":"2024-03-26T08:11:38.415254Z","description":"version1","ephemeral_properties":null,"latest":true,"revision":1,"secret_id":"324b271b-b085-4cff-8a70-83939846d12c","status":"enabled","updated_at":"2024-03-26T08:11:38.415254Z"}'
-    headers:
-      Content-Length:
-      - "244"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 26 Mar 2024 08:11:38 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6201c45f-3b29-4f83-a49c-d69414cd0111
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.1; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests Crossplane
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/324b271b-b085-4cff-8a70-83939846d12c
-    method: GET
-  response:
-    body: '{"created_at":"2024-03-26T08:11:38.177920Z","description":"","ephemeral_policy":null,"id":"324b271b-b085-4cff-8a70-83939846d12c","managed":false,"name":"dataSourceSecretVersionByNameSecret","path":"/","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"region":"fr-par","status":"ready","tags":["devtools","provider","terraform"],"type":"opaque","updated_at":"2024-03-26T08:11:38.177920Z","version_count":1}'
-    headers:
-      Content-Length:
-      - "442"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 26 Mar 2024 08:11:39 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 787e837b-443c-4042-b669-be8607e17a92
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.1; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests Crossplane
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/324b271b-b085-4cff-8a70-83939846d12c/versions/1
-    method: GET
-  response:
-    body: '{"created_at":"2024-03-26T08:11:38.415254Z","description":"version1","ephemeral_properties":null,"latest":true,"revision":1,"secret_id":"324b271b-b085-4cff-8a70-83939846d12c","status":"enabled","updated_at":"2024-03-26T08:11:38.415254Z"}'
-    headers:
-      Content-Length:
-      - "244"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 26 Mar 2024 08:11:39 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2be34c6d-4080-4450-9c59-d8af9885295d
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.1; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests Crossplane
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/324b271b-b085-4cff-8a70-83939846d12c
-    method: GET
-  response:
-    body: '{"created_at":"2024-03-26T08:11:38.177920Z","description":"","ephemeral_policy":null,"id":"324b271b-b085-4cff-8a70-83939846d12c","managed":false,"name":"dataSourceSecretVersionByNameSecret","path":"/","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"region":"fr-par","status":"ready","tags":["devtools","provider","terraform"],"type":"opaque","updated_at":"2024-03-26T08:11:38.177920Z","version_count":1}'
-    headers:
-      Content-Length:
-      - "442"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 26 Mar 2024 08:11:39 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e20d57d5-7f9f-4e91-8a0a-455f72e2fd68
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.1; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests Crossplane
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets?name=dataSourceSecretVersionByNameSecret&order_by=name_asc&type=unknown_type
-    method: GET
-  response:
-    body: '{"secrets":[{"created_at":"2024-03-26T08:11:38.177920Z","description":"","ephemeral_policy":null,"id":"324b271b-b085-4cff-8a70-83939846d12c","managed":false,"name":"dataSourceSecretVersionByNameSecret","path":"/","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"region":"fr-par","status":"ready","tags":["devtools","provider","terraform"],"type":"opaque","updated_at":"2024-03-26T08:11:38.177920Z","version_count":1}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "473"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 26 Mar 2024 08:11:39 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 35623829-78c2-4b1f-bd7e-de3d952aa737
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.1; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests Crossplane
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/324b271b-b085-4cff-8a70-83939846d12c/versions/1
-    method: GET
-  response:
-    body: '{"created_at":"2024-03-26T08:11:38.415254Z","description":"version1","ephemeral_properties":null,"latest":true,"revision":1,"secret_id":"324b271b-b085-4cff-8a70-83939846d12c","status":"enabled","updated_at":"2024-03-26T08:11:38.415254Z"}'
-    headers:
-      Content-Length:
-      - "244"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 26 Mar 2024 08:11:39 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d6d3714d-5dfb-46fd-8695-9d54a5fde1e1
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.1; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests Crossplane
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/324b271b-b085-4cff-8a70-83939846d12c/versions/1/access
-    method: GET
-  response:
-    body: '{"data":"bXlfc3VwZXJfc2VjcmV0","data_crc32":null,"revision":1,"secret_id":"324b271b-b085-4cff-8a70-83939846d12c"}'
-    headers:
-      Content-Length:
-      - "116"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 26 Mar 2024 08:11:39 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d0dd9ee4-c1be-48bf-a4f7-7de56dae1db8
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.1; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests Crossplane
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/324b271b-b085-4cff-8a70-83939846d12c/versions/1
-    method: GET
-  response:
-    body: '{"created_at":"2024-03-26T08:11:38.415254Z","description":"version1","ephemeral_properties":null,"latest":true,"revision":1,"secret_id":"324b271b-b085-4cff-8a70-83939846d12c","status":"enabled","updated_at":"2024-03-26T08:11:38.415254Z"}'
-    headers:
-      Content-Length:
-      - "244"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 26 Mar 2024 08:11:39 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c8615f30-f610-43aa-9ba4-9e306d84023b
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.1; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests Crossplane
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets?name=dataSourceSecretVersionByNameSecret&order_by=name_asc&type=unknown_type
-    method: GET
-  response:
-    body: '{"secrets":[{"created_at":"2024-03-26T08:11:38.177920Z","description":"","ephemeral_policy":null,"id":"324b271b-b085-4cff-8a70-83939846d12c","managed":false,"name":"dataSourceSecretVersionByNameSecret","path":"/","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"region":"fr-par","status":"ready","tags":["devtools","provider","terraform"],"type":"opaque","updated_at":"2024-03-26T08:11:38.177920Z","version_count":1}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "473"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 26 Mar 2024 08:11:39 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 40f98505-632e-45d2-a3d9-150eb7feb087
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.1; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests Crossplane
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/324b271b-b085-4cff-8a70-83939846d12c/versions/1/access
-    method: GET
-  response:
-    body: '{"data":"bXlfc3VwZXJfc2VjcmV0","data_crc32":null,"revision":1,"secret_id":"324b271b-b085-4cff-8a70-83939846d12c"}'
-    headers:
-      Content-Length:
-      - "116"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 26 Mar 2024 08:11:39 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0a324f33-fa56-4d84-8386-e8d01b9bb621
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.1; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests Crossplane
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/324b271b-b085-4cff-8a70-83939846d12c/versions/1
-    method: GET
-  response:
-    body: '{"created_at":"2024-03-26T08:11:38.415254Z","description":"version1","ephemeral_properties":null,"latest":true,"revision":1,"secret_id":"324b271b-b085-4cff-8a70-83939846d12c","status":"enabled","updated_at":"2024-03-26T08:11:38.415254Z"}'
-    headers:
-      Content-Length:
-      - "244"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 26 Mar 2024 08:11:39 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 47919311-df72-4420-81f1-4d2e10063031
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.1; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests Crossplane
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/324b271b-b085-4cff-8a70-83939846d12c/versions/1
-    method: GET
-  response:
-    body: '{"created_at":"2024-03-26T08:11:38.415254Z","description":"version1","ephemeral_properties":null,"latest":true,"revision":1,"secret_id":"324b271b-b085-4cff-8a70-83939846d12c","status":"enabled","updated_at":"2024-03-26T08:11:38.415254Z"}'
-    headers:
-      Content-Length:
-      - "244"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 26 Mar 2024 08:11:40 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 04354b5d-ed11-4c6f-a2dc-3fa9a941e433
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.1; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests Crossplane
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets?name=dataSourceSecretVersionByNameSecret&order_by=name_asc&type=unknown_type
-    method: GET
-  response:
-    body: '{"secrets":[{"created_at":"2024-03-26T08:11:38.177920Z","description":"","ephemeral_policy":null,"id":"324b271b-b085-4cff-8a70-83939846d12c","managed":false,"name":"dataSourceSecretVersionByNameSecret","path":"/","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"region":"fr-par","status":"ready","tags":["devtools","provider","terraform"],"type":"opaque","updated_at":"2024-03-26T08:11:38.177920Z","version_count":1}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "473"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 26 Mar 2024 08:11:40 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 467e4508-a0e0-4d0e-8445-bbaeccbae5d9
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.1; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests Crossplane
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/324b271b-b085-4cff-8a70-83939846d12c/versions/1/access
-    method: GET
-  response:
-    body: '{"data":"bXlfc3VwZXJfc2VjcmV0","data_crc32":null,"revision":1,"secret_id":"324b271b-b085-4cff-8a70-83939846d12c"}'
-    headers:
-      Content-Length:
-      - "116"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 26 Mar 2024 08:11:40 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8934519e-bd6c-4634-89e6-f50fa30c0f98
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.1; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests Crossplane
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/324b271b-b085-4cff-8a70-83939846d12c/versions/1
-    method: GET
-  response:
-    body: '{"created_at":"2024-03-26T08:11:38.415254Z","description":"version1","ephemeral_properties":null,"latest":true,"revision":1,"secret_id":"324b271b-b085-4cff-8a70-83939846d12c","status":"enabled","updated_at":"2024-03-26T08:11:38.415254Z"}'
-    headers:
-      Content-Length:
-      - "244"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 26 Mar 2024 08:11:40 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2646df17-d59c-4035-8b1b-06254b2ed73d
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.1; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests Crossplane
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/324b271b-b085-4cff-8a70-83939846d12c
-    method: GET
-  response:
-    body: '{"created_at":"2024-03-26T08:11:38.177920Z","description":"","ephemeral_policy":null,"id":"324b271b-b085-4cff-8a70-83939846d12c","managed":false,"name":"dataSourceSecretVersionByNameSecret","path":"/","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"region":"fr-par","status":"ready","tags":["devtools","provider","terraform"],"type":"opaque","updated_at":"2024-03-26T08:11:38.177920Z","version_count":1}'
-    headers:
-      Content-Length:
-      - "442"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 26 Mar 2024 08:11:40 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7b2187af-e9a2-4317-b709-7e949d80f797
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.1; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests Crossplane
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets?name=dataSourceSecretVersionByNameSecret&order_by=name_asc&type=unknown_type
-    method: GET
-  response:
-    body: '{"secrets":[{"created_at":"2024-03-26T08:11:38.177920Z","description":"","ephemeral_policy":null,"id":"324b271b-b085-4cff-8a70-83939846d12c","managed":false,"name":"dataSourceSecretVersionByNameSecret","path":"/","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"region":"fr-par","status":"ready","tags":["devtools","provider","terraform"],"type":"opaque","updated_at":"2024-03-26T08:11:38.177920Z","version_count":1}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "473"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 26 Mar 2024 08:11:40 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ef91e14e-dcee-4540-810c-69f20a12c832
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.1; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests Crossplane
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/324b271b-b085-4cff-8a70-83939846d12c/versions/1
-    method: GET
-  response:
-    body: '{"created_at":"2024-03-26T08:11:38.415254Z","description":"version1","ephemeral_properties":null,"latest":true,"revision":1,"secret_id":"324b271b-b085-4cff-8a70-83939846d12c","status":"enabled","updated_at":"2024-03-26T08:11:38.415254Z"}'
-    headers:
-      Content-Length:
-      - "244"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 26 Mar 2024 08:11:40 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3c5f1754-7fb7-4da9-902e-9360fbfe72a8
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.1; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests Crossplane
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/324b271b-b085-4cff-8a70-83939846d12c/versions/1/access
-    method: GET
-  response:
-    body: '{"data":"bXlfc3VwZXJfc2VjcmV0","data_crc32":null,"revision":1,"secret_id":"324b271b-b085-4cff-8a70-83939846d12c"}'
-    headers:
-      Content-Length:
-      - "116"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 26 Mar 2024 08:11:40 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ad01c36d-09fe-493f-b75e-0acaf47314f2
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.1; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests Crossplane
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/324b271b-b085-4cff-8a70-83939846d12c/versions/1
-    method: GET
-  response:
-    body: '{"created_at":"2024-03-26T08:11:38.415254Z","description":"version1","ephemeral_properties":null,"latest":true,"revision":1,"secret_id":"324b271b-b085-4cff-8a70-83939846d12c","status":"enabled","updated_at":"2024-03-26T08:11:38.415254Z"}'
-    headers:
-      Content-Length:
-      - "244"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 26 Mar 2024 08:11:40 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - da3c69bb-7319-4272-871d-9d9145fa8c97
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.1; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests Crossplane
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets?name=dataSourceSecretVersionByNameSecret&order_by=name_asc&type=unknown_type
-    method: GET
-  response:
-    body: '{"secrets":[{"created_at":"2024-03-26T08:11:38.177920Z","description":"","ephemeral_policy":null,"id":"324b271b-b085-4cff-8a70-83939846d12c","managed":false,"name":"dataSourceSecretVersionByNameSecret","path":"/","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"region":"fr-par","status":"ready","tags":["devtools","provider","terraform"],"type":"opaque","updated_at":"2024-03-26T08:11:38.177920Z","version_count":1}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "473"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 26 Mar 2024 08:11:40 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 10c73267-614e-4035-8905-dddfcdf1e596
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.1; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests Crossplane
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/324b271b-b085-4cff-8a70-83939846d12c/versions/1/access
-    method: GET
-  response:
-    body: '{"data":"bXlfc3VwZXJfc2VjcmV0","data_crc32":null,"revision":1,"secret_id":"324b271b-b085-4cff-8a70-83939846d12c"}'
-    headers:
-      Content-Length:
-      - "116"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 26 Mar 2024 08:11:41 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0252a22d-80c5-4744-b354-63633d0d8431
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.1; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests Crossplane
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/324b271b-b085-4cff-8a70-83939846d12c/versions/1
-    method: GET
-  response:
-    body: '{"created_at":"2024-03-26T08:11:38.415254Z","description":"version1","ephemeral_properties":null,"latest":true,"revision":1,"secret_id":"324b271b-b085-4cff-8a70-83939846d12c","status":"enabled","updated_at":"2024-03-26T08:11:38.415254Z"}'
-    headers:
-      Content-Length:
-      - "244"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 26 Mar 2024 08:11:41 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - bd296e76-447e-47f6-a05b-5f6042f9775b
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.1; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests Crossplane
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/324b271b-b085-4cff-8a70-83939846d12c/versions/1
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 26 Mar 2024 08:11:41 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 943c6af8-285f-41a8-9245-e57526cde094
-    status: 204 No Content
-    code: 204
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.1; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests Crossplane
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/324b271b-b085-4cff-8a70-83939846d12c
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 26 Mar 2024 08:11:41 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2c460d93-f558-4afc-b5b4-5587a988102c
-    status: 204 No Content
-    code: 204
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.1; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests Crossplane
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/324b271b-b085-4cff-8a70-83939846d12c/versions/1
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"secret","resource_id":"324b271b-b085-4cff-8a70-83939846d12c","type":"not_found"}'
-    headers:
-      Content-Length:
-      - "127"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 26 Mar 2024 08:11:41 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a9079728-ea59-433c-858c-f89a2a28385c
-    status: 404 Not Found
-    code: 404
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.1; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests Crossplane
-    url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/324b271b-b085-4cff-8a70-83939846d12c/versions/1
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"secret","resource_id":"324b271b-b085-4cff-8a70-83939846d12c","type":"not_found"}'
-    headers:
-      Content-Length:
-      - "127"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 26 Mar 2024 08:11:41 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 53827706-f6fb-431c-a144-d1ff78d70572
-    status: 404 Not Found
-    code: 404
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 192
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","name":"dataSourceSecretVersionByNameSecret","tags":["devtools","provider","terraform"],"type":"unknown_type","path":"/","protected":false}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 442
+        uncompressed: false
+        body: '{"created_at":"2024-08-07T13:05:33.127170Z","description":"","ephemeral_policy":null,"id":"c9ab866c-bdfa-4f1b-8a7b-d341dc81802a","managed":false,"name":"dataSourceSecretVersionByNameSecret","path":"/","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"region":"fr-par","status":"ready","tags":["devtools","provider","terraform"],"type":"opaque","updated_at":"2024-08-07T13:05:33.127170Z","version_count":0}'
+        headers:
+            Content-Length:
+                - "442"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:33 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 5e909313-7b98-4834-beeb-945d6289e572
+        status: 200 OK
+        code: 200
+        duration: 158.359529ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c9ab866c-bdfa-4f1b-8a7b-d341dc81802a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 442
+        uncompressed: false
+        body: '{"created_at":"2024-08-07T13:05:33.127170Z","description":"","ephemeral_policy":null,"id":"c9ab866c-bdfa-4f1b-8a7b-d341dc81802a","managed":false,"name":"dataSourceSecretVersionByNameSecret","path":"/","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"region":"fr-par","status":"ready","tags":["devtools","provider","terraform"],"type":"opaque","updated_at":"2024-08-07T13:05:33.127170Z","version_count":0}'
+        headers:
+            Content-Length:
+                - "442"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:33 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 2f5ba0e3-dfca-428a-a491-000dca389f68
+        status: 200 OK
+        code: 200
+        duration: 42.070547ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 56
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"data":"bXlfc3VwZXJfc2VjcmV0","description":"version1"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c9ab866c-bdfa-4f1b-8a7b-d341dc81802a/versions
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 244
+        uncompressed: false
+        body: '{"created_at":"2024-08-07T13:05:33.325572Z","description":"version1","ephemeral_properties":null,"latest":true,"revision":1,"secret_id":"c9ab866c-bdfa-4f1b-8a7b-d341dc81802a","status":"enabled","updated_at":"2024-08-07T13:05:33.325572Z"}'
+        headers:
+            Content-Length:
+                - "244"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:33 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - bd5f6d11-fbc7-49a1-98dc-e4b6193faf33
+        status: 200 OK
+        code: 200
+        duration: 250.480111ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c9ab866c-bdfa-4f1b-8a7b-d341dc81802a/versions/1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 244
+        uncompressed: false
+        body: '{"created_at":"2024-08-07T13:05:33.325572Z","description":"version1","ephemeral_properties":null,"latest":true,"revision":1,"secret_id":"c9ab866c-bdfa-4f1b-8a7b-d341dc81802a","status":"enabled","updated_at":"2024-08-07T13:05:33.325572Z"}'
+        headers:
+            Content-Length:
+                - "244"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:33 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f94efcd4-d3d8-4dd7-ba1d-8f069728fac9
+        status: 200 OK
+        code: 200
+        duration: 48.621285ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c9ab866c-bdfa-4f1b-8a7b-d341dc81802a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 442
+        uncompressed: false
+        body: '{"created_at":"2024-08-07T13:05:33.127170Z","description":"","ephemeral_policy":null,"id":"c9ab866c-bdfa-4f1b-8a7b-d341dc81802a","managed":false,"name":"dataSourceSecretVersionByNameSecret","path":"/","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"region":"fr-par","status":"ready","tags":["devtools","provider","terraform"],"type":"opaque","updated_at":"2024-08-07T13:05:33.127170Z","version_count":1}'
+        headers:
+            Content-Length:
+                - "442"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:33 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - dc70c98d-ee35-482e-a985-dc772a89a265
+        status: 200 OK
+        code: 200
+        duration: 19.343723ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c9ab866c-bdfa-4f1b-8a7b-d341dc81802a/versions/1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 244
+        uncompressed: false
+        body: '{"created_at":"2024-08-07T13:05:33.325572Z","description":"version1","ephemeral_properties":null,"latest":true,"revision":1,"secret_id":"c9ab866c-bdfa-4f1b-8a7b-d341dc81802a","status":"enabled","updated_at":"2024-08-07T13:05:33.325572Z"}'
+        headers:
+            Content-Length:
+                - "244"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:33 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - d5883e3a-258a-41e3-8f86-2c6b80b84e0c
+        status: 200 OK
+        code: 200
+        duration: 59.543266ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c9ab866c-bdfa-4f1b-8a7b-d341dc81802a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 442
+        uncompressed: false
+        body: '{"created_at":"2024-08-07T13:05:33.127170Z","description":"","ephemeral_policy":null,"id":"c9ab866c-bdfa-4f1b-8a7b-d341dc81802a","managed":false,"name":"dataSourceSecretVersionByNameSecret","path":"/","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"region":"fr-par","status":"ready","tags":["devtools","provider","terraform"],"type":"opaque","updated_at":"2024-08-07T13:05:33.127170Z","version_count":1}'
+        headers:
+            Content-Length:
+                - "442"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 42e9abc9-7b37-4ed4-a6bf-ccadaca94b1e
+        status: 200 OK
+        code: 200
+        duration: 27.232291ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets?name=dataSourceSecretVersionByNameSecret&order_by=name_asc&type=unknown_type
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 473
+        uncompressed: false
+        body: '{"secrets":[{"created_at":"2024-08-07T13:05:33.127170Z","description":"","ephemeral_policy":null,"id":"c9ab866c-bdfa-4f1b-8a7b-d341dc81802a","managed":false,"name":"dataSourceSecretVersionByNameSecret","path":"/","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"region":"fr-par","status":"ready","tags":["devtools","provider","terraform"],"type":"opaque","updated_at":"2024-08-07T13:05:33.127170Z","version_count":1}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "473"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 7a0ec5f2-982b-46ab-a214-41774e2b0a82
+        status: 200 OK
+        code: 200
+        duration: 43.882831ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets?name=dataSourceSecretVersionByNameSecret&order_by=name_asc&type=unknown_type
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 473
+        uncompressed: false
+        body: '{"secrets":[{"created_at":"2024-08-07T13:05:33.127170Z","description":"","ephemeral_policy":null,"id":"c9ab866c-bdfa-4f1b-8a7b-d341dc81802a","managed":false,"name":"dataSourceSecretVersionByNameSecret","path":"/","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"region":"fr-par","status":"ready","tags":["devtools","provider","terraform"],"type":"opaque","updated_at":"2024-08-07T13:05:33.127170Z","version_count":1}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "473"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 7900961a-1733-442a-b86f-b7156d55a27e
+        status: 200 OK
+        code: 200
+        duration: 49.972109ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c9ab866c-bdfa-4f1b-8a7b-d341dc81802a/versions/1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 244
+        uncompressed: false
+        body: '{"created_at":"2024-08-07T13:05:33.325572Z","description":"version1","ephemeral_properties":null,"latest":true,"revision":1,"secret_id":"c9ab866c-bdfa-4f1b-8a7b-d341dc81802a","status":"enabled","updated_at":"2024-08-07T13:05:33.325572Z"}'
+        headers:
+            Content-Length:
+                - "244"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 441db2e3-87db-4bcd-858e-3ac7ea58a911
+        status: 200 OK
+        code: 200
+        duration: 56.780572ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c9ab866c-bdfa-4f1b-8a7b-d341dc81802a/versions/latest/access
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 133
+        uncompressed: false
+        body: '{"data":"bXlfc3VwZXJfc2VjcmV0","data_crc32":null,"revision":1,"secret_id":"c9ab866c-bdfa-4f1b-8a7b-d341dc81802a","type":"opaque"}'
+        headers:
+            Content-Length:
+                - "133"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 25923dc2-7467-47d2-88e0-7b5d36461706
+        status: 200 OK
+        code: 200
+        duration: 86.905951ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c9ab866c-bdfa-4f1b-8a7b-d341dc81802a/versions/1/access
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 133
+        uncompressed: false
+        body: '{"data":"bXlfc3VwZXJfc2VjcmV0","data_crc32":null,"revision":1,"secret_id":"c9ab866c-bdfa-4f1b-8a7b-d341dc81802a","type":"opaque"}'
+        headers:
+            Content-Length:
+                - "133"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b1081ee8-90b0-4eb0-95b8-c1e42fce0da2
+        status: 200 OK
+        code: 200
+        duration: 94.920927ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c9ab866c-bdfa-4f1b-8a7b-d341dc81802a/versions/1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 244
+        uncompressed: false
+        body: '{"created_at":"2024-08-07T13:05:33.325572Z","description":"version1","ephemeral_properties":null,"latest":true,"revision":1,"secret_id":"c9ab866c-bdfa-4f1b-8a7b-d341dc81802a","status":"enabled","updated_at":"2024-08-07T13:05:33.325572Z"}'
+        headers:
+            Content-Length:
+                - "244"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 6b85bba1-df32-4afe-b258-0cc0ae3b89fa
+        status: 200 OK
+        code: 200
+        duration: 26.581915ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c9ab866c-bdfa-4f1b-8a7b-d341dc81802a/versions/1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 244
+        uncompressed: false
+        body: '{"created_at":"2024-08-07T13:05:33.325572Z","description":"version1","ephemeral_properties":null,"latest":true,"revision":1,"secret_id":"c9ab866c-bdfa-4f1b-8a7b-d341dc81802a","status":"enabled","updated_at":"2024-08-07T13:05:33.325572Z"}'
+        headers:
+            Content-Length:
+                - "244"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f45a9c5b-2010-4a17-8402-761f64252609
+        status: 200 OK
+        code: 200
+        duration: 24.815819ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets?name=dataSourceSecretVersionByNameSecret&order_by=name_asc&type=unknown_type
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 473
+        uncompressed: false
+        body: '{"secrets":[{"created_at":"2024-08-07T13:05:33.127170Z","description":"","ephemeral_policy":null,"id":"c9ab866c-bdfa-4f1b-8a7b-d341dc81802a","managed":false,"name":"dataSourceSecretVersionByNameSecret","path":"/","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"region":"fr-par","status":"ready","tags":["devtools","provider","terraform"],"type":"opaque","updated_at":"2024-08-07T13:05:33.127170Z","version_count":1}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "473"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 251d1daf-638b-49ac-b59b-6ae54094d17f
+        status: 200 OK
+        code: 200
+        duration: 28.502973ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets?name=dataSourceSecretVersionByNameSecret&order_by=name_asc&type=unknown_type
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 473
+        uncompressed: false
+        body: '{"secrets":[{"created_at":"2024-08-07T13:05:33.127170Z","description":"","ephemeral_policy":null,"id":"c9ab866c-bdfa-4f1b-8a7b-d341dc81802a","managed":false,"name":"dataSourceSecretVersionByNameSecret","path":"/","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"region":"fr-par","status":"ready","tags":["devtools","provider","terraform"],"type":"opaque","updated_at":"2024-08-07T13:05:33.127170Z","version_count":1}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "473"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ec7cee2f-1360-4906-94d4-a33637699c25
+        status: 200 OK
+        code: 200
+        duration: 54.016276ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c9ab866c-bdfa-4f1b-8a7b-d341dc81802a/versions/1/access
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 133
+        uncompressed: false
+        body: '{"data":"bXlfc3VwZXJfc2VjcmV0","data_crc32":null,"revision":1,"secret_id":"c9ab866c-bdfa-4f1b-8a7b-d341dc81802a","type":"opaque"}'
+        headers:
+            Content-Length:
+                - "133"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 89f8ef99-12ea-4d01-aa40-49598c1416a6
+        status: 200 OK
+        code: 200
+        duration: 44.038023ms
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c9ab866c-bdfa-4f1b-8a7b-d341dc81802a/versions/1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 244
+        uncompressed: false
+        body: '{"created_at":"2024-08-07T13:05:33.325572Z","description":"version1","ephemeral_properties":null,"latest":true,"revision":1,"secret_id":"c9ab866c-bdfa-4f1b-8a7b-d341dc81802a","status":"enabled","updated_at":"2024-08-07T13:05:33.325572Z"}'
+        headers:
+            Content-Length:
+                - "244"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 8908b974-f32d-4ab4-b6bb-165c3de97b42
+        status: 200 OK
+        code: 200
+        duration: 26.482368ms
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c9ab866c-bdfa-4f1b-8a7b-d341dc81802a/versions/latest/access
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 133
+        uncompressed: false
+        body: '{"data":"bXlfc3VwZXJfc2VjcmV0","data_crc32":null,"revision":1,"secret_id":"c9ab866c-bdfa-4f1b-8a7b-d341dc81802a","type":"opaque"}'
+        headers:
+            Content-Length:
+                - "133"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 0e44e752-62f4-4510-ba6c-99e18a470e24
+        status: 200 OK
+        code: 200
+        duration: 106.658083ms
+    - id: 19
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c9ab866c-bdfa-4f1b-8a7b-d341dc81802a/versions/1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 244
+        uncompressed: false
+        body: '{"created_at":"2024-08-07T13:05:33.325572Z","description":"version1","ephemeral_properties":null,"latest":true,"revision":1,"secret_id":"c9ab866c-bdfa-4f1b-8a7b-d341dc81802a","status":"enabled","updated_at":"2024-08-07T13:05:33.325572Z"}'
+        headers:
+            Content-Length:
+                - "244"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - c78bf609-6325-4774-8ae6-b98c3f9e73f1
+        status: 200 OK
+        code: 200
+        duration: 30.549388ms
+    - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c9ab866c-bdfa-4f1b-8a7b-d341dc81802a/versions/1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 244
+        uncompressed: false
+        body: '{"created_at":"2024-08-07T13:05:33.325572Z","description":"version1","ephemeral_properties":null,"latest":true,"revision":1,"secret_id":"c9ab866c-bdfa-4f1b-8a7b-d341dc81802a","status":"enabled","updated_at":"2024-08-07T13:05:33.325572Z"}'
+        headers:
+            Content-Length:
+                - "244"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 41a71728-62ee-4f54-afa0-0ac3fbfc5148
+        status: 200 OK
+        code: 200
+        duration: 48.813998ms
+    - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets?name=dataSourceSecretVersionByNameSecret&order_by=name_asc&type=unknown_type
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 473
+        uncompressed: false
+        body: '{"secrets":[{"created_at":"2024-08-07T13:05:33.127170Z","description":"","ephemeral_policy":null,"id":"c9ab866c-bdfa-4f1b-8a7b-d341dc81802a","managed":false,"name":"dataSourceSecretVersionByNameSecret","path":"/","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"region":"fr-par","status":"ready","tags":["devtools","provider","terraform"],"type":"opaque","updated_at":"2024-08-07T13:05:33.127170Z","version_count":1}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "473"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 6a3f2ec2-3791-46d2-b137-3367119e3e41
+        status: 200 OK
+        code: 200
+        duration: 24.58252ms
+    - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets?name=dataSourceSecretVersionByNameSecret&order_by=name_asc&type=unknown_type
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 473
+        uncompressed: false
+        body: '{"secrets":[{"created_at":"2024-08-07T13:05:33.127170Z","description":"","ephemeral_policy":null,"id":"c9ab866c-bdfa-4f1b-8a7b-d341dc81802a","managed":false,"name":"dataSourceSecretVersionByNameSecret","path":"/","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"region":"fr-par","status":"ready","tags":["devtools","provider","terraform"],"type":"opaque","updated_at":"2024-08-07T13:05:33.127170Z","version_count":1}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "473"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3a420a5e-f223-4bb9-a264-127ff8382e84
+        status: 200 OK
+        code: 200
+        duration: 26.296037ms
+    - id: 23
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c9ab866c-bdfa-4f1b-8a7b-d341dc81802a/versions/latest/access
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 133
+        uncompressed: false
+        body: '{"data":"bXlfc3VwZXJfc2VjcmV0","data_crc32":null,"revision":1,"secret_id":"c9ab866c-bdfa-4f1b-8a7b-d341dc81802a","type":"opaque"}'
+        headers:
+            Content-Length:
+                - "133"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - d771d5cd-e869-4eb5-ad17-57abb1637b57
+        status: 200 OK
+        code: 200
+        duration: 57.120202ms
+    - id: 24
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c9ab866c-bdfa-4f1b-8a7b-d341dc81802a/versions/1/access
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 133
+        uncompressed: false
+        body: '{"data":"bXlfc3VwZXJfc2VjcmV0","data_crc32":null,"revision":1,"secret_id":"c9ab866c-bdfa-4f1b-8a7b-d341dc81802a","type":"opaque"}'
+        headers:
+            Content-Length:
+                - "133"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 195ede27-0591-478e-87e4-ee4d8e4d7062
+        status: 200 OK
+        code: 200
+        duration: 65.046922ms
+    - id: 25
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c9ab866c-bdfa-4f1b-8a7b-d341dc81802a/versions/1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 244
+        uncompressed: false
+        body: '{"created_at":"2024-08-07T13:05:33.325572Z","description":"version1","ephemeral_properties":null,"latest":true,"revision":1,"secret_id":"c9ab866c-bdfa-4f1b-8a7b-d341dc81802a","status":"enabled","updated_at":"2024-08-07T13:05:33.325572Z"}'
+        headers:
+            Content-Length:
+                - "244"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 6d635c5e-0333-40af-899a-1252fe1322f4
+        status: 200 OK
+        code: 200
+        duration: 25.189412ms
+    - id: 26
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c9ab866c-bdfa-4f1b-8a7b-d341dc81802a/versions/1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 244
+        uncompressed: false
+        body: '{"created_at":"2024-08-07T13:05:33.325572Z","description":"version1","ephemeral_properties":null,"latest":true,"revision":1,"secret_id":"c9ab866c-bdfa-4f1b-8a7b-d341dc81802a","status":"enabled","updated_at":"2024-08-07T13:05:33.325572Z"}'
+        headers:
+            Content-Length:
+                - "244"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 5b9d1d00-fa05-4a35-9679-2684b04b4241
+        status: 200 OK
+        code: 200
+        duration: 50.310476ms
+    - id: 27
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c9ab866c-bdfa-4f1b-8a7b-d341dc81802a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 442
+        uncompressed: false
+        body: '{"created_at":"2024-08-07T13:05:33.127170Z","description":"","ephemeral_policy":null,"id":"c9ab866c-bdfa-4f1b-8a7b-d341dc81802a","managed":false,"name":"dataSourceSecretVersionByNameSecret","path":"/","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"region":"fr-par","status":"ready","tags":["devtools","provider","terraform"],"type":"opaque","updated_at":"2024-08-07T13:05:33.127170Z","version_count":1}'
+        headers:
+            Content-Length:
+                - "442"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - a724ac09-3dc5-4002-a3b6-e81aa96b1f21
+        status: 200 OK
+        code: 200
+        duration: 44.301619ms
+    - id: 28
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c9ab866c-bdfa-4f1b-8a7b-d341dc81802a/versions/1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 244
+        uncompressed: false
+        body: '{"created_at":"2024-08-07T13:05:33.325572Z","description":"version1","ephemeral_properties":null,"latest":true,"revision":1,"secret_id":"c9ab866c-bdfa-4f1b-8a7b-d341dc81802a","status":"enabled","updated_at":"2024-08-07T13:05:33.325572Z"}'
+        headers:
+            Content-Length:
+                - "244"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 457ff856-e6af-4f64-aa64-233257baf6c3
+        status: 200 OK
+        code: 200
+        duration: 28.465493ms
+    - id: 29
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets?name=dataSourceSecretVersionByNameSecret&order_by=name_asc&type=unknown_type
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 473
+        uncompressed: false
+        body: '{"secrets":[{"created_at":"2024-08-07T13:05:33.127170Z","description":"","ephemeral_policy":null,"id":"c9ab866c-bdfa-4f1b-8a7b-d341dc81802a","managed":false,"name":"dataSourceSecretVersionByNameSecret","path":"/","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"region":"fr-par","status":"ready","tags":["devtools","provider","terraform"],"type":"opaque","updated_at":"2024-08-07T13:05:33.127170Z","version_count":1}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "473"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 95525d6a-7f8e-4cea-8805-f13087cfa9ed
+        status: 200 OK
+        code: 200
+        duration: 45.04527ms
+    - id: 30
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets?name=dataSourceSecretVersionByNameSecret&order_by=name_asc&type=unknown_type
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 473
+        uncompressed: false
+        body: '{"secrets":[{"created_at":"2024-08-07T13:05:33.127170Z","description":"","ephemeral_policy":null,"id":"c9ab866c-bdfa-4f1b-8a7b-d341dc81802a","managed":false,"name":"dataSourceSecretVersionByNameSecret","path":"/","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"region":"fr-par","status":"ready","tags":["devtools","provider","terraform"],"type":"opaque","updated_at":"2024-08-07T13:05:33.127170Z","version_count":1}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "473"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 28144c48-4eab-4c45-ba32-baf3d7c0b9fd
+        status: 200 OK
+        code: 200
+        duration: 52.456107ms
+    - id: 31
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c9ab866c-bdfa-4f1b-8a7b-d341dc81802a/versions/1/access
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 133
+        uncompressed: false
+        body: '{"data":"bXlfc3VwZXJfc2VjcmV0","data_crc32":null,"revision":1,"secret_id":"c9ab866c-bdfa-4f1b-8a7b-d341dc81802a","type":"opaque"}'
+        headers:
+            Content-Length:
+                - "133"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - d901e9df-e232-453e-bb41-a0e08fad86af
+        status: 200 OK
+        code: 200
+        duration: 57.795314ms
+    - id: 32
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c9ab866c-bdfa-4f1b-8a7b-d341dc81802a/versions/latest/access
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 133
+        uncompressed: false
+        body: '{"data":"bXlfc3VwZXJfc2VjcmV0","data_crc32":null,"revision":1,"secret_id":"c9ab866c-bdfa-4f1b-8a7b-d341dc81802a","type":"opaque"}'
+        headers:
+            Content-Length:
+                - "133"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 100bee5e-a83d-4c37-a35f-d28da4c6f568
+        status: 200 OK
+        code: 200
+        duration: 61.645135ms
+    - id: 33
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c9ab866c-bdfa-4f1b-8a7b-d341dc81802a/versions/1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 244
+        uncompressed: false
+        body: '{"created_at":"2024-08-07T13:05:33.325572Z","description":"version1","ephemeral_properties":null,"latest":true,"revision":1,"secret_id":"c9ab866c-bdfa-4f1b-8a7b-d341dc81802a","status":"enabled","updated_at":"2024-08-07T13:05:33.325572Z"}'
+        headers:
+            Content-Length:
+                - "244"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 7e397ff8-d376-4b26-8b44-654fe779cda0
+        status: 200 OK
+        code: 200
+        duration: 24.025149ms
+    - id: 34
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c9ab866c-bdfa-4f1b-8a7b-d341dc81802a/versions/1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 244
+        uncompressed: false
+        body: '{"created_at":"2024-08-07T13:05:33.325572Z","description":"version1","ephemeral_properties":null,"latest":true,"revision":1,"secret_id":"c9ab866c-bdfa-4f1b-8a7b-d341dc81802a","status":"enabled","updated_at":"2024-08-07T13:05:33.325572Z"}'
+        headers:
+            Content-Length:
+                - "244"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 066d90a3-b983-4105-b62d-42559eca93d1
+        status: 200 OK
+        code: 200
+        duration: 23.925812ms
+    - id: 35
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets?name=dataSourceSecretVersionByNameSecret&order_by=name_asc&type=unknown_type
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 473
+        uncompressed: false
+        body: '{"secrets":[{"created_at":"2024-08-07T13:05:33.127170Z","description":"","ephemeral_policy":null,"id":"c9ab866c-bdfa-4f1b-8a7b-d341dc81802a","managed":false,"name":"dataSourceSecretVersionByNameSecret","path":"/","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"region":"fr-par","status":"ready","tags":["devtools","provider","terraform"],"type":"opaque","updated_at":"2024-08-07T13:05:33.127170Z","version_count":1}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "473"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 0dd6520c-c3cc-43b2-ac5d-c283766280f6
+        status: 200 OK
+        code: 200
+        duration: 24.29068ms
+    - id: 36
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets?name=dataSourceSecretVersionByNameSecret&order_by=name_asc&type=unknown_type
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 473
+        uncompressed: false
+        body: '{"secrets":[{"created_at":"2024-08-07T13:05:33.127170Z","description":"","ephemeral_policy":null,"id":"c9ab866c-bdfa-4f1b-8a7b-d341dc81802a","managed":false,"name":"dataSourceSecretVersionByNameSecret","path":"/","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"region":"fr-par","status":"ready","tags":["devtools","provider","terraform"],"type":"opaque","updated_at":"2024-08-07T13:05:33.127170Z","version_count":1}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "473"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 99a17ecb-8240-4ed8-8ffe-050bf1917abd
+        status: 200 OK
+        code: 200
+        duration: 24.250574ms
+    - id: 37
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c9ab866c-bdfa-4f1b-8a7b-d341dc81802a/versions/latest/access
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 133
+        uncompressed: false
+        body: '{"data":"bXlfc3VwZXJfc2VjcmV0","data_crc32":null,"revision":1,"secret_id":"c9ab866c-bdfa-4f1b-8a7b-d341dc81802a","type":"opaque"}'
+        headers:
+            Content-Length:
+                - "133"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - d6db98fa-7ae3-4ef9-bc37-2a277713e881
+        status: 200 OK
+        code: 200
+        duration: 88.535841ms
+    - id: 38
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c9ab866c-bdfa-4f1b-8a7b-d341dc81802a/versions/1/access
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 133
+        uncompressed: false
+        body: '{"data":"bXlfc3VwZXJfc2VjcmV0","data_crc32":null,"revision":1,"secret_id":"c9ab866c-bdfa-4f1b-8a7b-d341dc81802a","type":"opaque"}'
+        headers:
+            Content-Length:
+                - "133"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b45db099-1725-46d6-a67a-df303436ea63
+        status: 200 OK
+        code: 200
+        duration: 88.603269ms
+    - id: 39
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c9ab866c-bdfa-4f1b-8a7b-d341dc81802a/versions/1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 244
+        uncompressed: false
+        body: '{"created_at":"2024-08-07T13:05:33.325572Z","description":"version1","ephemeral_properties":null,"latest":true,"revision":1,"secret_id":"c9ab866c-bdfa-4f1b-8a7b-d341dc81802a","status":"enabled","updated_at":"2024-08-07T13:05:33.325572Z"}'
+        headers:
+            Content-Length:
+                - "244"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 5cbe2545-4d25-4bf4-a393-d891e1bd71f0
+        status: 200 OK
+        code: 200
+        duration: 28.134459ms
+    - id: 40
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c9ab866c-bdfa-4f1b-8a7b-d341dc81802a/versions/1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 244
+        uncompressed: false
+        body: '{"created_at":"2024-08-07T13:05:33.325572Z","description":"version1","ephemeral_properties":null,"latest":true,"revision":1,"secret_id":"c9ab866c-bdfa-4f1b-8a7b-d341dc81802a","status":"enabled","updated_at":"2024-08-07T13:05:33.325572Z"}'
+        headers:
+            Content-Length:
+                - "244"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 7b225cd3-32fe-4482-9e84-a4c251c3e4f1
+        status: 200 OK
+        code: 200
+        duration: 29.482558ms
+    - id: 41
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c9ab866c-bdfa-4f1b-8a7b-d341dc81802a/versions/1
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:36 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 67755149-8e26-4406-a6b1-45ccde8fbe8e
+        status: 204 No Content
+        code: 204
+        duration: 61.226866ms
+    - id: 42
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c9ab866c-bdfa-4f1b-8a7b-d341dc81802a
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:36 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 710726c7-6a14-4c38-9190-23022a796672
+        status: 204 No Content
+        code: 204
+        duration: 69.563258ms
+    - id: 43
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c9ab866c-bdfa-4f1b-8a7b-d341dc81802a/versions/1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 127
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"secret","resource_id":"c9ab866c-bdfa-4f1b-8a7b-d341dc81802a","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "127"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:36 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f0c19536-bfee-4dee-967b-5a5efee4c59e
+        status: 404 Not Found
+        code: 404
+        duration: 24.521855ms
+    - id: 44
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c9ab866c-bdfa-4f1b-8a7b-d341dc81802a/versions/1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 127
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"secret","resource_id":"c9ab866c-bdfa-4f1b-8a7b-d341dc81802a","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "127"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:36 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b2a47231-32ad-44c5-8519-6b71e788d76b
+        status: 404 Not Found
+        code: 404
+        duration: 25.567054ms
+    - id: 45
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c9ab866c-bdfa-4f1b-8a7b-d341dc81802a/versions/1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 127
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"secret","resource_id":"c9ab866c-bdfa-4f1b-8a7b-d341dc81802a","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "127"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 07 Aug 2024 13:05:36 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - a3dcc3d4-8550-4841-89d2-860c370f4e2c
+        status: 404 Not Found
+        code: 404
+        duration: 27.130148ms

--- a/internal/services/secret/version_data_source_test.go
+++ b/internal/services/secret/version_data_source_test.go
@@ -90,6 +90,11 @@ func TestAccDataSourceSecretVersion_Basic(t *testing.T) {
 				  secret_id = scaleway_secret.main.id
 				  revision  = "2"
 				}
+
+				data "scaleway_secret_version" "data_latest" {
+				  secret_id = scaleway_secret.main.id
+				  revision  = "latest"
+				}
 				`, secretName, secretDataDescription, secretVersionData, secretVersionDataV2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecretVersionExists(tt, "scaleway_secret_version.v1"),
@@ -100,6 +105,8 @@ func TestAccDataSourceSecretVersion_Basic(t *testing.T) {
 					testAccCheckSecretVersionExists(tt, "scaleway_secret_version.v2"),
 					resource.TestCheckResourceAttrPair("data.scaleway_secret_version.data_v2", "secret_id", "scaleway_secret.main", "id"),
 					resource.TestCheckResourceAttr("data.scaleway_secret_version.data_v2", "data", secret.Base64Encoded([]byte(secretVersionDataV2))),
+					resource.TestCheckResourceAttrPair("data.scaleway_secret_version.data_latest", "secret_id", "scaleway_secret.main", "id"),
+					resource.TestCheckResourceAttr("data.scaleway_secret_version.data_latest", "data", secret.Base64Encoded([]byte(secretVersionDataV2))),
 				),
 			},
 		},
@@ -148,13 +155,19 @@ func TestAccDataSourceSecretVersion_ByNameSecret(t *testing.T) {
 				  secret_name = scaleway_secret.main.name
 				  revision    = "1"
 				}
+
+				data "scaleway_secret_version" "data_by_name_latest" {
+				  secret_name = scaleway_secret.main.name
+				  revision    = "latest"
+				}
 				`, secretName, secretVersionData),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecretVersionExists(tt, "scaleway_secret_version.main"),
 					resource.TestCheckResourceAttrPair("data.scaleway_secret_version.data_by_name", "secret_id", "scaleway_secret.main", "id"),
 					resource.TestCheckResourceAttr("data.scaleway_secret_version.data_by_name", "data", secret.Base64Encoded([]byte(secretVersionData))),
 					resource.TestCheckResourceAttr("data.scaleway_secret_version.data_by_name", "revision", "1"),
-				),
+					resource.TestCheckResourceAttr("data.scaleway_secret_version.data_by_name_latest", "data", secret.Base64Encoded([]byte(secretVersionData))),
+					resource.TestCheckResourceAttr("data.scaleway_secret_version.data_by_name_latest", "revision", "1")),
 			},
 		},
 	})


### PR DESCRIPTION
Linked to #2655 