### PR TITLE
feat(instance): rely on api default volume type in server creation

### DIFF
--- a/internal/services/instance/helpers_instance_block.go
+++ b/internal/services/instance/helpers_instance_block.go
@@ -2,6 +2,7 @@ package instance
 
 import (
 	"errors"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	block "github.com/scaleway/scaleway-sdk-go/api/block/v1alpha1"
@@ -194,8 +195,14 @@ func instanceAndBlockAPIWithZoneAndID(m interface{}, zonedID string) (*BlockAndI
 }
 
 func volumeTypeToMarketplaceFilter(volumeType any) marketplace.LocalImageType {
-	if volumeType != nil && instance.VolumeVolumeType(volumeType.(string)) == instance.VolumeVolumeTypeSbsVolume {
-		return marketplace.LocalImageTypeInstanceSbs
+	if volumeType != nil {
+		volumeTypeString := volumeType.(string)
+		if strings.HasPrefix(volumeTypeString, "sbs") {
+			return marketplace.LocalImageTypeInstanceSbs
+		} else {
+			return marketplace.LocalImageTypeInstanceLocal
+		}
 	}
-	return marketplace.LocalImageTypeInstanceLocal
+
+	return marketplace.LocalImageTypeUnknownType
 }

--- a/internal/services/instance/server.go
+++ b/internal/services/instance/server.go
@@ -391,19 +391,7 @@ func ResourceInstanceServerCreate(ctx context.Context, d *schema.ResourceData, m
 	imageUUID := locality.ExpandID(d.Get("image"))
 	if imageUUID != "" && !scwvalidation.IsUUID(imageUUID) {
 		// Replace dashes with underscores ubuntu-focal -> ubuntu_focal
-		imageLabel := formatImageLabel(imageUUID)
-
-		marketPlaceAPI := marketplace.NewAPI(meta.ExtractScwClient(m))
-		image, err := marketPlaceAPI.GetLocalImageByLabel(&marketplace.GetLocalImageByLabelRequest{
-			CommercialType: commercialType,
-			Zone:           zone,
-			ImageLabel:     imageLabel,
-			Type:           volumeTypeToMarketplaceFilter(d.Get("root_volume.0.volume_type")),
-		})
-		if err != nil {
-			return diag.FromErr(fmt.Errorf("could not get image '%s': %s", zonal.NewID(zone, imageLabel), err))
-		}
-		imageUUID = image.ID
+		imageUUID = formatImageLabel(imageUUID)
 	}
 
 	req := &instanceSDK.CreateServerRequest{

--- a/internal/services/instance/server_test.go
+++ b/internal/services/instance/server_test.go
@@ -273,6 +273,33 @@ func TestAccServer_RootVolume_ID(t *testing.T) {
 	})
 }
 
+func TestAccServer_RootVolume_DefaultTypeSBS(t *testing.T) {
+	t.Skip("tmp")
+	tt := acctest.NewTestTools(t)
+	defer tt.Cleanup()
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ProviderFactories: tt.ProviderFactories,
+		CheckDestroy:      instancechecks.IsServerDestroyed(tt),
+		Steps: []resource.TestStep{
+			{
+				Config: `
+					resource "scaleway_instance_server" "base" {
+						image = "ubuntu_jammy"
+						type  = "PLAY2-PICO"
+						state = "stopped"
+						tags = [ "terraform-test", "scaleway_instance_server", "root_volume" ]
+					}`,
+				Check: resource.ComposeTestCheckFunc(
+					isServerPresent(tt, "scaleway_instance_server.base"),
+					resource.TestCheckResourceAttr("scaleway_instance_server.base", "root_volume.0.volume_type", "sbs_volume"),
+					serverHasNewVolume(tt, "scaleway_instance_server.base"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccServer_Basic(t *testing.T) {
 	tt := acctest.NewTestTools(t)
 	defer tt.Cleanup()


### PR DESCRIPTION
Closes #2765

Still require changes in scaleway-sdk-go as it will resolve on its own instead of relying on API.