### PR TITLE
feat(project): add the projects datasource

### DIFF
--- a/docs/data-sources/account_projects.md
+++ b/docs/data-sources/account_projects.md
@@ -1,0 +1,57 @@
+---
+subcategory: "Account"
+page_title: "Scaleway: scaleway_account_projects"
+---
+
+# scaleway_account_projects
+
+The `scaleway_account_projects` data source is used to list all Scaleway projects in an Organization.
+
+Refer to the Organizations and Projects [documentation](https://www.scaleway.com/en/docs/organizations-and-projects/) and [API documentation](https://www.scaleway.com/en/developers/api/account/project-api/) for more information.
+
+
+## Retrieve a Scaleway Projects
+
+The following commands allow you to:
+
+- retrieve all Projects in an Organization
+
+```hcl
+# Get all Projects in an Organization
+data scaleway_account_projects "all" {
+  organization_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+}
+```
+
+## Example Usage
+
+### Deploy an SSH key in all your organization's projects
+
+```hcl
+data scaleway_account_projects "all" {}
+
+resource "scaleway_account_ssh_key" "main" {
+  name       = "main"
+  public_key = local.public_key
+  count      = length(data.scaleway_account_projects.all.projects)
+  project_id = data.scaleway_account_projects.all.projects[count.index].id
+}
+```
+
+## Argument Reference
+
+- `organization_id` - (Optional) The unique identifier of the Organization with which the Projects are associated.
+  If no default `organization_id` is set, one must be set explicitly in this datasource
+
+
+## Attribute reference
+
+The `scaleway_account_projects` data source exports the following attributes:
+
+- `projects` - (Computed) A list of projects. Each project has the following attributes:
+  - `id` - (Computed) The unique identifier of the project.
+  - `name` - (Computed) The name of the project.
+  - `organization_id` - (Computed) The unique identifier of the organization with which the project is associated.
+  - `created_at` - (Computed) The date and time when the project was created.
+  - `updated_at` - (Computed) The date and time when the project was updated.
+  - `description` - (Computed) The description of the project.

--- a/docs/data-sources/account_projects.md
+++ b/docs/data-sources/account_projects.md
@@ -49,9 +49,9 @@ resource "scaleway_account_ssh_key" "main" {
 The `scaleway_account_projects` data source exports the following attributes:
 
 - `projects` - (Computed) A list of projects. Each project has the following attributes:
-  - `id` - (Computed) The unique identifier of the project.
-  - `name` - (Computed) The name of the project.
-  - `organization_id` - (Computed) The unique identifier of the organization with which the project is associated.
-  - `created_at` - (Computed) The date and time when the project was created.
-  - `updated_at` - (Computed) The date and time when the project was updated.
-  - `description` - (Computed) The description of the project.
+    - `id` - (Computed) The unique identifier of the project.
+    - `name` - (Computed) The name of the project.
+    - `organization_id` - (Computed) The unique identifier of the organization with which the project is associated.
+    - `created_at` - (Computed) The date and time when the project was created.
+    - `updated_at` - (Computed) The date and time when the project was updated.
+    - `description` - (Computed) The description of the project.

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -246,6 +246,7 @@ func Provider(config *Config) plugin.ProviderFunc {
 
 			DataSourcesMap: map[string]*schema.Resource{
 				"scaleway_account_project":                     account.DataSourceProject(),
+				"scaleway_account_projects":                    account.DataSourceProjects(),
 				"scaleway_account_ssh_key":                     iam.DataSourceSSHKey(),
 				"scaleway_availability_zones":                  az.DataSourceAvailabilityZones(),
 				"scaleway_baremetal_offer":                     baremetal.DataSourceOffer(),

--- a/internal/services/account/project_data_source.go
+++ b/internal/services/account/project_data_source.go
@@ -3,6 +3,7 @@ package account
 import (
 	"context"
 
+	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	accountSDK "github.com/scaleway/scaleway-sdk-go/api/account/v3"
@@ -22,7 +23,7 @@ func DataSourceProject() *schema.Resource {
 		Type:             schema.TypeString,
 		Computed:         true,
 		Optional:         true,
-		Description:      "The ID of the SSH key",
+		Description:      "The ID of the project",
 		ValidateDiagFunc: verify.IsUUID(),
 	}
 
@@ -84,4 +85,106 @@ func DataSourceAccountProjectRead(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	return nil
+}
+
+func DataSourceProjects() *schema.Resource {
+	dsSchema := datasource.SchemaFromResourceSchema(ResourceProject().Schema)
+	datasource.AddOptionalFieldsToSchema(dsSchema, "organization_id")
+
+	dsSchema["organization_id"] = &schema.Schema{
+		Type:             schema.TypeString,
+		Computed:         true,
+		Optional:         true,
+		Description:      "The ID of the organization",
+		ValidateDiagFunc: verify.IsUUID(),
+	}
+	dsSchema["projects"] = &schema.Schema{
+		Type:        schema.TypeList,
+		Computed:    true,
+		Description: "The list of projects",
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"id": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "ID of the Project",
+				},
+				"name": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "Name of the Project",
+				},
+				"organization_id": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "Organization ID of the Project",
+				},
+				"created_at": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "Creation date of the Project",
+				},
+				"updated_at": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "Update date of the Project",
+				},
+				"description": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "Description of the Project",
+				},
+			},
+		},
+	}
+
+	return &schema.Resource{
+		ReadContext: DataSourceAccountProjectsRead,
+		Schema:      dsSchema,
+	}
+}
+
+func DataSourceAccountProjectsRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	accountAPI := NewProjectAPI(m)
+
+	var orgID *string
+
+	if v, orgIDExists := d.GetOk("organization_id"); orgIDExists {
+		orgID = types.ExpandStringPtr(v)
+	} else {
+		orgID = GetOrganizationID(m, d)
+	}
+
+	if orgID == nil {
+		return diag.Errorf("organization_id was not specified nor found in the provider configuration")
+	}
+
+	res, err := accountAPI.ListProjects(&accountSDK.ProjectAPIListProjectsRequest{
+		OrganizationID: *orgID,
+	}, scw.WithContext(ctx))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(uuid.New().String())
+	_ = d.Set("projects", flattenProjects(res.Projects))
+	_ = d.Set("organization_id", orgID)
+
+	return nil
+}
+
+func flattenProjects(projects []*accountSDK.Project) []map[string]interface{} {
+	flattenedProjects := make([]map[string]interface{}, len(projects))
+	for i, project := range projects {
+		flattenedProjects[i] = map[string]interface{}{
+			"id":              project.ID,
+			"name":            project.Name,
+			"organization_id": project.OrganizationID,
+			"created_at":      types.FlattenTime(project.CreatedAt),
+			"updated_at":      types.FlattenTime(project.UpdatedAt),
+			"description":     project.Description,
+		}
+	}
+
+	return flattenedProjects
 }

--- a/internal/services/account/project_data_source_test.go
+++ b/internal/services/account/project_data_source_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/acctest"
 )
 
-const dummyOrgID = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+const dummyOrgID = "AB7BD9BF-E1BD-41E8-9F1D-F16A2E3F3925"
 
 func TestAccDataSourceProject_Basic(t *testing.T) {
 	tt := acctest.NewTestTools(t)
@@ -36,7 +36,7 @@ func TestAccDataSourceProject_Basic(t *testing.T) {
 						name = scaleway_account_project.project.name
 						organization_id = "%s"
 					}
-					
+
 					data scaleway_account_project "by_id" {
 						project_id = scaleway_account_project.project.id
 					}`, orgID),

--- a/internal/services/account/testdata/data-source-project-list.cassette.yaml
+++ b/internal/services/account/testdata/data-source-project-list.cassette.yaml
@@ -1,0 +1,248 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/account/v3/projects?order_by=created_at_asc&organization_id=6867048b-fe12-4e96-835e-41c79a39604b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2506
+        uncompressed: false
+        body: '{"projects":[{"created_at":"2025-03-28T10:50:07.046652Z","description":"","id":"6867048b-fe12-4e96-835e-41c79a39604b","name":"default","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","qualification":{"architecture_type":"unknown_architecture_type"},"updated_at":"2025-03-28T10:50:07.046652Z"},{"created_at":"2025-04-17T07:56:01.332697Z","description":"","id":"8cc8dd4d-a094-407a-89a3-9d004674e936","name":"tf_tests_container_trigger_sqs","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","qualification":{"architecture_type":"unknown_architecture_type"},"updated_at":"2025-04-17T07:56:01.332697Z"},{"created_at":"2025-04-17T07:56:07.275342Z","description":"","id":"c6dd3456-da8b-4aa0-9c34-16d7d9803aca","name":"tf_tests_container_trigger_sqs","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","qualification":{"architecture_type":"unknown_architecture_type"},"updated_at":"2025-04-17T07:56:07.275342Z"},{"created_at":"2025-04-28T08:36:29.372348Z","description":"","id":"c836593f-d01f-47e7-afef-2acd8dd12e4a","name":"tf_tests_function_trigger_sqs","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","qualification":{"architecture_type":"unknown_architecture_type"},"updated_at":"2025-04-28T08:36:29.372348Z"},{"created_at":"2025-05-05T08:35:05.993942Z","description":"","id":"c13349ad-dfcb-4df1-a3c5-7125b987d3fa","name":"onboarding","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","qualification":{"architecture_type":"unknown_architecture_type"},"updated_at":"2025-05-05T08:35:05.993942Z"},{"created_at":"2025-05-07T19:51:42.450139Z","description":"","id":"9c373336-7015-4ad6-995b-8153a8923c72","name":"my_test_project","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","qualification":{"architecture_type":"unknown_architecture_type"},"updated_at":"2025-05-07T19:51:42.450139Z"},{"created_at":"2025-05-13T08:56:14.908932Z","description":"","id":"0b9a80f3-29db-4ec2-ac2e-8845c00299e3","name":"cli-proj-inspiring-boyd","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","qualification":{"architecture_type":"unknown_architecture_type"},"updated_at":"2025-05-13T08:56:14.908932Z"},{"created_at":"2025-05-13T08:57:03.383382Z","description":"","id":"0f575b9b-cf87-49b5-a0cc-aed1842aad88","name":"cli-proj-busy-darwin","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","qualification":{"architecture_type":"unknown_architecture_type"},"updated_at":"2025-05-13T08:57:03.383382Z"}],"total_count":8}'
+        headers:
+            Content-Length:
+                - "2506"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 14 May 2025 16:32:17 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 0bb6255e-acec-44bf-b5bd-c4a12011b358
+        status: 200 OK
+        code: 200
+        duration: 169.356542ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/account/v3/projects?order_by=created_at_asc&organization_id=6867048b-fe12-4e96-835e-41c79a39604b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2506
+        uncompressed: false
+        body: '{"projects":[{"created_at":"2025-03-28T10:50:07.046652Z","description":"","id":"6867048b-fe12-4e96-835e-41c79a39604b","name":"default","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","qualification":{"architecture_type":"unknown_architecture_type"},"updated_at":"2025-03-28T10:50:07.046652Z"},{"created_at":"2025-04-17T07:56:01.332697Z","description":"","id":"8cc8dd4d-a094-407a-89a3-9d004674e936","name":"tf_tests_container_trigger_sqs","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","qualification":{"architecture_type":"unknown_architecture_type"},"updated_at":"2025-04-17T07:56:01.332697Z"},{"created_at":"2025-04-17T07:56:07.275342Z","description":"","id":"c6dd3456-da8b-4aa0-9c34-16d7d9803aca","name":"tf_tests_container_trigger_sqs","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","qualification":{"architecture_type":"unknown_architecture_type"},"updated_at":"2025-04-17T07:56:07.275342Z"},{"created_at":"2025-04-28T08:36:29.372348Z","description":"","id":"c836593f-d01f-47e7-afef-2acd8dd12e4a","name":"tf_tests_function_trigger_sqs","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","qualification":{"architecture_type":"unknown_architecture_type"},"updated_at":"2025-04-28T08:36:29.372348Z"},{"created_at":"2025-05-05T08:35:05.993942Z","description":"","id":"c13349ad-dfcb-4df1-a3c5-7125b987d3fa","name":"onboarding","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","qualification":{"architecture_type":"unknown_architecture_type"},"updated_at":"2025-05-05T08:35:05.993942Z"},{"created_at":"2025-05-07T19:51:42.450139Z","description":"","id":"9c373336-7015-4ad6-995b-8153a8923c72","name":"my_test_project","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","qualification":{"architecture_type":"unknown_architecture_type"},"updated_at":"2025-05-07T19:51:42.450139Z"},{"created_at":"2025-05-13T08:56:14.908932Z","description":"","id":"0b9a80f3-29db-4ec2-ac2e-8845c00299e3","name":"cli-proj-inspiring-boyd","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","qualification":{"architecture_type":"unknown_architecture_type"},"updated_at":"2025-05-13T08:56:14.908932Z"},{"created_at":"2025-05-13T08:57:03.383382Z","description":"","id":"0f575b9b-cf87-49b5-a0cc-aed1842aad88","name":"cli-proj-busy-darwin","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","qualification":{"architecture_type":"unknown_architecture_type"},"updated_at":"2025-05-13T08:57:03.383382Z"}],"total_count":8}'
+        headers:
+            Content-Length:
+                - "2506"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 14 May 2025 16:32:17 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 84593443-c44e-4270-b0aa-491a594dd095
+        status: 200 OK
+        code: 200
+        duration: 64.1495ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/account/v3/projects?order_by=created_at_asc&organization_id=6867048b-fe12-4e96-835e-41c79a39604b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2506
+        uncompressed: false
+        body: '{"projects":[{"created_at":"2025-03-28T10:50:07.046652Z","description":"","id":"6867048b-fe12-4e96-835e-41c79a39604b","name":"default","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","qualification":{"architecture_type":"unknown_architecture_type"},"updated_at":"2025-03-28T10:50:07.046652Z"},{"created_at":"2025-04-17T07:56:01.332697Z","description":"","id":"8cc8dd4d-a094-407a-89a3-9d004674e936","name":"tf_tests_container_trigger_sqs","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","qualification":{"architecture_type":"unknown_architecture_type"},"updated_at":"2025-04-17T07:56:01.332697Z"},{"created_at":"2025-04-17T07:56:07.275342Z","description":"","id":"c6dd3456-da8b-4aa0-9c34-16d7d9803aca","name":"tf_tests_container_trigger_sqs","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","qualification":{"architecture_type":"unknown_architecture_type"},"updated_at":"2025-04-17T07:56:07.275342Z"},{"created_at":"2025-04-28T08:36:29.372348Z","description":"","id":"c836593f-d01f-47e7-afef-2acd8dd12e4a","name":"tf_tests_function_trigger_sqs","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","qualification":{"architecture_type":"unknown_architecture_type"},"updated_at":"2025-04-28T08:36:29.372348Z"},{"created_at":"2025-05-05T08:35:05.993942Z","description":"","id":"c13349ad-dfcb-4df1-a3c5-7125b987d3fa","name":"onboarding","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","qualification":{"architecture_type":"unknown_architecture_type"},"updated_at":"2025-05-05T08:35:05.993942Z"},{"created_at":"2025-05-07T19:51:42.450139Z","description":"","id":"9c373336-7015-4ad6-995b-8153a8923c72","name":"my_test_project","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","qualification":{"architecture_type":"unknown_architecture_type"},"updated_at":"2025-05-07T19:51:42.450139Z"},{"created_at":"2025-05-13T08:56:14.908932Z","description":"","id":"0b9a80f3-29db-4ec2-ac2e-8845c00299e3","name":"cli-proj-inspiring-boyd","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","qualification":{"architecture_type":"unknown_architecture_type"},"updated_at":"2025-05-13T08:56:14.908932Z"},{"created_at":"2025-05-13T08:57:03.383382Z","description":"","id":"0f575b9b-cf87-49b5-a0cc-aed1842aad88","name":"cli-proj-busy-darwin","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","qualification":{"architecture_type":"unknown_architecture_type"},"updated_at":"2025-05-13T08:57:03.383382Z"}],"total_count":8}'
+        headers:
+            Content-Length:
+                - "2506"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 14 May 2025 16:32:17 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f813addd-96c4-44de-87c4-ed7ff05e0c47
+        status: 200 OK
+        code: 200
+        duration: 37.444709ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/account/v3/projects?order_by=created_at_asc&organization_id=6867048b-fe12-4e96-835e-41c79a39604b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2506
+        uncompressed: false
+        body: '{"projects":[{"created_at":"2025-03-28T10:50:07.046652Z","description":"","id":"6867048b-fe12-4e96-835e-41c79a39604b","name":"default","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","qualification":{"architecture_type":"unknown_architecture_type"},"updated_at":"2025-03-28T10:50:07.046652Z"},{"created_at":"2025-04-17T07:56:01.332697Z","description":"","id":"8cc8dd4d-a094-407a-89a3-9d004674e936","name":"tf_tests_container_trigger_sqs","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","qualification":{"architecture_type":"unknown_architecture_type"},"updated_at":"2025-04-17T07:56:01.332697Z"},{"created_at":"2025-04-17T07:56:07.275342Z","description":"","id":"c6dd3456-da8b-4aa0-9c34-16d7d9803aca","name":"tf_tests_container_trigger_sqs","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","qualification":{"architecture_type":"unknown_architecture_type"},"updated_at":"2025-04-17T07:56:07.275342Z"},{"created_at":"2025-04-28T08:36:29.372348Z","description":"","id":"c836593f-d01f-47e7-afef-2acd8dd12e4a","name":"tf_tests_function_trigger_sqs","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","qualification":{"architecture_type":"unknown_architecture_type"},"updated_at":"2025-04-28T08:36:29.372348Z"},{"created_at":"2025-05-05T08:35:05.993942Z","description":"","id":"c13349ad-dfcb-4df1-a3c5-7125b987d3fa","name":"onboarding","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","qualification":{"architecture_type":"unknown_architecture_type"},"updated_at":"2025-05-05T08:35:05.993942Z"},{"created_at":"2025-05-07T19:51:42.450139Z","description":"","id":"9c373336-7015-4ad6-995b-8153a8923c72","name":"my_test_project","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","qualification":{"architecture_type":"unknown_architecture_type"},"updated_at":"2025-05-07T19:51:42.450139Z"},{"created_at":"2025-05-13T08:56:14.908932Z","description":"","id":"0b9a80f3-29db-4ec2-ac2e-8845c00299e3","name":"cli-proj-inspiring-boyd","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","qualification":{"architecture_type":"unknown_architecture_type"},"updated_at":"2025-05-13T08:56:14.908932Z"},{"created_at":"2025-05-13T08:57:03.383382Z","description":"","id":"0f575b9b-cf87-49b5-a0cc-aed1842aad88","name":"cli-proj-busy-darwin","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","qualification":{"architecture_type":"unknown_architecture_type"},"updated_at":"2025-05-13T08:57:03.383382Z"}],"total_count":8}'
+        headers:
+            Content-Length:
+                - "2506"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 14 May 2025 16:32:17 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 9ff7703c-90d8-4982-9d3d-46e13396a706
+        status: 200 OK
+        code: 200
+        duration: 46.165958ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/account/v3/projects?order_by=created_at_asc&organization_id=6867048b-fe12-4e96-835e-41c79a39604b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2506
+        uncompressed: false
+        body: '{"projects":[{"created_at":"2025-03-28T10:50:07.046652Z","description":"","id":"6867048b-fe12-4e96-835e-41c79a39604b","name":"default","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","qualification":{"architecture_type":"unknown_architecture_type"},"updated_at":"2025-03-28T10:50:07.046652Z"},{"created_at":"2025-04-17T07:56:01.332697Z","description":"","id":"8cc8dd4d-a094-407a-89a3-9d004674e936","name":"tf_tests_container_trigger_sqs","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","qualification":{"architecture_type":"unknown_architecture_type"},"updated_at":"2025-04-17T07:56:01.332697Z"},{"created_at":"2025-04-17T07:56:07.275342Z","description":"","id":"c6dd3456-da8b-4aa0-9c34-16d7d9803aca","name":"tf_tests_container_trigger_sqs","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","qualification":{"architecture_type":"unknown_architecture_type"},"updated_at":"2025-04-17T07:56:07.275342Z"},{"created_at":"2025-04-28T08:36:29.372348Z","description":"","id":"c836593f-d01f-47e7-afef-2acd8dd12e4a","name":"tf_tests_function_trigger_sqs","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","qualification":{"architecture_type":"unknown_architecture_type"},"updated_at":"2025-04-28T08:36:29.372348Z"},{"created_at":"2025-05-05T08:35:05.993942Z","description":"","id":"c13349ad-dfcb-4df1-a3c5-7125b987d3fa","name":"onboarding","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","qualification":{"architecture_type":"unknown_architecture_type"},"updated_at":"2025-05-05T08:35:05.993942Z"},{"created_at":"2025-05-07T19:51:42.450139Z","description":"","id":"9c373336-7015-4ad6-995b-8153a8923c72","name":"my_test_project","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","qualification":{"architecture_type":"unknown_architecture_type"},"updated_at":"2025-05-07T19:51:42.450139Z"},{"created_at":"2025-05-13T08:56:14.908932Z","description":"","id":"0b9a80f3-29db-4ec2-ac2e-8845c00299e3","name":"cli-proj-inspiring-boyd","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","qualification":{"architecture_type":"unknown_architecture_type"},"updated_at":"2025-05-13T08:56:14.908932Z"},{"created_at":"2025-05-13T08:57:03.383382Z","description":"","id":"0f575b9b-cf87-49b5-a0cc-aed1842aad88","name":"cli-proj-busy-darwin","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","qualification":{"architecture_type":"unknown_architecture_type"},"updated_at":"2025-05-13T08:57:03.383382Z"}],"total_count":8}'
+        headers:
+            Content-Length:
+                - "2506"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 14 May 2025 16:32:17 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3c0cff7d-bce7-4bf5-bd4d-51544016b981
+        status: 200 OK
+        code: 200
+        duration: 56.302958ms


### PR DESCRIPTION
Example terraform

```
locals {
  public_key = "ssh-xxxx"
}

resource "scaleway_iam_ssh_key" "test" {
  name       = "main"
  public_key = local.public_key
  count      = length(data.scaleway_account_projects.test.projects)
  project_id = data.scaleway_account_projects.test.projects[count.index].id
}
```

fixes https://github.com/scaleway/terraform-provider-scaleway/issues/3078