### PR TITLE
feat(containers): add scaling_option block

### DIFF
--- a/docs/data-sources/container.md
+++ b/docs/data-sources/container.md
@@ -93,20 +93,16 @@ In addition to all arguments above, the following attributes are exported:
 
 - `sandbox` - Execution environment of the container.
 
-<<<<<<< HEAD
 - `heath_check` - Health check configuration block of the container.
     - `http` - HTTP health check configuration.
         - `path` - Path to use for the HTTP health check.
     - `failure_threshold` - Number of consecutive health check failures before considering the container unhealthy.
     - `interval`- Period between health checks (in seconds).
-||||||| parent of d04ca3f0 (feat(container/serverless): add scaling_option block)
 - `sandbox` - (Optional) Execution environment of the container.
-=======
 - `scaling_option` - Configuration block used to decide when to scale up or down. Possible values:
     - `concurrent_requests_threshold` - Scale depending on the number of concurrent requests being processed per container instance.
     - `cpu_usage_threshold` - Scale depending on the CPU usage of a container instance.
     - `memory_usage_threshold`- Scale depending on the memory usage of a container instance.
->>>>>>> d04ca3f0 (feat(container/serverless): add scaling_option block)
 
 - `status` - The container status.
 

--- a/docs/data-sources/container.md
+++ b/docs/data-sources/container.md
@@ -93,11 +93,20 @@ In addition to all arguments above, the following attributes are exported:
 
 - `sandbox` - Execution environment of the container.
 
+<<<<<<< HEAD
 - `heath_check` - Health check configuration block of the container.
     - `http` - HTTP health check configuration.
         - `path` - Path to use for the HTTP health check.
     - `failure_threshold` - Number of consecutive health check failures before considering the container unhealthy.
     - `interval`- Period between health checks (in seconds).
+||||||| parent of d04ca3f0 (feat(container/serverless): add scaling_option block)
+- `sandbox` - (Optional) Execution environment of the container.
+=======
+- `scaling_option` - Configuration block used to decide when to scale up or down. Possible values:
+    - `concurrent_requests_threshold` - Scale depending on the number of concurrent requests being processed per container instance.
+    - `cpu_usage_threshold` - Scale depending on the CPU usage of a container instance.
+    - `memory_usage_threshold`- Scale depending on the memory usage of a container instance.
+>>>>>>> d04ca3f0 (feat(container/serverless): add scaling_option block)
 
 - `status` - The container status.
 

--- a/docs/resources/container.md
+++ b/docs/resources/container.md
@@ -84,19 +84,16 @@ The following arguments are supported:
 
 - `sandbox` - (Optional) Execution environment of the container.
 
-<<<<<<< HEAD
 - `heath_check` - (Optional) Health check configuration block of the container.
     - `http` - HTTP health check configuration.
         - `path` - Path to use for the HTTP health check.
     - `failure_threshold` - Number of consecutive health check failures before considering the container unhealthy.
     - `interval`- Period between health checks (in seconds).
-||||||| parent of d04ca3f0 (feat(container/serverless): add scaling_option block)
-=======
+
 - `scaling_option` - (Optional) Configuration block used to decide when to scale up or down. Possible values:
     - `concurrent_requests_threshold` - Scale depending on the number of concurrent requests being processed per container instance.
     - `cpu_usage_threshold` - Scale depending on the CPU usage of a container instance.
     - `memory_usage_threshold`- Scale depending on the memory usage of a container instance.
->>>>>>> d04ca3f0 (feat(container/serverless): add scaling_option block)
 
 - `port` - (Optional) The port to expose the container.
 
@@ -168,7 +165,6 @@ The `memory_limit` (in MB) must correspond with the right amount of vCPU. Refer 
 ~>**Important:** Make sure to select the right resources, as you will be billed based on compute usage over time and the number of Containers executions.
 Refer to the [Serverless Containers pricing](https://www.scaleway.com/en/docs/faq/serverless-containers/#prices) for more information.
 
-<<<<<<< HEAD
 ## Health check configuration
 
 Custom health checks can be configured on the container.
@@ -197,9 +193,8 @@ resource scaleway_container main {
 
 ~>**Important:** Another probe type can be set to TCP with the API, but currently the SDK has not been updated with this parameter.
 This is why the only probe that can be used here is the HTTP probe.
-||||||| parent of d04ca3f0 (feat(container/serverless): add scaling_option block)
 Refer to the [Serverless Containers pricing](https://www.scaleway.com/en/docs/faq/serverless-containers/#prices) for more information.
-=======
+
 ## Scaling option configuration
 
 Scaling option block configuration allows you to choose which parameter will scale up/down containers.
@@ -220,5 +215,4 @@ resource scaleway_container main {
 ```
 
 ~>**Important**: A maximum of one of these parameters may be set. Also, when `cpu_usage_threshold` or `memory_usage_threshold` are used, `min_scale` can't be set to 0.
->>>>>>> d04ca3f0 (feat(container/serverless): add scaling_option block)
 Refer to the [API Reference](https://www.scaleway.com/en/developers/api/serverless-containers/#path-containers-create-a-new-container) for more information.

--- a/docs/resources/container.md
+++ b/docs/resources/container.md
@@ -84,11 +84,19 @@ The following arguments are supported:
 
 - `sandbox` - (Optional) Execution environment of the container.
 
+<<<<<<< HEAD
 - `heath_check` - (Optional) Health check configuration block of the container.
     - `http` - HTTP health check configuration.
         - `path` - Path to use for the HTTP health check.
     - `failure_threshold` - Number of consecutive health check failures before considering the container unhealthy.
     - `interval`- Period between health checks (in seconds).
+||||||| parent of d04ca3f0 (feat(container/serverless): add scaling_option block)
+=======
+- `scaling_option` - (Optional) Configuration block used to decide when to scale up or down. Possible values:
+    - `concurrent_requests_threshold` - Scale depending on the number of concurrent requests being processed per container instance.
+    - `cpu_usage_threshold` - Scale depending on the CPU usage of a container instance.
+    - `memory_usage_threshold`- Scale depending on the memory usage of a container instance.
+>>>>>>> d04ca3f0 (feat(container/serverless): add scaling_option block)
 
 - `port` - (Optional) The port to expose the container.
 
@@ -160,6 +168,7 @@ The `memory_limit` (in MB) must correspond with the right amount of vCPU. Refer 
 ~>**Important:** Make sure to select the right resources, as you will be billed based on compute usage over time and the number of Containers executions.
 Refer to the [Serverless Containers pricing](https://www.scaleway.com/en/docs/faq/serverless-containers/#prices) for more information.
 
+<<<<<<< HEAD
 ## Health check configuration
 
 Custom health checks can be configured on the container.
@@ -188,4 +197,27 @@ resource scaleway_container main {
 
 ~>**Important:** Another probe type can be set to TCP with the API, but currently the SDK has not been updated with this parameter.
 This is why the only probe that can be used here is the HTTP probe.
+||||||| parent of d04ca3f0 (feat(container/serverless): add scaling_option block)
+Refer to the [Serverless Containers pricing](https://www.scaleway.com/en/docs/faq/serverless-containers/#prices) for more information.
+=======
+## Scaling option configuration
+
+Scaling option block configuration allows you to choose which parameter will scale up/down containers. Options are number of concurrent requests, CPU or memory usage. 
+It replaces current `max_concurrency` that has been deprecated.
+
+Example:
+
+```terraform
+resource scaleway_container main {
+    name = "my-container-02"
+    namespace_id = scaleway_container_namespace.main.id
+
+    scaling_option {
+      concurrent_requests_threshold = 15
+    }
+}
+```
+
+~>**Important**: A maximum of one of these parameters may be set. Also, when `cpu_usage_threshold` or `memory_usage_threshold` are used, `min_scale` can't be set to 0.
+>>>>>>> d04ca3f0 (feat(container/serverless): add scaling_option block)
 Refer to the [API Reference](https://www.scaleway.com/en/developers/api/serverless-containers/#path-containers-create-a-new-container) for more information.

--- a/docs/resources/container.md
+++ b/docs/resources/container.md
@@ -202,7 +202,8 @@ Refer to the [Serverless Containers pricing](https://www.scaleway.com/en/docs/fa
 =======
 ## Scaling option configuration
 
-Scaling option block configuration allows you to choose which parameter will scale up/down containers. Options are number of concurrent requests, CPU or memory usage. 
+Scaling option block configuration allows you to choose which parameter will scale up/down containers.
+Options are number of concurrent requests, CPU or memory usage.
 It replaces current `max_concurrency` that has been deprecated.
 
 Example:

--- a/internal/services/container/container.go
+++ b/internal/services/container/container.go
@@ -130,6 +130,7 @@ func ResourceContainer() *schema.Resource {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				Computed:     true,
+				Deprecated:   "Use scaling_option.concurrent_requests_threshold instead. This attribute will be removed.",
 				Description:  "The maximum the number of simultaneous requests your container can handle at the same time.",
 				ValidateFunc: validation.IntAtMost(containerMaxConcurrencyLimit),
 			},
@@ -171,6 +172,7 @@ func ResourceContainer() *schema.Resource {
 				Description:      "Execution environment of the container.",
 				ValidateDiagFunc: verify.ValidateEnum[container.ContainerSandbox](),
 			},
+<<<<<<< HEAD
 			"health_check": {
 				Type:        schema.TypeSet,
 				Optional:    true,
@@ -205,6 +207,30 @@ func ResourceContainer() *schema.Resource {
 							DiffSuppressFunc: dsf.Duration,
 							ValidateDiagFunc: verify.IsDuration(),
 							Required:         true,
+||||||| parent of d04ca3f0 (feat(container/serverless): add scaling_option block)
+=======
+			"scaling_option": {
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Computed:    true,
+				Description: "Configuration used to decide when to scale up or down.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"concurrent_requests_threshold": {
+							Type:        schema.TypeInt,
+							Description: "Scale depending on the number of concurrent requests being processed per container instance.",
+							Optional:    true,
+						},
+						"cpu_usage_threshold": {
+							Type:        schema.TypeInt,
+							Description: "Scale depending on the CPU usage of a container instance.",
+							Optional:    true,
+						},
+						"memory_usage_threshold": {
+							Type:        schema.TypeInt,
+							Description: "Scale depending on the memory usage of a container instance.",
+							Optional:    true,
+>>>>>>> d04ca3f0 (feat(container/serverless): add scaling_option block)
 						},
 					},
 				},
@@ -322,7 +348,12 @@ func ResourceContainerRead(ctx context.Context, d *schema.ResourceData, m interf
 	_ = d.Set("deploy", scw.BoolPtr(*types.ExpandBoolPtr(d.Get("deploy"))))
 	_ = d.Set("http_option", co.HTTPOption)
 	_ = d.Set("sandbox", co.Sandbox)
+<<<<<<< HEAD
 	_ = d.Set("health_check", flattenHealthCheck(co.HealthCheck))
+||||||| parent of d04ca3f0 (feat(container/serverless): add scaling_option block)
+=======
+	_ = d.Set("scaling_option", flattenScalingOption(co.ScalingOption))
+>>>>>>> d04ca3f0 (feat(container/serverless): add scaling_option block)
 	_ = d.Set("region", co.Region.String())
 
 	return nil
@@ -418,6 +449,7 @@ func ResourceContainerUpdate(ctx context.Context, d *schema.ResourceData, m inte
 		req.Sandbox = container.ContainerSandbox(d.Get("sandbox").(string))
 	}
 
+<<<<<<< HEAD
 	if d.HasChanges("health_check") {
 		healthCheck := d.Get("health_check")
 
@@ -427,6 +459,17 @@ func ResourceContainerUpdate(ctx context.Context, d *schema.ResourceData, m inte
 		}
 
 		req.HealthCheck = healthCheckReq
+||||||| parent of d04ca3f0 (feat(container/serverless): add scaling_option block)
+=======
+	if d.HasChanges("scaling_option") {
+		scalingOption := d.Get("scaling_option")
+
+		scalingOptionReq, err := expandScalingOptions(scalingOption)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		req.ScalingOption = scalingOptionReq
+>>>>>>> d04ca3f0 (feat(container/serverless): add scaling_option block)
 	}
 
 	imageHasChanged := d.HasChanges("registry_sha256")

--- a/internal/services/container/container.go
+++ b/internal/services/container/container.go
@@ -172,7 +172,6 @@ func ResourceContainer() *schema.Resource {
 				Description:      "Execution environment of the container.",
 				ValidateDiagFunc: verify.ValidateEnum[container.ContainerSandbox](),
 			},
-<<<<<<< HEAD
 			"health_check": {
 				Type:        schema.TypeSet,
 				Optional:    true,
@@ -207,8 +206,10 @@ func ResourceContainer() *schema.Resource {
 							DiffSuppressFunc: dsf.Duration,
 							ValidateDiagFunc: verify.IsDuration(),
 							Required:         true,
-||||||| parent of d04ca3f0 (feat(container/serverless): add scaling_option block)
-=======
+						},
+					},
+				},
+			},
 			"scaling_option": {
 				Type:        schema.TypeSet,
 				Optional:    true,
@@ -230,7 +231,6 @@ func ResourceContainer() *schema.Resource {
 							Type:        schema.TypeInt,
 							Description: "Scale depending on the memory usage of a container instance.",
 							Optional:    true,
->>>>>>> d04ca3f0 (feat(container/serverless): add scaling_option block)
 						},
 					},
 				},
@@ -348,12 +348,8 @@ func ResourceContainerRead(ctx context.Context, d *schema.ResourceData, m interf
 	_ = d.Set("deploy", scw.BoolPtr(*types.ExpandBoolPtr(d.Get("deploy"))))
 	_ = d.Set("http_option", co.HTTPOption)
 	_ = d.Set("sandbox", co.Sandbox)
-<<<<<<< HEAD
 	_ = d.Set("health_check", flattenHealthCheck(co.HealthCheck))
-||||||| parent of d04ca3f0 (feat(container/serverless): add scaling_option block)
-=======
 	_ = d.Set("scaling_option", flattenScalingOption(co.ScalingOption))
->>>>>>> d04ca3f0 (feat(container/serverless): add scaling_option block)
 	_ = d.Set("region", co.Region.String())
 
 	return nil
@@ -449,7 +445,6 @@ func ResourceContainerUpdate(ctx context.Context, d *schema.ResourceData, m inte
 		req.Sandbox = container.ContainerSandbox(d.Get("sandbox").(string))
 	}
 
-<<<<<<< HEAD
 	if d.HasChanges("health_check") {
 		healthCheck := d.Get("health_check")
 
@@ -459,8 +454,8 @@ func ResourceContainerUpdate(ctx context.Context, d *schema.ResourceData, m inte
 		}
 
 		req.HealthCheck = healthCheckReq
-||||||| parent of d04ca3f0 (feat(container/serverless): add scaling_option block)
-=======
+	}
+
 	if d.HasChanges("scaling_option") {
 		scalingOption := d.Get("scaling_option")
 
@@ -470,7 +465,6 @@ func ResourceContainerUpdate(ctx context.Context, d *schema.ResourceData, m inte
 		}
 
 		req.ScalingOption = scalingOptionReq
->>>>>>> d04ca3f0 (feat(container/serverless): add scaling_option block)
 	}
 
 	imageHasChanged := d.HasChanges("registry_sha256")

--- a/internal/services/container/container.go
+++ b/internal/services/container/container.go
@@ -468,6 +468,7 @@ func ResourceContainerUpdate(ctx context.Context, d *schema.ResourceData, m inte
 		if err != nil {
 			return diag.FromErr(err)
 		}
+
 		req.ScalingOption = scalingOptionReq
 >>>>>>> d04ca3f0 (feat(container/serverless): add scaling_option block)
 	}

--- a/internal/services/container/container_data_source_test.go
+++ b/internal/services/container/container_data_source_test.go
@@ -50,7 +50,6 @@ func TestAccDataSourceContainer_Basic(t *testing.T) {
 	})
 }
 
-<<<<<<< HEAD
 func TestAccDataSourceContainer_HealthCheck(t *testing.T) {
 	tt := acctest.NewTestTools(t)
 	defer tt.Cleanup()
@@ -83,8 +82,11 @@ func TestAccDataSourceContainer_HealthCheck(t *testing.T) {
 					resource.TestCheckResourceAttr("data.scaleway_container.main", "health_check.#", "1"),
 					resource.TestCheckResourceAttr("data.scaleway_container.main", "health_check.0.failure_threshold", "30"),
 					resource.TestCheckResourceAttr("data.scaleway_container.main", "health_check.0.interval", "10s"),
-||||||| parent of d04ca3f0 (feat(container/serverless): add scaling_option block)
-=======
+			},
+		},
+	}
+}
+
 func TestAccDataSourceContainer_ScalingOption(t *testing.T) {
 	tt := acctest.NewTestTools(t)
 	defer tt.Cleanup()
@@ -114,7 +116,6 @@ func TestAccDataSourceContainer_ScalingOption(t *testing.T) {
 					resource.TestCheckResourceAttr("scaleway_container.main", "scaling_option.0.concurrent_requests_threshold", "50"),
 					resource.TestCheckResourceAttr("data.scaleway_container.main", "scaling_option.#", "1"),
 					resource.TestCheckResourceAttr("data.scaleway_container.main", "scaling_option.0.concurrent_requests_threshold", "50"),
->>>>>>> d04ca3f0 (feat(container/serverless): add scaling_option block)
 				),
 			},
 		},

--- a/internal/services/container/container_data_source_test.go
+++ b/internal/services/container/container_data_source_test.go
@@ -50,6 +50,7 @@ func TestAccDataSourceContainer_Basic(t *testing.T) {
 	})
 }
 
+<<<<<<< HEAD
 func TestAccDataSourceContainer_HealthCheck(t *testing.T) {
 	tt := acctest.NewTestTools(t)
 	defer tt.Cleanup()
@@ -82,6 +83,38 @@ func TestAccDataSourceContainer_HealthCheck(t *testing.T) {
 					resource.TestCheckResourceAttr("data.scaleway_container.main", "health_check.#", "1"),
 					resource.TestCheckResourceAttr("data.scaleway_container.main", "health_check.0.failure_threshold", "30"),
 					resource.TestCheckResourceAttr("data.scaleway_container.main", "health_check.0.interval", "10s"),
+||||||| parent of d04ca3f0 (feat(container/serverless): add scaling_option block)
+=======
+func TestAccDataSourceContainer_ScalingOption(t *testing.T) {
+	tt := acctest.NewTestTools(t)
+	defer tt.Cleanup()
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ProviderFactories: tt.ProviderFactories,
+		CheckDestroy:      isNamespaceDestroyed(tt),
+		Steps: []resource.TestStep{
+			{
+				Config: `
+					resource scaleway_container_namespace main {}
+
+					resource scaleway_container main {
+						namespace_id = scaleway_container_namespace.main.id
+						deploy = false
+					}
+
+					data scaleway_container main {
+						namespace_id = scaleway_container_namespace.main.id
+						container_id = scaleway_container.main.id
+					}
+				`,
+				Check: resource.ComposeTestCheckFunc(
+					isContainerPresent(tt, "scaleway_container.main"),
+					// Check default option returned by the API when you don't specify the scaling_option block.
+					resource.TestCheckResourceAttr("scaleway_container.main", "scaling_option.#", "1"),
+					resource.TestCheckResourceAttr("scaleway_container.main", "scaling_option.0.concurrent_requests_threshold", "50"),
+					resource.TestCheckResourceAttr("data.scaleway_container.main", "scaling_option.#", "1"),
+					resource.TestCheckResourceAttr("data.scaleway_container.main", "scaling_option.0.concurrent_requests_threshold", "50"),
+>>>>>>> d04ca3f0 (feat(container/serverless): add scaling_option block)
 				),
 			},
 		},

--- a/internal/services/container/container_data_source_test.go
+++ b/internal/services/container/container_data_source_test.go
@@ -82,9 +82,10 @@ func TestAccDataSourceContainer_HealthCheck(t *testing.T) {
 					resource.TestCheckResourceAttr("data.scaleway_container.main", "health_check.#", "1"),
 					resource.TestCheckResourceAttr("data.scaleway_container.main", "health_check.0.failure_threshold", "30"),
 					resource.TestCheckResourceAttr("data.scaleway_container.main", "health_check.0.interval", "10s"),
+				),
 			},
 		},
-	}
+	})
 }
 
 func TestAccDataSourceContainer_ScalingOption(t *testing.T) {

--- a/internal/services/container/container_test.go
+++ b/internal/services/container/container_test.go
@@ -400,7 +400,6 @@ func TestAccContainer_Sandbox(t *testing.T) {
 	})
 }
 
-<<<<<<< HEAD
 func TestAccContainer_HealthCheck(t *testing.T) {
 	tt := acctest.NewTestTools(t)
 	defer tt.Cleanup()
@@ -449,8 +448,12 @@ func TestAccContainer_HealthCheck(t *testing.T) {
 					resource.TestCheckResourceAttr("scaleway_container.main", "health_check.0.http.0.path", "/test"),
 					resource.TestCheckResourceAttr("scaleway_container.main", "health_check.0.failure_threshold", "40"),
 					resource.TestCheckResourceAttr("scaleway_container.main", "health_check.0.interval", "12s"),
-||||||| parent of d04ca3f0 (feat(container/serverless): add scaling_option block)
-=======
+				),
+			},
+		},
+	})
+}
+
 func TestAccContainer_ScalingOption(t *testing.T) {
 	tt := acctest.NewTestTools(t)
 	defer tt.Cleanup()
@@ -534,7 +537,6 @@ func TestAccContainer_ScalingOption(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					isContainerPresent(tt, "scaleway_container.main"),
 					resource.TestCheckResourceAttr("scaleway_container.main", "scaling_option.0.memory_usage_threshold", "66"),
->>>>>>> d04ca3f0 (feat(container/serverless): add scaling_option block)
 				),
 			},
 		},

--- a/internal/services/container/container_test.go
+++ b/internal/services/container/container_test.go
@@ -400,6 +400,7 @@ func TestAccContainer_Sandbox(t *testing.T) {
 	})
 }
 
+<<<<<<< HEAD
 func TestAccContainer_HealthCheck(t *testing.T) {
 	tt := acctest.NewTestTools(t)
 	defer tt.Cleanup()
@@ -448,6 +449,92 @@ func TestAccContainer_HealthCheck(t *testing.T) {
 					resource.TestCheckResourceAttr("scaleway_container.main", "health_check.0.http.0.path", "/test"),
 					resource.TestCheckResourceAttr("scaleway_container.main", "health_check.0.failure_threshold", "40"),
 					resource.TestCheckResourceAttr("scaleway_container.main", "health_check.0.interval", "12s"),
+||||||| parent of d04ca3f0 (feat(container/serverless): add scaling_option block)
+=======
+func TestAccContainer_ScalingOption(t *testing.T) {
+	tt := acctest.NewTestTools(t)
+	defer tt.Cleanup()
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ProviderFactories: tt.ProviderFactories,
+		CheckDestroy:      isContainerDestroyed(tt),
+		Steps: []resource.TestStep{
+			{
+				Config: `
+					resource scaleway_container_namespace main {}
+
+					resource scaleway_container main {
+						namespace_id = scaleway_container_namespace.main.id
+						deploy = false
+					}
+				`,
+				Check: resource.ComposeTestCheckFunc(
+					isContainerPresent(tt, "scaleway_container.main"),
+					// Check default option returned by the API when you don't specify the scaling_option block.
+					resource.TestCheckResourceAttr("scaleway_container.main", "scaling_option.#", "1"),
+					resource.TestCheckResourceAttr("scaleway_container.main", "scaling_option.0.concurrent_requests_threshold", "50"),
+				),
+			},
+			{
+				Config: `
+					resource scaleway_container_namespace main {}
+		
+					resource scaleway_container main {
+						namespace_id = scaleway_container_namespace.main.id
+						deploy = false
+
+						scaling_option {
+							concurrent_requests_threshold = 15
+						}
+					}
+				`,
+				Check: resource.ComposeTestCheckFunc(
+					isContainerPresent(tt, "scaleway_container.main"),
+					resource.TestCheckResourceAttr("scaleway_container.main", "scaling_option.#", "1"),
+					resource.TestCheckResourceAttr("scaleway_container.main", "scaling_option.0.concurrent_requests_threshold", "15"),
+				),
+			},
+			{
+				Config: `
+					resource scaleway_container_namespace main {}
+		
+					resource scaleway_container main {
+						namespace_id = scaleway_container_namespace.main.id
+						deploy = false
+
+						min_scale = 1
+
+						scaling_option {
+							cpu_usage_threshold = 72
+						}
+					}
+				`,
+				Check: resource.ComposeTestCheckFunc(
+					isContainerPresent(tt, "scaleway_container.main"),
+					resource.TestCheckResourceAttr("scaleway_container.main", "scaling_option.#", "1"),
+					resource.TestCheckResourceAttr("scaleway_container.main", "scaling_option.0.cpu_usage_threshold", "72"),
+				),
+			},
+
+			{
+				Config: `
+					resource scaleway_container_namespace main {}
+		
+					resource scaleway_container main {
+						namespace_id = scaleway_container_namespace.main.id
+						deploy = false
+
+						min_scale = 1
+
+						scaling_option {
+							memory_usage_threshold = 66
+						}
+					}
+				`,
+				Check: resource.ComposeTestCheckFunc(
+					isContainerPresent(tt, "scaleway_container.main"),
+					resource.TestCheckResourceAttr("scaleway_container.main", "scaling_option.0.memory_usage_threshold", "66"),
+>>>>>>> d04ca3f0 (feat(container/serverless): add scaling_option block)
 				),
 			},
 		},

--- a/internal/services/container/helpers_container.go
+++ b/internal/services/container/helpers_container.go
@@ -126,6 +126,14 @@ func setCreateContainerRequest(d *schema.ResourceData, region scw.Region) (*cont
 		req.HealthCheck = healthCheckReq
 	}
 
+	if scalingOption, ok := d.GetOk("scaling_option"); ok {
+		scalingOptionReq, err := expandScalingOptions(scalingOption)
+		if err != nil {
+			return nil, err
+		}
+		req.ScalingOption = scalingOptionReq
+	}
+
 	return req, nil
 }
 
@@ -218,6 +226,57 @@ func flattenHealthCheckHTTP(healthCheckHTTP *container.ContainerHealthCheckSpecH
 	})
 
 	return flattenedHealthCheckHTTP
+}
+
+func expandScalingOptions(scalingOptionSchema interface{}) (*container.ContainerScalingOption, error) {
+	scalingOption, ok := scalingOptionSchema.(*schema.Set)
+	if !ok {
+		return &container.ContainerScalingOption{}, nil
+	}
+
+	for _, option := range scalingOption.List() {
+		rawOption, isRawOption := option.(map[string]interface{})
+		if !isRawOption {
+			continue
+		}
+
+		setFields := 0
+		cso := &container.ContainerScalingOption{}
+		if concurrentRequestThresold, ok := rawOption["concurrent_requests_threshold"].(int); ok && concurrentRequestThresold != 0 {
+			cso.ConcurrentRequestsThreshold = scw.Uint32Ptr(uint32(concurrentRequestThresold))
+			setFields++
+		}
+		if cpuUsageThreshold, ok := rawOption["cpu_usage_threshold"].(int); ok && cpuUsageThreshold != 0 {
+			cso.CPUUsageThreshold = scw.Uint32Ptr(uint32(cpuUsageThreshold))
+			setFields++
+		}
+		if memoryUsageThreshold, ok := rawOption["memory_usage_threshold"].(int); ok && memoryUsageThreshold != 0 {
+			cso.MemoryUsageThreshold = scw.Uint32Ptr(uint32(memoryUsageThreshold))
+			setFields++
+		}
+
+		if setFields > 1 {
+			return &container.ContainerScalingOption{}, errors.New("a maximum of one scaling option can be set")
+		}
+		return cso, nil
+	}
+
+	return &container.ContainerScalingOption{}, nil
+}
+
+func flattenScalingOption(scalingOption *container.ContainerScalingOption) interface{} {
+	if scalingOption == nil {
+		return nil
+	}
+
+	flattenedScalingOption := []map[string]interface{}(nil)
+	flattenedScalingOption = append(flattenedScalingOption, map[string]interface{}{
+		"concurrent_requests_threshold": types.FlattenUint32Ptr(scalingOption.ConcurrentRequestsThreshold),
+		"cpu_usage_threshold":           types.FlattenUint32Ptr(scalingOption.CPUUsageThreshold),
+		"memory_usage_threshold":        types.FlattenUint32Ptr(scalingOption.MemoryUsageThreshold),
+	})
+
+	return flattenedScalingOption
 }
 
 func expandContainerSecrets(secretsRawMap interface{}) []*container.Secret {

--- a/internal/services/container/helpers_container.go
+++ b/internal/services/container/helpers_container.go
@@ -131,6 +131,7 @@ func setCreateContainerRequest(d *schema.ResourceData, region scw.Region) (*cont
 		if err != nil {
 			return nil, err
 		}
+
 		req.ScalingOption = scalingOptionReq
 	}
 
@@ -241,15 +242,18 @@ func expandScalingOptions(scalingOptionSchema interface{}) (*container.Container
 		}
 
 		setFields := 0
+
 		cso := &container.ContainerScalingOption{}
 		if concurrentRequestThresold, ok := rawOption["concurrent_requests_threshold"].(int); ok && concurrentRequestThresold != 0 {
 			cso.ConcurrentRequestsThreshold = scw.Uint32Ptr(uint32(concurrentRequestThresold))
 			setFields++
 		}
+
 		if cpuUsageThreshold, ok := rawOption["cpu_usage_threshold"].(int); ok && cpuUsageThreshold != 0 {
 			cso.CPUUsageThreshold = scw.Uint32Ptr(uint32(cpuUsageThreshold))
 			setFields++
 		}
+
 		if memoryUsageThreshold, ok := rawOption["memory_usage_threshold"].(int); ok && memoryUsageThreshold != 0 {
 			cso.MemoryUsageThreshold = scw.Uint32Ptr(uint32(memoryUsageThreshold))
 			setFields++
@@ -258,6 +262,7 @@ func expandScalingOptions(scalingOptionSchema interface{}) (*container.Container
 		if setFields > 1 {
 			return &container.ContainerScalingOption{}, errors.New("a maximum of one scaling option can be set")
 		}
+
 		return cso, nil
 	}
 

--- a/internal/services/container/testdata/container-scaling-option.cassette.yaml
+++ b/internal/services/container/testdata/container-scaling-option.cassette.yaml
@@ -1,0 +1,2855 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 154
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"name":"tf-ns-hungry-raman","environment_variables":{},"project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","secret_environment_variables":[],"tags":null}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 484
+        uncompressed: false
+        body: '{"created_at":"2025-01-15T14:25:06.718105673Z","description":"","environment_variables":{},"error_message":null,"id":"9c64cf6f-986b-43f5-add0-1c27794ab564","name":"tf-ns-hungry-raman","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-15T14:25:06.718105673Z"}'
+        headers:
+            Content-Length:
+                - "484"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:25:06 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - d5ec7203-a7f5-4f47-bb8f-67670c9ba7ef
+        status: 200 OK
+        code: 200
+        duration: 318.24725ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9c64cf6f-986b-43f5-add0-1c27794ab564
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 478
+        uncompressed: false
+        body: '{"created_at":"2025-01-15T14:25:06.718106Z","description":"","environment_variables":{},"error_message":null,"id":"9c64cf6f-986b-43f5-add0-1c27794ab564","name":"tf-ns-hungry-raman","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-15T14:25:06.718106Z"}'
+        headers:
+            Content-Length:
+                - "478"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:25:06 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - c9746937-5579-4d3e-a86c-a177fd679fb5
+        status: 200 OK
+        code: 200
+        duration: 54.630541ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9c64cf6f-986b-43f5-add0-1c27794ab564
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 562
+        uncompressed: false
+        body: '{"created_at":"2025-01-15T14:25:06.718106Z","description":"","environment_variables":{},"error_message":null,"id":"9c64cf6f-986b-43f5-add0-1c27794ab564","name":"tf-ns-hungry-raman","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f","registry_namespace_id":"b4999fd9-3117-4019-9dae-a7d4efebde8e","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-15T14:25:10.179302Z"}'
+        headers:
+            Content-Length:
+                - "562"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:25:11 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 961ea1ee-8488-495b-a771-623ae7d46b48
+        status: 200 OK
+        code: 200
+        duration: 45.760209ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9c64cf6f-986b-43f5-add0-1c27794ab564
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 562
+        uncompressed: false
+        body: '{"created_at":"2025-01-15T14:25:06.718106Z","description":"","environment_variables":{},"error_message":null,"id":"9c64cf6f-986b-43f5-add0-1c27794ab564","name":"tf-ns-hungry-raman","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f","registry_namespace_id":"b4999fd9-3117-4019-9dae-a7d4efebde8e","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-15T14:25:10.179302Z"}'
+        headers:
+            Content-Length:
+                - "562"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:25:11 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 49b4d89b-3cbb-4368-ab46-9cccc0d5a6d7
+        status: 200 OK
+        code: 200
+        duration: 50.066041ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9c64cf6f-986b-43f5-add0-1c27794ab564
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 562
+        uncompressed: false
+        body: '{"created_at":"2025-01-15T14:25:06.718106Z","description":"","environment_variables":{},"error_message":null,"id":"9c64cf6f-986b-43f5-add0-1c27794ab564","name":"tf-ns-hungry-raman","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f","registry_namespace_id":"b4999fd9-3117-4019-9dae-a7d4efebde8e","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-15T14:25:10.179302Z"}'
+        headers:
+            Content-Length:
+                - "562"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:25:11 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 68dc3901-6ec2-4741-b9df-d1d908a34397
+        status: 200 OK
+        code: 200
+        duration: 46.4005ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 209
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"namespace_id":"9c64cf6f-986b-43f5-add0-1c27794ab564","name":"tf-co-jolly-fermat","privacy":"public","protocol":"http1","secret_environment_variables":null,"http_option":"enabled","sandbox":"unknown_sandbox"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 925
+        uncompressed: false
+        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:25:12.144068658Z","description":"","domain_name":"tfnshungryramanms1v4s2f-tf-co-jolly-fermat.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f65c58fe-37f2-4510-aff4-007a09dde1d4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-jolly-fermat","namespace_id":"9c64cf6f-986b-43f5-add0-1c27794ab564","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f/tf-co-jolly-fermat:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-15T14:25:12.144068658Z"}'
+        headers:
+            Content-Length:
+                - "925"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:25:12 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 0cc7c61b-1d59-44e0-818a-0d3db1128d70
+        status: 200 OK
+        code: 200
+        duration: 287.932333ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f65c58fe-37f2-4510-aff4-007a09dde1d4
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 919
+        uncompressed: false
+        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:25:12.144069Z","description":"","domain_name":"tfnshungryramanms1v4s2f-tf-co-jolly-fermat.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f65c58fe-37f2-4510-aff4-007a09dde1d4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-jolly-fermat","namespace_id":"9c64cf6f-986b-43f5-add0-1c27794ab564","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f/tf-co-jolly-fermat:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-15T14:25:12.144069Z"}'
+        headers:
+            Content-Length:
+                - "919"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:25:12 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3ff29e5b-e1ca-4bf2-a94c-a9de8fd30a7b
+        status: 200 OK
+        code: 200
+        duration: 56.1205ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f65c58fe-37f2-4510-aff4-007a09dde1d4
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 919
+        uncompressed: false
+        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:25:12.144069Z","description":"","domain_name":"tfnshungryramanms1v4s2f-tf-co-jolly-fermat.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f65c58fe-37f2-4510-aff4-007a09dde1d4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-jolly-fermat","namespace_id":"9c64cf6f-986b-43f5-add0-1c27794ab564","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f/tf-co-jolly-fermat:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-15T14:25:12.144069Z"}'
+        headers:
+            Content-Length:
+                - "919"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:25:12 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 0a497b68-2400-41c6-ad07-334796d5758e
+        status: 200 OK
+        code: 200
+        duration: 48.314ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9c64cf6f-986b-43f5-add0-1c27794ab564
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 562
+        uncompressed: false
+        body: '{"created_at":"2025-01-15T14:25:06.718106Z","description":"","environment_variables":{},"error_message":null,"id":"9c64cf6f-986b-43f5-add0-1c27794ab564","name":"tf-ns-hungry-raman","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f","registry_namespace_id":"b4999fd9-3117-4019-9dae-a7d4efebde8e","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-15T14:25:10.179302Z"}'
+        headers:
+            Content-Length:
+                - "562"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:25:12 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 290350ea-fd25-42f0-b8e3-758c030fdabb
+        status: 200 OK
+        code: 200
+        duration: 42.256584ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f65c58fe-37f2-4510-aff4-007a09dde1d4
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 919
+        uncompressed: false
+        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:25:12.144069Z","description":"","domain_name":"tfnshungryramanms1v4s2f-tf-co-jolly-fermat.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f65c58fe-37f2-4510-aff4-007a09dde1d4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-jolly-fermat","namespace_id":"9c64cf6f-986b-43f5-add0-1c27794ab564","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f/tf-co-jolly-fermat:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-15T14:25:12.144069Z"}'
+        headers:
+            Content-Length:
+                - "919"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:25:12 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 6e5f76fd-74fb-43db-bbfa-f8ef836c52c4
+        status: 200 OK
+        code: 200
+        duration: 51.278167ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9c64cf6f-986b-43f5-add0-1c27794ab564
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 562
+        uncompressed: false
+        body: '{"created_at":"2025-01-15T14:25:06.718106Z","description":"","environment_variables":{},"error_message":null,"id":"9c64cf6f-986b-43f5-add0-1c27794ab564","name":"tf-ns-hungry-raman","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f","registry_namespace_id":"b4999fd9-3117-4019-9dae-a7d4efebde8e","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-15T14:25:10.179302Z"}'
+        headers:
+            Content-Length:
+                - "562"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:25:12 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 979be1ba-9be5-472c-a7a4-1558a6ea067f
+        status: 200 OK
+        code: 200
+        duration: 56.015542ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f65c58fe-37f2-4510-aff4-007a09dde1d4
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 919
+        uncompressed: false
+        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:25:12.144069Z","description":"","domain_name":"tfnshungryramanms1v4s2f-tf-co-jolly-fermat.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f65c58fe-37f2-4510-aff4-007a09dde1d4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-jolly-fermat","namespace_id":"9c64cf6f-986b-43f5-add0-1c27794ab564","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f/tf-co-jolly-fermat:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-15T14:25:12.144069Z"}'
+        headers:
+            Content-Length:
+                - "919"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:25:12 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 6117e83b-21e0-460d-9dd9-3055e1a843dd
+        status: 200 OK
+        code: 200
+        duration: 59.118708ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9c64cf6f-986b-43f5-add0-1c27794ab564
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 562
+        uncompressed: false
+        body: '{"created_at":"2025-01-15T14:25:06.718106Z","description":"","environment_variables":{},"error_message":null,"id":"9c64cf6f-986b-43f5-add0-1c27794ab564","name":"tf-ns-hungry-raman","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f","registry_namespace_id":"b4999fd9-3117-4019-9dae-a7d4efebde8e","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-15T14:25:10.179302Z"}'
+        headers:
+            Content-Length:
+                - "562"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:25:13 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - d53d0cb7-dac7-4050-be52-409693d359df
+        status: 200 OK
+        code: 200
+        duration: 56.944291ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f65c58fe-37f2-4510-aff4-007a09dde1d4
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 919
+        uncompressed: false
+        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:25:12.144069Z","description":"","domain_name":"tfnshungryramanms1v4s2f-tf-co-jolly-fermat.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f65c58fe-37f2-4510-aff4-007a09dde1d4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-jolly-fermat","namespace_id":"9c64cf6f-986b-43f5-add0-1c27794ab564","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f/tf-co-jolly-fermat:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-15T14:25:12.144069Z"}'
+        headers:
+            Content-Length:
+                - "919"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:25:13 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - bb391d9d-5ef5-4078-8a2f-fd610b6c7bfe
+        status: 200 OK
+        code: 200
+        duration: 61.971291ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 213
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"privacy":"unknown_privacy","protocol":"unknown_protocol","secret_environment_variables":null,"http_option":"unknown_http_option","sandbox":"unknown_sandbox","scaling_option":{"concurrent_requests_threshold":15}}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f65c58fe-37f2-4510-aff4-007a09dde1d4
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 922
+        uncompressed: false
+        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:25:12.144069Z","description":"","domain_name":"tfnshungryramanms1v4s2f-tf-co-jolly-fermat.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f65c58fe-37f2-4510-aff4-007a09dde1d4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-jolly-fermat","namespace_id":"9c64cf6f-986b-43f5-add0-1c27794ab564","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f/tf-co-jolly-fermat:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":15},"secret_environment_variables":[],"status":"pending","timeout":"300s","updated_at":"2025-01-15T14:25:13.191894651Z"}'
+        headers:
+            Content-Length:
+                - "922"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:25:13 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 55749356-b1c8-4ce7-8a7d-4d73f6289af2
+        status: 200 OK
+        code: 200
+        duration: 101.924708ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f65c58fe-37f2-4510-aff4-007a09dde1d4
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 919
+        uncompressed: false
+        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:25:12.144069Z","description":"","domain_name":"tfnshungryramanms1v4s2f-tf-co-jolly-fermat.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f65c58fe-37f2-4510-aff4-007a09dde1d4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-jolly-fermat","namespace_id":"9c64cf6f-986b-43f5-add0-1c27794ab564","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f/tf-co-jolly-fermat:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":15},"secret_environment_variables":[],"status":"pending","timeout":"300s","updated_at":"2025-01-15T14:25:13.191895Z"}'
+        headers:
+            Content-Length:
+                - "919"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:25:13 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - a5aa6050-4b29-46fe-89fe-f04556fa9f53
+        status: 200 OK
+        code: 200
+        duration: 55.86375ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f65c58fe-37f2-4510-aff4-007a09dde1d4
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 919
+        uncompressed: false
+        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:25:12.144069Z","description":"","domain_name":"tfnshungryramanms1v4s2f-tf-co-jolly-fermat.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f65c58fe-37f2-4510-aff4-007a09dde1d4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-jolly-fermat","namespace_id":"9c64cf6f-986b-43f5-add0-1c27794ab564","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f/tf-co-jolly-fermat:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":15},"secret_environment_variables":[],"status":"pending","timeout":"300s","updated_at":"2025-01-15T14:25:13.191895Z"}'
+        headers:
+            Content-Length:
+                - "919"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:25:18 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3f72a135-4b5d-4e77-9bf8-95d43d2e1967
+        status: 200 OK
+        code: 200
+        duration: 58.449833ms
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f65c58fe-37f2-4510-aff4-007a09dde1d4
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 957
+        uncompressed: false
+        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:25:12.144069Z","description":"","domain_name":"tfnshungryramanms1v4s2f-tf-co-jolly-fermat.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f65c58fe-37f2-4510-aff4-007a09dde1d4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-jolly-fermat","namespace_id":"9c64cf6f-986b-43f5-add0-1c27794ab564","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f/tf-co-jolly-fermat:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":15},"secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-15T14:25:20.224405Z"}'
+        headers:
+            Content-Length:
+                - "957"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:25:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - c0f91f31-8fab-4aca-848d-25661bd267be
+        status: 200 OK
+        code: 200
+        duration: 62.0645ms
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f65c58fe-37f2-4510-aff4-007a09dde1d4
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 957
+        uncompressed: false
+        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:25:12.144069Z","description":"","domain_name":"tfnshungryramanms1v4s2f-tf-co-jolly-fermat.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f65c58fe-37f2-4510-aff4-007a09dde1d4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-jolly-fermat","namespace_id":"9c64cf6f-986b-43f5-add0-1c27794ab564","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f/tf-co-jolly-fermat:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":15},"secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-15T14:25:20.224405Z"}'
+        headers:
+            Content-Length:
+                - "957"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:25:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 5905ecdb-6acb-429b-90d2-90b9e2d6496d
+        status: 200 OK
+        code: 200
+        duration: 52.571791ms
+    - id: 19
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f65c58fe-37f2-4510-aff4-007a09dde1d4
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 957
+        uncompressed: false
+        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:25:12.144069Z","description":"","domain_name":"tfnshungryramanms1v4s2f-tf-co-jolly-fermat.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f65c58fe-37f2-4510-aff4-007a09dde1d4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-jolly-fermat","namespace_id":"9c64cf6f-986b-43f5-add0-1c27794ab564","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f/tf-co-jolly-fermat:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":15},"secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-15T14:25:20.224405Z"}'
+        headers:
+            Content-Length:
+                - "957"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:25:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 49c8d070-594c-4362-a286-720c592c3e9d
+        status: 200 OK
+        code: 200
+        duration: 59.013584ms
+    - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9c64cf6f-986b-43f5-add0-1c27794ab564
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 562
+        uncompressed: false
+        body: '{"created_at":"2025-01-15T14:25:06.718106Z","description":"","environment_variables":{},"error_message":null,"id":"9c64cf6f-986b-43f5-add0-1c27794ab564","name":"tf-ns-hungry-raman","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f","registry_namespace_id":"b4999fd9-3117-4019-9dae-a7d4efebde8e","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-15T14:25:10.179302Z"}'
+        headers:
+            Content-Length:
+                - "562"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:25:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 9b148cfe-904e-4dce-b947-ba0fc77dd7e7
+        status: 200 OK
+        code: 200
+        duration: 43.44325ms
+    - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f65c58fe-37f2-4510-aff4-007a09dde1d4
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 957
+        uncompressed: false
+        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:25:12.144069Z","description":"","domain_name":"tfnshungryramanms1v4s2f-tf-co-jolly-fermat.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f65c58fe-37f2-4510-aff4-007a09dde1d4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-jolly-fermat","namespace_id":"9c64cf6f-986b-43f5-add0-1c27794ab564","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f/tf-co-jolly-fermat:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":15},"secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-15T14:25:20.224405Z"}'
+        headers:
+            Content-Length:
+                - "957"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:25:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 95babeb5-ef81-437d-b6c2-dcb947091d4e
+        status: 200 OK
+        code: 200
+        duration: 52.0675ms
+    - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9c64cf6f-986b-43f5-add0-1c27794ab564
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 562
+        uncompressed: false
+        body: '{"created_at":"2025-01-15T14:25:06.718106Z","description":"","environment_variables":{},"error_message":null,"id":"9c64cf6f-986b-43f5-add0-1c27794ab564","name":"tf-ns-hungry-raman","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f","registry_namespace_id":"b4999fd9-3117-4019-9dae-a7d4efebde8e","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-15T14:25:10.179302Z"}'
+        headers:
+            Content-Length:
+                - "562"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:25:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 76b41cee-6a2c-45fa-9be3-a1ac48b23b24
+        status: 200 OK
+        code: 200
+        duration: 43.959542ms
+    - id: 23
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f65c58fe-37f2-4510-aff4-007a09dde1d4
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 957
+        uncompressed: false
+        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:25:12.144069Z","description":"","domain_name":"tfnshungryramanms1v4s2f-tf-co-jolly-fermat.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f65c58fe-37f2-4510-aff4-007a09dde1d4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-jolly-fermat","namespace_id":"9c64cf6f-986b-43f5-add0-1c27794ab564","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f/tf-co-jolly-fermat:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":15},"secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-15T14:25:20.224405Z"}'
+        headers:
+            Content-Length:
+                - "957"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:25:24 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - fb46b8ac-1ba7-4033-aca8-b20f14d2ee5c
+        status: 200 OK
+        code: 200
+        duration: 57.861917ms
+    - id: 24
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9c64cf6f-986b-43f5-add0-1c27794ab564
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 562
+        uncompressed: false
+        body: '{"created_at":"2025-01-15T14:25:06.718106Z","description":"","environment_variables":{},"error_message":null,"id":"9c64cf6f-986b-43f5-add0-1c27794ab564","name":"tf-ns-hungry-raman","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f","registry_namespace_id":"b4999fd9-3117-4019-9dae-a7d4efebde8e","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-15T14:25:10.179302Z"}'
+        headers:
+            Content-Length:
+                - "562"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:25:24 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 74fec3f4-05cd-45e4-bcaf-2db0def94c74
+        status: 200 OK
+        code: 200
+        duration: 43.783709ms
+    - id: 25
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f65c58fe-37f2-4510-aff4-007a09dde1d4
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 957
+        uncompressed: false
+        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:25:12.144069Z","description":"","domain_name":"tfnshungryramanms1v4s2f-tf-co-jolly-fermat.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f65c58fe-37f2-4510-aff4-007a09dde1d4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-jolly-fermat","namespace_id":"9c64cf6f-986b-43f5-add0-1c27794ab564","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f/tf-co-jolly-fermat:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":15},"secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-15T14:25:20.224405Z"}'
+        headers:
+            Content-Length:
+                - "957"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:25:24 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 4f4ed3f9-dbc3-473a-a27f-e49a207073b0
+        status: 200 OK
+        code: 200
+        duration: 47.437666ms
+    - id: 26
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 217
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"min_scale":1,"privacy":"unknown_privacy","protocol":"unknown_protocol","secret_environment_variables":null,"http_option":"unknown_http_option","sandbox":"unknown_sandbox","scaling_option":{"cpu_usage_threshold":72}}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f65c58fe-37f2-4510-aff4-007a09dde1d4
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 912
+        uncompressed: false
+        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:25:12.144069Z","description":"","domain_name":"tfnshungryramanms1v4s2f-tf-co-jolly-fermat.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f65c58fe-37f2-4510-aff4-007a09dde1d4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":1,"name":"tf-co-jolly-fermat","namespace_id":"9c64cf6f-986b-43f5-add0-1c27794ab564","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f/tf-co-jolly-fermat:latest","sandbox":"v2","scaling_option":{"cpu_usage_threshold":72},"secret_environment_variables":[],"status":"pending","timeout":"300s","updated_at":"2025-01-15T14:25:24.337405525Z"}'
+        headers:
+            Content-Length:
+                - "912"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:25:24 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ed7ad6bb-a55f-494c-9ed5-d657f945f05a
+        status: 200 OK
+        code: 200
+        duration: 110.097584ms
+    - id: 27
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f65c58fe-37f2-4510-aff4-007a09dde1d4
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 909
+        uncompressed: false
+        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:25:12.144069Z","description":"","domain_name":"tfnshungryramanms1v4s2f-tf-co-jolly-fermat.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f65c58fe-37f2-4510-aff4-007a09dde1d4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":1,"name":"tf-co-jolly-fermat","namespace_id":"9c64cf6f-986b-43f5-add0-1c27794ab564","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f/tf-co-jolly-fermat:latest","sandbox":"v2","scaling_option":{"cpu_usage_threshold":72},"secret_environment_variables":[],"status":"pending","timeout":"300s","updated_at":"2025-01-15T14:25:24.337406Z"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:25:24 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - d382d7b8-5a24-4728-b816-09df2b32c0c9
+        status: 200 OK
+        code: 200
+        duration: 47.433417ms
+    - id: 28
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f65c58fe-37f2-4510-aff4-007a09dde1d4
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 909
+        uncompressed: false
+        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:25:12.144069Z","description":"","domain_name":"tfnshungryramanms1v4s2f-tf-co-jolly-fermat.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f65c58fe-37f2-4510-aff4-007a09dde1d4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":1,"name":"tf-co-jolly-fermat","namespace_id":"9c64cf6f-986b-43f5-add0-1c27794ab564","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f/tf-co-jolly-fermat:latest","sandbox":"v2","scaling_option":{"cpu_usage_threshold":72},"secret_environment_variables":[],"status":"pending","timeout":"300s","updated_at":"2025-01-15T14:25:24.337406Z"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:25:29 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 14b654b2-939a-4107-93c8-d2585a76c910
+        status: 200 OK
+        code: 200
+        duration: 61.425333ms
+    - id: 29
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f65c58fe-37f2-4510-aff4-007a09dde1d4
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 947
+        uncompressed: false
+        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:25:12.144069Z","description":"","domain_name":"tfnshungryramanms1v4s2f-tf-co-jolly-fermat.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f65c58fe-37f2-4510-aff4-007a09dde1d4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":1,"name":"tf-co-jolly-fermat","namespace_id":"9c64cf6f-986b-43f5-add0-1c27794ab564","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f/tf-co-jolly-fermat:latest","sandbox":"v2","scaling_option":{"cpu_usage_threshold":72},"secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-15T14:25:30.816438Z"}'
+        headers:
+            Content-Length:
+                - "947"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:25:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 676e7145-6509-4584-bc82-6fcb7dd6926b
+        status: 200 OK
+        code: 200
+        duration: 54.8425ms
+    - id: 30
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f65c58fe-37f2-4510-aff4-007a09dde1d4
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 947
+        uncompressed: false
+        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:25:12.144069Z","description":"","domain_name":"tfnshungryramanms1v4s2f-tf-co-jolly-fermat.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f65c58fe-37f2-4510-aff4-007a09dde1d4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":1,"name":"tf-co-jolly-fermat","namespace_id":"9c64cf6f-986b-43f5-add0-1c27794ab564","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f/tf-co-jolly-fermat:latest","sandbox":"v2","scaling_option":{"cpu_usage_threshold":72},"secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-15T14:25:30.816438Z"}'
+        headers:
+            Content-Length:
+                - "947"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:25:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 859ba456-639c-47e4-aa84-08ef53979f04
+        status: 200 OK
+        code: 200
+        duration: 61.547708ms
+    - id: 31
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f65c58fe-37f2-4510-aff4-007a09dde1d4
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 947
+        uncompressed: false
+        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:25:12.144069Z","description":"","domain_name":"tfnshungryramanms1v4s2f-tf-co-jolly-fermat.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f65c58fe-37f2-4510-aff4-007a09dde1d4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":1,"name":"tf-co-jolly-fermat","namespace_id":"9c64cf6f-986b-43f5-add0-1c27794ab564","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f/tf-co-jolly-fermat:latest","sandbox":"v2","scaling_option":{"cpu_usage_threshold":72},"secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-15T14:25:30.816438Z"}'
+        headers:
+            Content-Length:
+                - "947"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:25:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 36eff13f-2f75-49b2-8d49-079d069f44c7
+        status: 200 OK
+        code: 200
+        duration: 57.856875ms
+    - id: 32
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9c64cf6f-986b-43f5-add0-1c27794ab564
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 562
+        uncompressed: false
+        body: '{"created_at":"2025-01-15T14:25:06.718106Z","description":"","environment_variables":{},"error_message":null,"id":"9c64cf6f-986b-43f5-add0-1c27794ab564","name":"tf-ns-hungry-raman","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f","registry_namespace_id":"b4999fd9-3117-4019-9dae-a7d4efebde8e","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-15T14:25:10.179302Z"}'
+        headers:
+            Content-Length:
+                - "562"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:25:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 4b23f1db-c66a-4a60-adb0-16e884ec19f2
+        status: 200 OK
+        code: 200
+        duration: 41.669542ms
+    - id: 33
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f65c58fe-37f2-4510-aff4-007a09dde1d4
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 947
+        uncompressed: false
+        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:25:12.144069Z","description":"","domain_name":"tfnshungryramanms1v4s2f-tf-co-jolly-fermat.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f65c58fe-37f2-4510-aff4-007a09dde1d4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":1,"name":"tf-co-jolly-fermat","namespace_id":"9c64cf6f-986b-43f5-add0-1c27794ab564","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f/tf-co-jolly-fermat:latest","sandbox":"v2","scaling_option":{"cpu_usage_threshold":72},"secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-15T14:25:30.816438Z"}'
+        headers:
+            Content-Length:
+                - "947"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:25:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 53e890dd-0937-4df1-91ee-da2731665011
+        status: 200 OK
+        code: 200
+        duration: 53.509875ms
+    - id: 34
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9c64cf6f-986b-43f5-add0-1c27794ab564
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 562
+        uncompressed: false
+        body: '{"created_at":"2025-01-15T14:25:06.718106Z","description":"","environment_variables":{},"error_message":null,"id":"9c64cf6f-986b-43f5-add0-1c27794ab564","name":"tf-ns-hungry-raman","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f","registry_namespace_id":"b4999fd9-3117-4019-9dae-a7d4efebde8e","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-15T14:25:10.179302Z"}'
+        headers:
+            Content-Length:
+                - "562"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:25:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - aa31c1b5-65c7-446f-b195-ed8415b4819d
+        status: 200 OK
+        code: 200
+        duration: 41.19ms
+    - id: 35
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f65c58fe-37f2-4510-aff4-007a09dde1d4
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 947
+        uncompressed: false
+        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:25:12.144069Z","description":"","domain_name":"tfnshungryramanms1v4s2f-tf-co-jolly-fermat.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f65c58fe-37f2-4510-aff4-007a09dde1d4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":1,"name":"tf-co-jolly-fermat","namespace_id":"9c64cf6f-986b-43f5-add0-1c27794ab564","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f/tf-co-jolly-fermat:latest","sandbox":"v2","scaling_option":{"cpu_usage_threshold":72},"secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-15T14:25:30.816438Z"}'
+        headers:
+            Content-Length:
+                - "947"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:25:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - d5e18c95-5137-4d75-90d2-808b9a47d7ae
+        status: 200 OK
+        code: 200
+        duration: 65.242792ms
+    - id: 36
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9c64cf6f-986b-43f5-add0-1c27794ab564
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 562
+        uncompressed: false
+        body: '{"created_at":"2025-01-15T14:25:06.718106Z","description":"","environment_variables":{},"error_message":null,"id":"9c64cf6f-986b-43f5-add0-1c27794ab564","name":"tf-ns-hungry-raman","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f","registry_namespace_id":"b4999fd9-3117-4019-9dae-a7d4efebde8e","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-15T14:25:10.179302Z"}'
+        headers:
+            Content-Length:
+                - "562"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:25:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b598be2d-4ad9-4a07-a8e3-e7c69db14a41
+        status: 200 OK
+        code: 200
+        duration: 50.645292ms
+    - id: 37
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f65c58fe-37f2-4510-aff4-007a09dde1d4
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 947
+        uncompressed: false
+        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:25:12.144069Z","description":"","domain_name":"tfnshungryramanms1v4s2f-tf-co-jolly-fermat.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f65c58fe-37f2-4510-aff4-007a09dde1d4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":1,"name":"tf-co-jolly-fermat","namespace_id":"9c64cf6f-986b-43f5-add0-1c27794ab564","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f/tf-co-jolly-fermat:latest","sandbox":"v2","scaling_option":{"cpu_usage_threshold":72},"secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-15T14:25:30.816438Z"}'
+        headers:
+            Content-Length:
+                - "947"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:25:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b8b4066d-0b2f-4566-aaad-bc49db030ebe
+        status: 200 OK
+        code: 200
+        duration: 56.052792ms
+    - id: 38
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 206
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"privacy":"unknown_privacy","protocol":"unknown_protocol","secret_environment_variables":null,"http_option":"unknown_http_option","sandbox":"unknown_sandbox","scaling_option":{"memory_usage_threshold":66}}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f65c58fe-37f2-4510-aff4-007a09dde1d4
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 915
+        uncompressed: false
+        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:25:12.144069Z","description":"","domain_name":"tfnshungryramanms1v4s2f-tf-co-jolly-fermat.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f65c58fe-37f2-4510-aff4-007a09dde1d4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":1,"name":"tf-co-jolly-fermat","namespace_id":"9c64cf6f-986b-43f5-add0-1c27794ab564","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f/tf-co-jolly-fermat:latest","sandbox":"v2","scaling_option":{"memory_usage_threshold":66},"secret_environment_variables":[],"status":"pending","timeout":"300s","updated_at":"2025-01-15T14:25:35.505085545Z"}'
+        headers:
+            Content-Length:
+                - "915"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:25:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - cc35a6ca-bdda-41b8-bf78-cd13a1e39a1d
+        status: 200 OK
+        code: 200
+        duration: 101.10525ms
+    - id: 39
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f65c58fe-37f2-4510-aff4-007a09dde1d4
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 912
+        uncompressed: false
+        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:25:12.144069Z","description":"","domain_name":"tfnshungryramanms1v4s2f-tf-co-jolly-fermat.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f65c58fe-37f2-4510-aff4-007a09dde1d4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":1,"name":"tf-co-jolly-fermat","namespace_id":"9c64cf6f-986b-43f5-add0-1c27794ab564","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f/tf-co-jolly-fermat:latest","sandbox":"v2","scaling_option":{"memory_usage_threshold":66},"secret_environment_variables":[],"status":"pending","timeout":"300s","updated_at":"2025-01-15T14:25:35.505086Z"}'
+        headers:
+            Content-Length:
+                - "912"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:25:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e4cc464a-5b4f-427e-bd8a-f234008e8929
+        status: 200 OK
+        code: 200
+        duration: 53.779916ms
+    - id: 40
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f65c58fe-37f2-4510-aff4-007a09dde1d4
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 912
+        uncompressed: false
+        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:25:12.144069Z","description":"","domain_name":"tfnshungryramanms1v4s2f-tf-co-jolly-fermat.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f65c58fe-37f2-4510-aff4-007a09dde1d4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":1,"name":"tf-co-jolly-fermat","namespace_id":"9c64cf6f-986b-43f5-add0-1c27794ab564","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f/tf-co-jolly-fermat:latest","sandbox":"v2","scaling_option":{"memory_usage_threshold":66},"secret_environment_variables":[],"status":"pending","timeout":"300s","updated_at":"2025-01-15T14:25:35.505086Z"}'
+        headers:
+            Content-Length:
+                - "912"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:25:40 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - a2ba004c-f7b7-4e18-b91b-7946a1b6b5c8
+        status: 200 OK
+        code: 200
+        duration: 59.456583ms
+    - id: 41
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f65c58fe-37f2-4510-aff4-007a09dde1d4
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 950
+        uncompressed: false
+        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:25:12.144069Z","description":"","domain_name":"tfnshungryramanms1v4s2f-tf-co-jolly-fermat.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f65c58fe-37f2-4510-aff4-007a09dde1d4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":1,"name":"tf-co-jolly-fermat","namespace_id":"9c64cf6f-986b-43f5-add0-1c27794ab564","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f/tf-co-jolly-fermat:latest","sandbox":"v2","scaling_option":{"memory_usage_threshold":66},"secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-15T14:25:42.109483Z"}'
+        headers:
+            Content-Length:
+                - "950"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:25:45 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f88014a2-c23f-4438-a6b8-7e381495cf22
+        status: 200 OK
+        code: 200
+        duration: 85.053875ms
+    - id: 42
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f65c58fe-37f2-4510-aff4-007a09dde1d4
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 950
+        uncompressed: false
+        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:25:12.144069Z","description":"","domain_name":"tfnshungryramanms1v4s2f-tf-co-jolly-fermat.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f65c58fe-37f2-4510-aff4-007a09dde1d4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":1,"name":"tf-co-jolly-fermat","namespace_id":"9c64cf6f-986b-43f5-add0-1c27794ab564","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f/tf-co-jolly-fermat:latest","sandbox":"v2","scaling_option":{"memory_usage_threshold":66},"secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-15T14:25:42.109483Z"}'
+        headers:
+            Content-Length:
+                - "950"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:25:45 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3c509044-aa3d-4b37-b43a-2b867e404ab8
+        status: 200 OK
+        code: 200
+        duration: 57.478291ms
+    - id: 43
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f65c58fe-37f2-4510-aff4-007a09dde1d4
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 950
+        uncompressed: false
+        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:25:12.144069Z","description":"","domain_name":"tfnshungryramanms1v4s2f-tf-co-jolly-fermat.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f65c58fe-37f2-4510-aff4-007a09dde1d4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":1,"name":"tf-co-jolly-fermat","namespace_id":"9c64cf6f-986b-43f5-add0-1c27794ab564","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f/tf-co-jolly-fermat:latest","sandbox":"v2","scaling_option":{"memory_usage_threshold":66},"secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-15T14:25:42.109483Z"}'
+        headers:
+            Content-Length:
+                - "950"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:25:45 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 1160e60b-afec-4d97-8d4c-c15529a8d204
+        status: 200 OK
+        code: 200
+        duration: 53.333334ms
+    - id: 44
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9c64cf6f-986b-43f5-add0-1c27794ab564
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 562
+        uncompressed: false
+        body: '{"created_at":"2025-01-15T14:25:06.718106Z","description":"","environment_variables":{},"error_message":null,"id":"9c64cf6f-986b-43f5-add0-1c27794ab564","name":"tf-ns-hungry-raman","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f","registry_namespace_id":"b4999fd9-3117-4019-9dae-a7d4efebde8e","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-15T14:25:10.179302Z"}'
+        headers:
+            Content-Length:
+                - "562"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:25:46 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - bb08d95e-b42e-452a-b746-9358f8e526e8
+        status: 200 OK
+        code: 200
+        duration: 40.447959ms
+    - id: 45
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f65c58fe-37f2-4510-aff4-007a09dde1d4
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 950
+        uncompressed: false
+        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:25:12.144069Z","description":"","domain_name":"tfnshungryramanms1v4s2f-tf-co-jolly-fermat.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f65c58fe-37f2-4510-aff4-007a09dde1d4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":1,"name":"tf-co-jolly-fermat","namespace_id":"9c64cf6f-986b-43f5-add0-1c27794ab564","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f/tf-co-jolly-fermat:latest","sandbox":"v2","scaling_option":{"memory_usage_threshold":66},"secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-15T14:25:42.109483Z"}'
+        headers:
+            Content-Length:
+                - "950"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:25:46 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3c66c6b5-7a7c-4131-bfe4-9ed0ac8fb22f
+        status: 200 OK
+        code: 200
+        duration: 60.754292ms
+    - id: 46
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f65c58fe-37f2-4510-aff4-007a09dde1d4
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 950
+        uncompressed: false
+        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:25:12.144069Z","description":"","domain_name":"tfnshungryramanms1v4s2f-tf-co-jolly-fermat.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f65c58fe-37f2-4510-aff4-007a09dde1d4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":1,"name":"tf-co-jolly-fermat","namespace_id":"9c64cf6f-986b-43f5-add0-1c27794ab564","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f/tf-co-jolly-fermat:latest","sandbox":"v2","scaling_option":{"memory_usage_threshold":66},"secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-15T14:25:42.109483Z"}'
+        headers:
+            Content-Length:
+                - "950"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:25:46 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3b07544c-3469-443d-82d9-27463160f453
+        status: 200 OK
+        code: 200
+        duration: 48.908375ms
+    - id: 47
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f65c58fe-37f2-4510-aff4-007a09dde1d4
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 916
+        uncompressed: false
+        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:25:12.144069Z","description":"","domain_name":"tfnshungryramanms1v4s2f-tf-co-jolly-fermat.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f65c58fe-37f2-4510-aff4-007a09dde1d4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":1,"name":"tf-co-jolly-fermat","namespace_id":"9c64cf6f-986b-43f5-add0-1c27794ab564","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f/tf-co-jolly-fermat:latest","sandbox":"v2","scaling_option":{"memory_usage_threshold":66},"secret_environment_variables":[],"status":"deleting","timeout":"300s","updated_at":"2025-01-15T14:25:46.416251395Z"}'
+        headers:
+            Content-Length:
+                - "916"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:25:46 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e2730b9c-039d-4f38-afa0-57006b6c5cf2
+        status: 200 OK
+        code: 200
+        duration: 130.466083ms
+    - id: 48
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9c64cf6f-986b-43f5-add0-1c27794ab564
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 562
+        uncompressed: false
+        body: '{"created_at":"2025-01-15T14:25:06.718106Z","description":"","environment_variables":{},"error_message":null,"id":"9c64cf6f-986b-43f5-add0-1c27794ab564","name":"tf-ns-hungry-raman","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f","registry_namespace_id":"b4999fd9-3117-4019-9dae-a7d4efebde8e","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-15T14:25:10.179302Z"}'
+        headers:
+            Content-Length:
+                - "562"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:25:46 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 0da9fcad-ed15-4a3e-9fa4-5dd03e4319b2
+        status: 200 OK
+        code: 200
+        duration: 43.409458ms
+    - id: 49
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9c64cf6f-986b-43f5-add0-1c27794ab564
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 568
+        uncompressed: false
+        body: '{"created_at":"2025-01-15T14:25:06.718106Z","description":"","environment_variables":{},"error_message":null,"id":"9c64cf6f-986b-43f5-add0-1c27794ab564","name":"tf-ns-hungry-raman","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f","registry_namespace_id":"b4999fd9-3117-4019-9dae-a7d4efebde8e","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-15T14:25:46.585675920Z"}'
+        headers:
+            Content-Length:
+                - "568"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:25:46 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - fa506295-1c6e-4380-927c-f1b3511afb23
+        status: 200 OK
+        code: 200
+        duration: 199.553375ms
+    - id: 50
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9c64cf6f-986b-43f5-add0-1c27794ab564
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 565
+        uncompressed: false
+        body: '{"created_at":"2025-01-15T14:25:06.718106Z","description":"","environment_variables":{},"error_message":null,"id":"9c64cf6f-986b-43f5-add0-1c27794ab564","name":"tf-ns-hungry-raman","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f","registry_namespace_id":"b4999fd9-3117-4019-9dae-a7d4efebde8e","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-15T14:25:46.585676Z"}'
+        headers:
+            Content-Length:
+                - "565"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:25:46 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 4f2dd73d-330f-4d99-b75f-b11130c38167
+        status: 200 OK
+        code: 200
+        duration: 43.101584ms
+    - id: 51
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9c64cf6f-986b-43f5-add0-1c27794ab564
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 565
+        uncompressed: false
+        body: '{"created_at":"2025-01-15T14:25:06.718106Z","description":"","environment_variables":{},"error_message":null,"id":"9c64cf6f-986b-43f5-add0-1c27794ab564","name":"tf-ns-hungry-raman","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f","registry_namespace_id":"b4999fd9-3117-4019-9dae-a7d4efebde8e","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-15T14:25:46.585676Z"}'
+        headers:
+            Content-Length:
+                - "565"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:25:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 5ab53f49-70d8-4929-9616-4281a338f852
+        status: 200 OK
+        code: 200
+        duration: 41.22025ms
+    - id: 52
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9c64cf6f-986b-43f5-add0-1c27794ab564
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 565
+        uncompressed: false
+        body: '{"created_at":"2025-01-15T14:25:06.718106Z","description":"","environment_variables":{},"error_message":null,"id":"9c64cf6f-986b-43f5-add0-1c27794ab564","name":"tf-ns-hungry-raman","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f","registry_namespace_id":"b4999fd9-3117-4019-9dae-a7d4efebde8e","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-15T14:25:46.585676Z"}'
+        headers:
+            Content-Length:
+                - "565"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:25:56 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 03417a20-7d26-4633-a30e-1a7b814aa717
+        status: 200 OK
+        code: 200
+        duration: 41.028792ms
+    - id: 53
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9c64cf6f-986b-43f5-add0-1c27794ab564
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 565
+        uncompressed: false
+        body: '{"created_at":"2025-01-15T14:25:06.718106Z","description":"","environment_variables":{},"error_message":null,"id":"9c64cf6f-986b-43f5-add0-1c27794ab564","name":"tf-ns-hungry-raman","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f","registry_namespace_id":"b4999fd9-3117-4019-9dae-a7d4efebde8e","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-15T14:25:46.585676Z"}'
+        headers:
+            Content-Length:
+                - "565"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:26:01 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 76357d56-09ad-457a-9366-393a6509ad1f
+        status: 200 OK
+        code: 200
+        duration: 49.138708ms
+    - id: 54
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9c64cf6f-986b-43f5-add0-1c27794ab564
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 565
+        uncompressed: false
+        body: '{"created_at":"2025-01-15T14:25:06.718106Z","description":"","environment_variables":{},"error_message":null,"id":"9c64cf6f-986b-43f5-add0-1c27794ab564","name":"tf-ns-hungry-raman","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f","registry_namespace_id":"b4999fd9-3117-4019-9dae-a7d4efebde8e","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-15T14:25:46.585676Z"}'
+        headers:
+            Content-Length:
+                - "565"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:26:06 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 013ea993-8d0e-4035-b0ba-d5051de108ea
+        status: 200 OK
+        code: 200
+        duration: 54.541167ms
+    - id: 55
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9c64cf6f-986b-43f5-add0-1c27794ab564
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 565
+        uncompressed: false
+        body: '{"created_at":"2025-01-15T14:25:06.718106Z","description":"","environment_variables":{},"error_message":null,"id":"9c64cf6f-986b-43f5-add0-1c27794ab564","name":"tf-ns-hungry-raman","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f","registry_namespace_id":"b4999fd9-3117-4019-9dae-a7d4efebde8e","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-15T14:25:46.585676Z"}'
+        headers:
+            Content-Length:
+                - "565"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:26:12 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 0bb48bf1-2637-4944-b96f-41ed581b02c5
+        status: 200 OK
+        code: 200
+        duration: 43.820917ms
+    - id: 56
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9c64cf6f-986b-43f5-add0-1c27794ab564
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 37
+        uncompressed: false
+        body: '{"message":"Namespace was not found"}'
+        headers:
+            Content-Length:
+                - "37"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:26:17 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 1bddd23c-61d9-4020-8f43-966a96d0d201
+        status: 404 Not Found
+        code: 404
+        duration: 35.173708ms
+    - id: 57
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/9c64cf6f-986b-43f5-add0-1c27794ab564
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 37
+        uncompressed: false
+        body: '{"message":"Container was not found"}'
+        headers:
+            Content-Length:
+                - "37"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:26:17 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - aa864c87-8d67-4812-8031-00a125b27abc
+        status: 404 Not Found
+        code: 404
+        duration: 31.993458ms

--- a/internal/services/container/testdata/data-source-container-scaling-option.cassette.yaml
+++ b/internal/services/container/testdata/data-source-container-scaling-option.cassette.yaml
@@ -1,0 +1,1624 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 153
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"name":"tf-ns-happy-gould","environment_variables":{},"project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","secret_environment_variables":[],"tags":null}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 483
+        uncompressed: false
+        body: '{"created_at":"2025-01-15T14:43:21.307205802Z","description":"","environment_variables":{},"error_message":null,"id":"c3c7af1b-4e47-45af-99da-e8a3bb5a5c86","name":"tf-ns-happy-gould","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-15T14:43:21.307205802Z"}'
+        headers:
+            Content-Length:
+                - "483"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:43:21 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 87a0dc82-97f3-4540-8054-cb4961b155b4
+        status: 200 OK
+        code: 200
+        duration: 438.462875ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c3c7af1b-4e47-45af-99da-e8a3bb5a5c86
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 477
+        uncompressed: false
+        body: '{"created_at":"2025-01-15T14:43:21.307206Z","description":"","environment_variables":{},"error_message":null,"id":"c3c7af1b-4e47-45af-99da-e8a3bb5a5c86","name":"tf-ns-happy-gould","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-15T14:43:21.307206Z"}'
+        headers:
+            Content-Length:
+                - "477"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:43:21 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - fb9bacaa-0b81-4b52-bd9d-24a59fcb585c
+        status: 200 OK
+        code: 200
+        duration: 41.378291ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c3c7af1b-4e47-45af-99da-e8a3bb5a5c86
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 562
+        uncompressed: false
+        body: '{"created_at":"2025-01-15T14:43:21.307206Z","description":"","environment_variables":{},"error_message":null,"id":"c3c7af1b-4e47-45af-99da-e8a3bb5a5c86","name":"tf-ns-happy-gould","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshappygouldsn1vqbrl","registry_namespace_id":"a1825a3d-2245-4554-abee-b011122a7fbe","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-15T14:43:23.371902Z"}'
+        headers:
+            Content-Length:
+                - "562"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:43:26 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3f8d921c-f38e-4094-b498-9aa4bdb7853e
+        status: 200 OK
+        code: 200
+        duration: 49.187292ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c3c7af1b-4e47-45af-99da-e8a3bb5a5c86
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 562
+        uncompressed: false
+        body: '{"created_at":"2025-01-15T14:43:21.307206Z","description":"","environment_variables":{},"error_message":null,"id":"c3c7af1b-4e47-45af-99da-e8a3bb5a5c86","name":"tf-ns-happy-gould","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshappygouldsn1vqbrl","registry_namespace_id":"a1825a3d-2245-4554-abee-b011122a7fbe","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-15T14:43:23.371902Z"}'
+        headers:
+            Content-Length:
+                - "562"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:43:31 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 7bdac94b-9f32-4f17-8d79-dcc11f73cb79
+        status: 200 OK
+        code: 200
+        duration: 44.478584ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c3c7af1b-4e47-45af-99da-e8a3bb5a5c86
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 562
+        uncompressed: false
+        body: '{"created_at":"2025-01-15T14:43:21.307206Z","description":"","environment_variables":{},"error_message":null,"id":"c3c7af1b-4e47-45af-99da-e8a3bb5a5c86","name":"tf-ns-happy-gould","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshappygouldsn1vqbrl","registry_namespace_id":"a1825a3d-2245-4554-abee-b011122a7fbe","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-15T14:43:23.371902Z"}'
+        headers:
+            Content-Length:
+                - "562"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:43:36 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 429025f7-4f85-4b71-ac95-92038e5b5609
+        status: 200 OK
+        code: 200
+        duration: 48.278291ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c3c7af1b-4e47-45af-99da-e8a3bb5a5c86
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 562
+        uncompressed: false
+        body: '{"created_at":"2025-01-15T14:43:21.307206Z","description":"","environment_variables":{},"error_message":null,"id":"c3c7af1b-4e47-45af-99da-e8a3bb5a5c86","name":"tf-ns-happy-gould","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshappygouldsn1vqbrl","registry_namespace_id":"a1825a3d-2245-4554-abee-b011122a7fbe","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-15T14:43:23.371902Z"}'
+        headers:
+            Content-Length:
+                - "562"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:43:41 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b7a9b81d-cbbe-42f1-92c6-7a7a4d3d5b7c
+        status: 200 OK
+        code: 200
+        duration: 63.925125ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c3c7af1b-4e47-45af-99da-e8a3bb5a5c86
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 562
+        uncompressed: false
+        body: '{"created_at":"2025-01-15T14:43:21.307206Z","description":"","environment_variables":{},"error_message":null,"id":"c3c7af1b-4e47-45af-99da-e8a3bb5a5c86","name":"tf-ns-happy-gould","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshappygouldsn1vqbrl","registry_namespace_id":"a1825a3d-2245-4554-abee-b011122a7fbe","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-15T14:43:23.371902Z"}'
+        headers:
+            Content-Length:
+                - "562"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:43:46 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 13ea3858-ac13-4e89-8790-bd3c089ae5d0
+        status: 200 OK
+        code: 200
+        duration: 53.102667ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c3c7af1b-4e47-45af-99da-e8a3bb5a5c86
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 562
+        uncompressed: false
+        body: '{"created_at":"2025-01-15T14:43:21.307206Z","description":"","environment_variables":{},"error_message":null,"id":"c3c7af1b-4e47-45af-99da-e8a3bb5a5c86","name":"tf-ns-happy-gould","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshappygouldsn1vqbrl","registry_namespace_id":"a1825a3d-2245-4554-abee-b011122a7fbe","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-15T14:43:23.371902Z"}'
+        headers:
+            Content-Length:
+                - "562"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:43:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 23239b86-6b05-4935-93d5-9a643a5ea6fb
+        status: 200 OK
+        code: 200
+        duration: 54.749584ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c3c7af1b-4e47-45af-99da-e8a3bb5a5c86
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 560
+        uncompressed: false
+        body: '{"created_at":"2025-01-15T14:43:21.307206Z","description":"","environment_variables":{},"error_message":null,"id":"c3c7af1b-4e47-45af-99da-e8a3bb5a5c86","name":"tf-ns-happy-gould","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshappygouldsn1vqbrl","registry_namespace_id":"a1825a3d-2245-4554-abee-b011122a7fbe","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-15T14:43:53.723511Z"}'
+        headers:
+            Content-Length:
+                - "560"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:43:57 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 5d2bb2c3-4baf-4799-9404-9661e55a1889
+        status: 200 OK
+        code: 200
+        duration: 272.634667ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c3c7af1b-4e47-45af-99da-e8a3bb5a5c86
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 560
+        uncompressed: false
+        body: '{"created_at":"2025-01-15T14:43:21.307206Z","description":"","environment_variables":{},"error_message":null,"id":"c3c7af1b-4e47-45af-99da-e8a3bb5a5c86","name":"tf-ns-happy-gould","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshappygouldsn1vqbrl","registry_namespace_id":"a1825a3d-2245-4554-abee-b011122a7fbe","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-15T14:43:53.723511Z"}'
+        headers:
+            Content-Length:
+                - "560"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:43:57 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 6e03246a-d920-4c1c-a27d-5a328dad3e64
+        status: 200 OK
+        code: 200
+        duration: 606.923166ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c3c7af1b-4e47-45af-99da-e8a3bb5a5c86
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 560
+        uncompressed: false
+        body: '{"created_at":"2025-01-15T14:43:21.307206Z","description":"","environment_variables":{},"error_message":null,"id":"c3c7af1b-4e47-45af-99da-e8a3bb5a5c86","name":"tf-ns-happy-gould","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshappygouldsn1vqbrl","registry_namespace_id":"a1825a3d-2245-4554-abee-b011122a7fbe","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-15T14:43:53.723511Z"}'
+        headers:
+            Content-Length:
+                - "560"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:43:57 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 18684d58-38a0-4258-a6c6-f7a88cc01e3e
+        status: 200 OK
+        code: 200
+        duration: 119.093208ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 212
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"namespace_id":"c3c7af1b-4e47-45af-99da-e8a3bb5a5c86","name":"tf-co-hardcore-agnesi","privacy":"public","protocol":"http1","secret_environment_variables":null,"http_option":"enabled","sandbox":"unknown_sandbox"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 932
+        uncompressed: false
+        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:43:58.056116619Z","description":"","domain_name":"tfnshappygouldsn1vqbrl-tf-co-hardcore-agnesi.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"93e0702b-9a39-4ee2-be0c-d43edb3eff3c","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-hardcore-agnesi","namespace_id":"c3c7af1b-4e47-45af-99da-e8a3bb5a5c86","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshappygouldsn1vqbrl/tf-co-hardcore-agnesi:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-15T14:43:58.056116619Z"}'
+        headers:
+            Content-Length:
+                - "932"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:43:58 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 4ba25ae0-cd16-40c2-bd74-6e2bc29b31e1
+        status: 200 OK
+        code: 200
+        duration: 371.138833ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/93e0702b-9a39-4ee2-be0c-d43edb3eff3c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 926
+        uncompressed: false
+        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:43:58.056117Z","description":"","domain_name":"tfnshappygouldsn1vqbrl-tf-co-hardcore-agnesi.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"93e0702b-9a39-4ee2-be0c-d43edb3eff3c","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-hardcore-agnesi","namespace_id":"c3c7af1b-4e47-45af-99da-e8a3bb5a5c86","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshappygouldsn1vqbrl/tf-co-hardcore-agnesi:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-15T14:43:58.056117Z"}'
+        headers:
+            Content-Length:
+                - "926"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:43:58 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 2d8c5e4c-a8ba-4634-ae88-39507d8b88e5
+        status: 200 OK
+        code: 200
+        duration: 61.921417ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/93e0702b-9a39-4ee2-be0c-d43edb3eff3c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 926
+        uncompressed: false
+        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:43:58.056117Z","description":"","domain_name":"tfnshappygouldsn1vqbrl-tf-co-hardcore-agnesi.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"93e0702b-9a39-4ee2-be0c-d43edb3eff3c","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-hardcore-agnesi","namespace_id":"c3c7af1b-4e47-45af-99da-e8a3bb5a5c86","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshappygouldsn1vqbrl/tf-co-hardcore-agnesi:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-15T14:43:58.056117Z"}'
+        headers:
+            Content-Length:
+                - "926"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:43:58 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 921130d3-4259-4803-bd66-6f4f35d96d84
+        status: 200 OK
+        code: 200
+        duration: 62.9315ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/93e0702b-9a39-4ee2-be0c-d43edb3eff3c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 926
+        uncompressed: false
+        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:43:58.056117Z","description":"","domain_name":"tfnshappygouldsn1vqbrl-tf-co-hardcore-agnesi.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"93e0702b-9a39-4ee2-be0c-d43edb3eff3c","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-hardcore-agnesi","namespace_id":"c3c7af1b-4e47-45af-99da-e8a3bb5a5c86","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshappygouldsn1vqbrl/tf-co-hardcore-agnesi:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-15T14:43:58.056117Z"}'
+        headers:
+            Content-Length:
+                - "926"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:43:58 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ca6c94ee-e1fd-412c-84e0-565f326845e9
+        status: 200 OK
+        code: 200
+        duration: 101.7385ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/93e0702b-9a39-4ee2-be0c-d43edb3eff3c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 926
+        uncompressed: false
+        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:43:58.056117Z","description":"","domain_name":"tfnshappygouldsn1vqbrl-tf-co-hardcore-agnesi.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"93e0702b-9a39-4ee2-be0c-d43edb3eff3c","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-hardcore-agnesi","namespace_id":"c3c7af1b-4e47-45af-99da-e8a3bb5a5c86","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshappygouldsn1vqbrl/tf-co-hardcore-agnesi:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-15T14:43:58.056117Z"}'
+        headers:
+            Content-Length:
+                - "926"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:43:58 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 9d70617c-3f5a-447b-bcad-e6de2dc0a499
+        status: 200 OK
+        code: 200
+        duration: 86.351375ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c3c7af1b-4e47-45af-99da-e8a3bb5a5c86
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 560
+        uncompressed: false
+        body: '{"created_at":"2025-01-15T14:43:21.307206Z","description":"","environment_variables":{},"error_message":null,"id":"c3c7af1b-4e47-45af-99da-e8a3bb5a5c86","name":"tf-ns-happy-gould","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshappygouldsn1vqbrl","registry_namespace_id":"a1825a3d-2245-4554-abee-b011122a7fbe","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-15T14:43:53.723511Z"}'
+        headers:
+            Content-Length:
+                - "560"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:43:58 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 0bc426ba-c2e6-4d95-9b3f-268fbd0ddbcb
+        status: 200 OK
+        code: 200
+        duration: 51.516292ms
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/93e0702b-9a39-4ee2-be0c-d43edb3eff3c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 926
+        uncompressed: false
+        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:43:58.056117Z","description":"","domain_name":"tfnshappygouldsn1vqbrl-tf-co-hardcore-agnesi.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"93e0702b-9a39-4ee2-be0c-d43edb3eff3c","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-hardcore-agnesi","namespace_id":"c3c7af1b-4e47-45af-99da-e8a3bb5a5c86","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshappygouldsn1vqbrl/tf-co-hardcore-agnesi:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-15T14:43:58.056117Z"}'
+        headers:
+            Content-Length:
+                - "926"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:43:58 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 95c1ff5a-e876-470b-9e25-4aa705435d4b
+        status: 200 OK
+        code: 200
+        duration: 70.799125ms
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/93e0702b-9a39-4ee2-be0c-d43edb3eff3c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 926
+        uncompressed: false
+        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:43:58.056117Z","description":"","domain_name":"tfnshappygouldsn1vqbrl-tf-co-hardcore-agnesi.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"93e0702b-9a39-4ee2-be0c-d43edb3eff3c","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-hardcore-agnesi","namespace_id":"c3c7af1b-4e47-45af-99da-e8a3bb5a5c86","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshappygouldsn1vqbrl/tf-co-hardcore-agnesi:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-15T14:43:58.056117Z"}'
+        headers:
+            Content-Length:
+                - "926"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:43:58 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - df04e135-fc94-40a0-80d9-dc2f9cd58007
+        status: 200 OK
+        code: 200
+        duration: 53.4135ms
+    - id: 19
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/93e0702b-9a39-4ee2-be0c-d43edb3eff3c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 926
+        uncompressed: false
+        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:43:58.056117Z","description":"","domain_name":"tfnshappygouldsn1vqbrl-tf-co-hardcore-agnesi.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"93e0702b-9a39-4ee2-be0c-d43edb3eff3c","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-hardcore-agnesi","namespace_id":"c3c7af1b-4e47-45af-99da-e8a3bb5a5c86","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshappygouldsn1vqbrl/tf-co-hardcore-agnesi:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-15T14:43:58.056117Z"}'
+        headers:
+            Content-Length:
+                - "926"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:43:58 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3026702d-d147-435d-a8fd-f49c0bb9a63c
+        status: 200 OK
+        code: 200
+        duration: 49.423625ms
+    - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/93e0702b-9a39-4ee2-be0c-d43edb3eff3c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 926
+        uncompressed: false
+        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:43:58.056117Z","description":"","domain_name":"tfnshappygouldsn1vqbrl-tf-co-hardcore-agnesi.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"93e0702b-9a39-4ee2-be0c-d43edb3eff3c","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-hardcore-agnesi","namespace_id":"c3c7af1b-4e47-45af-99da-e8a3bb5a5c86","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshappygouldsn1vqbrl/tf-co-hardcore-agnesi:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-15T14:43:58.056117Z"}'
+        headers:
+            Content-Length:
+                - "926"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:43:59 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 6846d94e-cf5e-4831-9b6b-04f4037aa0aa
+        status: 200 OK
+        code: 200
+        duration: 64.481167ms
+    - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/93e0702b-9a39-4ee2-be0c-d43edb3eff3c
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 930
+        uncompressed: false
+        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:43:58.056117Z","description":"","domain_name":"tfnshappygouldsn1vqbrl-tf-co-hardcore-agnesi.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"93e0702b-9a39-4ee2-be0c-d43edb3eff3c","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-hardcore-agnesi","namespace_id":"c3c7af1b-4e47-45af-99da-e8a3bb5a5c86","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshappygouldsn1vqbrl/tf-co-hardcore-agnesi:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"deleting","timeout":"300s","updated_at":"2025-01-15T14:43:59.194545102Z"}'
+        headers:
+            Content-Length:
+                - "930"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:43:59 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 34f7dc91-7b02-4387-8ed7-2d64fec1f7c4
+        status: 200 OK
+        code: 200
+        duration: 146.539958ms
+    - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c3c7af1b-4e47-45af-99da-e8a3bb5a5c86
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 560
+        uncompressed: false
+        body: '{"created_at":"2025-01-15T14:43:21.307206Z","description":"","environment_variables":{},"error_message":null,"id":"c3c7af1b-4e47-45af-99da-e8a3bb5a5c86","name":"tf-ns-happy-gould","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshappygouldsn1vqbrl","registry_namespace_id":"a1825a3d-2245-4554-abee-b011122a7fbe","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-15T14:43:53.723511Z"}'
+        headers:
+            Content-Length:
+                - "560"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:43:59 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b8fbaaf3-0092-4e20-a066-f85e9ca71a7a
+        status: 200 OK
+        code: 200
+        duration: 61.746834ms
+    - id: 23
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c3c7af1b-4e47-45af-99da-e8a3bb5a5c86
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 566
+        uncompressed: false
+        body: '{"created_at":"2025-01-15T14:43:21.307206Z","description":"","environment_variables":{},"error_message":null,"id":"c3c7af1b-4e47-45af-99da-e8a3bb5a5c86","name":"tf-ns-happy-gould","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshappygouldsn1vqbrl","registry_namespace_id":"a1825a3d-2245-4554-abee-b011122a7fbe","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-15T14:43:59.400292789Z"}'
+        headers:
+            Content-Length:
+                - "566"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:44:00 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 1976ebc7-d007-4bf6-bec2-09f9c33cf326
+        status: 200 OK
+        code: 200
+        duration: 690.18225ms
+    - id: 24
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c3c7af1b-4e47-45af-99da-e8a3bb5a5c86
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 563
+        uncompressed: false
+        body: '{"created_at":"2025-01-15T14:43:21.307206Z","description":"","environment_variables":{},"error_message":null,"id":"c3c7af1b-4e47-45af-99da-e8a3bb5a5c86","name":"tf-ns-happy-gould","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshappygouldsn1vqbrl","registry_namespace_id":"a1825a3d-2245-4554-abee-b011122a7fbe","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-15T14:43:59.400293Z"}'
+        headers:
+            Content-Length:
+                - "563"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:44:00 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 8a57d96b-8a0c-4687-ad57-3f2d11fa33b2
+        status: 200 OK
+        code: 200
+        duration: 74.716166ms
+    - id: 25
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c3c7af1b-4e47-45af-99da-e8a3bb5a5c86
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 563
+        uncompressed: false
+        body: '{"created_at":"2025-01-15T14:43:21.307206Z","description":"","environment_variables":{},"error_message":null,"id":"c3c7af1b-4e47-45af-99da-e8a3bb5a5c86","name":"tf-ns-happy-gould","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshappygouldsn1vqbrl","registry_namespace_id":"a1825a3d-2245-4554-abee-b011122a7fbe","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-15T14:43:59.400293Z"}'
+        headers:
+            Content-Length:
+                - "563"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:44:05 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 04f6faa3-3d32-4d10-a540-03bb6f2b452b
+        status: 200 OK
+        code: 200
+        duration: 45.075333ms
+    - id: 26
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c3c7af1b-4e47-45af-99da-e8a3bb5a5c86
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 563
+        uncompressed: false
+        body: '{"created_at":"2025-01-15T14:43:21.307206Z","description":"","environment_variables":{},"error_message":null,"id":"c3c7af1b-4e47-45af-99da-e8a3bb5a5c86","name":"tf-ns-happy-gould","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshappygouldsn1vqbrl","registry_namespace_id":"a1825a3d-2245-4554-abee-b011122a7fbe","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-15T14:43:59.400293Z"}'
+        headers:
+            Content-Length:
+                - "563"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:44:10 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - a59e69ab-bc68-497b-8e69-aca5718f8b35
+        status: 200 OK
+        code: 200
+        duration: 44.604ms
+    - id: 27
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c3c7af1b-4e47-45af-99da-e8a3bb5a5c86
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 563
+        uncompressed: false
+        body: '{"created_at":"2025-01-15T14:43:21.307206Z","description":"","environment_variables":{},"error_message":null,"id":"c3c7af1b-4e47-45af-99da-e8a3bb5a5c86","name":"tf-ns-happy-gould","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshappygouldsn1vqbrl","registry_namespace_id":"a1825a3d-2245-4554-abee-b011122a7fbe","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-15T14:43:59.400293Z"}'
+        headers:
+            Content-Length:
+                - "563"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:44:15 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - bd3661fb-50d8-4d4b-a1f8-820c83a2eec6
+        status: 200 OK
+        code: 200
+        duration: 46.504833ms
+    - id: 28
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c3c7af1b-4e47-45af-99da-e8a3bb5a5c86
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 563
+        uncompressed: false
+        body: '{"created_at":"2025-01-15T14:43:21.307206Z","description":"","environment_variables":{},"error_message":null,"id":"c3c7af1b-4e47-45af-99da-e8a3bb5a5c86","name":"tf-ns-happy-gould","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshappygouldsn1vqbrl","registry_namespace_id":"a1825a3d-2245-4554-abee-b011122a7fbe","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-15T14:43:59.400293Z"}'
+        headers:
+            Content-Length:
+                - "563"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:44:20 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 8c0cf167-d89f-4713-a162-e85f9e251360
+        status: 200 OK
+        code: 200
+        duration: 51.156292ms
+    - id: 29
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c3c7af1b-4e47-45af-99da-e8a3bb5a5c86
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 563
+        uncompressed: false
+        body: '{"created_at":"2025-01-15T14:43:21.307206Z","description":"","environment_variables":{},"error_message":null,"id":"c3c7af1b-4e47-45af-99da-e8a3bb5a5c86","name":"tf-ns-happy-gould","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshappygouldsn1vqbrl","registry_namespace_id":"a1825a3d-2245-4554-abee-b011122a7fbe","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-15T14:43:59.400293Z"}'
+        headers:
+            Content-Length:
+                - "563"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:44:25 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 7d3e05ed-14ce-47ad-888b-7c5219ed97fc
+        status: 200 OK
+        code: 200
+        duration: 59.212291ms
+    - id: 30
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c3c7af1b-4e47-45af-99da-e8a3bb5a5c86
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 563
+        uncompressed: false
+        body: '{"created_at":"2025-01-15T14:43:21.307206Z","description":"","environment_variables":{},"error_message":null,"id":"c3c7af1b-4e47-45af-99da-e8a3bb5a5c86","name":"tf-ns-happy-gould","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshappygouldsn1vqbrl","registry_namespace_id":"a1825a3d-2245-4554-abee-b011122a7fbe","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-15T14:43:59.400293Z"}'
+        headers:
+            Content-Length:
+                - "563"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:44:30 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 795ab630-92d8-4e32-bb84-32aa6feb568e
+        status: 200 OK
+        code: 200
+        duration: 61.089208ms
+    - id: 31
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c3c7af1b-4e47-45af-99da-e8a3bb5a5c86
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 37
+        uncompressed: false
+        body: '{"message":"Namespace was not found"}'
+        headers:
+            Content-Length:
+                - "37"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:44:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e38d7376-7f97-4e28-86a7-f30a491e829b
+        status: 404 Not Found
+        code: 404
+        duration: 36.563125ms
+    - id: 32
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c3c7af1b-4e47-45af-99da-e8a3bb5a5c86
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 37
+        uncompressed: false
+        body: '{"message":"Namespace was not found"}'
+        headers:
+            Content-Length:
+                - "37"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 15 Jan 2025 14:44:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3397b93a-f696-48c3-895c-dc28ee914cb8
+        status: 404 Not Found
+        code: 404
+        duration: 31.835125ms


### PR DESCRIPTION
### Description
A new ScalingOption object was added to containers. It replace current max_concurrency. The old field should be marked as deprecated while adding the new object.

API Reference: https://www.scaleway.com/en/developers/api/serverless-containers/#path-containers-create-a-new-container

### New or Affected Resource(s)
* scaleway_container

### Terraform configuration
```terraform
resource scaleway_container main {
    namespace_id = scaleway_container_namespace.main.id
    deploy = false
    
    scaling_option {
        concurrent_requests_threshold = 15
    }
}
```

### Related issues
* https://github.com/scaleway/terraform-provider-scaleway/issues/2811
* https://github.com/scaleway/terraform-provider-scaleway/issues/2812

### Notes for the reviewer(s)
* Using `scaling_option` terraform configuration to be compliant with the API.
* Acceptance tests from real calls have been created on both resource and data.
* Documentation has been updated.
* An error is thrown if the user setup more than one option (according to API this should not be possible).
* Errors has not been checked with specific tests cases, it may be useful (but I don't know how to do it).