### PR TITLE
fix(functions): update function when runtime has changed and redeploy

### DIFF
--- a/internal/services/function/function.go
+++ b/internal/services/function/function.go
@@ -417,7 +417,7 @@ func ResourceFunctionUpdate(ctx context.Context, d *schema.ResourceData, m inter
 
 	// deploy only in some conditions
 	shouldDeploy := deploy
-	shouldDeploy = shouldDeploy || (zipHasChanged && shouldDeploy)
+	shouldDeploy = shouldDeploy || (zipHasChanged && deploy)
 	shouldDeploy = shouldDeploy || d.HasChange("runtime")
 
 	if shouldDeploy {


### PR DESCRIPTION
Hello :wave:

Just a small fix :bug:

When a function `runtime` is updated from Terraform:

1. the `runtime` field was actually not updated (e.g. when we `GET` from the API): this is because this case is simply not handled in the existing code
2. the function is not redeployed. When changing runtime, even if `deploy` is `false`, I think most users expect their function to be rebuilt with the new runtime (e.g. when bumping from `python310` to `python313`)

If 2. is controversial, maybe we can just replace:

```diff
-	shouldDeploy = shouldDeploy || d.HasChange("runtime")
+	shouldDeploy = shouldDeploy || (d.HasChange("runtime") && deploy)
```

So, runtime is changed, but function is not redeployed unless **explicitly** told to do so.

## Tests

`main.tf`:

```hcl
data "archive_file" "source_zip" {
  type        = "zip"
  source_dir  = "${path.module}/function"
  output_path = "${path.module}/files/function.zip"
}

resource "scaleway_function_namespace" "main" {
  name = "test"
}

resource "scaleway_function" "main" {
  namespace_id = scaleway_function_namespace.main.id
  name         = "test"
  runtime      = "python310"
  deploy        = true
  handler      = "handler.handle"
  privacy      = "public"
  zip_file     = data.archive_file.source_zip.output_path
  zip_hash     = filesha256(data.archive_file.source_zip.output_path)
}
```

`functions/handler.py`:

```python
import sys

def handle(event, context):
    return {
        "body": {
            "message": sys.version,
        },
        "statusCode": 200,
    }
```

Run `terraform apply` :heavy_check_mark:

Then, change in `main.tf`:

```diff
-  runtime      = "python310"
-  deploy        = true
+  runtime      = "python313"
```

Running `terraform apply` redeploys the function :heavy_check_mark: (we can check the version has changed by calling the function endpoint).

Thanks!