### PR TITLE
Fix nightly sweep 

### DIFF
--- a/internal/services/edgeservices/testfuncs/sweep.go
+++ b/internal/services/edgeservices/testfuncs/sweep.go
@@ -7,7 +7,6 @@ import (
 	edge "github.com/scaleway/scaleway-sdk-go/api/edge_services/v1beta1"
 	"github.com/scaleway/scaleway-sdk-go/scw"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/acctest"
-	"github.com/scaleway/terraform-provider-scaleway/v2/internal/services/edgeservices"
 )
 
 func AddTestSweepers() {
@@ -47,7 +46,7 @@ func AddTestSweepers() {
 
 func testSweepPipeline(_ string) error {
 	return acctest.Sweep(func(scwClient *scw.Client) error {
-		edgeAPI := edgeservices.NewEdgeServicesAPI(scwClient)
+		edgeAPI := edge.NewAPI(scwClient)
 
 		listPipelines, err := edgeAPI.ListPipelines(&edge.ListPipelinesRequest{})
 		if err != nil {
@@ -69,7 +68,7 @@ func testSweepPipeline(_ string) error {
 
 func testSweepDNS(_ string) error {
 	return acctest.Sweep(func(scwClient *scw.Client) error {
-		edgeAPI := edgeservices.NewEdgeServicesAPI(scwClient)
+		edgeAPI := edge.NewAPI(scwClient)
 
 		listDNS, err := edgeAPI.ListDNSStages(&edge.ListDNSStagesRequest{})
 		if err != nil {
@@ -91,7 +90,7 @@ func testSweepDNS(_ string) error {
 
 func testSweepTLS(_ string) error {
 	return acctest.Sweep(func(scwClient *scw.Client) error {
-		edgeAPI := edgeservices.NewEdgeServicesAPI(scwClient)
+		edgeAPI := edge.NewAPI(scwClient)
 
 		listTLS, err := edgeAPI.ListTLSStages(&edge.ListTLSStagesRequest{})
 		if err != nil {
@@ -113,7 +112,7 @@ func testSweepTLS(_ string) error {
 
 func testSweepCache(_ string) error {
 	return acctest.Sweep(func(scwClient *scw.Client) error {
-		edgeAPI := edgeservices.NewEdgeServicesAPI(scwClient)
+		edgeAPI := edge.NewAPI(scwClient)
 
 		listCaches, err := edgeAPI.ListCacheStages(&edge.ListCacheStagesRequest{})
 		if err != nil {
@@ -135,7 +134,7 @@ func testSweepCache(_ string) error {
 
 func testSweepBackend(_ string) error {
 	return acctest.Sweep(func(scwClient *scw.Client) error {
-		edgeAPI := edgeservices.NewEdgeServicesAPI(scwClient)
+		edgeAPI := edge.NewAPI(scwClient)
 
 		listBackends, err := edgeAPI.ListBackendStages(&edge.ListBackendStagesRequest{})
 		if err != nil {
@@ -157,7 +156,7 @@ func testSweepBackend(_ string) error {
 
 func testSweepPlan(_ string) error {
 	return acctest.Sweep(func(scwClient *scw.Client) error {
-		edgeAPI := edgeservices.NewEdgeServicesAPI(scwClient)
+		edgeAPI := edge.NewAPI(scwClient)
 
 		listPipelines, err := edgeAPI.ListPipelines(&edge.ListPipelinesRequest{})
 		if err != nil {
@@ -179,7 +178,7 @@ func testSweepPlan(_ string) error {
 
 func testSweepWAF(_ string) error {
 	return acctest.Sweep(func(scwClient *scw.Client) error {
-		edgeAPI := edgeservices.NewEdgeServicesAPI(scwClient)
+		edgeAPI := edge.NewAPI(scwClient)
 
 		listWAF, err := edgeAPI.ListWafStages(&edge.ListWafStagesRequest{})
 		if err != nil {
@@ -201,7 +200,7 @@ func testSweepWAF(_ string) error {
 
 func testSweepRoute(_ string) error {
 	return acctest.Sweep(func(scwClient *scw.Client) error {
-		edgeAPI := edgeservices.NewEdgeServicesAPI(scwClient)
+		edgeAPI := edge.NewAPI(scwClient)
 
 		listRoutes, err := edgeAPI.ListRouteStages(&edge.ListRouteStagesRequest{})
 		if err != nil {


### PR DESCRIPTION
fixes https://github.com/scaleway/terraform-provider-scaleway/actions/runs/14698141826/job/41244881374

When the `-sweep` flag is passed, the sweep function are ran by the Terraform SDK, and the edgeservices one are using a wrong method to instantiate the client which cause a panic
```
panic: interface conversion: interface {} is *scw.Client, not *meta.Meta

goroutine 1 [running]:
github.com/scaleway/terraform-provider-scaleway/v2/internal/meta.ExtractScwClient(...)
	/home/runner/work/terraform-provider-scaleway/terraform-provider-scaleway/internal/meta/extractors.go:97
github.com/scaleway/terraform-provider-scaleway/v2/internal/services/edgeservices.NewEdgeServicesAPI(...)
	/home/runner/work/terraform-provider-scaleway/terraform-provider-scaleway/internal/services/edgeservices/helpers.go:12
github.com/scaleway/terraform-provider-scaleway/v2/internal/services/edgeservices/testfuncs.testSweepRoute.func1(0x1c7b728?)
	/home/runner/work/terraform-provider-scaleway/terraform-provider-scaleway/internal/services/edgeservices/testfuncs/sweep.go:204 +0x2a
github.com/scaleway/terraform-provider-scaleway/v2/internal/acctest.Sweep(0x1a5cc48)
	/home/runner/work/terraform-provider-scaleway/terraform-provider-scaleway/internal/acctest/sweepers.go:21 +0x8f
github.com/scaleway/terraform-provider-scaleway/v2/internal/services/edgeservices/testfuncs.testSweepRoute({0xc0000bc300?, 0x0?})
	/home/runner/work/terraform-provider-scaleway/terraform-provider-scaleway/internal/services/edgeservices/testfuncs/sweep.go:203 +0x1a
github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource.runSweeperWithRegion({0x7ffe1b836aa2, 0xb}, 0xc0003655f0, 0xc000365200, 0xc000365680, 0x0)
	/home/runner/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.36.0/helper/resource/testing.go:267 +0x631
github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource.runSweepers({0xc000337180, 0x1, 0xc000365200?}, 0xc000365200, 0x0)
	/home/runner/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.36.0/helper/resource/testing.go:145 +0x5f2
github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource.TestMain({0x1c64ba0, 0xc000396640})
	/home/runner/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.36.0/helper/resource/testing.go:123 +0xe6
github.com/scaleway/terraform-provider-scaleway/v2/internal/services/edgeservices_test.TestMain(...)
	/home/runner/work/terraform-provider-scaleway/terraform-provider-scaleway/internal/services/edgeservices/sweep_test.go:15
main.main()
	_testmain.go:63 +0xb3
FAIL	github.com/scaleway/terraform-provider-scaleway/v2/internal/services/edgeservices	0.012s
```