### PR TITLE
fix(instance_server): use server volume to fetch volumes

### DIFF
--- a/internal/services/instance/server.go
+++ b/internal/services/instance/server.go
@@ -698,7 +698,7 @@ func ResourceInstanceServerRead(ctx context.Context, d *schema.ResourceData, m i
 
 				vol, err := api.GetUnknownVolume(&GetUnknownVolumeRequest{
 					VolumeID: volume.ID,
-					Zone:     volume.Zone,
+					Zone:     server.Zone,
 				})
 				if err != nil {
 					return diag.FromErr(fmt.Errorf("failed to read instance volume %s: %w", volume.ID, err))


### PR DESCRIPTION
Instance API currently miss zone when returning sbs volumes

Linked to https://github.com/scaleway/scaleway-sdk-go/issues/2273