### PR TITLE
fix(instance): EoS warning should only display the 5 most relevant types

### DIFF
--- a/internal/services/instance/server.go
+++ b/internal/services/instance/server.go
@@ -785,11 +785,23 @@ func ResourceInstanceServerRead(ctx context.Context, d *schema.ResourceData, m i
 			return diag.FromErr(err)
 		}
 
+		mostRelevantTypes := compatibleTypes.CompatibleTypes[:5]
+
 		return diag.Diagnostics{diag.Diagnostic{
 			Severity: diag.Warning,
 			Detail:   fmt.Sprintf("Instance type %q will soon reach End of Service", server.CommercialType),
 			Summary: fmt.Sprintf(`Your Instance will soon reach End of Service. You can check the exact date on the Scaleway console. We recommend that you migrate your Instance before that.
-Here are the best options for %q, ordered by relevance: [%s]`, server.CommercialType, strings.Join(compatibleTypes.CompatibleTypes, ", ")),
+Here are the %d best options for %q, ordered by relevance: [%s]
+
+You can check the full list of compatible server types:
+	- on the Scaleway console
+	- using the CLI command 'scw instance server get-compatible-types %s zone=%s'`,
+				len(mostRelevantTypes),
+				server.CommercialType,
+				strings.Join(mostRelevantTypes, ", "),
+				server.ID,
+				server.Zone,
+			),
 			AttributePath: cty.GetAttrPath("type"),
 		}}
 	}


### PR DESCRIPTION
For the end of service warning message to be clearer, we should only display the 5 most relevant Instance types, and redirect users to the CLI for the full list. The warning will be displayed as follows :
```
╷
│ Warning: Your Instance will soon reach End of Service. You can check the exact date on the Scaleway console. We recommend that you migrate your Instance before that.
│ Here are the 5 best options for "ENT1-S", ordered by relevance: [POP2-8C-32G, POP2-2C-8G, POP2-4C-16G, POP2-16C-64G, POP2-32C-128G]
│ 
│ You can check the full list of compatible server types:
│       - on the Scaleway console
│       - using the CLI command 'scw instance server get-compatible-types e957d3cb-8b5a-4881-804b-4ac1b612b3e3 zone=fr-par-1'
│ 
│   with scaleway_instance_server.eos,
│   on endofservice.tf line 14, in resource "scaleway_instance_server" "eos":
│   14:   type = "ENT1-S"
│ 
│ Instance type "ENT1-S" will soon reach End of Service
╵
```