### PR TITLE
doc: callouts don't support multiple paragraphs

### DIFF
--- a/docs/resources/instance_server.md
+++ b/docs/resources/instance_server.md
@@ -272,10 +272,8 @@ attached to the server. Updates to this field will trigger a stop/start of the s
 - `status` The private NIC state.
 - `zone` - (Defaults to [provider](../index.md#zone) `zone`) The [zone](../guides/regions_and_zones.md#zones) in which the server must be created.
 
-~> **Important:**
-
-- You can only attach an instance in the same [zone](../guides/regions_and_zones.md#zones) as a private network.
-- Instance supports maximum 8 different private networks.
+~> **Important:** You can only attach an instance in the same [zone](../guides/regions_and_zones.md#zones) as a private network.
+~> **Important:** Instance supports a maximum of 8 different private networks.
 
 ## Attributes Reference
 


### PR DESCRIPTION
As stated in Terraform documentation: https://developer.hashicorp.com/terraform/registry/providers/docs#callouts.

Indeed, it's displayed incorrectly:
<img width="692" alt="Screenshot 2024-11-29 at 14 30 52" src="https://github.com/user-attachments/assets/d2eeb5f4-58c3-450b-a736-29a1787f7233">


I also took the liberty to fix the grammar.
