### PR TITLE
fix(vpcgw): fix gatewayNetwork read nil pointer

### DIFF
--- a/internal/services/vpcgw/network.go
+++ b/internal/services/vpcgw/network.go
@@ -240,7 +240,7 @@ func ResourceVPCGatewayNetworkRead(ctx context.Context, d *schema.ResourceData, 
 				return diag.FromErr(err)
 			}
 
-			if gatewayNetwork.PrivateNetworkID != "" {
+			if gatewayNetwork != nil && gatewayNetwork.PrivateNetworkID != "" {
 				diags = setPrivateIPsV1(ctx, d, apiV1, gatewayV1, m)
 			}
 


### PR DESCRIPTION
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x38 pc=0x142aeae]

goroutine 1234 [running]:
github.com/scaleway/terraform-provider-scaleway/v2/internal/services/vpcgw.ResourceVPCGatewayNetworkRead({0x1a9f040, 0xc000b84770}, 0xc000676480, {0x1737b40, 0xc0004ca5e8})
        github.com/scaleway/terraform-provider-scaleway/v2/internal/services/vpcgw/network.go:242 +0x44e
 ```