### PR TITLE
doc(backend_guide): add documentation for scaleway object storage as tfstate backend

### DIFF
--- a/docs/guides/backend_guide.md
+++ b/docs/guides/backend_guide.md
@@ -246,9 +246,9 @@ profiles:
     insecure: false
 ```
 
-actualy terraform backend "s3" is not aware of any other kind of s3 compatible bucket and is by default assuming you ar using aws's S3 service
+actually terraform backend "s3" is not aware of any other kind of s3 compatible bucket and is by default assuming you ar using aws's S3 service
 
-so in order to read scw ccredentials, do not try to use `profile = myProfile1` it will not work, unless you can copy your scw credentials into aws shared configuration file
+so in order to read scw credentials, do not try to use `profile = myProfile1` it will not work, unless you can copy your scw credentials into aws shared configuration file
 
 >~/$HOME/.aws/credentials
 


### PR DESCRIPTION
Hello, as a Scaleway user i encountered an issue when i attempted to use S3 backend not with AWS's3 but with Scaleway object-storage bucket
i had to find a workaround to make Scaleway credentials be correctly read by terraform

the issue is : by default Terraform backend S3 will read aws shared config file 
>~/$HOME/.aws/credentials

instead of using the correct scw config file

>~/$HOME/.config/scw/config.yaml

 i thought usefull for other people facing the same issue to complete the backend guide with a chatper on "S3 Backend" 