### PR TITLE
feat(serverless): add support for tags on functions/containers namespaces

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/nats-io/jwt/v2 v2.7.2
 	github.com/nats-io/nats.go v1.37.0
 	github.com/robfig/cron/v3 v3.0.1
-	github.com/scaleway/scaleway-sdk-go v1.0.0-beta.30.0.20241021115642-2d127a2d76c7
+	github.com/scaleway/scaleway-sdk-go v1.0.0-beta.30.0.20241028153617-2a48843b5fcb
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/crypto v0.28.0
 	gopkg.in/dnaeon/go-vcr.v3 v3.2.0

--- a/go.sum
+++ b/go.sum
@@ -242,8 +242,8 @@ github.com/posener/complete v1.2.3 h1:NP0eAhjcjImqslEwo/1hq7gpajME0fTLTezBKDqfXq
 github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
 github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
 github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
-github.com/scaleway/scaleway-sdk-go v1.0.0-beta.30.0.20241021115642-2d127a2d76c7 h1:mWi3yS37Lhf73OP2Z4CboKtXJM4mWDAUWFHKSx2WK7k=
-github.com/scaleway/scaleway-sdk-go v1.0.0-beta.30.0.20241021115642-2d127a2d76c7/go.mod h1:3jrRJM7638J+P33hKy9MBvfOBxNo8pEGNQQoIv65Ihg=
+github.com/scaleway/scaleway-sdk-go v1.0.0-beta.30.0.20241028153617-2a48843b5fcb h1:OsRpbw60numCy/+3FS7UhZzkdiTu6OZwq29bb4b3gNo=
+github.com/scaleway/scaleway-sdk-go v1.0.0-beta.30.0.20241028153617-2a48843b5fcb/go.mod h1:3jrRJM7638J+P33hKy9MBvfOBxNo8pEGNQQoIv65Ihg=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/shopspring/decimal v1.2.0 h1:abSATXmQEYyShuxI4/vyW3tV1MrKAJzCZ/0zLUXYbsQ=

--- a/internal/services/container/namespace.go
+++ b/internal/services/container/namespace.go
@@ -46,6 +46,14 @@ func ResourceNamespace() *schema.Resource {
 				Optional:    true,
 				Description: "The description of the container namespace",
 			},
+			"tags": {
+				Type: schema.TypeList,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Optional:    true,
+				Description: "List of tags [\"tag1\", \"tag2\", ...] attached to the container namespace",
+			},
 			"environment_variables": {
 				Type:        schema.TypeMap,
 				Optional:    true,
@@ -97,14 +105,21 @@ func ResourceContainerNamespaceCreate(ctx context.Context, d *schema.ResourceDat
 		return diag.FromErr(err)
 	}
 
-	ns, err := api.CreateNamespace(&container.CreateNamespaceRequest{
+	createReq := &container.CreateNamespaceRequest{
 		Description:                types.ExpandStringPtr(d.Get("description").(string)),
 		EnvironmentVariables:       types.ExpandMapPtrStringString(d.Get("environment_variables")),
 		SecretEnvironmentVariables: expandContainerSecrets(d.Get("secret_environment_variables")),
 		Name:                       types.ExpandOrGenerateString(d.Get("name").(string), "ns"),
 		ProjectID:                  d.Get("project_id").(string),
 		Region:                     region,
-	}, scw.WithContext(ctx))
+	}
+
+	rawTag, tagExist := d.GetOk("tags")
+	if tagExist {
+		createReq.Tags = types.ExpandStrings(rawTag)
+	}
+
+	ns, err := api.CreateNamespace(createReq, scw.WithContext(ctx))
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -135,6 +150,7 @@ func ResourceContainerNamespaceRead(ctx context.Context, d *schema.ResourceData,
 	}
 
 	_ = d.Set("description", types.FlattenStringPtr(ns.Description))
+	_ = d.Set("tags", types.FlattenSliceString(ns.Tags))
 	_ = d.Set("environment_variables", ns.EnvironmentVariables)
 	_ = d.Set("name", ns.Name)
 	_ = d.Set("organization_id", ns.OrganizationID)
@@ -164,6 +180,10 @@ func ResourceContainerNamespaceUpdate(ctx context.Context, d *schema.ResourceDat
 
 	if d.HasChange("description") {
 		req.Description = types.ExpandUpdatedStringPtr(d.Get("description"))
+	}
+
+	if d.HasChange("tags") {
+		req.Tags = types.ExpandUpdatedStringsPtr(d.Get("tags"))
 	}
 
 	if d.HasChanges("environment_variables") {

--- a/internal/services/container/namespace_test.go
+++ b/internal/services/container/namespace_test.go
@@ -89,6 +89,7 @@ func TestAccNamespace_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("scaleway_container_namespace.main", "name", "test-cr-ns-01"),
 					resource.TestCheckResourceAttr("scaleway_container_namespace.main", "environment_variables.test", "test"),
 					resource.TestCheckResourceAttr("scaleway_container_namespace.main", "secret_environment_variables.test_secret", "test_secret"),
+					resource.TestCheckResourceAttr("scaleway_container_namespace.main", "tags.#", "2"),
 					resource.TestCheckResourceAttr("scaleway_container_namespace.main", "tags.0", "tag1"),
 					resource.TestCheckResourceAttr("scaleway_container_namespace.main", "tags.1", "tag2"),
 
@@ -105,6 +106,7 @@ func TestAccNamespace_Basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("scaleway_container_namespace.main", "name"),
 					resource.TestCheckResourceAttrSet("scaleway_container_namespace.main", "registry_endpoint"),
 					resource.TestCheckResourceAttrSet("scaleway_container_namespace.main", "registry_namespace_id"),
+					resource.TestCheckResourceAttr("scaleway_container_namespace.main", "tags.#", "0"),
 				),
 			},
 			{
@@ -124,7 +126,7 @@ func TestAccNamespace_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("scaleway_container_namespace.main", "name", "tf-env-test"),
 					resource.TestCheckResourceAttr("scaleway_container_namespace.main", "environment_variables.test", "test"),
 					resource.TestCheckResourceAttr("scaleway_container_namespace.main", "secret_environment_variables.test_secret", "test_secret"),
-
+					resource.TestCheckResourceAttr("scaleway_container_namespace.main", "tags.#", "0"),
 					acctest.CheckResourceAttrUUID("scaleway_container_namespace.main", "id"),
 				),
 			},
@@ -145,7 +147,7 @@ func TestAccNamespace_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("scaleway_container_namespace.main", "name", "tf-env-test"),
 					resource.TestCheckResourceAttr("scaleway_container_namespace.main", "environment_variables.foo", "bar"),
 					resource.TestCheckResourceAttr("scaleway_container_namespace.main", "secret_environment_variables.foo_secret", "bar_secret"),
-
+					resource.TestCheckResourceAttr("scaleway_container_namespace.main", "tags.#", "0"),
 					acctest.CheckResourceAttrUUID("scaleway_container_namespace.main", "id"),
 				),
 			},
@@ -159,6 +161,7 @@ func TestAccNamespace_Basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					isNamespacePresent(tt, "scaleway_container_namespace.main"),
 					resource.TestCheckResourceAttr("scaleway_container_namespace.main", "name", "tf-tags-test"),
+					resource.TestCheckResourceAttr("scaleway_container_namespace.main", "tags.#", "2"),
 					resource.TestCheckResourceAttr("scaleway_container_namespace.main", "tags.0", "tag1"),
 					resource.TestCheckResourceAttr("scaleway_container_namespace.main", "tags.1", "tag2"),
 

--- a/internal/services/container/namespace_test.go
+++ b/internal/services/container/namespace_test.go
@@ -124,6 +124,22 @@ func TestAccNamespace_Basic(t *testing.T) {
 					acctest.CheckResourceAttrUUID("scaleway_container_namespace.main", "id"),
 				),
 			},
+			{
+				Config: `
+					resource scaleway_container_namespace main {
+						name = "tf-tags-test"
+						tags = ["tag1", "tag2"]
+					}
+				`,
+				Check: resource.ComposeTestCheckFunc(
+					isNamespacePresent(tt, "scaleway_container_namespace.main"),
+					resource.TestCheckResourceAttr("scaleway_container_namespace.main", "name", "tf-tags-test"),
+					resource.TestCheckResourceAttr("scaleway_container_namespace.main", "tags.0", "tag1"),
+					resource.TestCheckResourceAttr("scaleway_container_namespace.main", "tags.1", "tag2"),
+
+					acctest.CheckResourceAttrUUID("scaleway_container_namespace.main", "id"),
+				),
+			},
 		},
 	})
 }

--- a/internal/services/container/namespace_test.go
+++ b/internal/services/container/namespace_test.go
@@ -73,6 +73,31 @@ func TestAccNamespace_Basic(t *testing.T) {
 			{
 				Config: `
 					resource scaleway_container_namespace main {
+						name = "test-cr-ns-01"
+						environment_variables = {
+							"test" = "test"
+						}
+						secret_environment_variables = {
+							"test_secret" = "test_secret"
+						}
+						tags = ["tag1", "tag2"]
+					}
+				`,
+				Check: resource.ComposeTestCheckFunc(
+					isNamespacePresent(tt, "scaleway_container_namespace.main"),
+					resource.TestCheckResourceAttr("scaleway_container_namespace.main", "description", ""),
+					resource.TestCheckResourceAttr("scaleway_container_namespace.main", "name", "test-cr-ns-01"),
+					resource.TestCheckResourceAttr("scaleway_container_namespace.main", "environment_variables.test", "test"),
+					resource.TestCheckResourceAttr("scaleway_container_namespace.main", "secret_environment_variables.test_secret", "test_secret"),
+					resource.TestCheckResourceAttr("scaleway_container_namespace.main", "tags.0", "tag1"),
+					resource.TestCheckResourceAttr("scaleway_container_namespace.main", "tags.1", "tag2"),
+
+					acctest.CheckResourceAttrUUID("scaleway_container_namespace.main", "id"),
+				),
+			},
+			{
+				Config: `
+					resource scaleway_container_namespace main {
 					}
 				`,
 				Check: resource.ComposeTestCheckFunc(

--- a/internal/services/container/testdata/namespace-basic.cassette.yaml
+++ b/internal/services/container/testdata/namespace-basic.cassette.yaml
@@ -1,1461 +1,3547 @@
 ---
 version: 2
 interactions:
-- request:
-    body: '{"name":"test-cr-ns-01","environment_variables":{},"project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","description":null,"secret_environment_variables":[]}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces
-    method: POST
-  response:
-    body: '{"id":"5f38ff86-dba1-414b-b71e-04f002a2c9b2","name":"test-cr-ns-01","environment_variables":{},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"pending","registry_namespace_id":"","error_message":null,"registry_endpoint":"","description":"","secret_environment_variables":[],"region":"fr-par"}'
-    headers:
-      Content-Length:
-      - "363"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 14:33:37 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a759b23a-0682-4147-825a-d9fc6f7842e8
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/5f38ff86-dba1-414b-b71e-04f002a2c9b2
-    method: GET
-  response:
-    body: '{"id":"5f38ff86-dba1-414b-b71e-04f002a2c9b2","name":"test-cr-ns-01","environment_variables":{},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"pending","registry_namespace_id":"","error_message":null,"registry_endpoint":"","description":"","secret_environment_variables":[],"region":"fr-par"}'
-    headers:
-      Content-Length:
-      - "363"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 14:33:37 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b575258c-5a63-4860-9fc8-f9873a2af714
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/5f38ff86-dba1-414b-b71e-04f002a2c9b2
-    method: GET
-  response:
-    body: '{"id":"5f38ff86-dba1-414b-b71e-04f002a2c9b2","name":"test-cr-ns-01","environment_variables":{},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","registry_namespace_id":"3c76f602-247e-4fd4-b7ad-5b39aebbcc47","error_message":null,"registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01e7feqemv","description":"","secret_environment_variables":[],"region":"fr-par"}'
-    headers:
-      Content-Length:
-      - "442"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 14:33:42 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 95321e1d-2a85-4ae5-8f26-80beb0f687bd
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/5f38ff86-dba1-414b-b71e-04f002a2c9b2
-    method: GET
-  response:
-    body: '{"id":"5f38ff86-dba1-414b-b71e-04f002a2c9b2","name":"test-cr-ns-01","environment_variables":{},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","registry_namespace_id":"3c76f602-247e-4fd4-b7ad-5b39aebbcc47","error_message":null,"registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01e7feqemv","description":"","secret_environment_variables":[],"region":"fr-par"}'
-    headers:
-      Content-Length:
-      - "442"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 14:33:42 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f772cf68-2975-4275-9116-0a36f8afb74a
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/5f38ff86-dba1-414b-b71e-04f002a2c9b2
-    method: GET
-  response:
-    body: '{"id":"5f38ff86-dba1-414b-b71e-04f002a2c9b2","name":"test-cr-ns-01","environment_variables":{},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","registry_namespace_id":"3c76f602-247e-4fd4-b7ad-5b39aebbcc47","error_message":null,"registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01e7feqemv","description":"","secret_environment_variables":[],"region":"fr-par"}'
-    headers:
-      Content-Length:
-      - "442"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 14:33:43 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 34fd5c10-10b7-443d-b6f8-d471568c4cd6
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/5f38ff86-dba1-414b-b71e-04f002a2c9b2
-    method: GET
-  response:
-    body: '{"id":"5f38ff86-dba1-414b-b71e-04f002a2c9b2","name":"test-cr-ns-01","environment_variables":{},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","registry_namespace_id":"3c76f602-247e-4fd4-b7ad-5b39aebbcc47","error_message":null,"registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01e7feqemv","description":"","secret_environment_variables":[],"region":"fr-par"}'
-    headers:
-      Content-Length:
-      - "442"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 14:33:43 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0449366b-aa6e-4dec-b277-5014833f2644
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/5f38ff86-dba1-414b-b71e-04f002a2c9b2
-    method: GET
-  response:
-    body: '{"id":"5f38ff86-dba1-414b-b71e-04f002a2c9b2","name":"test-cr-ns-01","environment_variables":{},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","registry_namespace_id":"3c76f602-247e-4fd4-b7ad-5b39aebbcc47","error_message":null,"registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01e7feqemv","description":"","secret_environment_variables":[],"region":"fr-par"}'
-    headers:
-      Content-Length:
-      - "442"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 14:33:44 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 36a8e7a9-3a60-4edc-8879-0960756960cb
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/5f38ff86-dba1-414b-b71e-04f002a2c9b2
-    method: GET
-  response:
-    body: '{"id":"5f38ff86-dba1-414b-b71e-04f002a2c9b2","name":"test-cr-ns-01","environment_variables":{},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","registry_namespace_id":"3c76f602-247e-4fd4-b7ad-5b39aebbcc47","error_message":null,"registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01e7feqemv","description":"","secret_environment_variables":[],"region":"fr-par"}'
-    headers:
-      Content-Length:
-      - "442"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 14:33:44 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 67ea968b-43cf-4571-860f-8959da483c5d
-    status: 200 OK
-    code: 200
-- request:
-    body: '{"environment_variables":null,"description":"test container namespace 01","secret_environment_variables":null}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/5f38ff86-dba1-414b-b71e-04f002a2c9b2
-    method: PATCH
-  response:
-    body: '{"id":"5f38ff86-dba1-414b-b71e-04f002a2c9b2","name":"test-cr-ns-01","environment_variables":{},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","registry_namespace_id":"3c76f602-247e-4fd4-b7ad-5b39aebbcc47","error_message":null,"registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01e7feqemv","description":"test
-      container namespace 01","secret_environment_variables":[],"region":"fr-par"}'
-    headers:
-      Content-Length:
-      - "469"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 14:33:45 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 865392fb-ad63-411c-8a5e-e81570ccb971
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/5f38ff86-dba1-414b-b71e-04f002a2c9b2
-    method: GET
-  response:
-    body: '{"id":"5f38ff86-dba1-414b-b71e-04f002a2c9b2","name":"test-cr-ns-01","environment_variables":{},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","registry_namespace_id":"3c76f602-247e-4fd4-b7ad-5b39aebbcc47","error_message":null,"registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01e7feqemv","description":"test
-      container namespace 01","secret_environment_variables":[],"region":"fr-par"}'
-    headers:
-      Content-Length:
-      - "469"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 14:33:45 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f7d46277-65a1-44f9-af3a-2073cab344c3
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/5f38ff86-dba1-414b-b71e-04f002a2c9b2
-    method: GET
-  response:
-    body: '{"id":"5f38ff86-dba1-414b-b71e-04f002a2c9b2","name":"test-cr-ns-01","environment_variables":{},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","registry_namespace_id":"3c76f602-247e-4fd4-b7ad-5b39aebbcc47","error_message":null,"registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01e7feqemv","description":"test
-      container namespace 01","secret_environment_variables":[],"region":"fr-par"}'
-    headers:
-      Content-Length:
-      - "469"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 14:33:45 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8baa7e84-efa3-488b-8bea-10a2239a5dca
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/5f38ff86-dba1-414b-b71e-04f002a2c9b2
-    method: GET
-  response:
-    body: '{"id":"5f38ff86-dba1-414b-b71e-04f002a2c9b2","name":"test-cr-ns-01","environment_variables":{},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","registry_namespace_id":"3c76f602-247e-4fd4-b7ad-5b39aebbcc47","error_message":null,"registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01e7feqemv","description":"test
-      container namespace 01","secret_environment_variables":[],"region":"fr-par"}'
-    headers:
-      Content-Length:
-      - "469"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 14:33:46 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5145cae7-d09f-440d-b2f8-c4ee0f50788a
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/5f38ff86-dba1-414b-b71e-04f002a2c9b2
-    method: GET
-  response:
-    body: '{"id":"5f38ff86-dba1-414b-b71e-04f002a2c9b2","name":"test-cr-ns-01","environment_variables":{},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","registry_namespace_id":"3c76f602-247e-4fd4-b7ad-5b39aebbcc47","error_message":null,"registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01e7feqemv","description":"test
-      container namespace 01","secret_environment_variables":[],"region":"fr-par"}'
-    headers:
-      Content-Length:
-      - "469"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 14:33:47 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2a572953-ac4b-4972-97fe-12b2a8a25201
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/5f38ff86-dba1-414b-b71e-04f002a2c9b2
-    method: GET
-  response:
-    body: '{"id":"5f38ff86-dba1-414b-b71e-04f002a2c9b2","name":"test-cr-ns-01","environment_variables":{},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","registry_namespace_id":"3c76f602-247e-4fd4-b7ad-5b39aebbcc47","error_message":null,"registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01e7feqemv","description":"test
-      container namespace 01","secret_environment_variables":[],"region":"fr-par"}'
-    headers:
-      Content-Length:
-      - "469"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 14:33:47 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3c83917b-2167-4e39-9d34-21066677c7cc
-    status: 200 OK
-    code: 200
-- request:
-    body: '{"environment_variables":{"test":"test"},"description":"","secret_environment_variables":[{"key":"test_secret","value":"test_secret"}]}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/5f38ff86-dba1-414b-b71e-04f002a2c9b2
-    method: PATCH
-  response:
-    body: '{"id":"5f38ff86-dba1-414b-b71e-04f002a2c9b2","name":"test-cr-ns-01","environment_variables":{"test":"test"},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","registry_namespace_id":"3c76f602-247e-4fd4-b7ad-5b39aebbcc47","error_message":null,"registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01e7feqemv","description":"","secret_environment_variables":[{"key":"test_secret","hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$iqqlEVb/5axjRAtN1Xkq3A$iKVflSe9h9xlB34vEZHGvd0I86Knjh/uxy4lz6DDv4U"}],"region":"fr-par"}'
-    headers:
-      Content-Length:
-      - "591"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 14:33:47 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 74a82b38-9ef1-465b-bc02-4ce4a1dafddf
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/5f38ff86-dba1-414b-b71e-04f002a2c9b2
-    method: GET
-  response:
-    body: '{"id":"5f38ff86-dba1-414b-b71e-04f002a2c9b2","name":"test-cr-ns-01","environment_variables":{"test":"test"},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","registry_namespace_id":"3c76f602-247e-4fd4-b7ad-5b39aebbcc47","error_message":null,"registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01e7feqemv","description":"","secret_environment_variables":[{"key":"test_secret","hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$iqqlEVb/5axjRAtN1Xkq3A$iKVflSe9h9xlB34vEZHGvd0I86Knjh/uxy4lz6DDv4U"}],"region":"fr-par"}'
-    headers:
-      Content-Length:
-      - "591"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 14:33:47 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 39309db3-0388-4b7f-827f-fc9b67242122
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/5f38ff86-dba1-414b-b71e-04f002a2c9b2
-    method: GET
-  response:
-    body: '{"id":"5f38ff86-dba1-414b-b71e-04f002a2c9b2","name":"test-cr-ns-01","environment_variables":{"test":"test"},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","registry_namespace_id":"3c76f602-247e-4fd4-b7ad-5b39aebbcc47","error_message":null,"registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01e7feqemv","description":"","secret_environment_variables":[{"key":"test_secret","hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$iqqlEVb/5axjRAtN1Xkq3A$iKVflSe9h9xlB34vEZHGvd0I86Knjh/uxy4lz6DDv4U"}],"region":"fr-par"}'
-    headers:
-      Content-Length:
-      - "591"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 14:33:48 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 768436a2-9f97-4948-a8de-328c826e6e2b
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/5f38ff86-dba1-414b-b71e-04f002a2c9b2
-    method: GET
-  response:
-    body: '{"id":"5f38ff86-dba1-414b-b71e-04f002a2c9b2","name":"test-cr-ns-01","environment_variables":{"test":"test"},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","registry_namespace_id":"3c76f602-247e-4fd4-b7ad-5b39aebbcc47","error_message":null,"registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01e7feqemv","description":"","secret_environment_variables":[{"key":"test_secret","hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$iqqlEVb/5axjRAtN1Xkq3A$iKVflSe9h9xlB34vEZHGvd0I86Knjh/uxy4lz6DDv4U"}],"region":"fr-par"}'
-    headers:
-      Content-Length:
-      - "591"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 14:33:48 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 35d278ce-c1df-4dcc-9b35-44cb822ff76c
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/5f38ff86-dba1-414b-b71e-04f002a2c9b2
-    method: GET
-  response:
-    body: '{"id":"5f38ff86-dba1-414b-b71e-04f002a2c9b2","name":"test-cr-ns-01","environment_variables":{"test":"test"},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","registry_namespace_id":"3c76f602-247e-4fd4-b7ad-5b39aebbcc47","error_message":null,"registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01e7feqemv","description":"","secret_environment_variables":[{"key":"test_secret","hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$iqqlEVb/5axjRAtN1Xkq3A$iKVflSe9h9xlB34vEZHGvd0I86Knjh/uxy4lz6DDv4U"}],"region":"fr-par"}'
-    headers:
-      Content-Length:
-      - "591"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 14:33:49 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c0807562-a335-486b-8ecb-e16ea27f04f2
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/5f38ff86-dba1-414b-b71e-04f002a2c9b2
-    method: GET
-  response:
-    body: '{"id":"5f38ff86-dba1-414b-b71e-04f002a2c9b2","name":"test-cr-ns-01","environment_variables":{"test":"test"},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","registry_namespace_id":"3c76f602-247e-4fd4-b7ad-5b39aebbcc47","error_message":null,"registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01e7feqemv","description":"","secret_environment_variables":[{"key":"test_secret","hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$iqqlEVb/5axjRAtN1Xkq3A$iKVflSe9h9xlB34vEZHGvd0I86Knjh/uxy4lz6DDv4U"}],"region":"fr-par"}'
-    headers:
-      Content-Length:
-      - "591"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 14:33:50 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 71a48719-f0b3-4e13-ae8e-c3d861dddca2
-    status: 200 OK
-    code: 200
-- request:
-    body: '{"environment_variables":{},"description":null,"secret_environment_variables":[]}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/5f38ff86-dba1-414b-b71e-04f002a2c9b2
-    method: PATCH
-  response:
-    body: '{"id":"5f38ff86-dba1-414b-b71e-04f002a2c9b2","name":"test-cr-ns-01","environment_variables":{},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","registry_namespace_id":"3c76f602-247e-4fd4-b7ad-5b39aebbcc47","error_message":null,"registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01e7feqemv","description":"","secret_environment_variables":[{"key":"test_secret","hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$iqqlEVb/5axjRAtN1Xkq3A$iKVflSe9h9xlB34vEZHGvd0I86Knjh/uxy4lz6DDv4U"}],"region":"fr-par"}'
-    headers:
-      Content-Length:
-      - "578"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 14:33:50 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - fad2bc3e-8a98-460f-8e0a-96c3aa58f11f
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/5f38ff86-dba1-414b-b71e-04f002a2c9b2
-    method: GET
-  response:
-    body: '{"id":"5f38ff86-dba1-414b-b71e-04f002a2c9b2","name":"test-cr-ns-01","environment_variables":{},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","registry_namespace_id":"3c76f602-247e-4fd4-b7ad-5b39aebbcc47","error_message":null,"registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01e7feqemv","description":"","secret_environment_variables":[{"key":"test_secret","hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$iqqlEVb/5axjRAtN1Xkq3A$iKVflSe9h9xlB34vEZHGvd0I86Knjh/uxy4lz6DDv4U"}],"region":"fr-par"}'
-    headers:
-      Content-Length:
-      - "578"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 14:33:50 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d686ae6a-cc92-4506-9f09-f8b405a4b11f
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/5f38ff86-dba1-414b-b71e-04f002a2c9b2
-    method: GET
-  response:
-    body: '{"id":"5f38ff86-dba1-414b-b71e-04f002a2c9b2","name":"test-cr-ns-01","environment_variables":{},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","registry_namespace_id":"3c76f602-247e-4fd4-b7ad-5b39aebbcc47","error_message":null,"registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01e7feqemv","description":"","secret_environment_variables":[{"key":"test_secret","hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$iqqlEVb/5axjRAtN1Xkq3A$iKVflSe9h9xlB34vEZHGvd0I86Knjh/uxy4lz6DDv4U"}],"region":"fr-par"}'
-    headers:
-      Content-Length:
-      - "578"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 14:33:51 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - daf0ebe5-6d8b-4753-a78d-92d40cc84541
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/5f38ff86-dba1-414b-b71e-04f002a2c9b2
-    method: GET
-  response:
-    body: '{"id":"5f38ff86-dba1-414b-b71e-04f002a2c9b2","name":"test-cr-ns-01","environment_variables":{},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","registry_namespace_id":"3c76f602-247e-4fd4-b7ad-5b39aebbcc47","error_message":null,"registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01e7feqemv","description":"","secret_environment_variables":[{"key":"test_secret","hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$iqqlEVb/5axjRAtN1Xkq3A$iKVflSe9h9xlB34vEZHGvd0I86Knjh/uxy4lz6DDv4U"}],"region":"fr-par"}'
-    headers:
-      Content-Length:
-      - "578"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 14:33:51 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2b682d3c-9dd7-4bf7-b133-6e873a79fb63
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/5f38ff86-dba1-414b-b71e-04f002a2c9b2
-    method: GET
-  response:
-    body: '{"id":"5f38ff86-dba1-414b-b71e-04f002a2c9b2","name":"test-cr-ns-01","environment_variables":{},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","registry_namespace_id":"3c76f602-247e-4fd4-b7ad-5b39aebbcc47","error_message":null,"registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01e7feqemv","description":"","secret_environment_variables":[{"key":"test_secret","hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$iqqlEVb/5axjRAtN1Xkq3A$iKVflSe9h9xlB34vEZHGvd0I86Knjh/uxy4lz6DDv4U"}],"region":"fr-par"}'
-    headers:
-      Content-Length:
-      - "578"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 14:33:52 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f1b25df6-6582-4bfd-b7b3-28507e8f7352
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/5f38ff86-dba1-414b-b71e-04f002a2c9b2
-    method: GET
-  response:
-    body: '{"id":"5f38ff86-dba1-414b-b71e-04f002a2c9b2","name":"test-cr-ns-01","environment_variables":{},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","registry_namespace_id":"3c76f602-247e-4fd4-b7ad-5b39aebbcc47","error_message":null,"registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01e7feqemv","description":"","secret_environment_variables":[{"key":"test_secret","hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$iqqlEVb/5axjRAtN1Xkq3A$iKVflSe9h9xlB34vEZHGvd0I86Knjh/uxy4lz6DDv4U"}],"region":"fr-par"}'
-    headers:
-      Content-Length:
-      - "578"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 14:33:53 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d8f5908f-bb7e-4c36-93e5-7f829b918d3a
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/5f38ff86-dba1-414b-b71e-04f002a2c9b2
-    method: DELETE
-  response:
-    body: '{"id":"5f38ff86-dba1-414b-b71e-04f002a2c9b2","name":"test-cr-ns-01","environment_variables":{},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"deleting","registry_namespace_id":"3c76f602-247e-4fd4-b7ad-5b39aebbcc47","error_message":null,"registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01e7feqemv","description":"","secret_environment_variables":[{"key":"test_secret","hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$iqqlEVb/5axjRAtN1Xkq3A$iKVflSe9h9xlB34vEZHGvd0I86Knjh/uxy4lz6DDv4U"}],"region":"fr-par"}'
-    headers:
-      Content-Length:
-      - "581"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 14:33:53 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2f8035ab-cd68-4bfa-a836-bcd7cd52990c
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/5f38ff86-dba1-414b-b71e-04f002a2c9b2
-    method: GET
-  response:
-    body: '{"message":"Namespace was not found"}'
-    headers:
-      Content-Length:
-      - "37"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 14:33:53 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9943a20a-394b-43a3-9a60-dadc5ed149b0
-    status: 404 Not Found
-    code: 404
-- request:
-    body: '{"name":"tf-env-test","environment_variables":{"test":"test"},"project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","description":null,"secret_environment_variables":[{"key":"test_secret","value":"test_secret"}]}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces
-    method: POST
-  response:
-    body: '{"id":"2659002a-557f-4e15-8c30-5a3880ec8866","name":"tf-env-test","environment_variables":{"test":"test"},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"pending","registry_namespace_id":"","error_message":null,"registry_endpoint":"","description":"","secret_environment_variables":[{"key":"test_secret","hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$rD+MUqUFZ/MbPMpc+17JJg$Nklw7EbD7rOwGQelfsahsHvbUmLv9PFQqxFRfJBA6AQ"}],"region":"fr-par"}'
-    headers:
-      Content-Length:
-      - "510"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 14:33:53 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 74ee54b0-29f2-48a9-aaa2-029c20be871a
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2659002a-557f-4e15-8c30-5a3880ec8866
-    method: GET
-  response:
-    body: '{"id":"2659002a-557f-4e15-8c30-5a3880ec8866","name":"tf-env-test","environment_variables":{"test":"test"},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"pending","registry_namespace_id":"","error_message":null,"registry_endpoint":"","description":"","secret_environment_variables":[{"key":"test_secret","hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$rD+MUqUFZ/MbPMpc+17JJg$Nklw7EbD7rOwGQelfsahsHvbUmLv9PFQqxFRfJBA6AQ"}],"region":"fr-par"}'
-    headers:
-      Content-Length:
-      - "510"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 14:33:54 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8bee851b-e7f7-4479-aa0f-d7576f9a6515
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2659002a-557f-4e15-8c30-5a3880ec8866
-    method: GET
-  response:
-    body: '{"id":"2659002a-557f-4e15-8c30-5a3880ec8866","name":"tf-env-test","environment_variables":{"test":"test"},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"pending","registry_namespace_id":"","error_message":null,"registry_endpoint":"","description":"","secret_environment_variables":[{"key":"test_secret","hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$rD+MUqUFZ/MbPMpc+17JJg$Nklw7EbD7rOwGQelfsahsHvbUmLv9PFQqxFRfJBA6AQ"}],"region":"fr-par"}'
-    headers:
-      Content-Length:
-      - "510"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 14:33:59 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 00bbbb93-f25f-44ba-b23c-720ecef02686
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2659002a-557f-4e15-8c30-5a3880ec8866
-    method: GET
-  response:
-    body: '{"id":"2659002a-557f-4e15-8c30-5a3880ec8866","name":"tf-env-test","environment_variables":{"test":"test"},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","registry_namespace_id":"c4866ee2-58aa-469b-b3ca-8433cf461a59","error_message":null,"registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestiqzj5dqn","description":"","secret_environment_variables":[{"key":"test_secret","hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$rD+MUqUFZ/MbPMpc+17JJg$Nklw7EbD7rOwGQelfsahsHvbUmLv9PFQqxFRfJBA6AQ"}],"region":"fr-par"}'
-    headers:
-      Content-Length:
-      - "588"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 14:34:04 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - afa4526c-c86d-42a9-adcc-214d3e51bb24
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2659002a-557f-4e15-8c30-5a3880ec8866
-    method: GET
-  response:
-    body: '{"id":"2659002a-557f-4e15-8c30-5a3880ec8866","name":"tf-env-test","environment_variables":{"test":"test"},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","registry_namespace_id":"c4866ee2-58aa-469b-b3ca-8433cf461a59","error_message":null,"registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestiqzj5dqn","description":"","secret_environment_variables":[{"key":"test_secret","hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$rD+MUqUFZ/MbPMpc+17JJg$Nklw7EbD7rOwGQelfsahsHvbUmLv9PFQqxFRfJBA6AQ"}],"region":"fr-par"}'
-    headers:
-      Content-Length:
-      - "588"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 14:34:04 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 95e2389f-35fd-4f6b-80e4-73631812e139
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2659002a-557f-4e15-8c30-5a3880ec8866
-    method: GET
-  response:
-    body: '{"id":"2659002a-557f-4e15-8c30-5a3880ec8866","name":"tf-env-test","environment_variables":{"test":"test"},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","registry_namespace_id":"c4866ee2-58aa-469b-b3ca-8433cf461a59","error_message":null,"registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestiqzj5dqn","description":"","secret_environment_variables":[{"key":"test_secret","hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$rD+MUqUFZ/MbPMpc+17JJg$Nklw7EbD7rOwGQelfsahsHvbUmLv9PFQqxFRfJBA6AQ"}],"region":"fr-par"}'
-    headers:
-      Content-Length:
-      - "588"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 14:34:05 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 83a5b0e2-807d-4b0f-9a36-815298f4b81f
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2659002a-557f-4e15-8c30-5a3880ec8866
-    method: GET
-  response:
-    body: '{"id":"2659002a-557f-4e15-8c30-5a3880ec8866","name":"tf-env-test","environment_variables":{"test":"test"},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","registry_namespace_id":"c4866ee2-58aa-469b-b3ca-8433cf461a59","error_message":null,"registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestiqzj5dqn","description":"","secret_environment_variables":[{"key":"test_secret","hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$rD+MUqUFZ/MbPMpc+17JJg$Nklw7EbD7rOwGQelfsahsHvbUmLv9PFQqxFRfJBA6AQ"}],"region":"fr-par"}'
-    headers:
-      Content-Length:
-      - "588"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 14:34:05 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6a2b3568-06f4-4578-b7df-6a3e9f255323
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2659002a-557f-4e15-8c30-5a3880ec8866
-    method: GET
-  response:
-    body: '{"id":"2659002a-557f-4e15-8c30-5a3880ec8866","name":"tf-env-test","environment_variables":{"test":"test"},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","registry_namespace_id":"c4866ee2-58aa-469b-b3ca-8433cf461a59","error_message":null,"registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestiqzj5dqn","description":"","secret_environment_variables":[{"key":"test_secret","hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$rD+MUqUFZ/MbPMpc+17JJg$Nklw7EbD7rOwGQelfsahsHvbUmLv9PFQqxFRfJBA6AQ"}],"region":"fr-par"}'
-    headers:
-      Content-Length:
-      - "588"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 14:34:06 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1058df5c-ce28-4b94-901e-638e218f0b22
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2659002a-557f-4e15-8c30-5a3880ec8866
-    method: GET
-  response:
-    body: '{"id":"2659002a-557f-4e15-8c30-5a3880ec8866","name":"tf-env-test","environment_variables":{"test":"test"},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","registry_namespace_id":"c4866ee2-58aa-469b-b3ca-8433cf461a59","error_message":null,"registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestiqzj5dqn","description":"","secret_environment_variables":[{"key":"test_secret","hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$rD+MUqUFZ/MbPMpc+17JJg$Nklw7EbD7rOwGQelfsahsHvbUmLv9PFQqxFRfJBA6AQ"}],"region":"fr-par"}'
-    headers:
-      Content-Length:
-      - "588"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 14:34:06 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2c29f1a5-de3c-495c-a4c3-64406854f8bb
-    status: 200 OK
-    code: 200
-- request:
-    body: '{"environment_variables":{"foo":"bar"},"description":null,"secret_environment_variables":[{"key":"foo_secret","value":"bar_secret"}]}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2659002a-557f-4e15-8c30-5a3880ec8866
-    method: PATCH
-  response:
-    body: '{"id":"2659002a-557f-4e15-8c30-5a3880ec8866","name":"tf-env-test","environment_variables":{"foo":"bar"},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","registry_namespace_id":"c4866ee2-58aa-469b-b3ca-8433cf461a59","error_message":null,"registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestiqzj5dqn","description":"","secret_environment_variables":[{"key":"test_secret","hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$rD+MUqUFZ/MbPMpc+17JJg$Nklw7EbD7rOwGQelfsahsHvbUmLv9PFQqxFRfJBA6AQ"},{"key":"foo_secret","hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$npG4wOOkdtUpw9uPnn63ZQ$GDHdGOqp1xNisQwTdsUpnEq/stsQKSoaebMpSvYGFPs"}],"region":"fr-par"}'
-    headers:
-      Content-Length:
-      - "722"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 14:34:07 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0fd97521-0b0a-4124-8aa5-912f6ca58c30
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2659002a-557f-4e15-8c30-5a3880ec8866
-    method: GET
-  response:
-    body: '{"id":"2659002a-557f-4e15-8c30-5a3880ec8866","name":"tf-env-test","environment_variables":{"foo":"bar"},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","registry_namespace_id":"c4866ee2-58aa-469b-b3ca-8433cf461a59","error_message":null,"registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestiqzj5dqn","description":"","secret_environment_variables":[{"key":"test_secret","hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$rD+MUqUFZ/MbPMpc+17JJg$Nklw7EbD7rOwGQelfsahsHvbUmLv9PFQqxFRfJBA6AQ"},{"key":"foo_secret","hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$npG4wOOkdtUpw9uPnn63ZQ$GDHdGOqp1xNisQwTdsUpnEq/stsQKSoaebMpSvYGFPs"}],"region":"fr-par"}'
-    headers:
-      Content-Length:
-      - "722"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 14:34:07 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ada0d544-ba43-4370-97a8-6e2ab1e0dc74
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2659002a-557f-4e15-8c30-5a3880ec8866
-    method: GET
-  response:
-    body: '{"id":"2659002a-557f-4e15-8c30-5a3880ec8866","name":"tf-env-test","environment_variables":{"foo":"bar"},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","registry_namespace_id":"c4866ee2-58aa-469b-b3ca-8433cf461a59","error_message":null,"registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestiqzj5dqn","description":"","secret_environment_variables":[{"key":"test_secret","hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$rD+MUqUFZ/MbPMpc+17JJg$Nklw7EbD7rOwGQelfsahsHvbUmLv9PFQqxFRfJBA6AQ"},{"key":"foo_secret","hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$npG4wOOkdtUpw9uPnn63ZQ$GDHdGOqp1xNisQwTdsUpnEq/stsQKSoaebMpSvYGFPs"}],"region":"fr-par"}'
-    headers:
-      Content-Length:
-      - "722"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 14:34:07 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9bbf7014-bb53-454f-8c5f-809c6351696c
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2659002a-557f-4e15-8c30-5a3880ec8866
-    method: GET
-  response:
-    body: '{"id":"2659002a-557f-4e15-8c30-5a3880ec8866","name":"tf-env-test","environment_variables":{"foo":"bar"},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","registry_namespace_id":"c4866ee2-58aa-469b-b3ca-8433cf461a59","error_message":null,"registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestiqzj5dqn","description":"","secret_environment_variables":[{"key":"test_secret","hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$rD+MUqUFZ/MbPMpc+17JJg$Nklw7EbD7rOwGQelfsahsHvbUmLv9PFQqxFRfJBA6AQ"},{"key":"foo_secret","hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$npG4wOOkdtUpw9uPnn63ZQ$GDHdGOqp1xNisQwTdsUpnEq/stsQKSoaebMpSvYGFPs"}],"region":"fr-par"}'
-    headers:
-      Content-Length:
-      - "722"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 14:34:08 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1069f1b3-a22e-43ba-803f-627f53c9b334
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2659002a-557f-4e15-8c30-5a3880ec8866
-    method: GET
-  response:
-    body: '{"id":"2659002a-557f-4e15-8c30-5a3880ec8866","name":"tf-env-test","environment_variables":{"foo":"bar"},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","registry_namespace_id":"c4866ee2-58aa-469b-b3ca-8433cf461a59","error_message":null,"registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestiqzj5dqn","description":"","secret_environment_variables":[{"key":"test_secret","hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$rD+MUqUFZ/MbPMpc+17JJg$Nklw7EbD7rOwGQelfsahsHvbUmLv9PFQqxFRfJBA6AQ"},{"key":"foo_secret","hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$npG4wOOkdtUpw9uPnn63ZQ$GDHdGOqp1xNisQwTdsUpnEq/stsQKSoaebMpSvYGFPs"}],"region":"fr-par"}'
-    headers:
-      Content-Length:
-      - "722"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 14:34:09 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0a6df9c1-b2f1-4e85-a61b-8ccf7a2f4a58
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2659002a-557f-4e15-8c30-5a3880ec8866
-    method: DELETE
-  response:
-    body: '{"id":"2659002a-557f-4e15-8c30-5a3880ec8866","name":"tf-env-test","environment_variables":{"foo":"bar"},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"deleting","registry_namespace_id":"c4866ee2-58aa-469b-b3ca-8433cf461a59","error_message":null,"registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestiqzj5dqn","description":"","secret_environment_variables":[{"key":"test_secret","hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$rD+MUqUFZ/MbPMpc+17JJg$Nklw7EbD7rOwGQelfsahsHvbUmLv9PFQqxFRfJBA6AQ"},{"key":"foo_secret","hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$npG4wOOkdtUpw9uPnn63ZQ$GDHdGOqp1xNisQwTdsUpnEq/stsQKSoaebMpSvYGFPs"}],"region":"fr-par"}'
-    headers:
-      Content-Length:
-      - "725"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 14:34:09 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 07ff4701-c466-4101-a050-2ec1c8a5b11f
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2659002a-557f-4e15-8c30-5a3880ec8866
-    method: GET
-  response:
-    body: '{"message":"Namespace was not found"}'
-    headers:
-      Content-Length:
-      - "37"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 14:34:09 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 804c0818-a90a-4e3b-b406-4484de7f2380
-    status: 404 Not Found
-    code: 404
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2659002a-557f-4e15-8c30-5a3880ec8866
-    method: DELETE
-  response:
-    body: '{"message":"Namespace was not found"}'
-    headers:
-      Content-Length:
-      - "37"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 14:34:09 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2efe1ef6-efc6-42b3-bfbc-654af672f075
-    status: 404 Not Found
-    code: 404
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 149
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"name":"test-cr-ns-01","environment_variables":{},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","secret_environment_variables":[],"tags":null}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 479
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T13:55:24.460045284Z","description":"","environment_variables":{},"error_message":null,"id":"57731da3-53e6-412b-8df6-cc46a60efc6f","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2024-11-20T13:55:24.460045284Z"}'
+        headers:
+            Content-Length:
+                - "479"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 13:55:24 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ae4a03b9-80d9-437c-a366-e0e929997e29
+        status: 200 OK
+        code: 200
+        duration: 289.027125ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/57731da3-53e6-412b-8df6-cc46a60efc6f
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 473
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T13:55:24.460045Z","description":"","environment_variables":{},"error_message":null,"id":"57731da3-53e6-412b-8df6-cc46a60efc6f","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2024-11-20T13:55:24.460045Z"}'
+        headers:
+            Content-Length:
+                - "473"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 13:55:24 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ae465aae-f455-49cf-9ac7-9539c9ae8230
+        status: 200 OK
+        code: 200
+        duration: 71.723709ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/57731da3-53e6-412b-8df6-cc46a60efc6f
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 552
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T13:55:24.460045Z","description":"","environment_variables":{},"error_message":null,"id":"57731da3-53e6-412b-8df6-cc46a60efc6f","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01fq4qoexf","registry_namespace_id":"1dddc1cb-e87e-4309-b616-372186cbe1a8","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2024-11-20T13:55:25.478057Z"}'
+        headers:
+            Content-Length:
+                - "552"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 13:55:29 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3661138e-64e0-46cd-b8d0-824ca9d442f1
+        status: 200 OK
+        code: 200
+        duration: 76.643167ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/57731da3-53e6-412b-8df6-cc46a60efc6f
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 552
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T13:55:24.460045Z","description":"","environment_variables":{},"error_message":null,"id":"57731da3-53e6-412b-8df6-cc46a60efc6f","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01fq4qoexf","registry_namespace_id":"1dddc1cb-e87e-4309-b616-372186cbe1a8","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2024-11-20T13:55:25.478057Z"}'
+        headers:
+            Content-Length:
+                - "552"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 13:55:29 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3cbb31a6-861d-4bb9-9e86-e2a93497b74b
+        status: 200 OK
+        code: 200
+        duration: 72.210208ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/57731da3-53e6-412b-8df6-cc46a60efc6f
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 552
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T13:55:24.460045Z","description":"","environment_variables":{},"error_message":null,"id":"57731da3-53e6-412b-8df6-cc46a60efc6f","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01fq4qoexf","registry_namespace_id":"1dddc1cb-e87e-4309-b616-372186cbe1a8","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2024-11-20T13:55:25.478057Z"}'
+        headers:
+            Content-Length:
+                - "552"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 13:55:29 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - fec788b2-4864-46f8-8d3c-55065c867915
+        status: 200 OK
+        code: 200
+        duration: 67.402291ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/57731da3-53e6-412b-8df6-cc46a60efc6f
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 552
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T13:55:24.460045Z","description":"","environment_variables":{},"error_message":null,"id":"57731da3-53e6-412b-8df6-cc46a60efc6f","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01fq4qoexf","registry_namespace_id":"1dddc1cb-e87e-4309-b616-372186cbe1a8","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2024-11-20T13:55:25.478057Z"}'
+        headers:
+            Content-Length:
+                - "552"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 13:55:30 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b0754e34-1ae8-4039-8b8d-76f15f49fc1a
+        status: 200 OK
+        code: 200
+        duration: 64.813917ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/57731da3-53e6-412b-8df6-cc46a60efc6f
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 552
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T13:55:24.460045Z","description":"","environment_variables":{},"error_message":null,"id":"57731da3-53e6-412b-8df6-cc46a60efc6f","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01fq4qoexf","registry_namespace_id":"1dddc1cb-e87e-4309-b616-372186cbe1a8","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2024-11-20T13:55:25.478057Z"}'
+        headers:
+            Content-Length:
+                - "552"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 13:55:30 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 18352877-7697-4e9b-8fd6-bcf24c54e4f5
+        status: 200 OK
+        code: 200
+        duration: 67.600958ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/57731da3-53e6-412b-8df6-cc46a60efc6f
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 552
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T13:55:24.460045Z","description":"","environment_variables":{},"error_message":null,"id":"57731da3-53e6-412b-8df6-cc46a60efc6f","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01fq4qoexf","registry_namespace_id":"1dddc1cb-e87e-4309-b616-372186cbe1a8","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2024-11-20T13:55:25.478057Z"}'
+        headers:
+            Content-Length:
+                - "552"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 13:55:30 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 2bddc919-7546-4e92-aafa-1173e8a98cda
+        status: 200 OK
+        code: 200
+        duration: 64.690916ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 81
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"description":"test container namespace 01","secret_environment_variables":null}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/57731da3-53e6-412b-8df6-cc46a60efc6f
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 582
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T13:55:24.460045Z","description":"test container namespace 01","environment_variables":{},"error_message":null,"id":"57731da3-53e6-412b-8df6-cc46a60efc6f","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01fq4qoexf","registry_namespace_id":"1dddc1cb-e87e-4309-b616-372186cbe1a8","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2024-11-20T13:55:30.775081964Z"}'
+        headers:
+            Content-Length:
+                - "582"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 13:55:30 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 5bd50655-feaa-44f3-bfcd-224258984012
+        status: 200 OK
+        code: 200
+        duration: 75.413083ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/57731da3-53e6-412b-8df6-cc46a60efc6f
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 579
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T13:55:24.460045Z","description":"test container namespace 01","environment_variables":{},"error_message":null,"id":"57731da3-53e6-412b-8df6-cc46a60efc6f","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01fq4qoexf","registry_namespace_id":"1dddc1cb-e87e-4309-b616-372186cbe1a8","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2024-11-20T13:55:30.775082Z"}'
+        headers:
+            Content-Length:
+                - "579"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 13:55:30 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 589bbbf6-6cd3-49d4-85af-d6b4827654bc
+        status: 200 OK
+        code: 200
+        duration: 66.19075ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/57731da3-53e6-412b-8df6-cc46a60efc6f
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 579
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T13:55:24.460045Z","description":"test container namespace 01","environment_variables":{},"error_message":null,"id":"57731da3-53e6-412b-8df6-cc46a60efc6f","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01fq4qoexf","registry_namespace_id":"1dddc1cb-e87e-4309-b616-372186cbe1a8","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2024-11-20T13:55:30.775082Z"}'
+        headers:
+            Content-Length:
+                - "579"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 13:55:30 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 5e22372e-d752-437c-9848-8c4b039401e9
+        status: 200 OK
+        code: 200
+        duration: 60.035416ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/57731da3-53e6-412b-8df6-cc46a60efc6f
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 579
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T13:55:24.460045Z","description":"test container namespace 01","environment_variables":{},"error_message":null,"id":"57731da3-53e6-412b-8df6-cc46a60efc6f","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01fq4qoexf","registry_namespace_id":"1dddc1cb-e87e-4309-b616-372186cbe1a8","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2024-11-20T13:55:30.775082Z"}'
+        headers:
+            Content-Length:
+                - "579"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 13:55:31 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 0b172d8e-12b6-43d4-b28e-5e6f78cddb88
+        status: 200 OK
+        code: 200
+        duration: 59.020583ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/57731da3-53e6-412b-8df6-cc46a60efc6f
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 579
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T13:55:24.460045Z","description":"test container namespace 01","environment_variables":{},"error_message":null,"id":"57731da3-53e6-412b-8df6-cc46a60efc6f","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01fq4qoexf","registry_namespace_id":"1dddc1cb-e87e-4309-b616-372186cbe1a8","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2024-11-20T13:55:30.775082Z"}'
+        headers:
+            Content-Length:
+                - "579"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 13:55:31 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 1ac0915d-068f-4279-83f0-631f7f84a414
+        status: 200 OK
+        code: 200
+        duration: 69.94025ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/57731da3-53e6-412b-8df6-cc46a60efc6f
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 579
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T13:55:24.460045Z","description":"test container namespace 01","environment_variables":{},"error_message":null,"id":"57731da3-53e6-412b-8df6-cc46a60efc6f","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01fq4qoexf","registry_namespace_id":"1dddc1cb-e87e-4309-b616-372186cbe1a8","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2024-11-20T13:55:30.775082Z"}'
+        headers:
+            Content-Length:
+                - "579"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 13:55:31 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 19ed9f34-1817-4555-a8ac-4a699539468f
+        status: 200 OK
+        code: 200
+        duration: 69.535917ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 135
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"environment_variables":{"test":"test"},"description":"","secret_environment_variables":[{"key":"test_secret","value":"test_secret"}]}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/57731da3-53e6-412b-8df6-cc46a60efc6f
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 707
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T13:55:24.460045Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"57731da3-53e6-412b-8df6-cc46a60efc6f","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01fq4qoexf","registry_namespace_id":"1dddc1cb-e87e-4309-b616-372186cbe1a8","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$5ZfjSKN6XIxYC0dr+ZlcrQ$B8KWAYKZx5Ec8ggMFJ2i0AaDK+9ArnCMTic8l6a3Dtc","key":"test_secret"}],"status":"pending","tags":[],"updated_at":"2024-11-20T13:55:32.147061173Z"}'
+        headers:
+            Content-Length:
+                - "707"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 13:55:32 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 758440cd-f474-49c9-b39a-5162a43a00fd
+        status: 200 OK
+        code: 200
+        duration: 516.158375ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/57731da3-53e6-412b-8df6-cc46a60efc6f
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 704
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T13:55:24.460045Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"57731da3-53e6-412b-8df6-cc46a60efc6f","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01fq4qoexf","registry_namespace_id":"1dddc1cb-e87e-4309-b616-372186cbe1a8","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$5ZfjSKN6XIxYC0dr+ZlcrQ$B8KWAYKZx5Ec8ggMFJ2i0AaDK+9ArnCMTic8l6a3Dtc","key":"test_secret"}],"status":"pending","tags":[],"updated_at":"2024-11-20T13:55:32.147061Z"}'
+        headers:
+            Content-Length:
+                - "704"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 13:55:32 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 0c90ce35-f56e-4266-9431-062df4c1d5f8
+        status: 200 OK
+        code: 200
+        duration: 72.545292ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/57731da3-53e6-412b-8df6-cc46a60efc6f
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 702
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T13:55:24.460045Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"57731da3-53e6-412b-8df6-cc46a60efc6f","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01fq4qoexf","registry_namespace_id":"1dddc1cb-e87e-4309-b616-372186cbe1a8","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$5ZfjSKN6XIxYC0dr+ZlcrQ$B8KWAYKZx5Ec8ggMFJ2i0AaDK+9ArnCMTic8l6a3Dtc","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2024-11-20T13:55:32.494949Z"}'
+        headers:
+            Content-Length:
+                - "702"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 13:55:37 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - d0cc32c3-1122-4296-9f3e-2d0b0e1b3f92
+        status: 200 OK
+        code: 200
+        duration: 64.869125ms
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/57731da3-53e6-412b-8df6-cc46a60efc6f
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 702
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T13:55:24.460045Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"57731da3-53e6-412b-8df6-cc46a60efc6f","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01fq4qoexf","registry_namespace_id":"1dddc1cb-e87e-4309-b616-372186cbe1a8","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$5ZfjSKN6XIxYC0dr+ZlcrQ$B8KWAYKZx5Ec8ggMFJ2i0AaDK+9ArnCMTic8l6a3Dtc","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2024-11-20T13:55:32.494949Z"}'
+        headers:
+            Content-Length:
+                - "702"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 13:55:37 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ef230686-4e36-4dc7-8f35-590233c9b1bc
+        status: 200 OK
+        code: 200
+        duration: 64.941791ms
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/57731da3-53e6-412b-8df6-cc46a60efc6f
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 702
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T13:55:24.460045Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"57731da3-53e6-412b-8df6-cc46a60efc6f","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01fq4qoexf","registry_namespace_id":"1dddc1cb-e87e-4309-b616-372186cbe1a8","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$5ZfjSKN6XIxYC0dr+ZlcrQ$B8KWAYKZx5Ec8ggMFJ2i0AaDK+9ArnCMTic8l6a3Dtc","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2024-11-20T13:55:32.494949Z"}'
+        headers:
+            Content-Length:
+                - "702"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 13:55:37 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f101d533-377b-4669-820e-988e49b13aa1
+        status: 200 OK
+        code: 200
+        duration: 68.186458ms
+    - id: 19
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/57731da3-53e6-412b-8df6-cc46a60efc6f
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 702
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T13:55:24.460045Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"57731da3-53e6-412b-8df6-cc46a60efc6f","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01fq4qoexf","registry_namespace_id":"1dddc1cb-e87e-4309-b616-372186cbe1a8","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$5ZfjSKN6XIxYC0dr+ZlcrQ$B8KWAYKZx5Ec8ggMFJ2i0AaDK+9ArnCMTic8l6a3Dtc","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2024-11-20T13:55:32.494949Z"}'
+        headers:
+            Content-Length:
+                - "702"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 13:55:38 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3bbc6c51-d5d0-40ae-a171-61c5c3b4e988
+        status: 200 OK
+        code: 200
+        duration: 70.437833ms
+    - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/57731da3-53e6-412b-8df6-cc46a60efc6f
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 702
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T13:55:24.460045Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"57731da3-53e6-412b-8df6-cc46a60efc6f","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01fq4qoexf","registry_namespace_id":"1dddc1cb-e87e-4309-b616-372186cbe1a8","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$5ZfjSKN6XIxYC0dr+ZlcrQ$B8KWAYKZx5Ec8ggMFJ2i0AaDK+9ArnCMTic8l6a3Dtc","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2024-11-20T13:55:32.494949Z"}'
+        headers:
+            Content-Length:
+                - "702"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 13:55:38 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 49443a49-1f59-415b-9f27-9f81a89b9fab
+        status: 200 OK
+        code: 200
+        duration: 75.96025ms
+    - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 60
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"secret_environment_variables":null,"tags":["tag1","tag2"]}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/57731da3-53e6-412b-8df6-cc46a60efc6f
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 719
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T13:55:24.460045Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"57731da3-53e6-412b-8df6-cc46a60efc6f","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01fq4qoexf","registry_namespace_id":"1dddc1cb-e87e-4309-b616-372186cbe1a8","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$5ZfjSKN6XIxYC0dr+ZlcrQ$B8KWAYKZx5Ec8ggMFJ2i0AaDK+9ArnCMTic8l6a3Dtc","key":"test_secret"}],"status":"ready","tags":["tag1","tag2"],"updated_at":"2024-11-20T13:55:38.642785911Z"}'
+        headers:
+            Content-Length:
+                - "719"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 13:55:38 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 5d97e7dd-df68-433b-8f94-188ff0571f13
+        status: 200 OK
+        code: 200
+        duration: 77.460917ms
+    - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/57731da3-53e6-412b-8df6-cc46a60efc6f
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 716
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T13:55:24.460045Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"57731da3-53e6-412b-8df6-cc46a60efc6f","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01fq4qoexf","registry_namespace_id":"1dddc1cb-e87e-4309-b616-372186cbe1a8","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$5ZfjSKN6XIxYC0dr+ZlcrQ$B8KWAYKZx5Ec8ggMFJ2i0AaDK+9ArnCMTic8l6a3Dtc","key":"test_secret"}],"status":"ready","tags":["tag1","tag2"],"updated_at":"2024-11-20T13:55:38.642786Z"}'
+        headers:
+            Content-Length:
+                - "716"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 13:55:38 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ad232ec3-d554-4421-9689-244bb0244fb5
+        status: 200 OK
+        code: 200
+        duration: 76.985042ms
+    - id: 23
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/57731da3-53e6-412b-8df6-cc46a60efc6f
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 716
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T13:55:24.460045Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"57731da3-53e6-412b-8df6-cc46a60efc6f","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01fq4qoexf","registry_namespace_id":"1dddc1cb-e87e-4309-b616-372186cbe1a8","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$5ZfjSKN6XIxYC0dr+ZlcrQ$B8KWAYKZx5Ec8ggMFJ2i0AaDK+9ArnCMTic8l6a3Dtc","key":"test_secret"}],"status":"ready","tags":["tag1","tag2"],"updated_at":"2024-11-20T13:55:38.642786Z"}'
+        headers:
+            Content-Length:
+                - "716"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 13:55:38 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - da293a5f-b5a0-4936-8dc7-da27206101d1
+        status: 200 OK
+        code: 200
+        duration: 76.51375ms
+    - id: 24
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/57731da3-53e6-412b-8df6-cc46a60efc6f
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 716
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T13:55:24.460045Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"57731da3-53e6-412b-8df6-cc46a60efc6f","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01fq4qoexf","registry_namespace_id":"1dddc1cb-e87e-4309-b616-372186cbe1a8","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$5ZfjSKN6XIxYC0dr+ZlcrQ$B8KWAYKZx5Ec8ggMFJ2i0AaDK+9ArnCMTic8l6a3Dtc","key":"test_secret"}],"status":"ready","tags":["tag1","tag2"],"updated_at":"2024-11-20T13:55:38.642786Z"}'
+        headers:
+            Content-Length:
+                - "716"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 13:55:39 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 9c92db05-46aa-4ec6-ad43-1d57ae7413cd
+        status: 200 OK
+        code: 200
+        duration: 56.387709ms
+    - id: 25
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/57731da3-53e6-412b-8df6-cc46a60efc6f
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 716
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T13:55:24.460045Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"57731da3-53e6-412b-8df6-cc46a60efc6f","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01fq4qoexf","registry_namespace_id":"1dddc1cb-e87e-4309-b616-372186cbe1a8","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$5ZfjSKN6XIxYC0dr+ZlcrQ$B8KWAYKZx5Ec8ggMFJ2i0AaDK+9ArnCMTic8l6a3Dtc","key":"test_secret"}],"status":"ready","tags":["tag1","tag2"],"updated_at":"2024-11-20T13:55:38.642786Z"}'
+        headers:
+            Content-Length:
+                - "716"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 13:55:39 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b3627e63-884d-49c3-a8be-2633a5e75f62
+        status: 200 OK
+        code: 200
+        duration: 62.280209ms
+    - id: 26
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/57731da3-53e6-412b-8df6-cc46a60efc6f
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 716
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T13:55:24.460045Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"57731da3-53e6-412b-8df6-cc46a60efc6f","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01fq4qoexf","registry_namespace_id":"1dddc1cb-e87e-4309-b616-372186cbe1a8","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$5ZfjSKN6XIxYC0dr+ZlcrQ$B8KWAYKZx5Ec8ggMFJ2i0AaDK+9ArnCMTic8l6a3Dtc","key":"test_secret"}],"status":"ready","tags":["tag1","tag2"],"updated_at":"2024-11-20T13:55:38.642786Z"}'
+        headers:
+            Content-Length:
+                - "716"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 13:55:39 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e457349a-6831-4287-b70b-465ca07f0755
+        status: 200 OK
+        code: 200
+        duration: 73.259833ms
+    - id: 27
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 72
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"environment_variables":{},"secret_environment_variables":[],"tags":[]}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/57731da3-53e6-412b-8df6-cc46a60efc6f
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 694
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T13:55:24.460045Z","description":"","environment_variables":{},"error_message":null,"id":"57731da3-53e6-412b-8df6-cc46a60efc6f","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01fq4qoexf","registry_namespace_id":"1dddc1cb-e87e-4309-b616-372186cbe1a8","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$5ZfjSKN6XIxYC0dr+ZlcrQ$B8KWAYKZx5Ec8ggMFJ2i0AaDK+9ArnCMTic8l6a3Dtc","key":"test_secret"}],"status":"pending","tags":[],"updated_at":"2024-11-20T13:55:39.954524029Z"}'
+        headers:
+            Content-Length:
+                - "694"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 13:55:39 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 44a657b5-c2e8-4ab9-aa97-cea420f124df
+        status: 200 OK
+        code: 200
+        duration: 82.624791ms
+    - id: 28
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/57731da3-53e6-412b-8df6-cc46a60efc6f
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 691
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T13:55:24.460045Z","description":"","environment_variables":{},"error_message":null,"id":"57731da3-53e6-412b-8df6-cc46a60efc6f","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01fq4qoexf","registry_namespace_id":"1dddc1cb-e87e-4309-b616-372186cbe1a8","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$5ZfjSKN6XIxYC0dr+ZlcrQ$B8KWAYKZx5Ec8ggMFJ2i0AaDK+9ArnCMTic8l6a3Dtc","key":"test_secret"}],"status":"pending","tags":[],"updated_at":"2024-11-20T13:55:39.954524Z"}'
+        headers:
+            Content-Length:
+                - "691"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 13:55:40 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ca42c8ae-4690-497f-a3d1-614272a331f4
+        status: 200 OK
+        code: 200
+        duration: 72.923792ms
+    - id: 29
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/57731da3-53e6-412b-8df6-cc46a60efc6f
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 689
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T13:55:24.460045Z","description":"","environment_variables":{},"error_message":null,"id":"57731da3-53e6-412b-8df6-cc46a60efc6f","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01fq4qoexf","registry_namespace_id":"1dddc1cb-e87e-4309-b616-372186cbe1a8","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$5ZfjSKN6XIxYC0dr+ZlcrQ$B8KWAYKZx5Ec8ggMFJ2i0AaDK+9ArnCMTic8l6a3Dtc","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2024-11-20T13:55:40.349848Z"}'
+        headers:
+            Content-Length:
+                - "689"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 13:55:45 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 7f076c23-dcd3-450f-83c9-afe917f587b9
+        status: 200 OK
+        code: 200
+        duration: 70.05975ms
+    - id: 30
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/57731da3-53e6-412b-8df6-cc46a60efc6f
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 689
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T13:55:24.460045Z","description":"","environment_variables":{},"error_message":null,"id":"57731da3-53e6-412b-8df6-cc46a60efc6f","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01fq4qoexf","registry_namespace_id":"1dddc1cb-e87e-4309-b616-372186cbe1a8","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$5ZfjSKN6XIxYC0dr+ZlcrQ$B8KWAYKZx5Ec8ggMFJ2i0AaDK+9ArnCMTic8l6a3Dtc","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2024-11-20T13:55:40.349848Z"}'
+        headers:
+            Content-Length:
+                - "689"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 13:55:45 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 074cd1a4-faa1-48e6-ba48-d4bf687c0f42
+        status: 200 OK
+        code: 200
+        duration: 71.601541ms
+    - id: 31
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/57731da3-53e6-412b-8df6-cc46a60efc6f
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 689
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T13:55:24.460045Z","description":"","environment_variables":{},"error_message":null,"id":"57731da3-53e6-412b-8df6-cc46a60efc6f","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01fq4qoexf","registry_namespace_id":"1dddc1cb-e87e-4309-b616-372186cbe1a8","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$5ZfjSKN6XIxYC0dr+ZlcrQ$B8KWAYKZx5Ec8ggMFJ2i0AaDK+9ArnCMTic8l6a3Dtc","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2024-11-20T13:55:40.349848Z"}'
+        headers:
+            Content-Length:
+                - "689"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 13:55:45 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f2a0a7d1-1499-4ad0-9e68-663f74402b5c
+        status: 200 OK
+        code: 200
+        duration: 63.574959ms
+    - id: 32
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/57731da3-53e6-412b-8df6-cc46a60efc6f
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 689
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T13:55:24.460045Z","description":"","environment_variables":{},"error_message":null,"id":"57731da3-53e6-412b-8df6-cc46a60efc6f","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01fq4qoexf","registry_namespace_id":"1dddc1cb-e87e-4309-b616-372186cbe1a8","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$5ZfjSKN6XIxYC0dr+ZlcrQ$B8KWAYKZx5Ec8ggMFJ2i0AaDK+9ArnCMTic8l6a3Dtc","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2024-11-20T13:55:40.349848Z"}'
+        headers:
+            Content-Length:
+                - "689"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 13:55:45 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - c823b4ca-90bf-4f65-af0b-f9962f7ac057
+        status: 200 OK
+        code: 200
+        duration: 66.9125ms
+    - id: 33
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/57731da3-53e6-412b-8df6-cc46a60efc6f
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 689
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T13:55:24.460045Z","description":"","environment_variables":{},"error_message":null,"id":"57731da3-53e6-412b-8df6-cc46a60efc6f","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01fq4qoexf","registry_namespace_id":"1dddc1cb-e87e-4309-b616-372186cbe1a8","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$5ZfjSKN6XIxYC0dr+ZlcrQ$B8KWAYKZx5Ec8ggMFJ2i0AaDK+9ArnCMTic8l6a3Dtc","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2024-11-20T13:55:40.349848Z"}'
+        headers:
+            Content-Length:
+                - "689"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 13:55:46 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - a898caa4-6044-40bd-a279-c9055ae60ede
+        status: 200 OK
+        code: 200
+        duration: 71.36475ms
+    - id: 34
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/57731da3-53e6-412b-8df6-cc46a60efc6f
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 695
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T13:55:24.460045Z","description":"","environment_variables":{},"error_message":null,"id":"57731da3-53e6-412b-8df6-cc46a60efc6f","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01fq4qoexf","registry_namespace_id":"1dddc1cb-e87e-4309-b616-372186cbe1a8","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$5ZfjSKN6XIxYC0dr+ZlcrQ$B8KWAYKZx5Ec8ggMFJ2i0AaDK+9ArnCMTic8l6a3Dtc","key":"test_secret"}],"status":"deleting","tags":[],"updated_at":"2024-11-20T13:55:46.153861769Z"}'
+        headers:
+            Content-Length:
+                - "695"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 13:55:46 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 87b0d63e-4b04-4c62-81f1-825eabd604f7
+        status: 200 OK
+        code: 200
+        duration: 198.495333ms
+    - id: 35
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/57731da3-53e6-412b-8df6-cc46a60efc6f
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 692
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T13:55:24.460045Z","description":"","environment_variables":{},"error_message":null,"id":"57731da3-53e6-412b-8df6-cc46a60efc6f","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01fq4qoexf","registry_namespace_id":"1dddc1cb-e87e-4309-b616-372186cbe1a8","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$5ZfjSKN6XIxYC0dr+ZlcrQ$B8KWAYKZx5Ec8ggMFJ2i0AaDK+9ArnCMTic8l6a3Dtc","key":"test_secret"}],"status":"deleting","tags":[],"updated_at":"2024-11-20T13:55:46.153862Z"}'
+        headers:
+            Content-Length:
+                - "692"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 13:55:46 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 9d3740ca-43f5-4043-b76b-cd9c94145ffb
+        status: 200 OK
+        code: 200
+        duration: 60.779291ms
+    - id: 36
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/57731da3-53e6-412b-8df6-cc46a60efc6f
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 37
+        uncompressed: false
+        body: '{"message":"Namespace was not found"}'
+        headers:
+            Content-Length:
+                - "37"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 13:55:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - d5699d8a-ad7f-451d-8cf0-99d381a45be3
+        status: 404 Not Found
+        code: 404
+        duration: 34.3725ms
+    - id: 37
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 203
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"name":"tf-env-test","environment_variables":{"test":"test"},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","secret_environment_variables":[{"key":"test_secret","value":"test_secret"}],"tags":null}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 627
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T13:55:51.850171667Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"d2756edf-f733-460b-8388-c6def00006c6","name":"tf-env-test","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$s9zhY4r7Ip0aMafY68C2UQ$3wLMsMuxss/QFKDp2gor2LK8eTgUq2UL0tsjWTK8hSY","key":"test_secret"}],"status":"pending","tags":[],"updated_at":"2024-11-20T13:55:51.850171667Z"}'
+        headers:
+            Content-Length:
+                - "627"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 13:55:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 7d04af9d-4f6f-437c-8eaf-1bd7aa54b8fd
+        status: 200 OK
+        code: 200
+        duration: 476.534958ms
+    - id: 38
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d2756edf-f733-460b-8388-c6def00006c6
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 621
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T13:55:51.850172Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"d2756edf-f733-460b-8388-c6def00006c6","name":"tf-env-test","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$s9zhY4r7Ip0aMafY68C2UQ$3wLMsMuxss/QFKDp2gor2LK8eTgUq2UL0tsjWTK8hSY","key":"test_secret"}],"status":"pending","tags":[],"updated_at":"2024-11-20T13:55:51.850172Z"}'
+        headers:
+            Content-Length:
+                - "621"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 13:55:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 52a677ec-1641-4189-b519-4c15c322a5c4
+        status: 200 OK
+        code: 200
+        duration: 60.262417ms
+    - id: 39
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d2756edf-f733-460b-8388-c6def00006c6
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 701
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T13:55:51.850172Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"d2756edf-f733-460b-8388-c6def00006c6","name":"tf-env-test","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestlrvltljy","registry_namespace_id":"ee42d292-cd3f-4646-b50e-1df027e9fa3a","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$s9zhY4r7Ip0aMafY68C2UQ$3wLMsMuxss/QFKDp2gor2LK8eTgUq2UL0tsjWTK8hSY","key":"test_secret"}],"status":"pending","tags":[],"updated_at":"2024-11-20T13:55:52.888547Z"}'
+        headers:
+            Content-Length:
+                - "701"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 13:55:56 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - a80fffc8-f904-4da8-a74d-e8d95b339368
+        status: 200 OK
+        code: 200
+        duration: 64.508916ms
+    - id: 40
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d2756edf-f733-460b-8388-c6def00006c6
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 701
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T13:55:51.850172Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"d2756edf-f733-460b-8388-c6def00006c6","name":"tf-env-test","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestlrvltljy","registry_namespace_id":"ee42d292-cd3f-4646-b50e-1df027e9fa3a","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$s9zhY4r7Ip0aMafY68C2UQ$3wLMsMuxss/QFKDp2gor2LK8eTgUq2UL0tsjWTK8hSY","key":"test_secret"}],"status":"pending","tags":[],"updated_at":"2024-11-20T13:55:52.888547Z"}'
+        headers:
+            Content-Length:
+                - "701"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 13:56:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 01317e5f-0a3f-4da8-93b1-1f873eb38069
+        status: 200 OK
+        code: 200
+        duration: 81.433458ms
+    - id: 41
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d2756edf-f733-460b-8388-c6def00006c6
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 701
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T13:55:51.850172Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"d2756edf-f733-460b-8388-c6def00006c6","name":"tf-env-test","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestlrvltljy","registry_namespace_id":"ee42d292-cd3f-4646-b50e-1df027e9fa3a","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$s9zhY4r7Ip0aMafY68C2UQ$3wLMsMuxss/QFKDp2gor2LK8eTgUq2UL0tsjWTK8hSY","key":"test_secret"}],"status":"pending","tags":[],"updated_at":"2024-11-20T13:55:52.888547Z"}'
+        headers:
+            Content-Length:
+                - "701"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 13:56:07 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 78b9385e-88ab-4b1e-8ca0-08908ff72448
+        status: 200 OK
+        code: 200
+        duration: 67.236291ms
+    - id: 42
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d2756edf-f733-460b-8388-c6def00006c6
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 701
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T13:55:51.850172Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"d2756edf-f733-460b-8388-c6def00006c6","name":"tf-env-test","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestlrvltljy","registry_namespace_id":"ee42d292-cd3f-4646-b50e-1df027e9fa3a","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$s9zhY4r7Ip0aMafY68C2UQ$3wLMsMuxss/QFKDp2gor2LK8eTgUq2UL0tsjWTK8hSY","key":"test_secret"}],"status":"pending","tags":[],"updated_at":"2024-11-20T13:55:52.888547Z"}'
+        headers:
+            Content-Length:
+                - "701"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 13:56:12 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 10194109-82c7-4656-ae20-d79dc1ef1899
+        status: 200 OK
+        code: 200
+        duration: 64.574916ms
+    - id: 43
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d2756edf-f733-460b-8388-c6def00006c6
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 701
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T13:55:51.850172Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"d2756edf-f733-460b-8388-c6def00006c6","name":"tf-env-test","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestlrvltljy","registry_namespace_id":"ee42d292-cd3f-4646-b50e-1df027e9fa3a","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$s9zhY4r7Ip0aMafY68C2UQ$3wLMsMuxss/QFKDp2gor2LK8eTgUq2UL0tsjWTK8hSY","key":"test_secret"}],"status":"pending","tags":[],"updated_at":"2024-11-20T13:55:52.888547Z"}'
+        headers:
+            Content-Length:
+                - "701"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 13:56:17 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - bfbec04d-8d6d-4899-ae3f-d3badd0a3505
+        status: 200 OK
+        code: 200
+        duration: 67.494042ms
+    - id: 44
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d2756edf-f733-460b-8388-c6def00006c6
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 701
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T13:55:51.850172Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"d2756edf-f733-460b-8388-c6def00006c6","name":"tf-env-test","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestlrvltljy","registry_namespace_id":"ee42d292-cd3f-4646-b50e-1df027e9fa3a","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$s9zhY4r7Ip0aMafY68C2UQ$3wLMsMuxss/QFKDp2gor2LK8eTgUq2UL0tsjWTK8hSY","key":"test_secret"}],"status":"pending","tags":[],"updated_at":"2024-11-20T13:55:52.888547Z"}'
+        headers:
+            Content-Length:
+                - "701"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 13:56:22 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 4fd0c071-26df-4d86-8c11-c3c7d9bcf2d1
+        status: 200 OK
+        code: 200
+        duration: 65.981292ms
+    - id: 45
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d2756edf-f733-460b-8388-c6def00006c6
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 699
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T13:55:51.850172Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"d2756edf-f733-460b-8388-c6def00006c6","name":"tf-env-test","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestlrvltljy","registry_namespace_id":"ee42d292-cd3f-4646-b50e-1df027e9fa3a","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$s9zhY4r7Ip0aMafY68C2UQ$3wLMsMuxss/QFKDp2gor2LK8eTgUq2UL0tsjWTK8hSY","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2024-11-20T13:56:23.214673Z"}'
+        headers:
+            Content-Length:
+                - "699"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 13:56:27 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 0a461166-b278-4cdf-b500-60f6bdb7c3fa
+        status: 200 OK
+        code: 200
+        duration: 69.994125ms
+    - id: 46
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d2756edf-f733-460b-8388-c6def00006c6
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 699
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T13:55:51.850172Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"d2756edf-f733-460b-8388-c6def00006c6","name":"tf-env-test","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestlrvltljy","registry_namespace_id":"ee42d292-cd3f-4646-b50e-1df027e9fa3a","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$s9zhY4r7Ip0aMafY68C2UQ$3wLMsMuxss/QFKDp2gor2LK8eTgUq2UL0tsjWTK8hSY","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2024-11-20T13:56:23.214673Z"}'
+        headers:
+            Content-Length:
+                - "699"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 13:56:27 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - d2f634c8-3cee-4882-bb2f-68f162c2243b
+        status: 200 OK
+        code: 200
+        duration: 78.374334ms
+    - id: 47
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d2756edf-f733-460b-8388-c6def00006c6
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 699
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T13:55:51.850172Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"d2756edf-f733-460b-8388-c6def00006c6","name":"tf-env-test","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestlrvltljy","registry_namespace_id":"ee42d292-cd3f-4646-b50e-1df027e9fa3a","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$s9zhY4r7Ip0aMafY68C2UQ$3wLMsMuxss/QFKDp2gor2LK8eTgUq2UL0tsjWTK8hSY","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2024-11-20T13:56:23.214673Z"}'
+        headers:
+            Content-Length:
+                - "699"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 13:56:27 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 78836794-6c35-4c10-80b3-1efbf0a88a38
+        status: 200 OK
+        code: 200
+        duration: 60.400792ms
+    - id: 48
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d2756edf-f733-460b-8388-c6def00006c6
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 699
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T13:55:51.850172Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"d2756edf-f733-460b-8388-c6def00006c6","name":"tf-env-test","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestlrvltljy","registry_namespace_id":"ee42d292-cd3f-4646-b50e-1df027e9fa3a","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$s9zhY4r7Ip0aMafY68C2UQ$3wLMsMuxss/QFKDp2gor2LK8eTgUq2UL0tsjWTK8hSY","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2024-11-20T13:56:23.214673Z"}'
+        headers:
+            Content-Length:
+                - "699"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 13:56:27 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3f1deb5b-862e-47e9-a524-321b82ed3762
+        status: 200 OK
+        code: 200
+        duration: 74.945541ms
+    - id: 49
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d2756edf-f733-460b-8388-c6def00006c6
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 699
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T13:55:51.850172Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"d2756edf-f733-460b-8388-c6def00006c6","name":"tf-env-test","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestlrvltljy","registry_namespace_id":"ee42d292-cd3f-4646-b50e-1df027e9fa3a","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$s9zhY4r7Ip0aMafY68C2UQ$3wLMsMuxss/QFKDp2gor2LK8eTgUq2UL0tsjWTK8hSY","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2024-11-20T13:56:23.214673Z"}'
+        headers:
+            Content-Length:
+                - "699"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 13:56:28 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ce0894fa-10cb-4c30-9344-03ef89e727f6
+        status: 200 OK
+        code: 200
+        duration: 69.853792ms
+    - id: 50
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d2756edf-f733-460b-8388-c6def00006c6
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 699
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T13:55:51.850172Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"d2756edf-f733-460b-8388-c6def00006c6","name":"tf-env-test","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestlrvltljy","registry_namespace_id":"ee42d292-cd3f-4646-b50e-1df027e9fa3a","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$s9zhY4r7Ip0aMafY68C2UQ$3wLMsMuxss/QFKDp2gor2LK8eTgUq2UL0tsjWTK8hSY","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2024-11-20T13:56:23.214673Z"}'
+        headers:
+            Content-Length:
+                - "699"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 13:56:28 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 73ac95cf-23c5-4f4b-b996-130fc65d5239
+        status: 200 OK
+        code: 200
+        duration: 80.887458ms
+    - id: 51
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 114
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"environment_variables":{"foo":"bar"},"secret_environment_variables":[{"key":"foo_secret","value":"bar_secret"}]}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d2756edf-f733-460b-8388-c6def00006c6
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 840
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T13:55:51.850172Z","description":"","environment_variables":{"foo":"bar"},"error_message":null,"id":"d2756edf-f733-460b-8388-c6def00006c6","name":"tf-env-test","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestlrvltljy","registry_namespace_id":"ee42d292-cd3f-4646-b50e-1df027e9fa3a","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$s9zhY4r7Ip0aMafY68C2UQ$3wLMsMuxss/QFKDp2gor2LK8eTgUq2UL0tsjWTK8hSY","key":"test_secret"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$uaKMRvfnmPmNo3WLwo/zJQ$fPy//CpQ4oMSkh4yGdWvYmR6ddzZ8Bca6FEu1BFuk7I","key":"foo_secret"}],"status":"pending","tags":[],"updated_at":"2024-11-20T13:56:28.634251275Z"}'
+        headers:
+            Content-Length:
+                - "840"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 13:56:28 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 71f3ac90-0473-4711-b3a9-56573c965f60
+        status: 200 OK
+        code: 200
+        duration: 164.0425ms
+    - id: 52
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d2756edf-f733-460b-8388-c6def00006c6
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 837
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T13:55:51.850172Z","description":"","environment_variables":{"foo":"bar"},"error_message":null,"id":"d2756edf-f733-460b-8388-c6def00006c6","name":"tf-env-test","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestlrvltljy","registry_namespace_id":"ee42d292-cd3f-4646-b50e-1df027e9fa3a","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$s9zhY4r7Ip0aMafY68C2UQ$3wLMsMuxss/QFKDp2gor2LK8eTgUq2UL0tsjWTK8hSY","key":"test_secret"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$uaKMRvfnmPmNo3WLwo/zJQ$fPy//CpQ4oMSkh4yGdWvYmR6ddzZ8Bca6FEu1BFuk7I","key":"foo_secret"}],"status":"pending","tags":[],"updated_at":"2024-11-20T13:56:28.634251Z"}'
+        headers:
+            Content-Length:
+                - "837"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 13:56:28 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 974f4792-9925-40f8-a211-b483aa2565c1
+        status: 200 OK
+        code: 200
+        duration: 81.434625ms
+    - id: 53
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d2756edf-f733-460b-8388-c6def00006c6
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 835
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T13:55:51.850172Z","description":"","environment_variables":{"foo":"bar"},"error_message":null,"id":"d2756edf-f733-460b-8388-c6def00006c6","name":"tf-env-test","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestlrvltljy","registry_namespace_id":"ee42d292-cd3f-4646-b50e-1df027e9fa3a","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$s9zhY4r7Ip0aMafY68C2UQ$3wLMsMuxss/QFKDp2gor2LK8eTgUq2UL0tsjWTK8hSY","key":"test_secret"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$uaKMRvfnmPmNo3WLwo/zJQ$fPy//CpQ4oMSkh4yGdWvYmR6ddzZ8Bca6FEu1BFuk7I","key":"foo_secret"}],"status":"ready","tags":[],"updated_at":"2024-11-20T13:56:28.959352Z"}'
+        headers:
+            Content-Length:
+                - "835"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 13:56:33 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e2c3fd9c-e289-45ea-8cee-7fb1b5765b9a
+        status: 200 OK
+        code: 200
+        duration: 69.724ms
+    - id: 54
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d2756edf-f733-460b-8388-c6def00006c6
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 835
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T13:55:51.850172Z","description":"","environment_variables":{"foo":"bar"},"error_message":null,"id":"d2756edf-f733-460b-8388-c6def00006c6","name":"tf-env-test","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestlrvltljy","registry_namespace_id":"ee42d292-cd3f-4646-b50e-1df027e9fa3a","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$s9zhY4r7Ip0aMafY68C2UQ$3wLMsMuxss/QFKDp2gor2LK8eTgUq2UL0tsjWTK8hSY","key":"test_secret"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$uaKMRvfnmPmNo3WLwo/zJQ$fPy//CpQ4oMSkh4yGdWvYmR6ddzZ8Bca6FEu1BFuk7I","key":"foo_secret"}],"status":"ready","tags":[],"updated_at":"2024-11-20T13:56:28.959352Z"}'
+        headers:
+            Content-Length:
+                - "835"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 13:56:33 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - cbe526d3-8210-45d8-baa4-2cbe75ed165b
+        status: 200 OK
+        code: 200
+        duration: 61.208167ms
+    - id: 55
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d2756edf-f733-460b-8388-c6def00006c6
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 835
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T13:55:51.850172Z","description":"","environment_variables":{"foo":"bar"},"error_message":null,"id":"d2756edf-f733-460b-8388-c6def00006c6","name":"tf-env-test","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestlrvltljy","registry_namespace_id":"ee42d292-cd3f-4646-b50e-1df027e9fa3a","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$s9zhY4r7Ip0aMafY68C2UQ$3wLMsMuxss/QFKDp2gor2LK8eTgUq2UL0tsjWTK8hSY","key":"test_secret"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$uaKMRvfnmPmNo3WLwo/zJQ$fPy//CpQ4oMSkh4yGdWvYmR6ddzZ8Bca6FEu1BFuk7I","key":"foo_secret"}],"status":"ready","tags":[],"updated_at":"2024-11-20T13:56:28.959352Z"}'
+        headers:
+            Content-Length:
+                - "835"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 13:56:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 57b15c64-1a43-4ced-b4df-d17722bcb1fa
+        status: 200 OK
+        code: 200
+        duration: 70.686042ms
+    - id: 56
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d2756edf-f733-460b-8388-c6def00006c6
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 835
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T13:55:51.850172Z","description":"","environment_variables":{"foo":"bar"},"error_message":null,"id":"d2756edf-f733-460b-8388-c6def00006c6","name":"tf-env-test","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestlrvltljy","registry_namespace_id":"ee42d292-cd3f-4646-b50e-1df027e9fa3a","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$s9zhY4r7Ip0aMafY68C2UQ$3wLMsMuxss/QFKDp2gor2LK8eTgUq2UL0tsjWTK8hSY","key":"test_secret"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$uaKMRvfnmPmNo3WLwo/zJQ$fPy//CpQ4oMSkh4yGdWvYmR6ddzZ8Bca6FEu1BFuk7I","key":"foo_secret"}],"status":"ready","tags":[],"updated_at":"2024-11-20T13:56:28.959352Z"}'
+        headers:
+            Content-Length:
+                - "835"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 13:56:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 14258420-23e3-4c0d-9c2d-278c6c1c74dd
+        status: 200 OK
+        code: 200
+        duration: 64.654041ms
+    - id: 57
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d2756edf-f733-460b-8388-c6def00006c6
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 835
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T13:55:51.850172Z","description":"","environment_variables":{"foo":"bar"},"error_message":null,"id":"d2756edf-f733-460b-8388-c6def00006c6","name":"tf-env-test","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestlrvltljy","registry_namespace_id":"ee42d292-cd3f-4646-b50e-1df027e9fa3a","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$s9zhY4r7Ip0aMafY68C2UQ$3wLMsMuxss/QFKDp2gor2LK8eTgUq2UL0tsjWTK8hSY","key":"test_secret"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$uaKMRvfnmPmNo3WLwo/zJQ$fPy//CpQ4oMSkh4yGdWvYmR6ddzZ8Bca6FEu1BFuk7I","key":"foo_secret"}],"status":"ready","tags":[],"updated_at":"2024-11-20T13:56:28.959352Z"}'
+        headers:
+            Content-Length:
+                - "835"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 13:56:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - cdc7fe8a-57b4-4f30-ade0-6401a2b344f6
+        status: 200 OK
+        code: 200
+        duration: 62.424542ms
+    - id: 58
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d2756edf-f733-460b-8388-c6def00006c6
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 841
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T13:55:51.850172Z","description":"","environment_variables":{"foo":"bar"},"error_message":null,"id":"d2756edf-f733-460b-8388-c6def00006c6","name":"tf-env-test","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestlrvltljy","registry_namespace_id":"ee42d292-cd3f-4646-b50e-1df027e9fa3a","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$s9zhY4r7Ip0aMafY68C2UQ$3wLMsMuxss/QFKDp2gor2LK8eTgUq2UL0tsjWTK8hSY","key":"test_secret"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$uaKMRvfnmPmNo3WLwo/zJQ$fPy//CpQ4oMSkh4yGdWvYmR6ddzZ8Bca6FEu1BFuk7I","key":"foo_secret"}],"status":"deleting","tags":[],"updated_at":"2024-11-20T13:56:34.840306133Z"}'
+        headers:
+            Content-Length:
+                - "841"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 13:56:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - bb7514a3-ecd9-47c5-afc0-f5b88c84ed01
+        status: 200 OK
+        code: 200
+        duration: 190.476416ms
+    - id: 59
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d2756edf-f733-460b-8388-c6def00006c6
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 838
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T13:55:51.850172Z","description":"","environment_variables":{"foo":"bar"},"error_message":null,"id":"d2756edf-f733-460b-8388-c6def00006c6","name":"tf-env-test","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestlrvltljy","registry_namespace_id":"ee42d292-cd3f-4646-b50e-1df027e9fa3a","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$s9zhY4r7Ip0aMafY68C2UQ$3wLMsMuxss/QFKDp2gor2LK8eTgUq2UL0tsjWTK8hSY","key":"test_secret"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$uaKMRvfnmPmNo3WLwo/zJQ$fPy//CpQ4oMSkh4yGdWvYmR6ddzZ8Bca6FEu1BFuk7I","key":"foo_secret"}],"status":"deleting","tags":[],"updated_at":"2024-11-20T13:56:34.840306Z"}'
+        headers:
+            Content-Length:
+                - "838"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 13:56:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 2ba9c856-b766-4b7e-98c2-c0bbb047809c
+        status: 200 OK
+        code: 200
+        duration: 65.423667ms
+    - id: 60
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d2756edf-f733-460b-8388-c6def00006c6
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 37
+        uncompressed: false
+        body: '{"message":"Namespace was not found"}'
+        headers:
+            Content-Length:
+                - "37"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 13:56:40 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 64215836-b9db-40aa-97aa-ec30923fad84
+        status: 404 Not Found
+        code: 404
+        duration: 39.963708ms
+    - id: 61
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 159
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"name":"tf-tags-test","environment_variables":{},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","secret_environment_variables":[],"tags":["tag1","tag2"]}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 492
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T13:56:40.335437604Z","description":"","environment_variables":{},"error_message":null,"id":"9d30679f-2439-4ce0-a389-c0a19736b881","name":"tf-tags-test","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":["tag1","tag2"],"updated_at":"2024-11-20T13:56:40.335437604Z"}'
+        headers:
+            Content-Length:
+                - "492"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 13:56:40 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - fa2192bd-656b-470c-88b8-e4598107feb8
+        status: 200 OK
+        code: 200
+        duration: 630.089167ms
+    - id: 62
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9d30679f-2439-4ce0-a389-c0a19736b881
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 486
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T13:56:40.335438Z","description":"","environment_variables":{},"error_message":null,"id":"9d30679f-2439-4ce0-a389-c0a19736b881","name":"tf-tags-test","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":["tag1","tag2"],"updated_at":"2024-11-20T13:56:40.335438Z"}'
+        headers:
+            Content-Length:
+                - "486"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 13:56:40 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 61d3bcdb-81c6-45bd-8533-f0fb98fec593
+        status: 200 OK
+        code: 200
+        duration: 58.15325ms
+    - id: 63
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9d30679f-2439-4ce0-a389-c0a19736b881
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 565
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T13:56:40.335438Z","description":"","environment_variables":{},"error_message":null,"id":"9d30679f-2439-4ce0-a389-c0a19736b881","name":"tf-tags-test","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftagstestp5u6dvey","registry_namespace_id":"3ff97e32-9633-48be-a801-c99ec712ad09","secret_environment_variables":[],"status":"ready","tags":["tag1","tag2"],"updated_at":"2024-11-20T13:56:42.261724Z"}'
+        headers:
+            Content-Length:
+                - "565"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 13:56:45 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 6aa278b4-c3a2-4cd0-9a7b-1a2eace9a6fa
+        status: 200 OK
+        code: 200
+        duration: 65.675333ms
+    - id: 64
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9d30679f-2439-4ce0-a389-c0a19736b881
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 565
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T13:56:40.335438Z","description":"","environment_variables":{},"error_message":null,"id":"9d30679f-2439-4ce0-a389-c0a19736b881","name":"tf-tags-test","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftagstestp5u6dvey","registry_namespace_id":"3ff97e32-9633-48be-a801-c99ec712ad09","secret_environment_variables":[],"status":"ready","tags":["tag1","tag2"],"updated_at":"2024-11-20T13:56:42.261724Z"}'
+        headers:
+            Content-Length:
+                - "565"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 13:56:45 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 806f2cc6-93fe-4f9f-a3c9-4a9c63e2925e
+        status: 200 OK
+        code: 200
+        duration: 63.326958ms
+    - id: 65
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9d30679f-2439-4ce0-a389-c0a19736b881
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 565
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T13:56:40.335438Z","description":"","environment_variables":{},"error_message":null,"id":"9d30679f-2439-4ce0-a389-c0a19736b881","name":"tf-tags-test","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftagstestp5u6dvey","registry_namespace_id":"3ff97e32-9633-48be-a801-c99ec712ad09","secret_environment_variables":[],"status":"ready","tags":["tag1","tag2"],"updated_at":"2024-11-20T13:56:42.261724Z"}'
+        headers:
+            Content-Length:
+                - "565"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 13:56:46 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - d31b77ba-3d5a-4218-9b52-bde5836ca23f
+        status: 200 OK
+        code: 200
+        duration: 60.846625ms
+    - id: 66
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9d30679f-2439-4ce0-a389-c0a19736b881
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 565
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T13:56:40.335438Z","description":"","environment_variables":{},"error_message":null,"id":"9d30679f-2439-4ce0-a389-c0a19736b881","name":"tf-tags-test","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftagstestp5u6dvey","registry_namespace_id":"3ff97e32-9633-48be-a801-c99ec712ad09","secret_environment_variables":[],"status":"ready","tags":["tag1","tag2"],"updated_at":"2024-11-20T13:56:42.261724Z"}'
+        headers:
+            Content-Length:
+                - "565"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 13:56:46 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - c0a0a212-ebc5-4777-85e8-e43380aed8e6
+        status: 200 OK
+        code: 200
+        duration: 59.932666ms
+    - id: 67
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9d30679f-2439-4ce0-a389-c0a19736b881
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 565
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T13:56:40.335438Z","description":"","environment_variables":{},"error_message":null,"id":"9d30679f-2439-4ce0-a389-c0a19736b881","name":"tf-tags-test","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftagstestp5u6dvey","registry_namespace_id":"3ff97e32-9633-48be-a801-c99ec712ad09","secret_environment_variables":[],"status":"ready","tags":["tag1","tag2"],"updated_at":"2024-11-20T13:56:42.261724Z"}'
+        headers:
+            Content-Length:
+                - "565"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 13:56:46 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ea232acd-f993-48f0-9eab-178b042b9a98
+        status: 200 OK
+        code: 200
+        duration: 58.445166ms
+    - id: 68
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9d30679f-2439-4ce0-a389-c0a19736b881
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 571
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T13:56:40.335438Z","description":"","environment_variables":{},"error_message":null,"id":"9d30679f-2439-4ce0-a389-c0a19736b881","name":"tf-tags-test","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftagstestp5u6dvey","registry_namespace_id":"3ff97e32-9633-48be-a801-c99ec712ad09","secret_environment_variables":[],"status":"deleting","tags":["tag1","tag2"],"updated_at":"2024-11-20T13:56:46.671552901Z"}'
+        headers:
+            Content-Length:
+                - "571"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 13:56:46 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - d8d27185-ac77-4e4e-9fad-c0b88f180456
+        status: 200 OK
+        code: 200
+        duration: 249.898333ms
+    - id: 69
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9d30679f-2439-4ce0-a389-c0a19736b881
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 568
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T13:56:40.335438Z","description":"","environment_variables":{},"error_message":null,"id":"9d30679f-2439-4ce0-a389-c0a19736b881","name":"tf-tags-test","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftagstestp5u6dvey","registry_namespace_id":"3ff97e32-9633-48be-a801-c99ec712ad09","secret_environment_variables":[],"status":"deleting","tags":["tag1","tag2"],"updated_at":"2024-11-20T13:56:46.671553Z"}'
+        headers:
+            Content-Length:
+                - "568"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 13:56:46 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 6d9df806-419a-45cc-9cd6-7864f68ba179
+        status: 200 OK
+        code: 200
+        duration: 70.914666ms
+    - id: 70
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9d30679f-2439-4ce0-a389-c0a19736b881
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 37
+        uncompressed: false
+        body: '{"message":"Namespace was not found"}'
+        headers:
+            Content-Length:
+                - "37"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 13:56:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 85eff93b-55d6-4e50-abfd-0e350f46e741
+        status: 404 Not Found
+        code: 404
+        duration: 25.90275ms
+    - id: 71
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9d30679f-2439-4ce0-a389-c0a19736b881
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 37
+        uncompressed: false
+        body: '{"message":"Namespace was not found"}'
+        headers:
+            Content-Length:
+                - "37"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 13:56:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 2afe1254-8911-48b7-84cf-7912dbe53f6e
+        status: 404 Not Found
+        code: 404
+        duration: 21.399333ms

--- a/internal/services/function/namespace.go
+++ b/internal/services/function/namespace.go
@@ -44,6 +44,14 @@ func ResourceNamespace() *schema.Resource {
 				Optional:    true,
 				Description: "The description of the function namespace",
 			},
+			"tags": {
+				Type: schema.TypeList,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Optional:    true,
+				Description: "List of tags [\"tag1\", \"tag2\", ...] attached to the function namespace",
+			},
 			"environment_variables": {
 				Type:        schema.TypeMap,
 				Optional:    true,
@@ -88,14 +96,21 @@ func ResourceFunctionNamespaceCreate(ctx context.Context, d *schema.ResourceData
 		return diag.FromErr(err)
 	}
 
-	ns, err := api.CreateNamespace(&function.CreateNamespaceRequest{
+	createReq := &function.CreateNamespaceRequest{
 		Description:                types.ExpandStringPtr(d.Get("description").(string)),
 		EnvironmentVariables:       types.ExpandMapPtrStringString(d.Get("environment_variables")),
 		SecretEnvironmentVariables: expandFunctionsSecrets(d.Get("secret_environment_variables")),
 		Name:                       types.ExpandOrGenerateString(d.Get("name").(string), "func"),
 		ProjectID:                  d.Get("project_id").(string),
 		Region:                     region,
-	}, scw.WithContext(ctx))
+	}
+
+	rawTag, tagExist := d.GetOk("tags")
+	if tagExist {
+		createReq.Tags = types.ExpandStrings(rawTag)
+	}
+
+	ns, err := api.CreateNamespace(createReq, scw.WithContext(ctx))
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -126,6 +141,7 @@ func ResourceFunctionNamespaceRead(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	_ = d.Set("description", ns.Description)
+	_ = d.Set("tags", types.FlattenSliceString(ns.Tags))
 	_ = d.Set("environment_variables", ns.EnvironmentVariables)
 	_ = d.Set("name", ns.Name)
 	_ = d.Set("organization_id", ns.OrganizationID)
@@ -159,6 +175,10 @@ func ResourceFunctionNamespaceUpdate(ctx context.Context, d *schema.ResourceData
 
 	if d.HasChange("description") {
 		req.Description = types.ExpandUpdatedStringPtr(d.Get("description"))
+	}
+
+	if d.HasChange("tags") {
+		req.Tags = types.ExpandUpdatedStringsPtr(d.Get("tags"))
 	}
 
 	if d.HasChanges("environment_variables") {

--- a/internal/services/function/namespace_test.go
+++ b/internal/services/function/namespace_test.go
@@ -71,13 +71,22 @@ func TestAccFunctionNamespace_Basic(t *testing.T) {
 			{
 				Config: `
                                         resource scaleway_function_namespace main {
-                                                name = "tf-tags-test"
+                                                name = "test-cr-ns-01"
+                                                environment_variables = {
+                                                        "test" = "test"
+                                                }
+                                                secret_environment_variables = {
+                                                        "test_secret" = "test_secret"
+                                                }
                                                 tags = ["tag1", "tag2"]
                                         }
                                `,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFunctionNamespaceExists(tt, "scaleway_function_namespace.main"),
-					resource.TestCheckResourceAttr("scaleway_function_namespace.main", "name", "tf-tags-test"),
+					resource.TestCheckResourceAttr("scaleway_function_namespace.main", "description", ""),
+					resource.TestCheckResourceAttr("scaleway_function_namespace.main", "name", "test-cr-ns-01"),
+					resource.TestCheckResourceAttr("scaleway_function_namespace.main", "environment_variables.test", "test"),
+					resource.TestCheckResourceAttr("scaleway_function_namespace.main", "secret_environment_variables.test_secret", "test_secret"),
 					resource.TestCheckResourceAttr("scaleway_function_namespace.main", "tags.0", "tag1"),
 					resource.TestCheckResourceAttr("scaleway_function_namespace.main", "tags.1", "tag2"),
 

--- a/internal/services/function/namespace_test.go
+++ b/internal/services/function/namespace_test.go
@@ -25,11 +25,15 @@ func TestAccFunctionNamespace_Basic(t *testing.T) {
 				Config: `
 					resource scaleway_function_namespace main {
 						name = "test-cr-ns-01"
+						tags = ["tag1", "tag2"]
 					}
 				`,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFunctionNamespaceExists(tt, "scaleway_function_namespace.main"),
 					acctest.CheckResourceAttrUUID("scaleway_function_namespace.main", "id"),
+					resource.TestCheckResourceAttr("scaleway_function_namespace.main", "tags.#", "2"),
+					resource.TestCheckResourceAttr("scaleway_function_namespace.main", "tags.0", "tag1"),
+					resource.TestCheckResourceAttr("scaleway_function_namespace.main", "tags.1", "tag2"),
 				),
 			},
 			{
@@ -44,6 +48,7 @@ func TestAccFunctionNamespace_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("scaleway_function_namespace.main", "description", "test function namespace 01"),
 					resource.TestCheckResourceAttr("scaleway_function_namespace.main", "name", "test-cr-ns-01"),
 					acctest.CheckResourceAttrUUID("scaleway_function_namespace.main", "id"),
+					resource.TestCheckResourceAttr("scaleway_function_namespace.main", "tags.#", "0"),
 				),
 			},
 			{
@@ -64,6 +69,7 @@ func TestAccFunctionNamespace_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("scaleway_function_namespace.main", "name", "test-cr-ns-01"),
 					resource.TestCheckResourceAttr("scaleway_function_namespace.main", "environment_variables.test", "test"),
 					resource.TestCheckResourceAttr("scaleway_function_namespace.main", "secret_environment_variables.test_secret", "test_secret"),
+					resource.TestCheckResourceAttr("scaleway_function_namespace.main", "tags.#", "0"),
 
 					acctest.CheckResourceAttrUUID("scaleway_function_namespace.main", "id"),
 				),
@@ -87,6 +93,7 @@ func TestAccFunctionNamespace_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("scaleway_function_namespace.main", "name", "test-cr-ns-01"),
 					resource.TestCheckResourceAttr("scaleway_function_namespace.main", "environment_variables.test", "test"),
 					resource.TestCheckResourceAttr("scaleway_function_namespace.main", "secret_environment_variables.test_secret", "test_secret"),
+					resource.TestCheckResourceAttr("scaleway_function_namespace.main", "tags.#", "2"),
 					resource.TestCheckResourceAttr("scaleway_function_namespace.main", "tags.0", "tag1"),
 					resource.TestCheckResourceAttr("scaleway_function_namespace.main", "tags.1", "tag2"),
 

--- a/internal/services/function/namespace_test.go
+++ b/internal/services/function/namespace_test.go
@@ -68,6 +68,22 @@ func TestAccFunctionNamespace_Basic(t *testing.T) {
 					acctest.CheckResourceAttrUUID("scaleway_function_namespace.main", "id"),
 				),
 			},
+			{
+				Config: `
+                                        resource scaleway_function_namespace main {
+                                                name = "tf-tags-test"
+                                                tags = ["tag1", "tag2"]
+                                        }
+                               `,
+				Check: resource.ComposeTestCheckFunc(
+					isNamespacePresent(tt, "scaleway_function_namespace.main"),
+					resource.TestCheckResourceAttr("scaleway_function_namespace.main", "name", "tf-tags-test"),
+					resource.TestCheckResourceAttr("scaleway_function_namespace.main", "tags.0", "tag1"),
+					resource.TestCheckResourceAttr("scaleway_function_namespace.main", "tags.1", "tag2"),
+
+					acctest.CheckResourceAttrUUID("scaleway_function_namespace.main", "id"),
+				),
+			},
 		},
 	})
 }

--- a/internal/services/function/namespace_test.go
+++ b/internal/services/function/namespace_test.go
@@ -76,7 +76,7 @@ func TestAccFunctionNamespace_Basic(t *testing.T) {
                                         }
                                `,
 				Check: resource.ComposeTestCheckFunc(
-					isNamespacePresent(tt, "scaleway_function_namespace.main"),
+					testAccCheckFunctionNamespaceExists(tt, "scaleway_function_namespace.main"),
 					resource.TestCheckResourceAttr("scaleway_function_namespace.main", "name", "tf-tags-test"),
 					resource.TestCheckResourceAttr("scaleway_function_namespace.main", "tags.0", "tag1"),
 					resource.TestCheckResourceAttr("scaleway_function_namespace.main", "tags.1", "tag2"),

--- a/internal/services/function/testdata/function-namespace-basic.cassette.yaml
+++ b/internal/services/function/testdata/function-namespace-basic.cassette.yaml
@@ -1,751 +1,1481 @@
 ---
 version: 2
 interactions:
-- request:
-    body: '{"name":"test-cr-ns-01","environment_variables":{},"project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","description":null,"secret_environment_variables":[]}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces
-    method: POST
-  response:
-    body: '{"id":"f01ebd3f-87cd-464c-bd45-fe88846f87f8","name":"test-cr-ns-01","environment_variables":{},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"pending","registry_namespace_id":"","error_message":null,"registry_endpoint":"","description":"","secret_environment_variables":[],"region":"fr-par"}'
-    headers:
-      Content-Length:
-      - "363"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 22 Nov 2022 13:20:35 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - bc6b7b11-e7e5-4548-ad84-cd956fa4e12c
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/f01ebd3f-87cd-464c-bd45-fe88846f87f8
-    method: GET
-  response:
-    body: '{"id":"f01ebd3f-87cd-464c-bd45-fe88846f87f8","name":"test-cr-ns-01","environment_variables":{},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"pending","registry_namespace_id":"","error_message":null,"registry_endpoint":"","description":"","secret_environment_variables":[],"region":"fr-par"}'
-    headers:
-      Content-Length:
-      - "363"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 22 Nov 2022 13:20:35 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 94a4baa1-3205-42d6-8a5b-509a142debaf
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/f01ebd3f-87cd-464c-bd45-fe88846f87f8
-    method: GET
-  response:
-    body: '{"id":"f01ebd3f-87cd-464c-bd45-fe88846f87f8","name":"test-cr-ns-01","environment_variables":{},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","registry_namespace_id":"5568642e-a27e-4a84-9977-659a5b3b87cb","error_message":null,"registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01g6pbqvzc","description":"","secret_environment_variables":[],"region":"fr-par"}'
-    headers:
-      Content-Length:
-      - "442"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 22 Nov 2022 13:20:40 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0e2154b8-4114-4737-bb9f-9eac55dd95e2
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/f01ebd3f-87cd-464c-bd45-fe88846f87f8
-    method: GET
-  response:
-    body: '{"id":"f01ebd3f-87cd-464c-bd45-fe88846f87f8","name":"test-cr-ns-01","environment_variables":{},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","registry_namespace_id":"5568642e-a27e-4a84-9977-659a5b3b87cb","error_message":null,"registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01g6pbqvzc","description":"","secret_environment_variables":[],"region":"fr-par"}'
-    headers:
-      Content-Length:
-      - "442"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 22 Nov 2022 13:20:40 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b64e7e5a-5802-4334-b2e6-2f8e43cdab69
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/f01ebd3f-87cd-464c-bd45-fe88846f87f8
-    method: GET
-  response:
-    body: '{"id":"f01ebd3f-87cd-464c-bd45-fe88846f87f8","name":"test-cr-ns-01","environment_variables":{},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","registry_namespace_id":"5568642e-a27e-4a84-9977-659a5b3b87cb","error_message":null,"registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01g6pbqvzc","description":"","secret_environment_variables":[],"region":"fr-par"}'
-    headers:
-      Content-Length:
-      - "442"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 22 Nov 2022 13:20:41 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d2791e1f-a66d-4edb-b78a-b3f25d143538
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/f01ebd3f-87cd-464c-bd45-fe88846f87f8
-    method: GET
-  response:
-    body: '{"id":"f01ebd3f-87cd-464c-bd45-fe88846f87f8","name":"test-cr-ns-01","environment_variables":{},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","registry_namespace_id":"5568642e-a27e-4a84-9977-659a5b3b87cb","error_message":null,"registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01g6pbqvzc","description":"","secret_environment_variables":[],"region":"fr-par"}'
-    headers:
-      Content-Length:
-      - "442"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 22 Nov 2022 13:20:41 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7b79b43a-9325-47b3-96c3-8e8f5e6360aa
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/f01ebd3f-87cd-464c-bd45-fe88846f87f8
-    method: GET
-  response:
-    body: '{"id":"f01ebd3f-87cd-464c-bd45-fe88846f87f8","name":"test-cr-ns-01","environment_variables":{},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","registry_namespace_id":"5568642e-a27e-4a84-9977-659a5b3b87cb","error_message":null,"registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01g6pbqvzc","description":"","secret_environment_variables":[],"region":"fr-par"}'
-    headers:
-      Content-Length:
-      - "442"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 22 Nov 2022 13:20:41 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0eb9564d-5813-4c73-9eea-24b7ec638255
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/f01ebd3f-87cd-464c-bd45-fe88846f87f8
-    method: GET
-  response:
-    body: '{"id":"f01ebd3f-87cd-464c-bd45-fe88846f87f8","name":"test-cr-ns-01","environment_variables":{},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","registry_namespace_id":"5568642e-a27e-4a84-9977-659a5b3b87cb","error_message":null,"registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01g6pbqvzc","description":"","secret_environment_variables":[],"region":"fr-par"}'
-    headers:
-      Content-Length:
-      - "442"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 22 Nov 2022 13:20:42 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 16ecadf0-87b3-4a2c-814e-0387b0b2c8f7
-    status: 200 OK
-    code: 200
-- request:
-    body: '{"environment_variables":null,"description":"test function namespace 01","secret_environment_variables":null}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/f01ebd3f-87cd-464c-bd45-fe88846f87f8
-    method: PATCH
-  response:
-    body: '{"id":"f01ebd3f-87cd-464c-bd45-fe88846f87f8","name":"test-cr-ns-01","environment_variables":{},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","registry_namespace_id":"5568642e-a27e-4a84-9977-659a5b3b87cb","error_message":null,"registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01g6pbqvzc","description":"test
-      function namespace 01","secret_environment_variables":[],"region":"fr-par"}'
-    headers:
-      Content-Length:
-      - "468"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 22 Nov 2022 13:20:42 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 67918ebd-bf80-4965-95b6-d9cef9b40f3c
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/f01ebd3f-87cd-464c-bd45-fe88846f87f8
-    method: GET
-  response:
-    body: '{"id":"f01ebd3f-87cd-464c-bd45-fe88846f87f8","name":"test-cr-ns-01","environment_variables":{},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","registry_namespace_id":"5568642e-a27e-4a84-9977-659a5b3b87cb","error_message":null,"registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01g6pbqvzc","description":"test
-      function namespace 01","secret_environment_variables":[],"region":"fr-par"}'
-    headers:
-      Content-Length:
-      - "468"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 22 Nov 2022 13:20:42 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 23986255-08c3-4f73-b62e-183a6bc7a8ad
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/f01ebd3f-87cd-464c-bd45-fe88846f87f8
-    method: GET
-  response:
-    body: '{"id":"f01ebd3f-87cd-464c-bd45-fe88846f87f8","name":"test-cr-ns-01","environment_variables":{},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","registry_namespace_id":"5568642e-a27e-4a84-9977-659a5b3b87cb","error_message":null,"registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01g6pbqvzc","description":"test
-      function namespace 01","secret_environment_variables":[],"region":"fr-par"}'
-    headers:
-      Content-Length:
-      - "468"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 22 Nov 2022 13:20:42 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9d293074-655b-4484-a7c9-325c850f068c
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/f01ebd3f-87cd-464c-bd45-fe88846f87f8
-    method: GET
-  response:
-    body: '{"id":"f01ebd3f-87cd-464c-bd45-fe88846f87f8","name":"test-cr-ns-01","environment_variables":{},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","registry_namespace_id":"5568642e-a27e-4a84-9977-659a5b3b87cb","error_message":null,"registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01g6pbqvzc","description":"test
-      function namespace 01","secret_environment_variables":[],"region":"fr-par"}'
-    headers:
-      Content-Length:
-      - "468"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 22 Nov 2022 13:20:42 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9123c603-7ead-421a-bd5a-ec333f59de3c
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/f01ebd3f-87cd-464c-bd45-fe88846f87f8
-    method: GET
-  response:
-    body: '{"id":"f01ebd3f-87cd-464c-bd45-fe88846f87f8","name":"test-cr-ns-01","environment_variables":{},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","registry_namespace_id":"5568642e-a27e-4a84-9977-659a5b3b87cb","error_message":null,"registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01g6pbqvzc","description":"test
-      function namespace 01","secret_environment_variables":[],"region":"fr-par"}'
-    headers:
-      Content-Length:
-      - "468"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 22 Nov 2022 13:20:43 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c2f9eb9b-60a0-4ab1-afa4-124c6147dc12
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/f01ebd3f-87cd-464c-bd45-fe88846f87f8
-    method: GET
-  response:
-    body: '{"id":"f01ebd3f-87cd-464c-bd45-fe88846f87f8","name":"test-cr-ns-01","environment_variables":{},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","registry_namespace_id":"5568642e-a27e-4a84-9977-659a5b3b87cb","error_message":null,"registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01g6pbqvzc","description":"test
-      function namespace 01","secret_environment_variables":[],"region":"fr-par"}'
-    headers:
-      Content-Length:
-      - "468"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 22 Nov 2022 13:20:43 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 05448ce0-6686-4f61-ae01-1264db56e8ea
-    status: 200 OK
-    code: 200
-- request:
-    body: '{"environment_variables":{"test":"test"},"description":"","secret_environment_variables":[{"key":"test_secret","value":"test_secret"}]}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/f01ebd3f-87cd-464c-bd45-fe88846f87f8
-    method: PATCH
-  response:
-    body: '{"id":"f01ebd3f-87cd-464c-bd45-fe88846f87f8","name":"test-cr-ns-01","environment_variables":{"test":"test"},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","registry_namespace_id":"5568642e-a27e-4a84-9977-659a5b3b87cb","error_message":null,"registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01g6pbqvzc","description":"","secret_environment_variables":[{"key":"test_secret","hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$uUkAQdVhxQy/mzie4LpU6w$yjlmNMhfKTjLCAzSmy96z9FlG1SnJe/Uy+dyOfoydw8"}],"region":"fr-par"}'
-    headers:
-      Content-Length:
-      - "591"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 22 Nov 2022 13:20:43 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 89d868a3-fb83-4099-8727-36338afe8aad
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/f01ebd3f-87cd-464c-bd45-fe88846f87f8
-    method: GET
-  response:
-    body: '{"id":"f01ebd3f-87cd-464c-bd45-fe88846f87f8","name":"test-cr-ns-01","environment_variables":{"test":"test"},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","registry_namespace_id":"5568642e-a27e-4a84-9977-659a5b3b87cb","error_message":null,"registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01g6pbqvzc","description":"","secret_environment_variables":[{"key":"test_secret","hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$uUkAQdVhxQy/mzie4LpU6w$yjlmNMhfKTjLCAzSmy96z9FlG1SnJe/Uy+dyOfoydw8"}],"region":"fr-par"}'
-    headers:
-      Content-Length:
-      - "591"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 22 Nov 2022 13:20:43 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a2f2e11e-fbe3-4043-8eec-dfb92a062236
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/f01ebd3f-87cd-464c-bd45-fe88846f87f8
-    method: GET
-  response:
-    body: '{"id":"f01ebd3f-87cd-464c-bd45-fe88846f87f8","name":"test-cr-ns-01","environment_variables":{"test":"test"},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","registry_namespace_id":"5568642e-a27e-4a84-9977-659a5b3b87cb","error_message":null,"registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01g6pbqvzc","description":"","secret_environment_variables":[{"key":"test_secret","hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$uUkAQdVhxQy/mzie4LpU6w$yjlmNMhfKTjLCAzSmy96z9FlG1SnJe/Uy+dyOfoydw8"}],"region":"fr-par"}'
-    headers:
-      Content-Length:
-      - "591"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 22 Nov 2022 13:20:43 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 13783f61-e312-4771-9fee-e4f531729f25
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/f01ebd3f-87cd-464c-bd45-fe88846f87f8
-    method: GET
-  response:
-    body: '{"id":"f01ebd3f-87cd-464c-bd45-fe88846f87f8","name":"test-cr-ns-01","environment_variables":{"test":"test"},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","registry_namespace_id":"5568642e-a27e-4a84-9977-659a5b3b87cb","error_message":null,"registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01g6pbqvzc","description":"","secret_environment_variables":[{"key":"test_secret","hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$uUkAQdVhxQy/mzie4LpU6w$yjlmNMhfKTjLCAzSmy96z9FlG1SnJe/Uy+dyOfoydw8"}],"region":"fr-par"}'
-    headers:
-      Content-Length:
-      - "591"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 22 Nov 2022 13:20:44 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - be52939d-226c-49bc-8e4a-c8fd239792ee
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/f01ebd3f-87cd-464c-bd45-fe88846f87f8
-    method: GET
-  response:
-    body: '{"id":"f01ebd3f-87cd-464c-bd45-fe88846f87f8","name":"test-cr-ns-01","environment_variables":{"test":"test"},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","registry_namespace_id":"5568642e-a27e-4a84-9977-659a5b3b87cb","error_message":null,"registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01g6pbqvzc","description":"","secret_environment_variables":[{"key":"test_secret","hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$uUkAQdVhxQy/mzie4LpU6w$yjlmNMhfKTjLCAzSmy96z9FlG1SnJe/Uy+dyOfoydw8"}],"region":"fr-par"}'
-    headers:
-      Content-Length:
-      - "591"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 22 Nov 2022 13:20:44 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1810bd61-9ebe-4d3f-a9ec-8665dc1fc6ae
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/f01ebd3f-87cd-464c-bd45-fe88846f87f8
-    method: DELETE
-  response:
-    body: '{"id":"f01ebd3f-87cd-464c-bd45-fe88846f87f8","name":"test-cr-ns-01","environment_variables":{"test":"test"},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"deleting","registry_namespace_id":"5568642e-a27e-4a84-9977-659a5b3b87cb","error_message":null,"registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01g6pbqvzc","description":"","secret_environment_variables":[{"key":"test_secret","hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$uUkAQdVhxQy/mzie4LpU6w$yjlmNMhfKTjLCAzSmy96z9FlG1SnJe/Uy+dyOfoydw8"}],"region":"fr-par"}'
-    headers:
-      Content-Length:
-      - "594"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 22 Nov 2022 13:20:44 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5e2dfe6c-5926-4186-a50b-11939ce8899a
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/f01ebd3f-87cd-464c-bd45-fe88846f87f8
-    method: GET
-  response:
-    body: '{"id":"f01ebd3f-87cd-464c-bd45-fe88846f87f8","name":"test-cr-ns-01","environment_variables":{"test":"test"},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"unknown","registry_namespace_id":"5568642e-a27e-4a84-9977-659a5b3b87cb","error_message":null,"registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01g6pbqvzc","description":"","secret_environment_variables":[{"key":"test_secret","hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$uUkAQdVhxQy/mzie4LpU6w$yjlmNMhfKTjLCAzSmy96z9FlG1SnJe/Uy+dyOfoydw8"}],"region":"fr-par"}'
-    headers:
-      Content-Length:
-      - "593"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 22 Nov 2022 13:20:44 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 03b1b646-cd41-4046-8621-3ba8b999a9d2
-    status: 200 OK
-    code: 200
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/f01ebd3f-87cd-464c-bd45-fe88846f87f8
-    method: GET
-  response:
-    body: '{"message":"Namespace was not found"}'
-    headers:
-      Content-Length:
-      - "37"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 22 Nov 2022 13:20:49 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - bec63979-f610-4e36-ab9c-f789b610ec9a
-    status: 404 Not Found
-    code: 404
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/f01ebd3f-87cd-464c-bd45-fe88846f87f8
-    method: DELETE
-  response:
-    body: '{"message":"Namespace was not found"}'
-    headers:
-      Content-Length:
-      - "37"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 22 Nov 2022 13:20:49 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2e65871e-6226-4d76-9954-8a17a0bf9c4f
-    status: 404 Not Found
-    code: 404
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 160
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"name":"test-cr-ns-01","environment_variables":{},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","secret_environment_variables":[],"tags":["tag1","tag2"]}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 493
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T14:03:49.305934351Z","description":"","environment_variables":{},"error_message":null,"id":"56f0293b-3796-4a56-9280-636938a540c5","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":["tag1","tag2"],"updated_at":"2024-11-20T14:03:49.305934351Z"}'
+        headers:
+            Content-Length:
+                - "493"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 14:03:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - cafbe59f-5897-49c2-bdf3-169ef78eed83
+        status: 200 OK
+        code: 200
+        duration: 448.354334ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/56f0293b-3796-4a56-9280-636938a540c5
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 487
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T14:03:49.305934Z","description":"","environment_variables":{},"error_message":null,"id":"56f0293b-3796-4a56-9280-636938a540c5","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":["tag1","tag2"],"updated_at":"2024-11-20T14:03:49.305934Z"}'
+        headers:
+            Content-Length:
+                - "487"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 14:03:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 1633129a-a6ce-40ab-8605-f672a37e2969
+        status: 200 OK
+        code: 200
+        duration: 86.923709ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/56f0293b-3796-4a56-9280-636938a540c5
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 566
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T14:03:49.305934Z","description":"","environment_variables":{},"error_message":null,"id":"56f0293b-3796-4a56-9280-636938a540c5","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01u78vnzwc","registry_namespace_id":"37eadba3-fbd4-4e62-8539-90f6f04e8553","secret_environment_variables":[],"status":"ready","tags":["tag1","tag2"],"updated_at":"2024-11-20T14:03:51.780004Z"}'
+        headers:
+            Content-Length:
+                - "566"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 14:03:54 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - a3130132-7424-4915-b080-f6952ed746bb
+        status: 200 OK
+        code: 200
+        duration: 77.151625ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/56f0293b-3796-4a56-9280-636938a540c5
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 566
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T14:03:49.305934Z","description":"","environment_variables":{},"error_message":null,"id":"56f0293b-3796-4a56-9280-636938a540c5","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01u78vnzwc","registry_namespace_id":"37eadba3-fbd4-4e62-8539-90f6f04e8553","secret_environment_variables":[],"status":"ready","tags":["tag1","tag2"],"updated_at":"2024-11-20T14:03:51.780004Z"}'
+        headers:
+            Content-Length:
+                - "566"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 14:03:54 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 0b7df66a-4db7-4c4d-9b91-d0e830171b80
+        status: 200 OK
+        code: 200
+        duration: 68.634667ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/56f0293b-3796-4a56-9280-636938a540c5
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 566
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T14:03:49.305934Z","description":"","environment_variables":{},"error_message":null,"id":"56f0293b-3796-4a56-9280-636938a540c5","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01u78vnzwc","registry_namespace_id":"37eadba3-fbd4-4e62-8539-90f6f04e8553","secret_environment_variables":[],"status":"ready","tags":["tag1","tag2"],"updated_at":"2024-11-20T14:03:51.780004Z"}'
+        headers:
+            Content-Length:
+                - "566"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 14:03:54 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3fe985d6-18c7-4fa8-a579-314329233226
+        status: 200 OK
+        code: 200
+        duration: 69.114666ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/56f0293b-3796-4a56-9280-636938a540c5
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 566
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T14:03:49.305934Z","description":"","environment_variables":{},"error_message":null,"id":"56f0293b-3796-4a56-9280-636938a540c5","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01u78vnzwc","registry_namespace_id":"37eadba3-fbd4-4e62-8539-90f6f04e8553","secret_environment_variables":[],"status":"ready","tags":["tag1","tag2"],"updated_at":"2024-11-20T14:03:51.780004Z"}'
+        headers:
+            Content-Length:
+                - "566"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 14:03:55 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e1d927c1-5a8d-4662-8ff9-59f86bb3084f
+        status: 200 OK
+        code: 200
+        duration: 85.503375ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/56f0293b-3796-4a56-9280-636938a540c5
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 566
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T14:03:49.305934Z","description":"","environment_variables":{},"error_message":null,"id":"56f0293b-3796-4a56-9280-636938a540c5","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01u78vnzwc","registry_namespace_id":"37eadba3-fbd4-4e62-8539-90f6f04e8553","secret_environment_variables":[],"status":"ready","tags":["tag1","tag2"],"updated_at":"2024-11-20T14:03:51.780004Z"}'
+        headers:
+            Content-Length:
+                - "566"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 14:03:55 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b7c7af77-aebf-45c7-8137-21fe513b750d
+        status: 200 OK
+        code: 200
+        duration: 68.824541ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/56f0293b-3796-4a56-9280-636938a540c5
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 566
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T14:03:49.305934Z","description":"","environment_variables":{},"error_message":null,"id":"56f0293b-3796-4a56-9280-636938a540c5","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01u78vnzwc","registry_namespace_id":"37eadba3-fbd4-4e62-8539-90f6f04e8553","secret_environment_variables":[],"status":"ready","tags":["tag1","tag2"],"updated_at":"2024-11-20T14:03:51.780004Z"}'
+        headers:
+            Content-Length:
+                - "566"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 14:03:55 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - a7e4c22c-5958-4410-b5fd-9f3ba7132d7d
+        status: 200 OK
+        code: 200
+        duration: 81.952083ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 90
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"description":"test function namespace 01","secret_environment_variables":null,"tags":[]}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/56f0293b-3796-4a56-9280-636938a540c5
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 581
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T14:03:49.305934Z","description":"test function namespace 01","environment_variables":{},"error_message":null,"id":"56f0293b-3796-4a56-9280-636938a540c5","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01u78vnzwc","registry_namespace_id":"37eadba3-fbd4-4e62-8539-90f6f04e8553","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2024-11-20T14:03:55.665295985Z"}'
+        headers:
+            Content-Length:
+                - "581"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 14:03:55 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 7abfe809-b0b3-4a6a-8972-50cda9f42d5f
+        status: 200 OK
+        code: 200
+        duration: 116.276ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/56f0293b-3796-4a56-9280-636938a540c5
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 578
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T14:03:49.305934Z","description":"test function namespace 01","environment_variables":{},"error_message":null,"id":"56f0293b-3796-4a56-9280-636938a540c5","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01u78vnzwc","registry_namespace_id":"37eadba3-fbd4-4e62-8539-90f6f04e8553","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2024-11-20T14:03:55.665296Z"}'
+        headers:
+            Content-Length:
+                - "578"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 14:03:55 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 74d9b697-195d-43f2-8f1a-484e1d37f888
+        status: 200 OK
+        code: 200
+        duration: 72.803791ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/56f0293b-3796-4a56-9280-636938a540c5
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 578
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T14:03:49.305934Z","description":"test function namespace 01","environment_variables":{},"error_message":null,"id":"56f0293b-3796-4a56-9280-636938a540c5","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01u78vnzwc","registry_namespace_id":"37eadba3-fbd4-4e62-8539-90f6f04e8553","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2024-11-20T14:03:55.665296Z"}'
+        headers:
+            Content-Length:
+                - "578"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 14:03:55 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 969db93a-8d89-43c6-91f0-5bf01b9eeb3d
+        status: 200 OK
+        code: 200
+        duration: 64.125875ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/56f0293b-3796-4a56-9280-636938a540c5
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 578
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T14:03:49.305934Z","description":"test function namespace 01","environment_variables":{},"error_message":null,"id":"56f0293b-3796-4a56-9280-636938a540c5","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01u78vnzwc","registry_namespace_id":"37eadba3-fbd4-4e62-8539-90f6f04e8553","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2024-11-20T14:03:55.665296Z"}'
+        headers:
+            Content-Length:
+                - "578"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 14:03:56 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - a5ac60cf-5343-4c4f-a27d-bc5d86363b60
+        status: 200 OK
+        code: 200
+        duration: 71.25025ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/56f0293b-3796-4a56-9280-636938a540c5
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 578
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T14:03:49.305934Z","description":"test function namespace 01","environment_variables":{},"error_message":null,"id":"56f0293b-3796-4a56-9280-636938a540c5","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01u78vnzwc","registry_namespace_id":"37eadba3-fbd4-4e62-8539-90f6f04e8553","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2024-11-20T14:03:55.665296Z"}'
+        headers:
+            Content-Length:
+                - "578"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 14:03:56 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - cf6b11ae-d668-4af4-8be8-eb03c70d0485
+        status: 200 OK
+        code: 200
+        duration: 64.052584ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/56f0293b-3796-4a56-9280-636938a540c5
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 578
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T14:03:49.305934Z","description":"test function namespace 01","environment_variables":{},"error_message":null,"id":"56f0293b-3796-4a56-9280-636938a540c5","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01u78vnzwc","registry_namespace_id":"37eadba3-fbd4-4e62-8539-90f6f04e8553","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2024-11-20T14:03:55.665296Z"}'
+        headers:
+            Content-Length:
+                - "578"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 14:03:56 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 899c393a-7b0b-4150-9a08-aeac8e22dc73
+        status: 200 OK
+        code: 200
+        duration: 54.973458ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 135
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"environment_variables":{"test":"test"},"description":"","secret_environment_variables":[{"key":"test_secret","value":"test_secret"}]}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/56f0293b-3796-4a56-9280-636938a540c5
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 707
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T14:03:49.305934Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"56f0293b-3796-4a56-9280-636938a540c5","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01u78vnzwc","registry_namespace_id":"37eadba3-fbd4-4e62-8539-90f6f04e8553","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$gF+HkvafxwPZI/xBtj9S0A$uEFPmGoW+pLGYG3EnOmg0Lc0/tQs3q7fPxaZpnPAOco","key":"test_secret"}],"status":"pending","tags":[],"updated_at":"2024-11-20T14:03:56.888789641Z"}'
+        headers:
+            Content-Length:
+                - "707"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 14:03:56 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 99f89fa6-f1e6-4315-af4c-aba14f7ddbd1
+        status: 200 OK
+        code: 200
+        duration: 182.585291ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/56f0293b-3796-4a56-9280-636938a540c5
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 704
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T14:03:49.305934Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"56f0293b-3796-4a56-9280-636938a540c5","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01u78vnzwc","registry_namespace_id":"37eadba3-fbd4-4e62-8539-90f6f04e8553","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$gF+HkvafxwPZI/xBtj9S0A$uEFPmGoW+pLGYG3EnOmg0Lc0/tQs3q7fPxaZpnPAOco","key":"test_secret"}],"status":"pending","tags":[],"updated_at":"2024-11-20T14:03:56.888790Z"}'
+        headers:
+            Content-Length:
+                - "704"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 14:03:56 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 2e9691db-1b3e-4d82-adca-785d6e41aa85
+        status: 200 OK
+        code: 200
+        duration: 68.64075ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/56f0293b-3796-4a56-9280-636938a540c5
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 702
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T14:03:49.305934Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"56f0293b-3796-4a56-9280-636938a540c5","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01u78vnzwc","registry_namespace_id":"37eadba3-fbd4-4e62-8539-90f6f04e8553","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$gF+HkvafxwPZI/xBtj9S0A$uEFPmGoW+pLGYG3EnOmg0Lc0/tQs3q7fPxaZpnPAOco","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2024-11-20T14:03:57.235223Z"}'
+        headers:
+            Content-Length:
+                - "702"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 14:04:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3853a599-977d-451f-9d69-1072385f10d9
+        status: 200 OK
+        code: 200
+        duration: 66.318458ms
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/56f0293b-3796-4a56-9280-636938a540c5
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 702
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T14:03:49.305934Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"56f0293b-3796-4a56-9280-636938a540c5","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01u78vnzwc","registry_namespace_id":"37eadba3-fbd4-4e62-8539-90f6f04e8553","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$gF+HkvafxwPZI/xBtj9S0A$uEFPmGoW+pLGYG3EnOmg0Lc0/tQs3q7fPxaZpnPAOco","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2024-11-20T14:03:57.235223Z"}'
+        headers:
+            Content-Length:
+                - "702"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 14:04:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - d0e3d6b6-2f66-46e6-82f6-70894e35bf8e
+        status: 200 OK
+        code: 200
+        duration: 56.894792ms
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/56f0293b-3796-4a56-9280-636938a540c5
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 702
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T14:03:49.305934Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"56f0293b-3796-4a56-9280-636938a540c5","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01u78vnzwc","registry_namespace_id":"37eadba3-fbd4-4e62-8539-90f6f04e8553","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$gF+HkvafxwPZI/xBtj9S0A$uEFPmGoW+pLGYG3EnOmg0Lc0/tQs3q7fPxaZpnPAOco","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2024-11-20T14:03:57.235223Z"}'
+        headers:
+            Content-Length:
+                - "702"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 14:04:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 14868ef5-d30b-494a-949c-3e265696a7d1
+        status: 200 OK
+        code: 200
+        duration: 61.968584ms
+    - id: 19
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/56f0293b-3796-4a56-9280-636938a540c5
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 702
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T14:03:49.305934Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"56f0293b-3796-4a56-9280-636938a540c5","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01u78vnzwc","registry_namespace_id":"37eadba3-fbd4-4e62-8539-90f6f04e8553","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$gF+HkvafxwPZI/xBtj9S0A$uEFPmGoW+pLGYG3EnOmg0Lc0/tQs3q7fPxaZpnPAOco","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2024-11-20T14:03:57.235223Z"}'
+        headers:
+            Content-Length:
+                - "702"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 14:04:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 00507720-3352-4e9d-9fae-82dc7863f5ce
+        status: 200 OK
+        code: 200
+        duration: 68.120417ms
+    - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/56f0293b-3796-4a56-9280-636938a540c5
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 702
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T14:03:49.305934Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"56f0293b-3796-4a56-9280-636938a540c5","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01u78vnzwc","registry_namespace_id":"37eadba3-fbd4-4e62-8539-90f6f04e8553","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$gF+HkvafxwPZI/xBtj9S0A$uEFPmGoW+pLGYG3EnOmg0Lc0/tQs3q7fPxaZpnPAOco","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2024-11-20T14:03:57.235223Z"}'
+        headers:
+            Content-Length:
+                - "702"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 14:04:03 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 75c0efc3-db46-4759-bcf2-327229ca8053
+        status: 200 OK
+        code: 200
+        duration: 65.484292ms
+    - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 60
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"secret_environment_variables":null,"tags":["tag1","tag2"]}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/56f0293b-3796-4a56-9280-636938a540c5
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 719
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T14:03:49.305934Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"56f0293b-3796-4a56-9280-636938a540c5","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01u78vnzwc","registry_namespace_id":"37eadba3-fbd4-4e62-8539-90f6f04e8553","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$gF+HkvafxwPZI/xBtj9S0A$uEFPmGoW+pLGYG3EnOmg0Lc0/tQs3q7fPxaZpnPAOco","key":"test_secret"}],"status":"ready","tags":["tag1","tag2"],"updated_at":"2024-11-20T14:04:03.204372246Z"}'
+        headers:
+            Content-Length:
+                - "719"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 14:04:03 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 9e50b402-adb9-4b11-8e83-9ca3343bd9d3
+        status: 200 OK
+        code: 200
+        duration: 184.971666ms
+    - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/56f0293b-3796-4a56-9280-636938a540c5
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 716
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T14:03:49.305934Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"56f0293b-3796-4a56-9280-636938a540c5","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01u78vnzwc","registry_namespace_id":"37eadba3-fbd4-4e62-8539-90f6f04e8553","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$gF+HkvafxwPZI/xBtj9S0A$uEFPmGoW+pLGYG3EnOmg0Lc0/tQs3q7fPxaZpnPAOco","key":"test_secret"}],"status":"ready","tags":["tag1","tag2"],"updated_at":"2024-11-20T14:04:03.204372Z"}'
+        headers:
+            Content-Length:
+                - "716"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 14:04:03 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e06d6940-0d5d-4224-ba84-be916fe3a7ba
+        status: 200 OK
+        code: 200
+        duration: 77.7785ms
+    - id: 23
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/56f0293b-3796-4a56-9280-636938a540c5
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 716
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T14:03:49.305934Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"56f0293b-3796-4a56-9280-636938a540c5","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01u78vnzwc","registry_namespace_id":"37eadba3-fbd4-4e62-8539-90f6f04e8553","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$gF+HkvafxwPZI/xBtj9S0A$uEFPmGoW+pLGYG3EnOmg0Lc0/tQs3q7fPxaZpnPAOco","key":"test_secret"}],"status":"ready","tags":["tag1","tag2"],"updated_at":"2024-11-20T14:04:03.204372Z"}'
+        headers:
+            Content-Length:
+                - "716"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 14:04:03 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 930c1c87-d038-493f-9ac0-14fc26eb8684
+        status: 200 OK
+        code: 200
+        duration: 64.493208ms
+    - id: 24
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/56f0293b-3796-4a56-9280-636938a540c5
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 716
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T14:03:49.305934Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"56f0293b-3796-4a56-9280-636938a540c5","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01u78vnzwc","registry_namespace_id":"37eadba3-fbd4-4e62-8539-90f6f04e8553","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$gF+HkvafxwPZI/xBtj9S0A$uEFPmGoW+pLGYG3EnOmg0Lc0/tQs3q7fPxaZpnPAOco","key":"test_secret"}],"status":"ready","tags":["tag1","tag2"],"updated_at":"2024-11-20T14:04:03.204372Z"}'
+        headers:
+            Content-Length:
+                - "716"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 14:04:03 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3a0fd5ab-9ef2-4fa5-be0e-232b44a941c1
+        status: 200 OK
+        code: 200
+        duration: 71.692875ms
+    - id: 25
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/56f0293b-3796-4a56-9280-636938a540c5
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 716
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T14:03:49.305934Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"56f0293b-3796-4a56-9280-636938a540c5","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01u78vnzwc","registry_namespace_id":"37eadba3-fbd4-4e62-8539-90f6f04e8553","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$gF+HkvafxwPZI/xBtj9S0A$uEFPmGoW+pLGYG3EnOmg0Lc0/tQs3q7fPxaZpnPAOco","key":"test_secret"}],"status":"ready","tags":["tag1","tag2"],"updated_at":"2024-11-20T14:04:03.204372Z"}'
+        headers:
+            Content-Length:
+                - "716"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 14:04:04 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - c43c366d-5f43-4dbc-b50b-7205e8d6eadb
+        status: 200 OK
+        code: 200
+        duration: 57.387833ms
+    - id: 26
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/56f0293b-3796-4a56-9280-636938a540c5
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 722
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T14:03:49.305934Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"56f0293b-3796-4a56-9280-636938a540c5","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01u78vnzwc","registry_namespace_id":"37eadba3-fbd4-4e62-8539-90f6f04e8553","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$gF+HkvafxwPZI/xBtj9S0A$uEFPmGoW+pLGYG3EnOmg0Lc0/tQs3q7fPxaZpnPAOco","key":"test_secret"}],"status":"deleting","tags":["tag1","tag2"],"updated_at":"2024-11-20T14:04:04.172392536Z"}'
+        headers:
+            Content-Length:
+                - "722"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 14:04:04 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 52ff1a39-5fa5-482b-b1eb-05a051108906
+        status: 200 OK
+        code: 200
+        duration: 203.900292ms
+    - id: 27
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/56f0293b-3796-4a56-9280-636938a540c5
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 719
+        uncompressed: false
+        body: '{"created_at":"2024-11-20T14:03:49.305934Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"56f0293b-3796-4a56-9280-636938a540c5","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01u78vnzwc","registry_namespace_id":"37eadba3-fbd4-4e62-8539-90f6f04e8553","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$gF+HkvafxwPZI/xBtj9S0A$uEFPmGoW+pLGYG3EnOmg0Lc0/tQs3q7fPxaZpnPAOco","key":"test_secret"}],"status":"deleting","tags":["tag1","tag2"],"updated_at":"2024-11-20T14:04:04.172393Z"}'
+        headers:
+            Content-Length:
+                - "719"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 14:04:04 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 8e56d1c5-23b8-41d9-bd8f-66993e0cc673
+        status: 200 OK
+        code: 200
+        duration: 73.136125ms
+    - id: 28
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/56f0293b-3796-4a56-9280-636938a540c5
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 37
+        uncompressed: false
+        body: '{"message":"Namespace was not found"}'
+        headers:
+            Content-Length:
+                - "37"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 14:04:09 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 4302b0f4-133b-44b9-bfdc-c9f49ca83e7e
+        status: 404 Not Found
+        code: 404
+        duration: 30.806709ms
+    - id: 29
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/56f0293b-3796-4a56-9280-636938a540c5
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 37
+        uncompressed: false
+        body: '{"message":"Namespace was not found"}'
+        headers:
+            Content-Length:
+                - "37"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 20 Nov 2024 14:04:09 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 7bc03c82-3015-4533-9a5e-83c8e950b85a
+        status: 404 Not Found
+        code: 404
+        duration: 25.255875ms


### PR DESCRIPTION
Hello,

Go SDK now supports tags on functions and container namespaces since https://github.com/scaleway/scaleway-sdk-go/commit/2a48843b5fcba4ab5624b25ebe1dc79cae5fdac1 (hence the bump in `go.mod`). This PR adds support in Terraform for these fields in both functions and containers namespaces.

:warning: please wait 2024/11/19 before merging, but this doesn't prevent from reviewing :warning:

Tested with a local build of the provider and the following config:

```hcl
resource "scaleway_container_namespace" "main" {
  name = "test"
  tags = ["tag1", "tag2"]
}

resource "scaleway_function_namespace" "main" {
  name = "test"
  tags = ["tag1", "tag2", "tag3"]
}
```

After `terraform apply`ing, tags are added to the namespaces.

For containers:

```shell
$ curl -s -H "X-Auth-Token: $SCW_SECRET_KEY" $SCW_API_URL/containers/v1beta1/regions/$SCW_DEFAULT_REGION/namespaces | jq '.namespaces[] | {"name": .name, "tags": .tags}'
{
  "name": "test",
  "tags": [
    "tag1",
    "tag2"
  ]
}
```

For functions:

```shell
$ curl -s -H "X-Auth-Token: $SCW_SECRET_KEY" $SCW_API_URL/functions/v1beta1/regions/$SCW_DEFAULT_REGION/namespaces | jq '.namespaces[] | {"name": .name, "tags": .tags}'
{
  "name": "test",
  "tags: [
    "tag1",
    "tag2",
    "tag3"
  ]
}
```

I have also tested that there are no regressions if we don't add tags at all, and added an acceptance test.

Thanks.