### PR TITLE
docs: correct `wait_for_pool_ready` default value in documentation

### DIFF
--- a/docs/resources/k8s_pool.md
+++ b/docs/resources/k8s_pool.md
@@ -90,7 +90,7 @@ The following arguments are supported:
 
 - `region` - (Defaults to [provider](../index.md#region) `region`) The [region](../guides/regions_and_zones.md#regions) in which the pool should be created.
 
-- `wait_for_pool_ready` - (Defaults to `false`) Whether to wait for the pool to be ready.
+- `wait_for_pool_ready` - (Defaults to `true`) Whether to wait for the pool to be ready.
 
 - `public_ip_disabled` - (Defaults to `false`) Defines if the public IP should be removed from Nodes. To use this feature, your Cluster must have an attached [Private Network](vpc_private_network.md) set up with a [Public Gateway](vpc_public_gateway.md).
 


### PR DESCRIPTION
Adjust documentation to match code

https://github.com/scaleway/terraform-provider-scaleway/blob/f5d4aa65717c1fd9f4c18d5e29112df9a16420ad/internal/services/k8s/pool.go#L101-L106