### PR TITLE
doc: format examples and relocate inference model datasource

### DIFF
--- a/docs/data-sources/availability_zones.md
+++ b/docs/data-sources/availability_zones.md
@@ -18,7 +18,7 @@ The following command allow you to retrieve a the AZs of a Region.
 
 ```hcl
 # Get info by Region key
-data scaleway_availability_zones main {
+data "scaleway_availability_zones" "main" {
   region = "nl-ams"
 }
 ```

--- a/docs/data-sources/container.md
+++ b/docs/data-sources/container.md
@@ -18,10 +18,10 @@ The following commands allow you to:
 - retrieve a container by its ID
 
 ```hcl
-resource scaleway_container_namespace main {
+resource "scaleway_container_namespace" "main" {
 }
 
-resource scaleway_container main {
+resource "scaleway_container" "main" {
   name         = "test-container-data"
   namespace_id = scaleway_container_namespace.main.id
 }

--- a/docs/data-sources/inference_model.md
+++ b/docs/data-sources/inference_model.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "inference"
+subcategory: "Inference"
 page_title: "Scaleway: scaleway_inference_model"
 ---
 

--- a/docs/data-sources/lb_certificate.md
+++ b/docs/data-sources/lb_certificate.md
@@ -16,16 +16,16 @@ For more information, see the [main documentation](https://www.scaleway.com/en/d
 ### Let's Encrypt
 
 ```hcl
-resource scaleway_lb_ip main {
+resource "scaleway_lb_ip" "main" {
 }
 
-resource scaleway_lb main {
+resource "scaleway_lb" "main" {
   ip_id = scaleway_lb_ip.main.id
   name  = "data-test-lb-cert"
   type  = "LB-S"
 }
 
-resource scaleway_lb_certificate main {
+resource "scaleway_lb_certificate" "main" {
   lb_id = scaleway_lb.main.id
   name  = "data-test-lb-cert"
   letsencrypt {

--- a/docs/data-sources/rdb_database_backup.md
+++ b/docs/data-sources/rdb_database_backup.md
@@ -10,16 +10,16 @@ Gets information about an RDB backup.
 ## Example Usage
 
 ```hcl
-data scaleway_rdb_database_backup find_by_name {
+data "scaleway_rdb_database_backup" "find_by_name" {
   name = "mybackup"
 }
 
-data scaleway_rdb_database_backup find_by_name_and_instance {
+data "scaleway_rdb_database_backup" "find_by_name_and_instance" {
   name        = "mybackup"
   instance_id = "11111111-1111-1111-1111-111111111111"
 }
 
-data scaleway_rdb_database_backup find_by_id {
+data "scaleway_rdb_database_backup" "find_by_id" {
   backup_id = "11111111-1111-1111-1111-111111111111"
 }
 ```

--- a/docs/data-sources/vpc_gateway_network.md
+++ b/docs/data-sources/vpc_gateway_network.md
@@ -18,11 +18,11 @@ resource "scaleway_vpc_gateway_network" "main" {
   enable_masquerade  = true
 }
 
-data scaleway_vpc_gateway_network by_id {
+data "scaleway_vpc_gateway_network" "by_id" {
   gateway_network_id = scaleway_vpc_gateway_network.main.id
 }
 
-data scaleway_vpc_gateway_network by_gateway_and_pn {
+data "scaleway_vpc_gateway_network" "by_gateway_and_pn" {
   gateway_id         = scaleway_vpc_public_gateway.pg01.id
   private_network_id = scaleway_vpc_private_network.pn01.id
 }

--- a/docs/data-sources/vpc_routes.md
+++ b/docs/data-sources/vpc_routes.md
@@ -10,17 +10,17 @@ Gets information about multiple VPC routes.
 ## Example Usage
 
 ```hcl
-resource scaleway_vpc vpc01 {
+resource "scaleway_vpc" "vpc01" {
   name           = "tf-vpc-route"
   enable_routing = true
 }
 
-resource scaleway_vpc_private_network pn01 {
+resource "scaleway_vpc_private_network" "pn01" {
   name   = "tf-pn-route"
   vpc_id = scaleway_vpc.vpc01.id
 }
 
-resource scaleway_vpc_private_network pn02 {
+resource "scaleway_vpc_private_network" "pn02" {
   name   = "tf-pn_route-2"
   vpc_id = scaleway_vpc.vpc01.id
 }

--- a/docs/resources/apple_silicon_server.md
+++ b/docs/resources/apple_silicon_server.md
@@ -13,7 +13,7 @@ see the [API documentation](https://www.scaleway.com/en/developers/api/apple-sil
 ### Basic
 
 ```terraform
-resource scaleway_apple_silicon_server server {
+resource "scaleway_apple_silicon_server" "server" {
   name = "test-m1"
   type = "M1-M"
 }

--- a/docs/resources/container.md
+++ b/docs/resources/container.md
@@ -14,12 +14,12 @@ For more information on the limitations of Serverless Containers, refer to the [
 ## Example Usage
 
 ```terraform
-resource scaleway_container_namespace main {
+resource "scaleway_container_namespace" "main" {
   name        = "my-ns-test"
   description = "test container"
 }
 
-resource scaleway_container main {
+resource "scaleway_container" "main" {
   name            = "my-container-02"
   description     = "environment variables test"
   namespace_id    = scaleway_container_namespace.main.id
@@ -179,7 +179,7 @@ The period between health checks is also configurable.
 Example:
 
 ```terraform
-resource scaleway_container main {
+resource "scaleway_container" "main" {
   name         = "my-container-02"
   namespace_id = scaleway_container_namespace.main.id
 
@@ -206,7 +206,7 @@ It replaces current `max_concurrency` that has been deprecated.
 Example:
 
 ```terraform
-resource scaleway_container main {
+resource "scaleway_container" "main" {
   name         = "my-container-02"
   namespace_id = scaleway_container_namespace.main.id
 

--- a/docs/resources/container_cron.md
+++ b/docs/resources/container_cron.md
@@ -14,15 +14,15 @@ Refer to the Containers CRON triggers [documentation](https://www.scaleway.com/e
 The following command allows you to add a CRON trigger to a Serverless Container.
 
 ```terraform
-resource scaleway_container_namespace main {
+resource "scaleway_container_namespace" "main" {
 }
 
-resource scaleway_container main {
+resource "scaleway_container" "main" {
   name         = "my-container-with-cron-tf"
   namespace_id = scaleway_container_namespace.main.id
 }
 
-resource scaleway_container_cron main {
+resource "scaleway_container_cron" "main" {
   container_id = scaleway_container.main.id
   name         = "my-cron-name"
   schedule     = "5 4 1 * *" #cron at 04:05 on day-of-month 1

--- a/docs/resources/container_domain.md
+++ b/docs/resources/container_domain.md
@@ -16,7 +16,7 @@ The commands below shows how to bind a custom domain name to a container.
 ### Simple
 
 ```terraform
-resource scaleway_container app {}
+resource "scaleway_container" "app" {}
 
 resource scaleway_container_domain "app" {
   container_id = scaleway_container.app.id
@@ -27,12 +27,12 @@ resource scaleway_container_domain "app" {
 ### Complete example with domain
 
 ```terraform
-resource scaleway_container_namespace main {
+resource "scaleway_container_namespace" "main" {
   name        = "my-ns-test"
   description = "test container"
 }
 
-resource scaleway_container app {
+resource "scaleway_container" "app" {
   name            = "app"
   namespace_id    = scaleway_container_namespace.main.id
   registry_image  = "${scaleway_container_namespace.main.registry_endpoint}/nginx:alpine"

--- a/docs/resources/container_token.md
+++ b/docs/resources/container_token.md
@@ -12,22 +12,22 @@ Refer to the Containers tokens [documentation](https://www.scaleway.com/en/docs/
 ## Example Usage
 
 ```terraform
-resource scaleway_container_namespace main {
+resource "scaleway_container_namespace" "main" {
   name = "test-container-token-ns"
 }
 
-resource scaleway_container main {
+resource "scaleway_container" "main" {
   namespace_id = scaleway_container_namespace.main.id
 }
 
 // Namespace Token
-resource scaleway_container_token namespace {
+resource "scaleway_container_token" "namespace" {
   namespace_id = scaleway_container_namespace.main.id
   expires_at   = "2022-10-18T11:35:15+02:00"
 }
 
 // Container Token
-resource scaleway_container_token container {
+resource "scaleway_container_token" "container" {
   container_id = scaleway_container.main.id
 }
 ```

--- a/docs/resources/container_trigger.md
+++ b/docs/resources/container_trigger.md
@@ -14,7 +14,7 @@ Refer to the Containers triggers [documentation](https://www.scaleway.com/en/doc
 ### SQS
 
 ```terraform
-resource scaleway_container_trigger main {
+resource "scaleway_container_trigger" "main" {
   container_id = scaleway_container.main.id
   name         = "my-trigger"
   sqs {
@@ -29,7 +29,7 @@ resource scaleway_container_trigger main {
 ### NATS
 
 ```terraform
-resource scaleway_container_trigger main {
+resource "scaleway_container_trigger" "main" {
   container_id = scaleway_container.main.id
   name         = "my-trigger"
   nats {

--- a/docs/resources/function.md
+++ b/docs/resources/function.md
@@ -21,7 +21,7 @@ resource "scaleway_function_namespace" "main" {
   description = "Main function namespace"
 }
 
-resource scaleway_function main {
+resource "scaleway_function" "main" {
   namespace_id = scaleway_function_namespace.main.id
   runtime      = "go118"
   handler      = "Handle"
@@ -39,7 +39,7 @@ resource "scaleway_function_namespace" "main" {
   description = "Main function namespace"
 }
 
-resource scaleway_function main {
+resource "scaleway_function" "main" {
   namespace_id = scaleway_function_namespace.main.id
   runtime      = "go118"
   handler      = "Handle"

--- a/docs/resources/function_cron.md
+++ b/docs/resources/function_cron.md
@@ -14,11 +14,11 @@ Refer to the Functions CRON triggers [documentation](https://www.scaleway.com/en
 The following command allows you to add a CRON trigger to a Serverless Function.
 
 ```terraform
-resource scaleway_function_namespace main {
+resource "scaleway_function_namespace" "main" {
   name = "test-cron"
 }
 
-resource scaleway_function main {
+resource "scaleway_function" "main" {
   name         = "test-cron"
   namespace_id = scaleway_function_namespace.main.id
   runtime      = "node14"
@@ -26,14 +26,14 @@ resource scaleway_function main {
   handler      = "handler.handle"
 }
 
-resource scaleway_function_cron main {
+resource "scaleway_function_cron" "main" {
   name        = "test-cron"
   function_id = scaleway_function.main.id
   schedule    = "0 0 * * *"
   args        = jsonencode({ test = "scw" })
 }
 
-resource scaleway_function_cron func {
+resource "scaleway_function_cron" "func" {
   function_id = scaleway_function.main.id
   schedule    = "0 1 * * *"
   args        = jsonencode({ my_var = "terraform" })

--- a/docs/resources/function_domain.md
+++ b/docs/resources/function_domain.md
@@ -23,9 +23,9 @@ resource "scaleway_function_domain" "main" {
   ]
 }
 
-resource scaleway_function_namespace main {}
+resource "scaleway_function_namespace" "main" {}
 
-resource scaleway_function main {
+resource "scaleway_function" "main" {
   namespace_id = scaleway_function_namespace.main.id
   runtime      = "go118"
   privacy      = "private"

--- a/docs/resources/function_token.md
+++ b/docs/resources/function_token.md
@@ -12,11 +12,11 @@ Refer to the Functions tokens [documentation](https://www.scaleway.com/en/docs/s
 ## Example Usage
 
 ```terraform
-resource scaleway_function_namespace main {
+resource "scaleway_function_namespace" "main" {
   name = "test-function-token-ns"
 }
 
-resource scaleway_function main {
+resource "scaleway_function" "main" {
   namespace_id = scaleway_function_namespace.main.id
   runtime      = "go118"
   handler      = "Handle"
@@ -24,13 +24,13 @@ resource scaleway_function main {
 }
 
 // Namespace Token
-resource scaleway_function_token namespace {
+resource "scaleway_function_token" "namespace" {
   namespace_id = scaleway_function_namespace.main.id
   expires_at   = "2022-10-18T11:35:15+02:00"
 }
 
 // Function Token
-resource scaleway_function_token function {
+resource "scaleway_function_token" "function" {
   function_id = scaleway_function.main.id
 }
 ```

--- a/docs/resources/function_trigger.md
+++ b/docs/resources/function_trigger.md
@@ -14,7 +14,7 @@ Refer to the Functions triggers [documentation](https://www.scaleway.com/en/docs
 ### SQS
 
 ```terraform
-resource scaleway_function_trigger main {
+resource "scaleway_function_trigger" "main" {
   function_id = scaleway_function.main.id
   name        = "my-trigger"
   sqs {
@@ -29,7 +29,7 @@ resource scaleway_function_trigger main {
 ### NATS
 
 ```terraform
-resource scaleway_function_trigger main {
+resource "scaleway_function_trigger" "main" {
   function_id = scaleway_function.main.id
   name        = "my-trigger"
   nats {

--- a/docs/resources/instance_server.md
+++ b/docs/resources/instance_server.md
@@ -114,7 +114,7 @@ resource "scaleway_instance_server" "web" {
 ### With private network
 
 ```terraform
-resource scaleway_vpc_private_network pn01 {
+resource "scaleway_vpc_private_network" "pn01" {
   name = "private_network_instance"
 }
 

--- a/docs/resources/instance_user_data.md
+++ b/docs/resources/instance_user_data.md
@@ -40,7 +40,7 @@ resource "scaleway_instance_user_data" "main" {
 }
 
 # User Data with many keys.
-resource scaleway_instance_user_data data {
+resource "scaleway_instance_user_data" "data" {
   server_id = scaleway_instance_server.main.id
   for_each  = var.user_data
   key       = each.key

--- a/docs/resources/job_definition.md
+++ b/docs/resources/job_definition.md
@@ -12,7 +12,7 @@ Creates and manages a Scaleway Serverless Job Definition. For more information, 
 ### Basic
 
 ```terraform
-resource scaleway_job_definition main {
+resource "scaleway_job_definition" "main" {
   name         = "testjob"
   cpu_limit    = 140
   memory_limit = 256
@@ -34,7 +34,7 @@ resource scaleway_job_definition main {
 ### With Secret Reference
 
 ```terraform
-resource scaleway_job_definition main {
+resource "scaleway_job_definition" "main" {
   name         = "testjob"
   cpu_limit    = 140
   memory_limit = 256

--- a/docs/resources/lb_frontend.md
+++ b/docs/resources/lb_frontend.md
@@ -25,22 +25,22 @@ resource "scaleway_lb_frontend" "frontend01" {
 ## With Certificate
 
 ```terraform
-resource scaleway_lb_ip ip01 {}
+resource "scaleway_lb_ip" "ip01" {}
 
-resource scaleway_lb lb01 {
+resource "scaleway_lb" "lb01" {
   ip_id = scaleway_lb_ip.ip01.id
   name  = "test-lb"
   type  = "lb-s"
 }
 
-resource scaleway_lb_backend bkd01 {
+resource "scaleway_lb_backend" "bkd01" {
   lb_id            = scaleway_lb.lb01.id
   forward_protocol = "tcp"
   forward_port     = 443
   proxy_protocol   = "none"
 }
 
-resource scaleway_lb_certificate cert01 {
+resource "scaleway_lb_certificate" "cert01" {
   lb_id = scaleway_lb.lb01.id
   name  = "test-cert-front-end"
   letsencrypt {
@@ -52,7 +52,7 @@ resource scaleway_lb_certificate cert01 {
   }
 }
 
-resource scaleway_lb_frontend frt01 {
+resource "scaleway_lb_frontend" "frt01" {
   lb_id           = scaleway_lb.lb01.id
   backend_id      = scaleway_lb_backend.bkd01.id
   inbound_port    = 443

--- a/docs/resources/mnq_sns.md
+++ b/docs/resources/mnq_sns.md
@@ -22,7 +22,7 @@ resource scaleway_mnq_sns "main" {}
 Activate SNS in a specific Project
 
 ```terraform
-data scaleway_account_project project {
+data "scaleway_account_project" "project" {
   name = "default"
 }
 

--- a/docs/resources/mnq_sns_credentials.md
+++ b/docs/resources/mnq_sns_credentials.md
@@ -16,7 +16,7 @@ our [main documentation](https://www.scaleway.com/en/docs/messaging/reference-co
 ```terraform
 resource "scaleway_mnq_sns" "main" {}
 
-resource scaleway_mnq_sns_credentials main {
+resource "scaleway_mnq_sns_credentials" "main" {
   project_id = scaleway_mnq_sns.main.project_id
   name       = "sns-credentials"
 

--- a/docs/resources/mnq_sns_topic.md
+++ b/docs/resources/mnq_sns_topic.md
@@ -16,7 +16,7 @@ our [main documentation](https://www.scaleway.com/en/docs/messaging/how-to/creat
 ```terraform
 resource "scaleway_mnq_sns" "main" {}
 
-resource scaleway_mnq_sns_credentials main {
+resource "scaleway_mnq_sns_credentials" "main" {
   project_id = scaleway_mnq_sns.main.project_id
   permissions {
     can_manage = true

--- a/docs/resources/mnq_sns_topic_subscription.md
+++ b/docs/resources/mnq_sns_topic_subscription.md
@@ -17,7 +17,7 @@ our [main documentation](https://www.scaleway.com/en/docs/messaging/reference-co
 // For default project in default region
 resource "scaleway_mnq_sns" "main" {}
 
-resource scaleway_mnq_sns_credentials main {
+resource "scaleway_mnq_sns_credentials" "main" {
   project_id = scaleway_mnq_sns.main.project_id
   permissions {
     can_manage  = true
@@ -33,7 +33,7 @@ resource "scaleway_mnq_sns_topic" "topic" {
   secret_key = scaleway_mnq_sns_credentials.main.secret_key
 }
 
-resource scaleway_mnq_sns_topic_subscription main {
+resource "scaleway_mnq_sns_topic_subscription" "main" {
   project_id = scaleway_mnq_sns.main.project_id
   access_key = scaleway_mnq_sns_credentials.main.access_key
   secret_key = scaleway_mnq_sns_credentials.main.secret_key

--- a/docs/resources/mnq_sqs.md
+++ b/docs/resources/mnq_sqs.md
@@ -22,7 +22,7 @@ resource "scaleway_mnq_sqs" "main" {}
 Activate SQS for a specific project
 
 ```terraform
-data scaleway_account_project project {
+data "scaleway_account_project" "project" {
   name = "default"
 }
 

--- a/docs/resources/mnq_sqs_credentials.md
+++ b/docs/resources/mnq_sqs_credentials.md
@@ -16,7 +16,7 @@ our [main documentation](https://www.scaleway.com/en/docs/messaging/reference-co
 ```terraform
 resource "scaleway_mnq_sqs" "main" {}
 
-resource scaleway_mnq_sqs_credentials main {
+resource "scaleway_mnq_sqs_credentials" "main" {
   project_id = scaleway_mnq_sqs.main.project_id
   name       = "sqs-credentials"
 

--- a/docs/resources/mnq_sqs_queue.md
+++ b/docs/resources/mnq_sqs_queue.md
@@ -16,7 +16,7 @@ our [main documentation](https://www.scaleway.com/en/docs/messaging/how-to/creat
 ```terraform
 resource "scaleway_mnq_sqs" "main" {}
 
-resource scaleway_mnq_sqs_credentials main {
+resource "scaleway_mnq_sqs_credentials" "main" {
   project_id = scaleway_mnq_sqs.main.project_id
   name       = "sqs-credentials"
 
@@ -27,7 +27,7 @@ resource scaleway_mnq_sqs_credentials main {
   }
 }
 
-resource scaleway_mnq_sqs_queue main {
+resource "scaleway_mnq_sqs_queue" "main" {
   project_id   = scaleway_mnq_sqs.main.project_id
   name         = "my-queue"
   sqs_endpoint = scaleway_mnq_sqs.main.endpoint

--- a/docs/resources/mongodb_instance.md
+++ b/docs/resources/mongodb_instance.md
@@ -28,7 +28,7 @@ resource "scaleway_mongodb_instance" "main" {
 ### Private Network
 
 ```terraform
-resource scaleway_vpc_private_network pn01 {
+resource "scaleway_vpc_private_network" "pn01" {
   name   = "my_private_network"
   region = "fr-par"
 }
@@ -52,7 +52,7 @@ resource "scaleway_mongodb_instance" "main" {
 ### Private Network and Public Network
 
 ```terraform
-resource scaleway_vpc_private_network pn01 {
+resource "scaleway_vpc_private_network" "pn01" {
   name   = "my_private_network"
   region = "fr-par"
 }

--- a/docs/resources/object_bucket_policy.md
+++ b/docs/resources/object_bucket_policy.md
@@ -126,7 +126,7 @@ provider "scaleway" {
   alias      = "reading-profile"
 }
 
-data scaleway_object_bucket bucket {
+data "scaleway_object_bucket" "bucket" {
   provider   = scaleway.reading-profile
   name       = "some-unique-name"
   depends_on = [scaleway_iam_api_key.reading-api-key]

--- a/docs/resources/vpc_gateway_network.md
+++ b/docs/resources/vpc_gateway_network.md
@@ -15,11 +15,11 @@ For more information, see [the API documentation](https://www.scaleway.com/en/de
 ### Create a GatewayNetwork with IPAM configuration
 
 ```terraform
-resource scaleway_vpc vpc01 {
+resource "scaleway_vpc" "vpc01" {
   name = "my vpc"
 }
 
-resource scaleway_vpc_private_network pn01 {
+resource "scaleway_vpc_private_network" "pn01" {
   name = "pn_test_network"
   ipv4_subnet {
     subnet = "172.16.64.0/22"
@@ -27,12 +27,12 @@ resource scaleway_vpc_private_network pn01 {
   vpc_id = scaleway_vpc.vpc01.id
 }
 
-resource scaleway_vpc_public_gateway pg01 {
+resource "scaleway_vpc_public_gateway" "pg01" {
   name = "foobar"
   type = "VPC-GW-S"
 }
 
-resource scaleway_vpc_gateway_network main {
+resource "scaleway_vpc_gateway_network" "main" {
   gateway_id         = scaleway_vpc_public_gateway.pg01.id
   private_network_id = scaleway_vpc_private_network.pn01.id
   enable_masquerade  = true
@@ -45,11 +45,11 @@ resource scaleway_vpc_gateway_network main {
 ### Create a GatewayNetwork with a booked IPAM IP
 
 ```terraform
-resource scaleway_vpc vpc01 {
+resource "scaleway_vpc" "vpc01" {
   name = "my vpc"
 }
 
-resource scaleway_vpc_private_network pn01 {
+resource "scaleway_vpc_private_network" "pn01" {
   name = "pn_test_network"
   ipv4_subnet {
     subnet = "172.16.64.0/22"
@@ -64,12 +64,12 @@ resource "scaleway_ipam_ip" "ip01" {
   }
 }
 
-resource scaleway_vpc_public_gateway pg01 {
+resource "scaleway_vpc_public_gateway" "pg01" {
   name = "foobar"
   type = "VPC-GW-S"
 }
 
-resource scaleway_vpc_gateway_network main {
+resource "scaleway_vpc_gateway_network" "main" {
   gateway_id         = scaleway_vpc_public_gateway.pg01.id
   private_network_id = scaleway_vpc_private_network.pn01.id
   enable_masquerade  = true

--- a/docs/resources/vpc_public_gateway_dhcp_reservation.md
+++ b/docs/resources/vpc_public_gateway_dhcp_reservation.md
@@ -22,7 +22,7 @@ For more information, see the [API documentation](https://www.scaleway.com/en/de
 ## Example Usage
 
 ```terraform
-resource scaleway_vpc_private_network main {
+resource "scaleway_vpc_private_network" "main" {
   name = "your_private_network"
 }
 
@@ -36,20 +36,20 @@ resource "scaleway_instance_server" "main" {
   }
 }
 
-resource scaleway_vpc_public_gateway_ip main {
+resource "scaleway_vpc_public_gateway_ip" "main" {
 }
 
-resource scaleway_vpc_public_gateway_dhcp main {
+resource "scaleway_vpc_public_gateway_dhcp" "main" {
   subnet = "192.168.1.0/24"
 }
 
-resource scaleway_vpc_public_gateway main {
+resource "scaleway_vpc_public_gateway" "main" {
   name  = "foobar"
   type  = "VPC-GW-S"
   ip_id = scaleway_vpc_public_gateway_ip.main.id
 }
 
-resource scaleway_vpc_gateway_network main {
+resource "scaleway_vpc_gateway_network" "main" {
   gateway_id         = scaleway_vpc_public_gateway.main.id
   private_network_id = scaleway_vpc_private_network.main.id
   dhcp_id            = scaleway_vpc_public_gateway_dhcp.main.id
@@ -58,7 +58,7 @@ resource scaleway_vpc_gateway_network main {
   depends_on         = [scaleway_vpc_public_gateway_ip.main, scaleway_vpc_private_network.main]
 }
 
-resource scaleway_vpc_public_gateway_dhcp_reservation main {
+resource "scaleway_vpc_public_gateway_dhcp_reservation" "main" {
   gateway_network_id = scaleway_vpc_gateway_network.main.id
   mac_address        = scaleway_instance_server.main.private_network.0.mac_address
   ip_address         = "192.168.1.1"

--- a/docs/resources/vpc_public_gateway_ip.md
+++ b/docs/resources/vpc_public_gateway_ip.md
@@ -20,7 +20,7 @@ resource "scaleway_domain_record" "tf_A" {
   priority = 1
 }
 
-resource scaleway_vpc_public_gateway_ip main {
+resource "scaleway_vpc_public_gateway_ip" "main" {
   reverse = "tf.example.com"
 }
 ```


### PR DESCRIPTION
Following hahiscorp guidelines, resource type and name should be wrapped in double quotes.
https://developer.hashicorp.com/terraform/language/style#code-style

`scaleway_inference_model` looks isolated due to a typo : 

![image](https://github.com/user-attachments/assets/06617249-602b-4d4e-9f40-71550eb2ec5f)
