### PR TITLE
fix(mnq): mark field 'file' as sensitive

### DIFF
--- a/internal/services/mnq/nats_credentials.go
+++ b/internal/services/mnq/nats_credentials.go
@@ -42,6 +42,7 @@ func ResourceNatsCredentials() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The credentials file",
+				Sensitive:   true,
 			},
 			"region": regional.Schema(),
 		},


### PR DESCRIPTION
Currently, when creating NATS credentials, the field 'file' is not marked as sensitive. While it does not cause issue during creation since this value is not yet computed, it causes issue during deletion where the secret is leaked:

```
  # scaleway_mnq_nats_credentials.key-manager will be destroyed
  # (because scaleway_mnq_nats_credentials.key-manager is not in configuration)
  - resource "scaleway_mnq_nats_credentials" "key-manager" {
      - account_id = (sensitive value) -> null
      - file       = <<-EOT
            -----BEGIN NATS USER JWT-----
             XXX REDACTED XXX
            ------END NATS USER JWT------

            ************************* IMPORTANT *************************
            NKEY Seed printed below can be used to sign and prove identity.
            NKEYs are sensitive and should be treated as secrets.

            -----BEGIN USER NKEY SEED-----
            XXX REDACTED XXX
            ------END USER NKEY SEED------

            *************************************************************
        EOT -> null
      - id         = "REDACTED" -> null
      - name       = "key-manager.fr-srr.nats" -> null
      - region     = "fr-srr" -> null
    }
```