### PR TITLE
fix(iam_ssh_key): do not read public key in resource

### DIFF
--- a/internal/services/iam/ssh_key.go
+++ b/internal/services/iam/ssh_key.go
@@ -55,6 +55,14 @@ func ResourceSSKKey() *schema.Resource {
 					areEqual := bytes.Equal(marshalledOldValue, marshalledNewValue)
 					return areEqual
 				},
+				StateFunc: func(v interface{}) string {
+					switch v := v.(type) {
+					case string:
+						return strings.TrimSpace(v)
+					default:
+						return ""
+					}
+				},
 			},
 			"fingerprint": {
 				Type:        schema.TypeString,
@@ -125,7 +133,6 @@ func resourceIamSSHKeyRead(ctx context.Context, d *schema.ResourceData, m interf
 	}
 
 	_ = d.Set("name", res.Name)
-	_ = d.Set("public_key", res.PublicKey)
 	_ = d.Set("fingerprint", res.Fingerprint)
 	_ = d.Set("created_at", types.FlattenTime(res.CreatedAt))
 	_ = d.Set("updated_at", types.FlattenTime(res.UpdatedAt))

--- a/internal/services/iam/ssh_key_account_test.go
+++ b/internal/services/iam/ssh_key_account_test.go
@@ -12,7 +12,6 @@ import (
 func TestAccSSHKeyAccount_basic(t *testing.T) {
 	name := "tf-test-account-ssh-key-basic"
 	SSHKey := "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEEYrzDOZmhItdKaDAEqJQ4ORS2GyBMtBozYsK5kiXXX opensource@scaleway.com"
-	FormattedSSHKey := "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEEYrzDOZmhItdKaDAEqJQ4ORS2GyBMtBozYsK5kiXXX"
 	tt := acctest.NewTestTools(t)
 	defer tt.Cleanup()
 
@@ -31,7 +30,7 @@ func TestAccSSHKeyAccount_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					iamchecks.CheckSSHKeyExists(tt, "scaleway_account_ssh_key.main"),
 					resource.TestCheckResourceAttr("scaleway_account_ssh_key.main", "name", name),
-					resource.TestCheckResourceAttr("scaleway_account_ssh_key.main", "public_key", FormattedSSHKey),
+					resource.TestCheckResourceAttr("scaleway_account_ssh_key.main", "public_key", SSHKey),
 				),
 			},
 			{
@@ -44,7 +43,7 @@ func TestAccSSHKeyAccount_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					iamchecks.CheckSSHKeyExists(tt, "scaleway_account_ssh_key.main"),
 					resource.TestCheckResourceAttr("scaleway_account_ssh_key.main", "name", name+"-updated"),
-					resource.TestCheckResourceAttr("scaleway_account_ssh_key.main", "public_key", FormattedSSHKey),
+					resource.TestCheckResourceAttr("scaleway_account_ssh_key.main", "public_key", SSHKey),
 				),
 			},
 		},
@@ -54,7 +53,6 @@ func TestAccSSHKeyAccount_basic(t *testing.T) {
 func TestAccSSHKeyAccount_WithNewLine(t *testing.T) {
 	name := "tf-test-account-ssh-key-newline"
 	SSHKey := "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDjfkdWCwkYlVQMDUfiZlVrmjaGOfBYnmkucssae8Iup opensource@scaleway.com"
-	FormattedSSHKey := "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDjfkdWCwkYlVQMDUfiZlVrmjaGOfBYnmkucssae8Iup"
 	tt := acctest.NewTestTools(t)
 	defer tt.Cleanup()
 
@@ -73,7 +71,7 @@ func TestAccSSHKeyAccount_WithNewLine(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					iamchecks.CheckSSHKeyExists(tt, "scaleway_account_ssh_key.main"),
 					resource.TestCheckResourceAttr("scaleway_account_ssh_key.main", "name", name),
-					resource.TestCheckResourceAttr("scaleway_account_ssh_key.main", "public_key", FormattedSSHKey),
+					resource.TestCheckResourceAttr("scaleway_account_ssh_key.main", "public_key", SSHKey),
 				),
 			},
 		},
@@ -83,7 +81,6 @@ func TestAccSSHKeyAccount_WithNewLine(t *testing.T) {
 func TestAccSSHKeyAccount_ChangeResourceName(t *testing.T) {
 	name := "TestAccScalewayAccountSSHKey_ChangeResourceName"
 	SSHKey := "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICJEoOOgQBLJPs4g/XcPTKT82NywNPpxeuA20FlOPlpO opensource@scaleway.com"
-	FormattedSSHKey := "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICJEoOOgQBLJPs4g/XcPTKT82NywNPpxeuA20FlOPlpO"
 	tt := acctest.NewTestTools(t)
 	defer tt.Cleanup()
 
@@ -102,7 +99,7 @@ func TestAccSSHKeyAccount_ChangeResourceName(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					iamchecks.CheckSSHKeyExists(tt, "scaleway_account_ssh_key.first"),
 					resource.TestCheckResourceAttr("scaleway_account_ssh_key.first", "name", name),
-					resource.TestCheckResourceAttr("scaleway_account_ssh_key.first", "public_key", FormattedSSHKey),
+					resource.TestCheckResourceAttr("scaleway_account_ssh_key.first", "public_key", SSHKey),
 				),
 			},
 			{
@@ -115,7 +112,7 @@ func TestAccSSHKeyAccount_ChangeResourceName(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					iamchecks.CheckSSHKeyExists(tt, "scaleway_account_ssh_key.second"),
 					resource.TestCheckResourceAttr("scaleway_account_ssh_key.second", "name", name),
-					resource.TestCheckResourceAttr("scaleway_account_ssh_key.second", "public_key", FormattedSSHKey),
+					resource.TestCheckResourceAttr("scaleway_account_ssh_key.second", "public_key", SSHKey),
 				),
 			},
 		},

--- a/internal/services/iam/ssh_key_test.go
+++ b/internal/services/iam/ssh_key_test.go
@@ -10,8 +10,7 @@ import (
 )
 
 const (
-	SSHKey               = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICJEoOOgQBLJPs4g/XcPTKT82NywNPpxeuA20FlOPlpO opensource@scaleway.com"
-	SSHKeyWithoutComment = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICJEoOOgQBLJPs4g/XcPTKT82NywNPpxeuA20FlOPlpO"
+	SSHKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICJEoOOgQBLJPs4g/XcPTKT82NywNPpxeuA20FlOPlpO opensource@scaleway.com"
 )
 
 func TestAccSSHKey_basic(t *testing.T) {
@@ -34,7 +33,7 @@ func TestAccSSHKey_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					iamchecks.CheckSSHKeyExists(tt, "scaleway_iam_ssh_key.main"),
 					resource.TestCheckResourceAttr("scaleway_iam_ssh_key.main", "name", name),
-					resource.TestCheckResourceAttr("scaleway_iam_ssh_key.main", "public_key", SSHKeyWithoutComment),
+					resource.TestCheckResourceAttr("scaleway_iam_ssh_key.main", "public_key", SSHKey),
 				),
 			},
 			{
@@ -47,7 +46,7 @@ func TestAccSSHKey_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					iamchecks.CheckSSHKeyExists(tt, "scaleway_iam_ssh_key.main"),
 					resource.TestCheckResourceAttr("scaleway_iam_ssh_key.main", "name", name+"-updated"),
-					resource.TestCheckResourceAttr("scaleway_iam_ssh_key.main", "public_key", SSHKeyWithoutComment),
+					resource.TestCheckResourceAttr("scaleway_iam_ssh_key.main", "public_key", SSHKey),
 				),
 			},
 		},
@@ -74,7 +73,7 @@ func TestAccSSHKey_WithNewLine(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					iamchecks.CheckSSHKeyExists(tt, "scaleway_iam_ssh_key.main"),
 					resource.TestCheckResourceAttr("scaleway_iam_ssh_key.main", "name", name),
-					resource.TestCheckResourceAttr("scaleway_iam_ssh_key.main", "public_key", SSHKeyWithoutComment),
+					resource.TestCheckResourceAttr("scaleway_iam_ssh_key.main", "public_key", SSHKey),
 				),
 			},
 		},
@@ -101,7 +100,7 @@ func TestAccSSHKey_ChangeResourceName(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					iamchecks.CheckSSHKeyExists(tt, "scaleway_iam_ssh_key.first"),
 					resource.TestCheckResourceAttr("scaleway_iam_ssh_key.first", "name", name),
-					resource.TestCheckResourceAttr("scaleway_iam_ssh_key.first", "public_key", SSHKeyWithoutComment),
+					resource.TestCheckResourceAttr("scaleway_iam_ssh_key.first", "public_key", SSHKey),
 				),
 			},
 			{
@@ -114,7 +113,7 @@ func TestAccSSHKey_ChangeResourceName(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					iamchecks.CheckSSHKeyExists(tt, "scaleway_iam_ssh_key.second"),
 					resource.TestCheckResourceAttr("scaleway_iam_ssh_key.second", "name", name),
-					resource.TestCheckResourceAttr("scaleway_iam_ssh_key.second", "public_key", SSHKeyWithoutComment),
+					resource.TestCheckResourceAttr("scaleway_iam_ssh_key.second", "public_key", SSHKey),
 				),
 			},
 		},
@@ -141,7 +140,7 @@ func TestAccSSHKey_Disabled(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					iamchecks.CheckSSHKeyExists(tt, "scaleway_iam_ssh_key.main"),
 					resource.TestCheckResourceAttr("scaleway_iam_ssh_key.main", "name", name),
-					resource.TestCheckResourceAttr("scaleway_iam_ssh_key.main", "public_key", SSHKeyWithoutComment),
+					resource.TestCheckResourceAttr("scaleway_iam_ssh_key.main", "public_key", SSHKey),
 					resource.TestCheckResourceAttr("scaleway_iam_ssh_key.main", "disabled", "false"),
 				),
 			},
@@ -156,7 +155,7 @@ func TestAccSSHKey_Disabled(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					iamchecks.CheckSSHKeyExists(tt, "scaleway_iam_ssh_key.main"),
 					resource.TestCheckResourceAttr("scaleway_iam_ssh_key.main", "name", name),
-					resource.TestCheckResourceAttr("scaleway_iam_ssh_key.main", "public_key", SSHKeyWithoutComment),
+					resource.TestCheckResourceAttr("scaleway_iam_ssh_key.main", "public_key", SSHKey),
 					resource.TestCheckResourceAttr("scaleway_iam_ssh_key.main", "disabled", "true"),
 				),
 			},
@@ -171,7 +170,7 @@ func TestAccSSHKey_Disabled(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					iamchecks.CheckSSHKeyExists(tt, "scaleway_iam_ssh_key.main"),
 					resource.TestCheckResourceAttr("scaleway_iam_ssh_key.main", "name", name),
-					resource.TestCheckResourceAttr("scaleway_iam_ssh_key.main", "public_key", SSHKeyWithoutComment),
+					resource.TestCheckResourceAttr("scaleway_iam_ssh_key.main", "public_key", SSHKey),
 					resource.TestCheckResourceAttr("scaleway_iam_ssh_key.main", "disabled", "false"),
 				),
 			},


### PR DESCRIPTION
This caused the value to differ from requested input and this can lead to issue in terraform if the value is used in other resources. 
Also as it cannot be updated, it seems right to assume the local key is the correct key