### PR TITLE
docs(lb): clarify health check URI description

### DIFF
--- a/docs/data-sources/lb_backends.md
+++ b/docs/data-sources/lb_backends.md
@@ -58,12 +58,12 @@ In addition to all arguments above, the following attributes are exported:
     - `health_check_max_retries` - Number of allowed failed health check requests before the backend server is marked as down.
     - `health_check_tcp` - This block enables TCP health checks.
     - `health_check_http` - This block enables HTTP health checks.
-        - `uri` - The HTTP endpoint URL to call for health check requests.
+        - `uri` - The path of health check requests.
         - `method` - The HTTP method to use for health check requests.
         - `code` - The expected HTTP status code.
         - `host_header` -  The HTTP host header to use for health check requests.
     - `health_check_https` - This block enables HTTPS health checks.
-        - `uri` - The HTTPS endpoint URL to call for health check requests.
+        - `uri` - The path of health check requests.
         - `method` - The HTTP method to use for health check requests.
         - `code` - The expected HTTP status code.
         - `host_header` - The HTTP host header to use for health check requests.

--- a/docs/resources/lb_backend.md
+++ b/docs/resources/lb_backend.md
@@ -32,7 +32,7 @@ resource "scaleway_lb_backend" "backend01" {
   forward_port     = "80"
 
   health_check_http {
-    uri = "www.test.com/health"
+    uri = "/health"
   }
 }
 ```
@@ -79,12 +79,12 @@ You may use one of the following health check types: `TCP`, `HTTP` or `HTTPS`. (
 - `health_check_max_retries`      - (Default: `2`) Number of allowed failed health check requests before the backend server is marked as down.
 - `health_check_tcp`              - (Optional) This block enables TCP health checks. Only one of `health_check_tcp`, `health_check_http` and `health_check_https` should be specified.
 - `health_check_http`             - (Optional) This block enables HTTP health checks. Only one of `health_check_tcp`, `health_check_http` and `health_check_https` should be specified.
-    - `uri`                         - (Required) The HTTP endpoint URL to call for health check requests.
+    - `uri`                         - (Required) The path for health check requests.
     - `method`                      - (Default: `GET`) The HTTP method to use for health check requests.
     - `code`                        - (Default: `200`) The expected HTTP status code.
     - `host_header`                 - (Optional) The HTTP host header to use for health check requests.
 - `health_check_https`            - (Optional) This block enable HTTPS health checks. Only one of `health_check_tcp`, `health_check_http` and `health_check_https` should be specified.
-    - `uri`                         - (Required) The HTTPS endpoint URL to call for health check requests.
+    - `uri`                         - (Required) The path for health check requests.
     - `method`                      - (Default: `GET`) The HTTP method to use for health check requests.
     - `code`                        - (Default: `200`) The expected HTTP status code.
     - `host_header`                 - (Optional) The HTTP host header to use for health check requests.


### PR DESCRIPTION
The `uri` parameter takes a path, not a full URI. Otherwise, the health check doesn't work and the servers are always reported as down.