### PR TITLE
fix(apple-silicon): increase timeout for server creation

### DIFF
--- a/internal/services/applesilicon/waiters.go
+++ b/internal/services/applesilicon/waiters.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	defaultAppleSiliconServerTimeout       = 2 * time.Minute
+	defaultAppleSiliconServerTimeout       = 20 * time.Minute
 	defaultAppleSiliconServerRetryInterval = 5 * time.Second
 )
 


### PR DESCRIPTION
**Problem occured**:
While trying to create a M2-L server using Terraform and the Scaleway provider, I got a timeout after 2 minutes which seems short for a server creation. With a timeout this short, it makes the developer experience quite bad because the Apple Silicon's server needs to be used at least an entire day (24 hours) before I can destroy them.

**Solutions**:
I found 2 solutions, 1 short term and 1 long term. Here there are:
1. **Short term**: We can fix this issue easily by adding this piece of code in the `scaleway_apple_silicon_server` resource:
```
resource scaleway_apple_silicon_server "server" {
...
timeouts {
    create = "20m" 
  }
...
}
```

2. **Long term**: We can also just increase the duration of the timeout to 20 minutes, the default for a creation in Terraform (source here: https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/retries-and-customizable-timeouts#default-timeouts-and-deadline-exceeded-errors). 

I recommend the long term solution, that's why I created this PR.

Have a nice day! 👍 