### PR TITLE
docs: importing a secret is not correct

### DIFF
--- a/docs/resources/secret.md
+++ b/docs/resources/secret.md
@@ -69,8 +69,8 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-This section explains how to import a secret using the `{region}/{id}` format.
+This section explains how to import a secret using the `{region}/{id}/{version}` format.
 
 ```bash
-terraform import scaleway_secret.main fr-par/11111111-1111-1111-1111-111111111111
+terraform import scaleway_secret.main fr-par/11111111-1111-1111-1111-111111111111/1
 ```


### PR DESCRIPTION
The documentation was not correct. 

Importing a secret with `{region}/{id}` will result in the following: 

```
Error: cant parse localized id: fr-par/11111111-1111-1111-1111-111111111111
```

Turns out the expected format is `{region}/{id}/{version}`

