### PR TITLE
container: use project_id from provider configuration

### DIFF
--- a/internal/services/account/project_data_source_test.go
+++ b/internal/services/account/project_data_source_test.go
@@ -95,30 +95,6 @@ func TestAccDataSourceProject_Default(t *testing.T) {
 	})
 }
 
-func TestAccDataSourceProject_Extract(t *testing.T) {
-	tt := acctest.NewTestTools(t)
-	defer tt.Cleanup()
-
-	projectID, projectIDExists := tt.Meta.ScwClient().GetDefaultProjectID()
-	if !projectIDExists {
-		t.Skip("no default project ID")
-	}
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t) },
-		ProviderFactories: tt.ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: `data scaleway_account_project "project" {}`,
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.scaleway_account_project.project", "id", projectID),
-					resource.TestCheckResourceAttrSet("data.scaleway_account_project.project", "name"),
-				),
-			},
-		},
-	})
-}
-
 func TestAccDataSourceProject_List(t *testing.T) {
 	tt := acctest.NewTestTools(t)
 	defer tt.Cleanup()

--- a/internal/services/billing/consumption_data_source_test.go
+++ b/internal/services/billing/consumption_data_source_test.go
@@ -10,7 +10,8 @@ import (
 )
 
 func TestAccDataSourceConsumption_Basic(t *testing.T) {
-	tt := acctest.NewTestTools(t)
+	// somehow the project_id is not set in the query parameters locally when the organization_id is set
+	tt := acctest.NewTestToolsWithoutDefaultProjectID(t)
 	defer tt.Cleanup()
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/internal/services/container/container_data_source.go
+++ b/internal/services/container/container_data_source.go
@@ -9,6 +9,7 @@ import (
 	"github.com/scaleway/scaleway-sdk-go/scw"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/datasource"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/locality"
+	"github.com/scaleway/terraform-provider-scaleway/v2/internal/meta"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/types"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/verify"
 )
@@ -58,11 +59,16 @@ func DataSourceContainerRead(ctx context.Context, d *schema.ResourceData, m inte
 	if !ok {
 		containerName := d.Get("name").(string)
 
+		projectID, _, err := meta.ExtractProjectID(d, m)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
 		res, err := api.ListContainers(&container.ListContainersRequest{
 			Region:      region,
 			Name:        types.ExpandStringPtr(containerName),
 			NamespaceID: locality.ExpandID(namespaceID),
-			ProjectID:   types.ExpandStringPtr(d.Get("project_id")),
+			ProjectID:   types.ExpandStringPtr(projectID),
 		}, scw.WithContext(ctx))
 		if err != nil {
 			return diag.FromErr(err)

--- a/internal/services/container/container_data_source_test.go
+++ b/internal/services/container/container_data_source_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestAccDataSourceContainer_Basic(t *testing.T) {
-	tt := acctest.NewTestTools(t)
+	tt := acctest.NewTestToolsWithoutDefaultProjectID(t)
 	defer tt.Cleanup()
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -30,7 +30,7 @@ func TestAccDataSourceContainer_Basic(t *testing.T) {
 						namespace_id = scaleway_container_namespace.main.id
 						name = scaleway_container.main.name
 					}
-					
+
 					data "scaleway_container" "by_id" {
 						namespace_id = scaleway_container_namespace.main.id
 						container_id = scaleway_container.main.id
@@ -51,7 +51,7 @@ func TestAccDataSourceContainer_Basic(t *testing.T) {
 }
 
 func TestAccDataSourceContainer_HealthCheck(t *testing.T) {
-	tt := acctest.NewTestTools(t)
+	tt := acctest.NewTestToolsWithoutDefaultProjectID(t)
 	defer tt.Cleanup()
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/internal/services/container/container_test.go
+++ b/internal/services/container/container_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/acctest"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/httperrors"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/services/container"
-	containerchecks "github.com/scaleway/terraform-provider-scaleway/v2/internal/services/container/testfuncs"
 )
 
 func TestAccContainer_Basic(t *testing.T) {
@@ -220,51 +219,32 @@ func TestAccContainer_WithIMG(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`
-					resource scaleway_container_namespace main {
-						name = "%s"
-						description = "test container"
-					}
-				`, containerNamespace),
-			},
-			{
-				Config: fmt.Sprintf(`
-					resource scaleway_container_namespace main {
-						name = "%s"
-						description = "test container"
-					}
-				`, containerNamespace),
-				Check: resource.ComposeTestCheckFunc(
-					containerchecks.TestConfigContainerNamespace(tt, "scaleway_container_namespace.main"),
-				),
-			},
-			{
-				Config: fmt.Sprintf(`
-					resource scaleway_container_namespace main {
-						name = "%s"
-						description = "test container"
-					}
+								resource scaleway_container_namespace main {
+									name = "%s"
+									description = "test container"
+								}
 
-					resource scaleway_container main {
-						name = "my-container-02"
-						description = "environment variables test"
-						namespace_id = scaleway_container_namespace.main.id
-						registry_image = "${scaleway_container_namespace.main.registry_endpoint}/nginx:test"
-						port = 80
-						cpu_limit = 140
-						memory_limit = 256
-						min_scale = 3
-						max_scale = 5
-						timeout = 600
-						max_concurrency = 80
-						privacy = "private"
-						protocol = "h2c"
-						deploy = true
+								resource scaleway_container main {
+									name = "my-container-02"
+									description = "environment variables test"
+									namespace_id = scaleway_container_namespace.main.id
+									registry_image = "docker.io/library/nginx:latest"
+									port = 80
+									cpu_limit = 140
+									memory_limit = 256
+									min_scale = 3
+									max_scale = 5
+									timeout = 600
+									max_concurrency = 80
+									privacy = "private"
+									protocol = "h2c"
+									deploy = true
 
-						environment_variables = {
-							"foo" = "var"
-						}
-					}
-				`, containerNamespace),
+									environment_variables = {
+										"foo" = "var"
+									}
+								}
+							`, containerNamespace),
 				Check: resource.ComposeTestCheckFunc(
 					isContainerPresent(tt, "scaleway_container.main"),
 					acctest.CheckResourceAttrUUID("scaleway_container.main", "id"),
@@ -493,7 +473,7 @@ func TestAccContainer_ScalingOption(t *testing.T) {
 			{
 				Config: `
 					resource scaleway_container_namespace main {}
-		
+
 					resource scaleway_container main {
 						namespace_id = scaleway_container_namespace.main.id
 						deploy = false
@@ -512,7 +492,7 @@ func TestAccContainer_ScalingOption(t *testing.T) {
 			{
 				Config: `
 					resource scaleway_container_namespace main {}
-		
+
 					resource scaleway_container main {
 						namespace_id = scaleway_container_namespace.main.id
 						deploy = false
@@ -534,7 +514,7 @@ func TestAccContainer_ScalingOption(t *testing.T) {
 			{
 				Config: `
 					resource scaleway_container_namespace main {}
-		
+
 					resource scaleway_container main {
 						namespace_id = scaleway_container_namespace.main.id
 						deploy = false

--- a/internal/services/container/namespace.go
+++ b/internal/services/container/namespace.go
@@ -12,6 +12,7 @@ import (
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/dsf"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/httperrors"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/locality/regional"
+	"github.com/scaleway/terraform-provider-scaleway/v2/internal/meta"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/services/account"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/services/registry"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/types"
@@ -108,12 +109,17 @@ func ResourceContainerNamespaceCreate(ctx context.Context, d *schema.ResourceDat
 		return diag.FromErr(err)
 	}
 
+	projectId, _, err := meta.ExtractProjectID(d, m)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
 	createReq := &container.CreateNamespaceRequest{
 		Description:                types.ExpandStringPtr(d.Get("description").(string)),
 		EnvironmentVariables:       types.ExpandMapPtrStringString(d.Get("environment_variables")),
 		SecretEnvironmentVariables: expandContainerSecrets(d.Get("secret_environment_variables")),
 		Name:                       types.ExpandOrGenerateString(d.Get("name").(string), "ns"),
-		ProjectID:                  d.Get("project_id").(string),
+		ProjectID:                  projectId,
 		Region:                     region,
 	}
 

--- a/internal/services/container/namespace_data_source.go
+++ b/internal/services/container/namespace_data_source.go
@@ -8,6 +8,7 @@ import (
 	container "github.com/scaleway/scaleway-sdk-go/api/container/v1beta1"
 	"github.com/scaleway/scaleway-sdk-go/scw"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/datasource"
+	"github.com/scaleway/terraform-provider-scaleway/v2/internal/meta"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/types"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/verify"
 )
@@ -43,10 +44,15 @@ func DataSourceContainerNamespaceRead(ctx context.Context, d *schema.ResourceDat
 	if !ok {
 		namespaceName := d.Get("name").(string)
 
+		projectID, _, err := meta.ExtractProjectID(d, m)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
 		res, err := api.ListNamespaces(&container.ListNamespacesRequest{
 			Region:    region,
 			Name:      types.ExpandStringPtr(namespaceName),
-			ProjectID: types.ExpandStringPtr(d.Get("project_id")),
+			ProjectID: types.ExpandStringPtr(projectID),
 		}, scw.WithContext(ctx))
 		if err != nil {
 			return diag.FromErr(err)

--- a/internal/services/container/namespace_data_source_test.go
+++ b/internal/services/container/namespace_data_source_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestAccDataSourceNamespace_Basic(t *testing.T) {
-	tt := acctest.NewTestTools(t)
+	tt := acctest.NewTestToolsWithoutDefaultProjectID(t)
 	defer tt.Cleanup()
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -21,11 +21,11 @@ func TestAccDataSourceNamespace_Basic(t *testing.T) {
 					resource "scaleway_container_namespace" "main" {
 						name = "test-cr-data"
 					}
-					
+
 					data "scaleway_container_namespace" "by_name" {
 						name = scaleway_container_namespace.main.name
 					}
-					
+
 					data "scaleway_container_namespace" "by_id" {
 						namespace_id = scaleway_container_namespace.main.id
 					}

--- a/internal/services/container/testdata/container-with-img.cassette.yaml
+++ b/internal/services/container/testdata/container-with-img.cassette.yaml
@@ -12,13 +12,13 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"test-cr-ns-02","environment_variables":{},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","description":"test container","secret_environment_variables":[],"tags":null}'
+        body: '{"name":"test-cr-ns-02","environment_variables":{},"project_id":"6867048b-fe12-4e96-835e-41c79a39604b","description":"test container","secret_environment_variables":[],"tags":null}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces
         method: POST
       response:
@@ -27,20 +27,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 479
+        content_length: 528
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.279671570Z","description":"test container","environment_variables":{},"error_message":null,"id":"0f7cb2d4-469a-4dbe-995b-9e8947611a18","name":"test-cr-ns-02","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:37:49.279671570Z"}'
+        body: '{"created_at":"2025-05-19T14:02:54.104072175Z","description":"test container","environment_variables":{},"error_message":null,"id":"2eb366fe-cf26-4587-a98f-57d2c1bbe349","name":"test-cr-ns-02","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-05-19T14:02:54.104072175Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "479"
+                - "528"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:37:49 GMT
+                - Mon, 19 May 2025 14:02:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 935cb29e-4bea-4fd5-9d0a-37402bb014b4
+                - 78815491-a50d-44a7-b678-23b09bc8f950
         status: 200 OK
         code: 200
-        duration: 1.00173525s
+        duration: 813.235208ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -67,8 +67,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/0f7cb2d4-469a-4dbe-995b-9e8947611a18
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2eb366fe-cf26-4587-a98f-57d2c1bbe349
         method: GET
       response:
         proto: HTTP/2.0
@@ -76,20 +76,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 473
+        content_length: 522
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.279672Z","description":"test container","environment_variables":{},"error_message":null,"id":"0f7cb2d4-469a-4dbe-995b-9e8947611a18","name":"test-cr-ns-02","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:37:49.279672Z"}'
+        body: '{"created_at":"2025-05-19T14:02:54.104072Z","description":"test container","environment_variables":{},"error_message":null,"id":"2eb366fe-cf26-4587-a98f-57d2c1bbe349","name":"test-cr-ns-02","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-05-19T14:02:54.104072Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "473"
+                - "522"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:37:49 GMT
+                - Mon, 19 May 2025 14:02:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5e07ffb1-cc99-4543-b920-c7aa7b5ff4c8
+                - d9fac518-3eb6-470b-bbaa-7972e75a4443
         status: 200 OK
         code: 200
-        duration: 72.899958ms
+        duration: 38.607334ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -116,8 +116,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/0f7cb2d4-469a-4dbe-995b-9e8947611a18
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2eb366fe-cf26-4587-a98f-57d2c1bbe349
         method: GET
       response:
         proto: HTTP/2.0
@@ -125,20 +125,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 552
+        content_length: 601
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.279672Z","description":"test container","environment_variables":{},"error_message":null,"id":"0f7cb2d4-469a-4dbe-995b-9e8947611a18","name":"test-cr-ns-02","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns02c1j0hsbc","registry_namespace_id":"01e7c8df-1be1-467b-ae76-3aa90958f9e2","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:37:53.129815Z"}'
+        body: '{"created_at":"2025-05-19T14:02:54.104072Z","description":"test container","environment_variables":{},"error_message":null,"id":"2eb366fe-cf26-4587-a98f-57d2c1bbe349","name":"test-cr-ns-02","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns02idavh1tf","registry_namespace_id":"ca5e2711-db7c-45da-bd04-7c9c72993eab","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-05-19T14:02:56.967744Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "552"
+                - "601"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:37:54 GMT
+                - Mon, 19 May 2025 14:02:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -146,10 +146,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6c80512f-03aa-453b-9b1b-bb248eb9ecb4
+                - 6e12cb14-9566-46ee-b327-3f858749b5df
         status: 200 OK
         code: 200
-        duration: 124.67875ms
+        duration: 43.539042ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -165,8 +165,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/0f7cb2d4-469a-4dbe-995b-9e8947611a18
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2eb366fe-cf26-4587-a98f-57d2c1bbe349
         method: GET
       response:
         proto: HTTP/2.0
@@ -174,20 +174,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 552
+        content_length: 601
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.279672Z","description":"test container","environment_variables":{},"error_message":null,"id":"0f7cb2d4-469a-4dbe-995b-9e8947611a18","name":"test-cr-ns-02","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns02c1j0hsbc","registry_namespace_id":"01e7c8df-1be1-467b-ae76-3aa90958f9e2","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:37:53.129815Z"}'
+        body: '{"created_at":"2025-05-19T14:02:54.104072Z","description":"test container","environment_variables":{},"error_message":null,"id":"2eb366fe-cf26-4587-a98f-57d2c1bbe349","name":"test-cr-ns-02","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns02idavh1tf","registry_namespace_id":"ca5e2711-db7c-45da-bd04-7c9c72993eab","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-05-19T14:02:56.967744Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "552"
+                - "601"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:37:54 GMT
+                - Mon, 19 May 2025 14:02:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -195,10 +195,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 80908e45-de97-41a1-afdd-2dc003fc8780
+                - 93a2f93e-d8bd-42a6-83f8-538ece2827b3
         status: 200 OK
         code: 200
-        duration: 100.338916ms
+        duration: 41.9565ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -214,8 +214,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/0f7cb2d4-469a-4dbe-995b-9e8947611a18
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2eb366fe-cf26-4587-a98f-57d2c1bbe349
         method: GET
       response:
         proto: HTTP/2.0
@@ -223,20 +223,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 552
+        content_length: 601
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.279672Z","description":"test container","environment_variables":{},"error_message":null,"id":"0f7cb2d4-469a-4dbe-995b-9e8947611a18","name":"test-cr-ns-02","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns02c1j0hsbc","registry_namespace_id":"01e7c8df-1be1-467b-ae76-3aa90958f9e2","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:37:53.129815Z"}'
+        body: '{"created_at":"2025-05-19T14:02:54.104072Z","description":"test container","environment_variables":{},"error_message":null,"id":"2eb366fe-cf26-4587-a98f-57d2c1bbe349","name":"test-cr-ns-02","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns02idavh1tf","registry_namespace_id":"ca5e2711-db7c-45da-bd04-7c9c72993eab","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-05-19T14:02:56.967744Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "552"
+                - "601"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:37:55 GMT
+                - Mon, 19 May 2025 14:02:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -244,48 +244,50 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0fc34113-d66f-4147-9061-a5f50d2fe1f6
+                - f29ee3dc-7055-4cce-ad70-46d55d71df02
         status: 200 OK
         code: 200
-        duration: 70.031375ms
+        duration: 48.341125ms
     - id: 5
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 469
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"namespace_id":"2eb366fe-cf26-4587-a98f-57d2c1bbe349","name":"my-container-02","environment_variables":{"foo":"var"},"min_scale":3,"max_scale":5,"memory_limit":256,"cpu_limit":140,"timeout":"600.000000000s","privacy":"private","description":"environment variables test","registry_image":"docker.io/library/nginx:latest","max_concurrency":80,"protocol":"h2c","port":80,"secret_environment_variables":null,"http_option":"enabled","sandbox":"unknown_sandbox","tags":null}'
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/0f7cb2d4-469a-4dbe-995b-9e8947611a18
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 552
+        content_length: 938
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.279672Z","description":"test container","environment_variables":{},"error_message":null,"id":"0f7cb2d4-469a-4dbe-995b-9e8947611a18","name":"test-cr-ns-02","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns02c1j0hsbc","registry_namespace_id":"01e7c8df-1be1-467b-ae76-3aa90958f9e2","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:37:53.129815Z"}'
+        body: '{"cpu_limit":140,"created_at":"2025-05-19T14:02:59.637633765Z","description":"environment variables test","domain_name":"testcrns02idavh1tf-my-container-02.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"var"},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"8973b4fb-618a-4ef8-a23c-e9128394e6ca","local_storage_limit":1000,"max_concurrency":80,"max_scale":5,"memory_limit":256,"min_scale":3,"name":"my-container-02","namespace_id":"2eb366fe-cf26-4587-a98f-57d2c1bbe349","port":80,"privacy":"private","private_network_id":null,"protocol":"h2c","ready_at":null,"region":"fr-par","registry_image":"docker.io/library/nginx:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":80},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"600s","updated_at":"2025-05-19T14:02:59.637633765Z"}'
         headers:
             Content-Length:
-                - "552"
+                - "938"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:37:56 GMT
+                - Mon, 19 May 2025 14:02:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -293,10 +295,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 52faff45-538f-4ac2-a32f-20020533d808
+                - 5e5e4a20-4cb5-4bb2-b2e9-673343cffdcd
         status: 200 OK
         code: 200
-        duration: 65.019042ms
+        duration: 364.23475ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -312,8 +314,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/0f7cb2d4-469a-4dbe-995b-9e8947611a18
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/8973b4fb-618a-4ef8-a23c-e9128394e6ca
         method: GET
       response:
         proto: HTTP/2.0
@@ -321,20 +323,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 552
+        content_length: 932
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.279672Z","description":"test container","environment_variables":{},"error_message":null,"id":"0f7cb2d4-469a-4dbe-995b-9e8947611a18","name":"test-cr-ns-02","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns02c1j0hsbc","registry_namespace_id":"01e7c8df-1be1-467b-ae76-3aa90958f9e2","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:37:53.129815Z"}'
+        body: '{"cpu_limit":140,"created_at":"2025-05-19T14:02:59.637634Z","description":"environment variables test","domain_name":"testcrns02idavh1tf-my-container-02.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"var"},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"8973b4fb-618a-4ef8-a23c-e9128394e6ca","local_storage_limit":1000,"max_concurrency":80,"max_scale":5,"memory_limit":256,"min_scale":3,"name":"my-container-02","namespace_id":"2eb366fe-cf26-4587-a98f-57d2c1bbe349","port":80,"privacy":"private","private_network_id":null,"protocol":"h2c","ready_at":null,"region":"fr-par","registry_image":"docker.io/library/nginx:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":80},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"600s","updated_at":"2025-05-19T14:02:59.637634Z"}'
         headers:
             Content-Length:
-                - "552"
+                - "932"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:37:56 GMT
+                - Mon, 19 May 2025 14:02:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -342,307 +344,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 584b74ee-e55c-4957-8e6f-ba78296169a7
+                - c825e16c-4d08-4e63-a393-89f7f584dcc2
         status: 200 OK
         code: 200
-        duration: 70.163584ms
+        duration: 64.508083ms
     - id: 7
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/0f7cb2d4-469a-4dbe-995b-9e8947611a18
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 552
-        uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.279672Z","description":"test container","environment_variables":{},"error_message":null,"id":"0f7cb2d4-469a-4dbe-995b-9e8947611a18","name":"test-cr-ns-02","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns02c1j0hsbc","registry_namespace_id":"01e7c8df-1be1-467b-ae76-3aa90958f9e2","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:37:53.129815Z"}'
-        headers:
-            Content-Length:
-                - "552"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:38:17 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 12d9e340-0df6-4efb-8927-62e6c0183db0
-        status: 200 OK
-        code: 200
-        duration: 71.442625ms
-    - id: 8
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/0f7cb2d4-469a-4dbe-995b-9e8947611a18
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 552
-        uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.279672Z","description":"test container","environment_variables":{},"error_message":null,"id":"0f7cb2d4-469a-4dbe-995b-9e8947611a18","name":"test-cr-ns-02","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns02c1j0hsbc","registry_namespace_id":"01e7c8df-1be1-467b-ae76-3aa90958f9e2","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:37:53.129815Z"}'
-        headers:
-            Content-Length:
-                - "552"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:38:18 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - fbaedc49-0968-400d-9b07-97c55738635f
-        status: 200 OK
-        code: 200
-        duration: 81.698333ms
-    - id: 9
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/0f7cb2d4-469a-4dbe-995b-9e8947611a18
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 552
-        uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.279672Z","description":"test container","environment_variables":{},"error_message":null,"id":"0f7cb2d4-469a-4dbe-995b-9e8947611a18","name":"test-cr-ns-02","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns02c1j0hsbc","registry_namespace_id":"01e7c8df-1be1-467b-ae76-3aa90958f9e2","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:37:53.129815Z"}'
-        headers:
-            Content-Length:
-                - "552"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:38:19 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 8ca6d78d-cdc8-4a69-b5f8-4075c021a5e9
-        status: 200 OK
-        code: 200
-        duration: 62.537292ms
-    - id: 10
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/0f7cb2d4-469a-4dbe-995b-9e8947611a18
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 552
-        uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.279672Z","description":"test container","environment_variables":{},"error_message":null,"id":"0f7cb2d4-469a-4dbe-995b-9e8947611a18","name":"test-cr-ns-02","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns02c1j0hsbc","registry_namespace_id":"01e7c8df-1be1-467b-ae76-3aa90958f9e2","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:37:53.129815Z"}'
-        headers:
-            Content-Length:
-                - "552"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:38:20 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 552fa328-f0b1-49ac-a762-baa4f3451007
-        status: 200 OK
-        code: 200
-        duration: 110.396166ms
-    - id: 11
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 483
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"namespace_id":"0f7cb2d4-469a-4dbe-995b-9e8947611a18","name":"my-container-02","environment_variables":{"foo":"var"},"min_scale":3,"max_scale":5,"memory_limit":256,"cpu_limit":140,"timeout":"600.000000000s","privacy":"private","description":"environment variables test","registry_image":"rg.fr-par.scw.cloud/funcscwtestcrns02c1j0hsbc/nginx:test","max_concurrency":80,"protocol":"h2c","port":80,"secret_environment_variables":null,"http_option":"enabled","sandbox":"unknown_sandbox"}'
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 897
-        uncompressed: false
-        body: '{"cpu_limit":140,"created_at":"2025-01-24T15:38:20.937009289Z","description":"environment variables test","domain_name":"testcrns02c1j0hsbc-my-container-02.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"var"},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"9998419a-8765-47f3-a3d2-36dc747c4967","local_storage_limit":1000,"max_concurrency":80,"max_scale":5,"memory_limit":256,"min_scale":3,"name":"my-container-02","namespace_id":"0f7cb2d4-469a-4dbe-995b-9e8947611a18","port":80,"privacy":"private","protocol":"h2c","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtestcrns02c1j0hsbc/nginx:test","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":80},"secret_environment_variables":[],"status":"created","timeout":"600s","updated_at":"2025-01-24T15:38:20.937009289Z"}'
-        headers:
-            Content-Length:
-                - "897"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:38:20 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - cb1710af-662b-4179-9caf-04703d0517e4
-        status: 200 OK
-        code: 200
-        duration: 738.050666ms
-    - id: 12
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/9998419a-8765-47f3-a3d2-36dc747c4967
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 891
-        uncompressed: false
-        body: '{"cpu_limit":140,"created_at":"2025-01-24T15:38:20.937009Z","description":"environment variables test","domain_name":"testcrns02c1j0hsbc-my-container-02.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"var"},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"9998419a-8765-47f3-a3d2-36dc747c4967","local_storage_limit":1000,"max_concurrency":80,"max_scale":5,"memory_limit":256,"min_scale":3,"name":"my-container-02","namespace_id":"0f7cb2d4-469a-4dbe-995b-9e8947611a18","port":80,"privacy":"private","protocol":"h2c","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtestcrns02c1j0hsbc/nginx:test","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":80},"secret_environment_variables":[],"status":"created","timeout":"600s","updated_at":"2025-01-24T15:38:20.937009Z"}'
-        headers:
-            Content-Length:
-                - "891"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:38:21 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - aee258f2-1916-4d75-aec4-76f64ab8d95b
-        status: 200 OK
-        code: 200
-        duration: 74.978542ms
-    - id: 13
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -659,8 +365,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/9998419a-8765-47f3-a3d2-36dc747c4967
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/8973b4fb-618a-4ef8-a23c-e9128394e6ca
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -668,20 +374,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 894
+        content_length: 935
         uncompressed: false
-        body: '{"cpu_limit":140,"created_at":"2025-01-24T15:38:20.937009Z","description":"environment variables test","domain_name":"testcrns02c1j0hsbc-my-container-02.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"var"},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"9998419a-8765-47f3-a3d2-36dc747c4967","local_storage_limit":1000,"max_concurrency":80,"max_scale":5,"memory_limit":256,"min_scale":3,"name":"my-container-02","namespace_id":"0f7cb2d4-469a-4dbe-995b-9e8947611a18","port":80,"privacy":"private","protocol":"h2c","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtestcrns02c1j0hsbc/nginx:test","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":80},"secret_environment_variables":[],"status":"pending","timeout":"600s","updated_at":"2025-01-24T15:38:21.121854678Z"}'
+        body: '{"cpu_limit":140,"created_at":"2025-05-19T14:02:59.637634Z","description":"environment variables test","domain_name":"testcrns02idavh1tf-my-container-02.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"var"},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"8973b4fb-618a-4ef8-a23c-e9128394e6ca","local_storage_limit":1000,"max_concurrency":80,"max_scale":5,"memory_limit":256,"min_scale":3,"name":"my-container-02","namespace_id":"2eb366fe-cf26-4587-a98f-57d2c1bbe349","port":80,"privacy":"private","private_network_id":null,"protocol":"h2c","ready_at":null,"region":"fr-par","registry_image":"docker.io/library/nginx:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":80},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"600s","updated_at":"2025-05-19T14:02:59.825967960Z"}'
         headers:
             Content-Length:
-                - "894"
+                - "935"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:21 GMT
+                - Mon, 19 May 2025 14:02:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -689,10 +395,304 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fd161a20-c452-45cf-a0cf-265f1cb17b31
+                - d874a45e-3fe0-4e31-9561-c62ee0e90481
         status: 200 OK
         code: 200
-        duration: 92.785208ms
+        duration: 106.37025ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/8973b4fb-618a-4ef8-a23c-e9128394e6ca
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 932
+        uncompressed: false
+        body: '{"cpu_limit":140,"created_at":"2025-05-19T14:02:59.637634Z","description":"environment variables test","domain_name":"testcrns02idavh1tf-my-container-02.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"var"},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"8973b4fb-618a-4ef8-a23c-e9128394e6ca","local_storage_limit":1000,"max_concurrency":80,"max_scale":5,"memory_limit":256,"min_scale":3,"name":"my-container-02","namespace_id":"2eb366fe-cf26-4587-a98f-57d2c1bbe349","port":80,"privacy":"private","private_network_id":null,"protocol":"h2c","ready_at":null,"region":"fr-par","registry_image":"docker.io/library/nginx:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":80},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"600s","updated_at":"2025-05-19T14:02:59.825968Z"}'
+        headers:
+            Content-Length:
+                - "932"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 19 May 2025 14:02:59 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 58813927-c4c1-445f-a23d-13eae1bb75dd
+        status: 200 OK
+        code: 200
+        duration: 46.474ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/8973b4fb-618a-4ef8-a23c-e9128394e6ca
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 932
+        uncompressed: false
+        body: '{"cpu_limit":140,"created_at":"2025-05-19T14:02:59.637634Z","description":"environment variables test","domain_name":"testcrns02idavh1tf-my-container-02.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"var"},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"8973b4fb-618a-4ef8-a23c-e9128394e6ca","local_storage_limit":1000,"max_concurrency":80,"max_scale":5,"memory_limit":256,"min_scale":3,"name":"my-container-02","namespace_id":"2eb366fe-cf26-4587-a98f-57d2c1bbe349","port":80,"privacy":"private","private_network_id":null,"protocol":"h2c","ready_at":null,"region":"fr-par","registry_image":"docker.io/library/nginx:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":80},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"600s","updated_at":"2025-05-19T14:02:59.825968Z"}'
+        headers:
+            Content-Length:
+                - "932"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 19 May 2025 14:03:04 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 1dca822b-449b-4139-9f38-939c0f393561
+        status: 200 OK
+        code: 200
+        duration: 71.50975ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/8973b4fb-618a-4ef8-a23c-e9128394e6ca
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 932
+        uncompressed: false
+        body: '{"cpu_limit":140,"created_at":"2025-05-19T14:02:59.637634Z","description":"environment variables test","domain_name":"testcrns02idavh1tf-my-container-02.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"var"},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"8973b4fb-618a-4ef8-a23c-e9128394e6ca","local_storage_limit":1000,"max_concurrency":80,"max_scale":5,"memory_limit":256,"min_scale":3,"name":"my-container-02","namespace_id":"2eb366fe-cf26-4587-a98f-57d2c1bbe349","port":80,"privacy":"private","private_network_id":null,"protocol":"h2c","ready_at":null,"region":"fr-par","registry_image":"docker.io/library/nginx:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":80},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"600s","updated_at":"2025-05-19T14:02:59.825968Z"}'
+        headers:
+            Content-Length:
+                - "932"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 19 May 2025 14:03:10 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 66e474e2-b67f-439a-af03-cb3592a964d6
+        status: 200 OK
+        code: 200
+        duration: 58.15225ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/8973b4fb-618a-4ef8-a23c-e9128394e6ca
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 932
+        uncompressed: false
+        body: '{"cpu_limit":140,"created_at":"2025-05-19T14:02:59.637634Z","description":"environment variables test","domain_name":"testcrns02idavh1tf-my-container-02.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"var"},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"8973b4fb-618a-4ef8-a23c-e9128394e6ca","local_storage_limit":1000,"max_concurrency":80,"max_scale":5,"memory_limit":256,"min_scale":3,"name":"my-container-02","namespace_id":"2eb366fe-cf26-4587-a98f-57d2c1bbe349","port":80,"privacy":"private","private_network_id":null,"protocol":"h2c","ready_at":null,"region":"fr-par","registry_image":"docker.io/library/nginx:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":80},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"600s","updated_at":"2025-05-19T14:02:59.825968Z"}'
+        headers:
+            Content-Length:
+                - "932"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 19 May 2025 14:03:15 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f483954a-2a58-4487-b1e9-c87fe6a95c7a
+        status: 200 OK
+        code: 200
+        duration: 48.960583ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/8973b4fb-618a-4ef8-a23c-e9128394e6ca
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 932
+        uncompressed: false
+        body: '{"cpu_limit":140,"created_at":"2025-05-19T14:02:59.637634Z","description":"environment variables test","domain_name":"testcrns02idavh1tf-my-container-02.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"var"},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"8973b4fb-618a-4ef8-a23c-e9128394e6ca","local_storage_limit":1000,"max_concurrency":80,"max_scale":5,"memory_limit":256,"min_scale":3,"name":"my-container-02","namespace_id":"2eb366fe-cf26-4587-a98f-57d2c1bbe349","port":80,"privacy":"private","private_network_id":null,"protocol":"h2c","ready_at":null,"region":"fr-par","registry_image":"docker.io/library/nginx:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":80},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"600s","updated_at":"2025-05-19T14:02:59.825968Z"}'
+        headers:
+            Content-Length:
+                - "932"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 19 May 2025 14:03:20 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 9116581d-f7de-4ca1-ba55-bae4f4e28333
+        status: 200 OK
+        code: 200
+        duration: 152.666875ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/8973b4fb-618a-4ef8-a23c-e9128394e6ca
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 955
+        uncompressed: false
+        body: '{"cpu_limit":140,"created_at":"2025-05-19T14:02:59.637634Z","description":"environment variables test","domain_name":"testcrns02idavh1tf-my-container-02.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"var"},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"8973b4fb-618a-4ef8-a23c-e9128394e6ca","local_storage_limit":1000,"max_concurrency":80,"max_scale":5,"memory_limit":256,"min_scale":3,"name":"my-container-02","namespace_id":"2eb366fe-cf26-4587-a98f-57d2c1bbe349","port":80,"privacy":"private","private_network_id":null,"protocol":"h2c","ready_at":"2025-05-19T14:03:21.427474Z","region":"fr-par","registry_image":"docker.io/library/nginx:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":80},"secret_environment_variables":[],"status":"ready","tags":[],"timeout":"600s","updated_at":"2025-05-19T14:03:21.444630Z"}'
+        headers:
+            Content-Length:
+                - "955"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 19 May 2025 14:03:25 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 1023ad44-8bc6-4821-85f4-af984608a31b
+        status: 200 OK
+        code: 200
+        duration: 56.210625ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -708,8 +708,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/9998419a-8765-47f3-a3d2-36dc747c4967
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/8973b4fb-618a-4ef8-a23c-e9128394e6ca
         method: GET
       response:
         proto: HTTP/2.0
@@ -717,20 +717,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 891
+        content_length: 955
         uncompressed: false
-        body: '{"cpu_limit":140,"created_at":"2025-01-24T15:38:20.937009Z","description":"environment variables test","domain_name":"testcrns02c1j0hsbc-my-container-02.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"var"},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"9998419a-8765-47f3-a3d2-36dc747c4967","local_storage_limit":1000,"max_concurrency":80,"max_scale":5,"memory_limit":256,"min_scale":3,"name":"my-container-02","namespace_id":"0f7cb2d4-469a-4dbe-995b-9e8947611a18","port":80,"privacy":"private","protocol":"h2c","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtestcrns02c1j0hsbc/nginx:test","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":80},"secret_environment_variables":[],"status":"pending","timeout":"600s","updated_at":"2025-01-24T15:38:21.121855Z"}'
+        body: '{"cpu_limit":140,"created_at":"2025-05-19T14:02:59.637634Z","description":"environment variables test","domain_name":"testcrns02idavh1tf-my-container-02.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"var"},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"8973b4fb-618a-4ef8-a23c-e9128394e6ca","local_storage_limit":1000,"max_concurrency":80,"max_scale":5,"memory_limit":256,"min_scale":3,"name":"my-container-02","namespace_id":"2eb366fe-cf26-4587-a98f-57d2c1bbe349","port":80,"privacy":"private","private_network_id":null,"protocol":"h2c","ready_at":"2025-05-19T14:03:21.427474Z","region":"fr-par","registry_image":"docker.io/library/nginx:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":80},"secret_environment_variables":[],"status":"ready","tags":[],"timeout":"600s","updated_at":"2025-05-19T14:03:21.444630Z"}'
         headers:
             Content-Length:
-                - "891"
+                - "955"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:21 GMT
+                - Mon, 19 May 2025 14:03:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -738,10 +738,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c712dc9e-2a6b-494b-a19c-f69266161c92
+                - 2912e373-fdbd-476c-ad0f-0f5742225887
         status: 200 OK
         code: 200
-        duration: 75.209833ms
+        duration: 48.246666ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -757,8 +757,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/9998419a-8765-47f3-a3d2-36dc747c4967
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/8973b4fb-618a-4ef8-a23c-e9128394e6ca
         method: GET
       response:
         proto: HTTP/2.0
@@ -766,20 +766,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1149
+        content_length: 955
         uncompressed: false
-        body: '{"cpu_limit":140,"created_at":"2025-01-24T15:38:20.937009Z","description":"environment variables test","domain_name":"testcrns02c1j0hsbc-my-container-02.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"var"},"error_message":"Invalid Image architecture. Serverless Containers only support the amd64 architecture, but the image was built for the following architectures: arm64. Please rebuild the image for the correct architecture using the `--platform=linux/amd64` Docker build argument.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"9998419a-8765-47f3-a3d2-36dc747c4967","local_storage_limit":1000,"max_concurrency":80,"max_scale":5,"memory_limit":256,"min_scale":3,"name":"my-container-02","namespace_id":"0f7cb2d4-469a-4dbe-995b-9e8947611a18","port":80,"privacy":"private","protocol":"h2c","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtestcrns02c1j0hsbc/nginx:test","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":80},"secret_environment_variables":[],"status":"error","timeout":"600s","updated_at":"2025-01-24T15:38:21.682411Z"}'
+        body: '{"cpu_limit":140,"created_at":"2025-05-19T14:02:59.637634Z","description":"environment variables test","domain_name":"testcrns02idavh1tf-my-container-02.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"var"},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"8973b4fb-618a-4ef8-a23c-e9128394e6ca","local_storage_limit":1000,"max_concurrency":80,"max_scale":5,"memory_limit":256,"min_scale":3,"name":"my-container-02","namespace_id":"2eb366fe-cf26-4587-a98f-57d2c1bbe349","port":80,"privacy":"private","private_network_id":null,"protocol":"h2c","ready_at":"2025-05-19T14:03:21.427474Z","region":"fr-par","registry_image":"docker.io/library/nginx:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":80},"secret_environment_variables":[],"status":"ready","tags":[],"timeout":"600s","updated_at":"2025-05-19T14:03:21.444630Z"}'
         headers:
             Content-Length:
-                - "1149"
+                - "955"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:26 GMT
+                - Mon, 19 May 2025 14:03:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -787,10 +787,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 65a159b8-d3ca-4e62-86d0-22e9ce9f8b7b
+                - 130ec0e0-8a63-499f-b130-6cc301ce9357
         status: 200 OK
         code: 200
-        duration: 69.207667ms
+        duration: 52.946625ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -806,8 +806,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/9998419a-8765-47f3-a3d2-36dc747c4967
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2eb366fe-cf26-4587-a98f-57d2c1bbe349
         method: GET
       response:
         proto: HTTP/2.0
@@ -815,20 +815,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1149
+        content_length: 601
         uncompressed: false
-        body: '{"cpu_limit":140,"created_at":"2025-01-24T15:38:20.937009Z","description":"environment variables test","domain_name":"testcrns02c1j0hsbc-my-container-02.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"var"},"error_message":"Invalid Image architecture. Serverless Containers only support the amd64 architecture, but the image was built for the following architectures: arm64. Please rebuild the image for the correct architecture using the `--platform=linux/amd64` Docker build argument.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"9998419a-8765-47f3-a3d2-36dc747c4967","local_storage_limit":1000,"max_concurrency":80,"max_scale":5,"memory_limit":256,"min_scale":3,"name":"my-container-02","namespace_id":"0f7cb2d4-469a-4dbe-995b-9e8947611a18","port":80,"privacy":"private","protocol":"h2c","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtestcrns02c1j0hsbc/nginx:test","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":80},"secret_environment_variables":[],"status":"error","timeout":"600s","updated_at":"2025-01-24T15:38:21.682411Z"}'
+        body: '{"created_at":"2025-05-19T14:02:54.104072Z","description":"test container","environment_variables":{},"error_message":null,"id":"2eb366fe-cf26-4587-a98f-57d2c1bbe349","name":"test-cr-ns-02","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns02idavh1tf","registry_namespace_id":"ca5e2711-db7c-45da-bd04-7c9c72993eab","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-05-19T14:02:56.967744Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "1149"
+                - "601"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:26 GMT
+                - Mon, 19 May 2025 14:03:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -836,10 +836,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d38357a1-40e9-4fe4-8d5b-e96073dd3e3c
+                - 9c688df3-1507-4f56-8146-9907730951dd
         status: 200 OK
         code: 200
-        duration: 182.0625ms
+        duration: 49.445ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -855,8 +855,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/9998419a-8765-47f3-a3d2-36dc747c4967
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/8973b4fb-618a-4ef8-a23c-e9128394e6ca
         method: GET
       response:
         proto: HTTP/2.0
@@ -864,20 +864,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1149
+        content_length: 955
         uncompressed: false
-        body: '{"cpu_limit":140,"created_at":"2025-01-24T15:38:20.937009Z","description":"environment variables test","domain_name":"testcrns02c1j0hsbc-my-container-02.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"var"},"error_message":"Invalid Image architecture. Serverless Containers only support the amd64 architecture, but the image was built for the following architectures: arm64. Please rebuild the image for the correct architecture using the `--platform=linux/amd64` Docker build argument.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"9998419a-8765-47f3-a3d2-36dc747c4967","local_storage_limit":1000,"max_concurrency":80,"max_scale":5,"memory_limit":256,"min_scale":3,"name":"my-container-02","namespace_id":"0f7cb2d4-469a-4dbe-995b-9e8947611a18","port":80,"privacy":"private","protocol":"h2c","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtestcrns02c1j0hsbc/nginx:test","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":80},"secret_environment_variables":[],"status":"error","timeout":"600s","updated_at":"2025-01-24T15:38:21.682411Z"}'
+        body: '{"cpu_limit":140,"created_at":"2025-05-19T14:02:59.637634Z","description":"environment variables test","domain_name":"testcrns02idavh1tf-my-container-02.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"var"},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"8973b4fb-618a-4ef8-a23c-e9128394e6ca","local_storage_limit":1000,"max_concurrency":80,"max_scale":5,"memory_limit":256,"min_scale":3,"name":"my-container-02","namespace_id":"2eb366fe-cf26-4587-a98f-57d2c1bbe349","port":80,"privacy":"private","private_network_id":null,"protocol":"h2c","ready_at":"2025-05-19T14:03:21.427474Z","region":"fr-par","registry_image":"docker.io/library/nginx:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":80},"secret_environment_variables":[],"status":"ready","tags":[],"timeout":"600s","updated_at":"2025-05-19T14:03:21.444630Z"}'
         headers:
             Content-Length:
-                - "1149"
+                - "955"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:26 GMT
+                - Mon, 19 May 2025 14:03:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -885,10 +885,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cb70074e-ada7-48ee-b868-8a501f9a4fcd
+                - 970f110e-c5b3-480e-8b84-3939c2208925
         status: 200 OK
         code: 200
-        duration: 79.898459ms
+        duration: 63.094542ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -904,8 +904,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/0f7cb2d4-469a-4dbe-995b-9e8947611a18
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/8973b4fb-618a-4ef8-a23c-e9128394e6ca
         method: GET
       response:
         proto: HTTP/2.0
@@ -913,20 +913,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 552
+        content_length: 955
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.279672Z","description":"test container","environment_variables":{},"error_message":null,"id":"0f7cb2d4-469a-4dbe-995b-9e8947611a18","name":"test-cr-ns-02","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns02c1j0hsbc","registry_namespace_id":"01e7c8df-1be1-467b-ae76-3aa90958f9e2","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:37:53.129815Z"}'
+        body: '{"cpu_limit":140,"created_at":"2025-05-19T14:02:59.637634Z","description":"environment variables test","domain_name":"testcrns02idavh1tf-my-container-02.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"var"},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"8973b4fb-618a-4ef8-a23c-e9128394e6ca","local_storage_limit":1000,"max_concurrency":80,"max_scale":5,"memory_limit":256,"min_scale":3,"name":"my-container-02","namespace_id":"2eb366fe-cf26-4587-a98f-57d2c1bbe349","port":80,"privacy":"private","private_network_id":null,"protocol":"h2c","ready_at":"2025-05-19T14:03:21.427474Z","region":"fr-par","registry_image":"docker.io/library/nginx:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":80},"secret_environment_variables":[],"status":"ready","tags":[],"timeout":"600s","updated_at":"2025-05-19T14:03:21.444630Z"}'
         headers:
             Content-Length:
-                - "552"
+                - "955"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:27 GMT
+                - Mon, 19 May 2025 14:03:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -934,10 +934,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8c6c22d8-4ccd-4177-9a40-c427575457b5
+                - f196abb1-144e-481a-93cb-b4a6f2a474ce
         status: 200 OK
         code: 200
-        duration: 58.062ms
+        duration: 62.731875ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -953,29 +953,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/9998419a-8765-47f3-a3d2-36dc747c4967
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/8973b4fb-618a-4ef8-a23c-e9128394e6ca
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1149
+        content_length: 961
         uncompressed: false
-        body: '{"cpu_limit":140,"created_at":"2025-01-24T15:38:20.937009Z","description":"environment variables test","domain_name":"testcrns02c1j0hsbc-my-container-02.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"var"},"error_message":"Invalid Image architecture. Serverless Containers only support the amd64 architecture, but the image was built for the following architectures: arm64. Please rebuild the image for the correct architecture using the `--platform=linux/amd64` Docker build argument.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"9998419a-8765-47f3-a3d2-36dc747c4967","local_storage_limit":1000,"max_concurrency":80,"max_scale":5,"memory_limit":256,"min_scale":3,"name":"my-container-02","namespace_id":"0f7cb2d4-469a-4dbe-995b-9e8947611a18","port":80,"privacy":"private","protocol":"h2c","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtestcrns02c1j0hsbc/nginx:test","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":80},"secret_environment_variables":[],"status":"error","timeout":"600s","updated_at":"2025-01-24T15:38:21.682411Z"}'
+        body: '{"cpu_limit":140,"created_at":"2025-05-19T14:02:59.637634Z","description":"environment variables test","domain_name":"testcrns02idavh1tf-my-container-02.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"var"},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"8973b4fb-618a-4ef8-a23c-e9128394e6ca","local_storage_limit":1000,"max_concurrency":80,"max_scale":5,"memory_limit":256,"min_scale":3,"name":"my-container-02","namespace_id":"2eb366fe-cf26-4587-a98f-57d2c1bbe349","port":80,"privacy":"private","private_network_id":null,"protocol":"h2c","ready_at":"2025-05-19T14:03:21.427474Z","region":"fr-par","registry_image":"docker.io/library/nginx:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":80},"secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"600s","updated_at":"2025-05-19T14:03:26.090966600Z"}'
         headers:
             Content-Length:
-                - "1149"
+                - "961"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:27 GMT
+                - Mon, 19 May 2025 14:03:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -983,10 +983,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 655335b7-202a-49dc-9485-304e8f38dfc0
+                - 2ef70604-3506-4a0d-bf66-add4fa9b20cd
         status: 200 OK
         code: 200
-        duration: 69.504666ms
+        duration: 131.144583ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1002,8 +1002,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/9998419a-8765-47f3-a3d2-36dc747c4967
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2eb366fe-cf26-4587-a98f-57d2c1bbe349
         method: GET
       response:
         proto: HTTP/2.0
@@ -1011,20 +1011,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1149
+        content_length: 601
         uncompressed: false
-        body: '{"cpu_limit":140,"created_at":"2025-01-24T15:38:20.937009Z","description":"environment variables test","domain_name":"testcrns02c1j0hsbc-my-container-02.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"var"},"error_message":"Invalid Image architecture. Serverless Containers only support the amd64 architecture, but the image was built for the following architectures: arm64. Please rebuild the image for the correct architecture using the `--platform=linux/amd64` Docker build argument.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"9998419a-8765-47f3-a3d2-36dc747c4967","local_storage_limit":1000,"max_concurrency":80,"max_scale":5,"memory_limit":256,"min_scale":3,"name":"my-container-02","namespace_id":"0f7cb2d4-469a-4dbe-995b-9e8947611a18","port":80,"privacy":"private","protocol":"h2c","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtestcrns02c1j0hsbc/nginx:test","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":80},"secret_environment_variables":[],"status":"error","timeout":"600s","updated_at":"2025-01-24T15:38:21.682411Z"}'
+        body: '{"created_at":"2025-05-19T14:02:54.104072Z","description":"test container","environment_variables":{},"error_message":null,"id":"2eb366fe-cf26-4587-a98f-57d2c1bbe349","name":"test-cr-ns-02","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns02idavh1tf","registry_namespace_id":"ca5e2711-db7c-45da-bd04-7c9c72993eab","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-05-19T14:02:56.967744Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "1149"
+                - "601"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:28 GMT
+                - Mon, 19 May 2025 14:03:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1032,10 +1032,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8648555d-c5e6-4e89-90b9-370c5408001c
+                - fd75ab6c-0741-4711-afae-a79b426cbd35
         status: 200 OK
         code: 200
-        duration: 88.324125ms
+        duration: 44.743375ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1051,8 +1051,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/9998419a-8765-47f3-a3d2-36dc747c4967
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2eb366fe-cf26-4587-a98f-57d2c1bbe349
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1060,20 +1060,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 895
+        content_length: 607
         uncompressed: false
-        body: '{"cpu_limit":140,"created_at":"2025-01-24T15:38:20.937009Z","description":"environment variables test","domain_name":"testcrns02c1j0hsbc-my-container-02.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"var"},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"9998419a-8765-47f3-a3d2-36dc747c4967","local_storage_limit":1000,"max_concurrency":80,"max_scale":5,"memory_limit":256,"min_scale":3,"name":"my-container-02","namespace_id":"0f7cb2d4-469a-4dbe-995b-9e8947611a18","port":80,"privacy":"private","protocol":"h2c","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtestcrns02c1j0hsbc/nginx:test","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":80},"secret_environment_variables":[],"status":"deleting","timeout":"600s","updated_at":"2025-01-24T15:38:28.567742646Z"}'
+        body: '{"created_at":"2025-05-19T14:02:54.104072Z","description":"test container","environment_variables":{},"error_message":null,"id":"2eb366fe-cf26-4587-a98f-57d2c1bbe349","name":"test-cr-ns-02","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns02idavh1tf","registry_namespace_id":"ca5e2711-db7c-45da-bd04-7c9c72993eab","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-05-19T14:03:26.273178161Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "895"
+                - "607"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:28 GMT
+                - Mon, 19 May 2025 14:03:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1081,10 +1081,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a8c4c6b9-f18e-4aa0-b978-21725cff5176
+                - a0e709dc-9fed-42c5-8be7-b98c62d64fe0
         status: 200 OK
         code: 200
-        duration: 145.766291ms
+        duration: 257.743708ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1100,8 +1100,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/0f7cb2d4-469a-4dbe-995b-9e8947611a18
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2eb366fe-cf26-4587-a98f-57d2c1bbe349
         method: GET
       response:
         proto: HTTP/2.0
@@ -1109,20 +1109,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 552
+        content_length: 604
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.279672Z","description":"test container","environment_variables":{},"error_message":null,"id":"0f7cb2d4-469a-4dbe-995b-9e8947611a18","name":"test-cr-ns-02","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns02c1j0hsbc","registry_namespace_id":"01e7c8df-1be1-467b-ae76-3aa90958f9e2","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:37:53.129815Z"}'
+        body: '{"created_at":"2025-05-19T14:02:54.104072Z","description":"test container","environment_variables":{},"error_message":null,"id":"2eb366fe-cf26-4587-a98f-57d2c1bbe349","name":"test-cr-ns-02","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns02idavh1tf","registry_namespace_id":"ca5e2711-db7c-45da-bd04-7c9c72993eab","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-05-19T14:03:26.273178Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "552"
+                - "604"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:28 GMT
+                - Mon, 19 May 2025 14:03:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1130,10 +1130,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 94b829e1-6f5c-4b98-bbe0-f6b5dc09c103
+                - d978cda0-d79c-4411-93ff-0e6b263dfc83
         status: 200 OK
         code: 200
-        duration: 65.532375ms
+        duration: 45.216083ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1149,29 +1149,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/0f7cb2d4-469a-4dbe-995b-9e8947611a18
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2eb366fe-cf26-4587-a98f-57d2c1bbe349
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 558
+        content_length: 604
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.279672Z","description":"test container","environment_variables":{},"error_message":null,"id":"0f7cb2d4-469a-4dbe-995b-9e8947611a18","name":"test-cr-ns-02","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns02c1j0hsbc","registry_namespace_id":"01e7c8df-1be1-467b-ae76-3aa90958f9e2","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:38:28.767247940Z"}'
+        body: '{"created_at":"2025-05-19T14:02:54.104072Z","description":"test container","environment_variables":{},"error_message":null,"id":"2eb366fe-cf26-4587-a98f-57d2c1bbe349","name":"test-cr-ns-02","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns02idavh1tf","registry_namespace_id":"ca5e2711-db7c-45da-bd04-7c9c72993eab","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-05-19T14:03:26.273178Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "558"
+                - "604"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:28 GMT
+                - Mon, 19 May 2025 14:03:31 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1179,10 +1179,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 04e3ce82-657f-4f42-8379-691ebc3ba846
+                - 460db394-0c82-423e-b7be-6cf24950b63b
         status: 200 OK
         code: 200
-        duration: 202.334542ms
+        duration: 45.71325ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1198,8 +1198,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/0f7cb2d4-469a-4dbe-995b-9e8947611a18
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2eb366fe-cf26-4587-a98f-57d2c1bbe349
         method: GET
       response:
         proto: HTTP/2.0
@@ -1207,20 +1207,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 555
+        content_length: 604
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.279672Z","description":"test container","environment_variables":{},"error_message":null,"id":"0f7cb2d4-469a-4dbe-995b-9e8947611a18","name":"test-cr-ns-02","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns02c1j0hsbc","registry_namespace_id":"01e7c8df-1be1-467b-ae76-3aa90958f9e2","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:38:28.767248Z"}'
+        body: '{"created_at":"2025-05-19T14:02:54.104072Z","description":"test container","environment_variables":{},"error_message":null,"id":"2eb366fe-cf26-4587-a98f-57d2c1bbe349","name":"test-cr-ns-02","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns02idavh1tf","registry_namespace_id":"ca5e2711-db7c-45da-bd04-7c9c72993eab","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-05-19T14:03:26.273178Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "555"
+                - "604"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:28 GMT
+                - Mon, 19 May 2025 14:03:36 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1228,10 +1228,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b9ce9060-c649-4e2d-bded-97f3aa2439de
+                - 2963a017-8dbc-417f-90c7-ca05d17f8d21
         status: 200 OK
         code: 200
-        duration: 65.312625ms
+        duration: 57.212625ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1247,8 +1247,155 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/0f7cb2d4-469a-4dbe-995b-9e8947611a18
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2eb366fe-cf26-4587-a98f-57d2c1bbe349
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 604
+        uncompressed: false
+        body: '{"created_at":"2025-05-19T14:02:54.104072Z","description":"test container","environment_variables":{},"error_message":null,"id":"2eb366fe-cf26-4587-a98f-57d2c1bbe349","name":"test-cr-ns-02","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns02idavh1tf","registry_namespace_id":"ca5e2711-db7c-45da-bd04-7c9c72993eab","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-05-19T14:03:26.273178Z","vpc_integration_activated":false}'
+        headers:
+            Content-Length:
+                - "604"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 19 May 2025 14:03:41 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 5525c759-4389-4166-bf3b-ab0854ecb97e
+        status: 200 OK
+        code: 200
+        duration: 57.695792ms
+    - id: 26
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2eb366fe-cf26-4587-a98f-57d2c1bbe349
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 604
+        uncompressed: false
+        body: '{"created_at":"2025-05-19T14:02:54.104072Z","description":"test container","environment_variables":{},"error_message":null,"id":"2eb366fe-cf26-4587-a98f-57d2c1bbe349","name":"test-cr-ns-02","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns02idavh1tf","registry_namespace_id":"ca5e2711-db7c-45da-bd04-7c9c72993eab","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-05-19T14:03:26.273178Z","vpc_integration_activated":false}'
+        headers:
+            Content-Length:
+                - "604"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 19 May 2025 14:03:46 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 41e24839-8ac3-46ed-9a96-cfa493b28f29
+        status: 200 OK
+        code: 200
+        duration: 57.258208ms
+    - id: 27
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2eb366fe-cf26-4587-a98f-57d2c1bbe349
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 604
+        uncompressed: false
+        body: '{"created_at":"2025-05-19T14:02:54.104072Z","description":"test container","environment_variables":{},"error_message":null,"id":"2eb366fe-cf26-4587-a98f-57d2c1bbe349","name":"test-cr-ns-02","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns02idavh1tf","registry_namespace_id":"ca5e2711-db7c-45da-bd04-7c9c72993eab","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-05-19T14:03:26.273178Z","vpc_integration_activated":false}'
+        headers:
+            Content-Length:
+                - "604"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 19 May 2025 14:03:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 420136c2-9f9f-42b2-a1cd-adea5116fce7
+        status: 200 OK
+        code: 200
+        duration: 49.018125ms
+    - id: 28
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2eb366fe-cf26-4587-a98f-57d2c1bbe349
         method: GET
       response:
         proto: HTTP/2.0
@@ -1267,9 +1414,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:34 GMT
+                - Mon, 19 May 2025 14:03:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1277,11 +1424,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3613fd37-3222-40ef-bda5-b2b141969042
+                - d5e8384f-6349-4c8c-abef-9fb9b337eec3
         status: 404 Not Found
         code: 404
-        duration: 33.698625ms
-    - id: 26
+        duration: 36.274167ms
+    - id: 29
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1296,8 +1443,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/0f7cb2d4-469a-4dbe-995b-9e8947611a18
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/2eb366fe-cf26-4587-a98f-57d2c1bbe349
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1316,9 +1463,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:34 GMT
+                - Mon, 19 May 2025 14:03:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1326,7 +1473,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e8db8032-8364-4c96-a5d3-ef5d7f441135
+                - 19b41696-c43d-4d31-bd71-74488ee66750
         status: 404 Not Found
         code: 404
-        duration: 29.546834ms
+        duration: 26.523084ms

--- a/internal/services/container/trigger_test.go
+++ b/internal/services/container/trigger_test.go
@@ -35,14 +35,14 @@ func TestAccTrigger_SQS(t *testing.T) {
 
 					resource "scaleway_mnq_sqs_credentials" "main" {
 						project_id = scaleway_mnq_sqs.main.project_id
-					
+
 						permissions {
 							can_publish = true
 							can_receive = true
 							can_manage  = true
 						}
 					}
-					
+
 					resource "scaleway_mnq_sqs_queue" "queue" {
 						project_id = scaleway_mnq_sqs.main.project_id
 						name = "TestQueue"


### PR DESCRIPTION
As a user bring recently, in most of the modules, we ignore the `project_id` parameter set at the provider level in some cases, because the environment takes precedence over the provider config [here](https://github.com/scaleway/terraform-provider-scaleway/blob/ee4eaf3c1e02119c3c7ed37a572337fb999e9de3/internal/meta/meta.go#L225C83-L225C93)

partly fixes https://github.com/scaleway/terraform-provider-scaleway/issues/3068

The provider configuration should probably override other configuration sources but this could be impactful / breaking for users used to provide environment variables

The change imply to explicitly find a `project_id` at the resource / client level and raise an error if not found, instead of relying on the SDK logic to eventually find it or use an empty string  in some cases.

=> Now when running the test in CI, we need to inject a project ID in the [meta configuration](https://github.com/scaleway/terraform-provider-scaleway/pull/3093/files#diff-7a0b4bba956f7f07d7f1b0b1b3f83f28dda76464bf8a7bc0c98d406a1029efdbR45).

But this reveal another corner case: resources calling HTTP GET query with the optional `project_id` parameter that where not using it, [namespace container datasource](https://github.com/scaleway/terraform-provider-scaleway/blob/ee4eaf3c1e02119c3c7ed37a572337fb999e9de3/internal/services/container/testdata/data-source-namespace-basic.cassette.yaml#L71) for instance, are now using the fake project_id set in the test suite (`&project_id=1111111`).
So [we strip this parameter](https://github.com/scaleway/terraform-provider-scaleway/pull/3093/files#diff-7a0b4bba956f7f07d7f1b0b1b3f83f28dda76464bf8a7bc0c98d406a1029efdbR70) from the query to address these kind of cases
