### PR TITLE
chore(container/function): namespace: deprecate activate_vpc_integration

### DIFF
--- a/docs/resources/container_namespace.md
+++ b/docs/resources/container_namespace.md
@@ -40,9 +40,9 @@ The following arguments are supported:
 
 - `secret_environment_variables` - (Optional) The secret environment variables of the namespace.
 
-- `activate_vpc_integration` - (Optional) Activates VPC integration for the namespace. Containers of a namespace with VPC integration activated will be able to connect to a Private Network.
+- `activate_vpc_integration` - (Deprecated) Activates VPC integration for the namespace. Containers of a namespace with VPC integration activated will be able to connect to a Private Network.
 
-~> **Important** Updates to `activate_vpc_integration` will recreate the namespace.
+~> **Important:** VPC integration is now available on all namespaces, so this field is not configurable anymore and its value will always be "true".
 
 ## Attributes Reference
 

--- a/docs/resources/function_namespace.md
+++ b/docs/resources/function_namespace.md
@@ -40,9 +40,9 @@ The following arguments are supported:
 
 - `secret_environment_variables` - (Optional) The secret environment variables of the namespace.
 
-- `activate_vpc_integration` - (Optional) Activates VPC integration for the namespace. Functions of a namespace with VPC integration activated will be able to connect to a Private Network.
+- `activate_vpc_integration` - (Deprecated) Activates VPC integration for the namespace. Functions of a namespace with VPC integration activated will be able to connect to a Private Network.
 
-~> **Important** Updates to `activate_vpc_integration` will recreate the namespace.
+~> **Important:** VPC integration is now available on all namespaces, so this field is not configurable anymore and its value will always be "true".
 
 ## Attributes Reference
 

--- a/internal/services/container/namespace.go
+++ b/internal/services/container/namespace.go
@@ -122,6 +122,7 @@ func ResourceContainerNamespaceCreate(ctx context.Context, d *schema.ResourceDat
 		Name:                       types.ExpandOrGenerateString(d.Get("name").(string), "ns"),
 		ProjectID:                  d.Get("project_id").(string),
 		Region:                     region,
+		ActivateVpcIntegration:     true,
 	}
 
 	rawTag, tagExist := d.GetOk("tags")

--- a/internal/services/container/namespace.go
+++ b/internal/services/container/namespace.go
@@ -97,9 +97,9 @@ func ResourceNamespace() *schema.Resource {
 			},
 			"activate_vpc_integration": {
 				Type:        schema.TypeBool,
-				ForceNew:    true,
+				Deprecated:  "VPC integration is now available on all namespaces, so this field is not configurable anymore and its value will always be \"true\".",
 				Optional:    true,
-				Default:     false,
+				Default:     true,
 				Description: "Activate VPC integration for the namespace",
 			},
 			"region":          regional.Schema(),
@@ -127,10 +127,6 @@ func ResourceContainerNamespaceCreate(ctx context.Context, d *schema.ResourceDat
 	rawTag, tagExist := d.GetOk("tags")
 	if tagExist {
 		createReq.Tags = types.ExpandStrings(rawTag)
-	}
-
-	if activateVPC, ok := d.GetOk("activate_vpc_integration"); ok {
-		createReq.ActivateVpcIntegration = activateVPC.(bool)
 	}
 
 	ns, err := api.CreateNamespace(createReq, scw.WithContext(ctx))

--- a/internal/services/container/namespace_test.go
+++ b/internal/services/container/namespace_test.go
@@ -2,7 +2,6 @@ package container_test
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -295,23 +294,9 @@ func TestAccNamespace_VPCIntegration(t *testing.T) {
 				`,
 				Check: resource.ComposeTestCheckFunc(
 					isNamespacePresent(tt, "scaleway_container_namespace.main"),
-					resource.TestCheckResourceAttr("scaleway_container_namespace.main", "activate_vpc_integration", "false"),
+					resource.TestCheckResourceAttr("scaleway_container_namespace.main", "activate_vpc_integration", "true"),
 					acctest.CheckResourceIDPersisted("scaleway_container_namespace.main", &namespaceID),
 				),
-			},
-			{
-				Config: `
-					resource scaleway_vpc_private_network main {}
-			
-					resource scaleway_container_namespace main {}
-			
-					resource scaleway_container main {
-						namespace_id = scaleway_container_namespace.main.id
-						private_network_id = scaleway_vpc_private_network.main.id
-						sandbox = "v1"
-					}
-				`,
-				ExpectError: regexp.MustCompile("Application can't be attached to private network, vpc integration must be activated on its parent namespace"),
 			},
 			{
 				Config: `
@@ -332,7 +317,7 @@ func TestAccNamespace_VPCIntegration(t *testing.T) {
 					isContainerPresent(tt, "scaleway_container.main"),
 					resource.TestCheckResourceAttr("scaleway_container_namespace.main", "activate_vpc_integration", "true"),
 					resource.TestCheckResourceAttrPair("scaleway_container.main", "private_network_id", "scaleway_vpc_private_network.main", "id"),
-					acctest.CheckResourceIDChanged("scaleway_container_namespace.main", &namespaceID),
+					acctest.CheckResourceIDPersisted("scaleway_container_namespace.main", &namespaceID),
 				),
 			},
 		},

--- a/internal/services/container/testdata/container-basic.cassette.yaml
+++ b/internal/services/container/testdata/container-basic.cassette.yaml
@@ -6,19 +6,19 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 189
+        content_length: 191
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-ns-festive-merkle","environment_variables":{},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","secret_environment_variables":[],"tags":null,"activate_vpc_integration":false}'
+        body: '{"name":"tf-ns-quizzical-ptolemy","environment_variables":{},"project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","secret_environment_variables":[],"tags":null,"activate_vpc_integration":true}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces
         method: POST
       response:
@@ -27,18 +27,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 521
+        content_length: 508
         uncompressed: false
-        body: '{"created_at":"2025-06-11T12:01:11.009723088Z","description":"","environment_variables":{},"error_message":null,"id":"d2d2f713-994c-4c04-8c3d-6321d7a97d78","name":"tf-ns-festive-merkle","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-06-11T12:01:11.009723088Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2025-08-27T15:05:41.107749244Z","description":"","environment_variables":{},"error_message":null,"id":"f3c8d254-0d74-4372-96a4-ea1855c38342","name":"tf-ns-quizzical-ptolemy","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:41.107749244Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "521"
+                - "508"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:01:11 GMT
+                - Wed, 27 Aug 2025 15:05:41 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8e20a752-4cde-4c12-bbf3-73f13b4056d2
+                - ef68b39b-ccea-4dc5-9d1e-ec0f9886600f
         status: 200 OK
         code: 200
-        duration: 1.4506785s
+        duration: 5.201825138s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -67,8 +67,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d2d2f713-994c-4c04-8c3d-6321d7a97d78
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/f3c8d254-0d74-4372-96a4-ea1855c38342
         method: GET
       response:
         proto: HTTP/2.0
@@ -76,18 +76,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 515
+        content_length: 502
         uncompressed: false
-        body: '{"created_at":"2025-06-11T12:01:11.009723Z","description":"","environment_variables":{},"error_message":null,"id":"d2d2f713-994c-4c04-8c3d-6321d7a97d78","name":"tf-ns-festive-merkle","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-06-11T12:01:11.009723Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2025-08-27T15:05:41.107749Z","description":"","environment_variables":{},"error_message":null,"id":"f3c8d254-0d74-4372-96a4-ea1855c38342","name":"tf-ns-quizzical-ptolemy","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:41.107749Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "515"
+                - "502"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:01:11 GMT
+                - Wed, 27 Aug 2025 15:05:41 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c5d6805c-64f5-4722-80a5-f700deef3db3
+                - 72a6e194-9b85-4805-aa41-17199d653726
         status: 200 OK
         code: 200
-        duration: 91.895125ms
+        duration: 83.40958ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -116,8 +116,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d2d2f713-994c-4c04-8c3d-6321d7a97d78
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/f3c8d254-0d74-4372-96a4-ea1855c38342
         method: GET
       response:
         proto: HTTP/2.0
@@ -125,18 +125,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 601
+        content_length: 593
         uncompressed: false
-        body: '{"created_at":"2025-06-11T12:01:11.009723Z","description":"","environment_variables":{},"error_message":null,"id":"d2d2f713-994c-4c04-8c3d-6321d7a97d78","name":"tf-ns-festive-merkle","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsfestivemerkle1qlua5qo","registry_namespace_id":"6e61270a-e1ce-438e-a954-88838f63def7","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-11T12:01:12.975036Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2025-08-27T15:05:41.107749Z","description":"","environment_variables":{},"error_message":null,"id":"f3c8d254-0d74-4372-96a4-ea1855c38342","name":"tf-ns-quizzical-ptolemy","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsquizzicalptolemyco2lwtn7","registry_namespace_id":"dfe94e06-48b4-4c0d-9a59-f8b63baf222d","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:43.766340Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "601"
+                - "593"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:01:16 GMT
+                - Wed, 27 Aug 2025 15:05:46 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -146,10 +146,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 004622e9-613d-4954-8b73-bda5310a8d24
+                - ad47c528-4580-4255-b7f0-3a5d55670ba5
         status: 200 OK
         code: 200
-        duration: 82.505041ms
+        duration: 84.594465ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -165,8 +165,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d2d2f713-994c-4c04-8c3d-6321d7a97d78
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/f3c8d254-0d74-4372-96a4-ea1855c38342
         method: GET
       response:
         proto: HTTP/2.0
@@ -174,18 +174,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 601
+        content_length: 591
         uncompressed: false
-        body: '{"created_at":"2025-06-11T12:01:11.009723Z","description":"","environment_variables":{},"error_message":null,"id":"d2d2f713-994c-4c04-8c3d-6321d7a97d78","name":"tf-ns-festive-merkle","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsfestivemerkle1qlua5qo","registry_namespace_id":"6e61270a-e1ce-438e-a954-88838f63def7","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-11T12:01:12.975036Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2025-08-27T15:05:41.107749Z","description":"","environment_variables":{},"error_message":null,"id":"f3c8d254-0d74-4372-96a4-ea1855c38342","name":"tf-ns-quizzical-ptolemy","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsquizzicalptolemyco2lwtn7","registry_namespace_id":"dfe94e06-48b4-4c0d-9a59-f8b63baf222d","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:47.985407Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "601"
+                - "591"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:01:16 GMT
+                - Wed, 27 Aug 2025 15:05:51 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -195,10 +195,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2836c370-62aa-4d44-9db5-524cecf3e8ac
+                - d6e0a116-e868-4481-8822-b81a224e6347
         status: 200 OK
         code: 200
-        duration: 87.281375ms
+        duration: 78.76618ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -214,8 +214,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d2d2f713-994c-4c04-8c3d-6321d7a97d78
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/f3c8d254-0d74-4372-96a4-ea1855c38342
         method: GET
       response:
         proto: HTTP/2.0
@@ -223,18 +223,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 601
+        content_length: 591
         uncompressed: false
-        body: '{"created_at":"2025-06-11T12:01:11.009723Z","description":"","environment_variables":{},"error_message":null,"id":"d2d2f713-994c-4c04-8c3d-6321d7a97d78","name":"tf-ns-festive-merkle","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsfestivemerkle1qlua5qo","registry_namespace_id":"6e61270a-e1ce-438e-a954-88838f63def7","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-11T12:01:12.975036Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2025-08-27T15:05:41.107749Z","description":"","environment_variables":{},"error_message":null,"id":"f3c8d254-0d74-4372-96a4-ea1855c38342","name":"tf-ns-quizzical-ptolemy","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsquizzicalptolemyco2lwtn7","registry_namespace_id":"dfe94e06-48b4-4c0d-9a59-f8b63baf222d","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:47.985407Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "601"
+                - "591"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:01:16 GMT
+                - Wed, 27 Aug 2025 15:05:51 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -244,62 +244,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 12a92dde-ae99-49d6-897b-419f6b7750dd
+                - 44e6b5d3-ffb1-457e-87b6-2d76805a2155
         status: 200 OK
         code: 200
-        duration: 91.0215ms
+        duration: 82.734716ms
     - id: 5
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 258
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"namespace_id":"d2d2f713-994c-4c04-8c3d-6321d7a97d78","name":"tf-co-angry-chaum","privacy":"public","protocol":"http1","secret_environment_variables":null,"http_option":"enabled","sandbox":"unknown_sandbox","tags":["tag1","tag2"],"command":null,"args":null}'
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 1003
-        uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-11T12:01:16.957204285Z","description":"","domain_name":"tfnsfestivemerkle1qlua5qo-tf-co-angry-chaum.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"1eed4a92-9e0a-4c95-8485-719f269f9255","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-angry-chaum","namespace_id":"d2d2f713-994c-4c04-8c3d-6321d7a97d78","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsfestivemerkle1qlua5qo/tf-co-angry-chaum:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":["tag1","tag2"],"timeout":"300s","updated_at":"2025-06-11T12:01:16.957204285Z"}'
-        headers:
-            Content-Length:
-                - "1003"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 11 Jun 2025 12:01:16 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 74d95cc4-4971-43e8-a527-c26c853ea76c
-        status: 200 OK
-        code: 200
-        duration: 598.126416ms
-    - id: 6
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -314,8 +263,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/1eed4a92-9e0a-4c95-8485-719f269f9255
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/f3c8d254-0d74-4372-96a4-ea1855c38342
         method: GET
       response:
         proto: HTTP/2.0
@@ -323,18 +272,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 997
+        content_length: 591
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-11T12:01:16.957204Z","description":"","domain_name":"tfnsfestivemerkle1qlua5qo-tf-co-angry-chaum.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"1eed4a92-9e0a-4c95-8485-719f269f9255","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-angry-chaum","namespace_id":"d2d2f713-994c-4c04-8c3d-6321d7a97d78","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsfestivemerkle1qlua5qo/tf-co-angry-chaum:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":["tag1","tag2"],"timeout":"300s","updated_at":"2025-06-11T12:01:16.957204Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.107749Z","description":"","environment_variables":{},"error_message":null,"id":"f3c8d254-0d74-4372-96a4-ea1855c38342","name":"tf-ns-quizzical-ptolemy","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsquizzicalptolemyco2lwtn7","registry_namespace_id":"dfe94e06-48b4-4c0d-9a59-f8b63baf222d","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:47.985407Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "997"
+                - "591"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:01:17 GMT
+                - Wed, 27 Aug 2025 15:05:51 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -344,10 +293,61 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b5c5fe34-5ad5-401d-a1af-13d8e238ff30
+                - 3526b519-7761-42e6-aaf2-67ef3574afa6
         status: 200 OK
         code: 200
-        duration: 96.231084ms
+        duration: 85.773749ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 267
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"namespace_id":"f3c8d254-0d74-4372-96a4-ea1855c38342","name":"tf-co-priceless-kowalevski","privacy":"public","protocol":"http1","secret_environment_variables":null,"http_option":"enabled","sandbox":"unknown_sandbox","tags":["tag1","tag2"],"command":null,"args":null}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1002
+        uncompressed: false
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:53.670650700Z","description":"","domain_name":"tfnsquizzicalptolemyco2lwtn7-tf-co-priceless-kowalevski.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"aad8c7e7-6e01-4e10-af12-5e66433f1080","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-priceless-kowalevski","namespace_id":"f3c8d254-0d74-4372-96a4-ea1855c38342","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsquizzicalptolemyco2lwtn7/tf-co-priceless-kowalevski:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":["tag1","tag2"],"timeout":"300s","updated_at":"2025-08-27T15:05:53.670650700Z"}'
+        headers:
+            Content-Length:
+                - "1002"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:05:53 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 49f3186e-6fb1-45d1-9cc5-79a1e9ffa1c0
+        status: 200 OK
+        code: 200
+        duration: 2.151225137s
     - id: 7
       request:
         proto: HTTP/1.1
@@ -363,8 +363,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/1eed4a92-9e0a-4c95-8485-719f269f9255
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/aad8c7e7-6e01-4e10-af12-5e66433f1080
         method: GET
       response:
         proto: HTTP/2.0
@@ -372,18 +372,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 997
+        content_length: 996
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-11T12:01:16.957204Z","description":"","domain_name":"tfnsfestivemerkle1qlua5qo-tf-co-angry-chaum.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"1eed4a92-9e0a-4c95-8485-719f269f9255","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-angry-chaum","namespace_id":"d2d2f713-994c-4c04-8c3d-6321d7a97d78","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsfestivemerkle1qlua5qo/tf-co-angry-chaum:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":["tag1","tag2"],"timeout":"300s","updated_at":"2025-06-11T12:01:16.957204Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:53.670651Z","description":"","domain_name":"tfnsquizzicalptolemyco2lwtn7-tf-co-priceless-kowalevski.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"aad8c7e7-6e01-4e10-af12-5e66433f1080","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-priceless-kowalevski","namespace_id":"f3c8d254-0d74-4372-96a4-ea1855c38342","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsquizzicalptolemyco2lwtn7/tf-co-priceless-kowalevski:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":["tag1","tag2"],"timeout":"300s","updated_at":"2025-08-27T15:05:53.670651Z"}'
         headers:
             Content-Length:
-                - "997"
+                - "996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:01:17 GMT
+                - Wed, 27 Aug 2025 15:05:53 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -393,10 +393,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a0911df6-868d-46e0-b28c-576ee9a7fafa
+                - e3dd7ead-d890-4d38-864d-054894753d8e
         status: 200 OK
         code: 200
-        duration: 80.635791ms
+        duration: 85.325017ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -412,8 +412,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d2d2f713-994c-4c04-8c3d-6321d7a97d78
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/aad8c7e7-6e01-4e10-af12-5e66433f1080
         method: GET
       response:
         proto: HTTP/2.0
@@ -421,18 +421,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 601
+        content_length: 996
         uncompressed: false
-        body: '{"created_at":"2025-06-11T12:01:11.009723Z","description":"","environment_variables":{},"error_message":null,"id":"d2d2f713-994c-4c04-8c3d-6321d7a97d78","name":"tf-ns-festive-merkle","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsfestivemerkle1qlua5qo","registry_namespace_id":"6e61270a-e1ce-438e-a954-88838f63def7","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-11T12:01:12.975036Z","vpc_integration_activated":false}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:53.670651Z","description":"","domain_name":"tfnsquizzicalptolemyco2lwtn7-tf-co-priceless-kowalevski.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"aad8c7e7-6e01-4e10-af12-5e66433f1080","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-priceless-kowalevski","namespace_id":"f3c8d254-0d74-4372-96a4-ea1855c38342","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsquizzicalptolemyco2lwtn7/tf-co-priceless-kowalevski:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":["tag1","tag2"],"timeout":"300s","updated_at":"2025-08-27T15:05:53.670651Z"}'
         headers:
             Content-Length:
-                - "601"
+                - "996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:01:17 GMT
+                - Wed, 27 Aug 2025 15:05:54 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -442,10 +442,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6175d5f4-3b05-41ad-8f5f-cf315a8f67fb
+                - adef2207-79e7-4809-bba5-a2a92225d4ee
         status: 200 OK
         code: 200
-        duration: 71.941625ms
+        duration: 135.667072ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -461,8 +461,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/1eed4a92-9e0a-4c95-8485-719f269f9255
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/f3c8d254-0d74-4372-96a4-ea1855c38342
         method: GET
       response:
         proto: HTTP/2.0
@@ -470,18 +470,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 997
+        content_length: 591
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-11T12:01:16.957204Z","description":"","domain_name":"tfnsfestivemerkle1qlua5qo-tf-co-angry-chaum.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"1eed4a92-9e0a-4c95-8485-719f269f9255","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-angry-chaum","namespace_id":"d2d2f713-994c-4c04-8c3d-6321d7a97d78","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsfestivemerkle1qlua5qo/tf-co-angry-chaum:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":["tag1","tag2"],"timeout":"300s","updated_at":"2025-06-11T12:01:16.957204Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.107749Z","description":"","environment_variables":{},"error_message":null,"id":"f3c8d254-0d74-4372-96a4-ea1855c38342","name":"tf-ns-quizzical-ptolemy","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsquizzicalptolemyco2lwtn7","registry_namespace_id":"dfe94e06-48b4-4c0d-9a59-f8b63baf222d","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:47.985407Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "997"
+                - "591"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:01:17 GMT
+                - Wed, 27 Aug 2025 15:05:54 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -491,10 +491,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bd03f83c-76fe-44f2-a554-56d773f7359d
+                - 6824292a-4b1c-4916-9b92-9713897cda85
         status: 200 OK
         code: 200
-        duration: 113.837292ms
+        duration: 142.243833ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -510,8 +510,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d2d2f713-994c-4c04-8c3d-6321d7a97d78
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/aad8c7e7-6e01-4e10-af12-5e66433f1080
         method: GET
       response:
         proto: HTTP/2.0
@@ -519,18 +519,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 601
+        content_length: 996
         uncompressed: false
-        body: '{"created_at":"2025-06-11T12:01:11.009723Z","description":"","environment_variables":{},"error_message":null,"id":"d2d2f713-994c-4c04-8c3d-6321d7a97d78","name":"tf-ns-festive-merkle","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsfestivemerkle1qlua5qo","registry_namespace_id":"6e61270a-e1ce-438e-a954-88838f63def7","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-11T12:01:12.975036Z","vpc_integration_activated":false}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:53.670651Z","description":"","domain_name":"tfnsquizzicalptolemyco2lwtn7-tf-co-priceless-kowalevski.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"aad8c7e7-6e01-4e10-af12-5e66433f1080","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-priceless-kowalevski","namespace_id":"f3c8d254-0d74-4372-96a4-ea1855c38342","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsquizzicalptolemyco2lwtn7/tf-co-priceless-kowalevski:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":["tag1","tag2"],"timeout":"300s","updated_at":"2025-08-27T15:05:53.670651Z"}'
         headers:
             Content-Length:
-                - "601"
+                - "996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:01:17 GMT
+                - Wed, 27 Aug 2025 15:05:54 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -540,10 +540,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8a1528af-bf57-4e75-9c52-107fa457f495
+                - 6de3a14d-a91f-4e6a-b515-e47fb605f9b4
         status: 200 OK
         code: 200
-        duration: 76.33825ms
+        duration: 82.797014ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -559,8 +559,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/1eed4a92-9e0a-4c95-8485-719f269f9255
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/f3c8d254-0d74-4372-96a4-ea1855c38342
         method: GET
       response:
         proto: HTTP/2.0
@@ -568,18 +568,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 997
+        content_length: 591
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-11T12:01:16.957204Z","description":"","domain_name":"tfnsfestivemerkle1qlua5qo-tf-co-angry-chaum.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"1eed4a92-9e0a-4c95-8485-719f269f9255","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-angry-chaum","namespace_id":"d2d2f713-994c-4c04-8c3d-6321d7a97d78","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsfestivemerkle1qlua5qo/tf-co-angry-chaum:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":["tag1","tag2"],"timeout":"300s","updated_at":"2025-06-11T12:01:16.957204Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.107749Z","description":"","environment_variables":{},"error_message":null,"id":"f3c8d254-0d74-4372-96a4-ea1855c38342","name":"tf-ns-quizzical-ptolemy","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsquizzicalptolemyco2lwtn7","registry_namespace_id":"dfe94e06-48b4-4c0d-9a59-f8b63baf222d","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:47.985407Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "997"
+                - "591"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:01:17 GMT
+                - Wed, 27 Aug 2025 15:05:55 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -589,10 +589,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d1dfe28a-0805-41d5-a214-52a5d1168e9d
+                - 0ca151ec-7f77-41e4-b060-56d929473bc1
         status: 200 OK
         code: 200
-        duration: 83.779875ms
+        duration: 85.223427ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -608,8 +608,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/1eed4a92-9e0a-4c95-8485-719f269f9255
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/aad8c7e7-6e01-4e10-af12-5e66433f1080
         method: GET
       response:
         proto: HTTP/2.0
@@ -617,18 +617,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 997
+        content_length: 996
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-11T12:01:16.957204Z","description":"","domain_name":"tfnsfestivemerkle1qlua5qo-tf-co-angry-chaum.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"1eed4a92-9e0a-4c95-8485-719f269f9255","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-angry-chaum","namespace_id":"d2d2f713-994c-4c04-8c3d-6321d7a97d78","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsfestivemerkle1qlua5qo/tf-co-angry-chaum:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":["tag1","tag2"],"timeout":"300s","updated_at":"2025-06-11T12:01:16.957204Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:53.670651Z","description":"","domain_name":"tfnsquizzicalptolemyco2lwtn7-tf-co-priceless-kowalevski.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"aad8c7e7-6e01-4e10-af12-5e66433f1080","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-priceless-kowalevski","namespace_id":"f3c8d254-0d74-4372-96a4-ea1855c38342","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsquizzicalptolemyco2lwtn7/tf-co-priceless-kowalevski:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":["tag1","tag2"],"timeout":"300s","updated_at":"2025-08-27T15:05:53.670651Z"}'
         headers:
             Content-Length:
-                - "997"
+                - "996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:01:18 GMT
+                - Wed, 27 Aug 2025 15:05:55 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -638,10 +638,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e7c921ed-5970-4d9b-b370-b364724fc3b5
+                - 110e957f-c3ee-4def-bed5-c669a047028f
         status: 200 OK
         code: 200
-        duration: 87.46375ms
+        duration: 96.184516ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -657,27 +657,27 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/1eed4a92-9e0a-4c95-8485-719f269f9255
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/aad8c7e7-6e01-4e10-af12-5e66433f1080
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1001
+        content_length: 996
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-11T12:01:16.957204Z","description":"","domain_name":"tfnsfestivemerkle1qlua5qo-tf-co-angry-chaum.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"1eed4a92-9e0a-4c95-8485-719f269f9255","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-angry-chaum","namespace_id":"d2d2f713-994c-4c04-8c3d-6321d7a97d78","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsfestivemerkle1qlua5qo/tf-co-angry-chaum:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"deleting","tags":["tag1","tag2"],"timeout":"300s","updated_at":"2025-06-11T12:01:18.409668840Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:53.670651Z","description":"","domain_name":"tfnsquizzicalptolemyco2lwtn7-tf-co-priceless-kowalevski.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"aad8c7e7-6e01-4e10-af12-5e66433f1080","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-priceless-kowalevski","namespace_id":"f3c8d254-0d74-4372-96a4-ea1855c38342","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsquizzicalptolemyco2lwtn7/tf-co-priceless-kowalevski:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":["tag1","tag2"],"timeout":"300s","updated_at":"2025-08-27T15:05:53.670651Z"}'
         headers:
             Content-Length:
-                - "1001"
+                - "996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:01:18 GMT
+                - Wed, 27 Aug 2025 15:05:55 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -687,10 +687,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a7efb414-1998-413c-a135-d12754756563
+                - 6ed0102c-4d78-4815-a138-3f980e113ceb
         status: 200 OK
         code: 200
-        duration: 184.421666ms
+        duration: 101.358144ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -706,27 +706,27 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d2d2f713-994c-4c04-8c3d-6321d7a97d78
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/aad8c7e7-6e01-4e10-af12-5e66433f1080
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 601
+        content_length: 1000
         uncompressed: false
-        body: '{"created_at":"2025-06-11T12:01:11.009723Z","description":"","environment_variables":{},"error_message":null,"id":"d2d2f713-994c-4c04-8c3d-6321d7a97d78","name":"tf-ns-festive-merkle","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsfestivemerkle1qlua5qo","registry_namespace_id":"6e61270a-e1ce-438e-a954-88838f63def7","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-11T12:01:12.975036Z","vpc_integration_activated":false}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:53.670651Z","description":"","domain_name":"tfnsquizzicalptolemyco2lwtn7-tf-co-priceless-kowalevski.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"aad8c7e7-6e01-4e10-af12-5e66433f1080","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-priceless-kowalevski","namespace_id":"f3c8d254-0d74-4372-96a4-ea1855c38342","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsquizzicalptolemyco2lwtn7/tf-co-priceless-kowalevski:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"deleting","tags":["tag1","tag2"],"timeout":"300s","updated_at":"2025-08-27T15:05:55.644770840Z"}'
         headers:
             Content-Length:
-                - "601"
+                - "1000"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:01:18 GMT
+                - Wed, 27 Aug 2025 15:05:55 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -736,62 +736,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b81a85a3-663d-4f6d-9cbe-457ece0c349f
+                - 92415cec-f0df-44d9-a10e-bc5d20ee4de4
         status: 200 OK
         code: 200
-        duration: 117.982458ms
+        duration: 225.064933ms
     - id: 15
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 363
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"namespace_id":"d2d2f713-994c-4c04-8c3d-6321d7a97d78","name":"my-container-tf","max_scale":20,"memory_limit":128,"cpu_limit":70,"timeout":"300.000000000s","privacy":"public","protocol":"http1","port":8080,"secret_environment_variables":null,"http_option":"enabled","sandbox":"unknown_sandbox","local_storage_limit":1000,"tags":["tag"],"command":null,"args":null}'
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 986
-        uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":70,"created_at":"2025-06-11T12:01:19.142183223Z","description":"","domain_name":"tfnsfestivemerkle1qlua5qo-my-container-tf.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"28d4e293-cab9-4340-951f-d14accf668c8","local_storage_limit":1000,"max_concurrency":50,"max_scale":20,"memory_limit":128,"min_scale":0,"name":"my-container-tf","namespace_id":"d2d2f713-994c-4c04-8c3d-6321d7a97d78","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsfestivemerkle1qlua5qo/my-container-tf:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":["tag"],"timeout":"300s","updated_at":"2025-06-11T12:01:19.142183223Z"}'
-        headers:
-            Content-Length:
-                - "986"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 11 Jun 2025 12:01:19 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 6c94faff-1632-46d2-ba70-5b45e6c450b1
-        status: 200 OK
-        code: 200
-        duration: 547.136333ms
-    - id: 16
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -806,8 +755,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/28d4e293-cab9-4340-951f-d14accf668c8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/f3c8d254-0d74-4372-96a4-ea1855c38342
         method: GET
       response:
         proto: HTTP/2.0
@@ -815,18 +764,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 980
+        content_length: 591
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":70,"created_at":"2025-06-11T12:01:19.142183Z","description":"","domain_name":"tfnsfestivemerkle1qlua5qo-my-container-tf.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"28d4e293-cab9-4340-951f-d14accf668c8","local_storage_limit":1000,"max_concurrency":50,"max_scale":20,"memory_limit":128,"min_scale":0,"name":"my-container-tf","namespace_id":"d2d2f713-994c-4c04-8c3d-6321d7a97d78","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsfestivemerkle1qlua5qo/my-container-tf:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":["tag"],"timeout":"300s","updated_at":"2025-06-11T12:01:19.142183Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.107749Z","description":"","environment_variables":{},"error_message":null,"id":"f3c8d254-0d74-4372-96a4-ea1855c38342","name":"tf-ns-quizzical-ptolemy","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsquizzicalptolemyco2lwtn7","registry_namespace_id":"dfe94e06-48b4-4c0d-9a59-f8b63baf222d","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:47.985407Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "980"
+                - "591"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:01:19 GMT
+                - Wed, 27 Aug 2025 15:05:55 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -836,10 +785,61 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 605cd87e-1aab-46dc-b662-f485cf3b259d
+                - 3a2b2102-d125-4fb6-949e-3aeff62cbdb4
         status: 200 OK
         code: 200
-        duration: 111.742042ms
+        duration: 66.052124ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 363
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"namespace_id":"f3c8d254-0d74-4372-96a4-ea1855c38342","name":"my-container-tf","max_scale":20,"memory_limit":128,"cpu_limit":70,"timeout":"300.000000000s","privacy":"public","protocol":"http1","port":8080,"secret_environment_variables":null,"http_option":"enabled","sandbox":"unknown_sandbox","local_storage_limit":1000,"tags":["tag"],"command":null,"args":null}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 959
+        uncompressed: false
+        body: '{"args":[],"command":[],"cpu_limit":70,"created_at":"2025-08-27T15:05:57.067522157Z","description":"","domain_name":"tfnsquizzicalptolemyco2lwtn7-my-container-tf.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"1c67fd5e-4493-4811-b894-d45038e5cdb8","local_storage_limit":1000,"max_concurrency":50,"max_scale":20,"memory_limit":128,"min_scale":0,"name":"my-container-tf","namespace_id":"f3c8d254-0d74-4372-96a4-ea1855c38342","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsquizzicalptolemyco2lwtn7/my-container-tf:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":["tag"],"timeout":"300s","updated_at":"2025-08-27T15:05:57.067522157Z"}'
+        headers:
+            Content-Length:
+                - "959"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:05:57 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 22c70244-334f-4f87-8d0f-a532480e4758
+        status: 200 OK
+        code: 200
+        duration: 1.280544341s
     - id: 17
       request:
         proto: HTTP/1.1
@@ -855,8 +855,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/28d4e293-cab9-4340-951f-d14accf668c8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/1c67fd5e-4493-4811-b894-d45038e5cdb8
         method: GET
       response:
         proto: HTTP/2.0
@@ -864,18 +864,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 980
+        content_length: 953
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":70,"created_at":"2025-06-11T12:01:19.142183Z","description":"","domain_name":"tfnsfestivemerkle1qlua5qo-my-container-tf.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"28d4e293-cab9-4340-951f-d14accf668c8","local_storage_limit":1000,"max_concurrency":50,"max_scale":20,"memory_limit":128,"min_scale":0,"name":"my-container-tf","namespace_id":"d2d2f713-994c-4c04-8c3d-6321d7a97d78","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsfestivemerkle1qlua5qo/my-container-tf:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":["tag"],"timeout":"300s","updated_at":"2025-06-11T12:01:19.142183Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":70,"created_at":"2025-08-27T15:05:57.067522Z","description":"","domain_name":"tfnsquizzicalptolemyco2lwtn7-my-container-tf.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"1c67fd5e-4493-4811-b894-d45038e5cdb8","local_storage_limit":1000,"max_concurrency":50,"max_scale":20,"memory_limit":128,"min_scale":0,"name":"my-container-tf","namespace_id":"f3c8d254-0d74-4372-96a4-ea1855c38342","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsquizzicalptolemyco2lwtn7/my-container-tf:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":["tag"],"timeout":"300s","updated_at":"2025-08-27T15:05:57.067522Z"}'
         headers:
             Content-Length:
-                - "980"
+                - "953"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:01:19 GMT
+                - Wed, 27 Aug 2025 15:05:57 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -885,10 +885,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6549c56e-f813-4b93-a1e6-9952ccc7d3b9
+                - 5e23013b-3bea-4bbe-9dc8-3f4cf6f452d7
         status: 200 OK
         code: 200
-        duration: 80.380709ms
+        duration: 141.03171ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -904,8 +904,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d2d2f713-994c-4c04-8c3d-6321d7a97d78
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/1c67fd5e-4493-4811-b894-d45038e5cdb8
         method: GET
       response:
         proto: HTTP/2.0
@@ -913,18 +913,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 601
+        content_length: 953
         uncompressed: false
-        body: '{"created_at":"2025-06-11T12:01:11.009723Z","description":"","environment_variables":{},"error_message":null,"id":"d2d2f713-994c-4c04-8c3d-6321d7a97d78","name":"tf-ns-festive-merkle","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsfestivemerkle1qlua5qo","registry_namespace_id":"6e61270a-e1ce-438e-a954-88838f63def7","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-11T12:01:12.975036Z","vpc_integration_activated":false}'
+        body: '{"args":[],"command":[],"cpu_limit":70,"created_at":"2025-08-27T15:05:57.067522Z","description":"","domain_name":"tfnsquizzicalptolemyco2lwtn7-my-container-tf.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"1c67fd5e-4493-4811-b894-d45038e5cdb8","local_storage_limit":1000,"max_concurrency":50,"max_scale":20,"memory_limit":128,"min_scale":0,"name":"my-container-tf","namespace_id":"f3c8d254-0d74-4372-96a4-ea1855c38342","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsquizzicalptolemyco2lwtn7/my-container-tf:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":["tag"],"timeout":"300s","updated_at":"2025-08-27T15:05:57.067522Z"}'
         headers:
             Content-Length:
-                - "601"
+                - "953"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:01:19 GMT
+                - Wed, 27 Aug 2025 15:05:57 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -934,10 +934,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 84082a19-c1f1-421e-85a1-ce883d4bb214
+                - cad43113-0573-4aa1-9a0e-885dce01ddb8
         status: 200 OK
         code: 200
-        duration: 73.989ms
+        duration: 103.667107ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -953,8 +953,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/28d4e293-cab9-4340-951f-d14accf668c8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/f3c8d254-0d74-4372-96a4-ea1855c38342
         method: GET
       response:
         proto: HTTP/2.0
@@ -962,18 +962,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 980
+        content_length: 591
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":70,"created_at":"2025-06-11T12:01:19.142183Z","description":"","domain_name":"tfnsfestivemerkle1qlua5qo-my-container-tf.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"28d4e293-cab9-4340-951f-d14accf668c8","local_storage_limit":1000,"max_concurrency":50,"max_scale":20,"memory_limit":128,"min_scale":0,"name":"my-container-tf","namespace_id":"d2d2f713-994c-4c04-8c3d-6321d7a97d78","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsfestivemerkle1qlua5qo/my-container-tf:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":["tag"],"timeout":"300s","updated_at":"2025-06-11T12:01:19.142183Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.107749Z","description":"","environment_variables":{},"error_message":null,"id":"f3c8d254-0d74-4372-96a4-ea1855c38342","name":"tf-ns-quizzical-ptolemy","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsquizzicalptolemyco2lwtn7","registry_namespace_id":"dfe94e06-48b4-4c0d-9a59-f8b63baf222d","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:47.985407Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "980"
+                - "591"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:01:19 GMT
+                - Wed, 27 Aug 2025 15:05:57 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -983,10 +983,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f7d89ee9-e692-459e-ad20-d7d90391b12a
+                - 7888bfdc-f4b3-4b2f-bdb3-c3df73b6f801
         status: 200 OK
         code: 200
-        duration: 83.270417ms
+        duration: 80.302344ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1002,8 +1002,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d2d2f713-994c-4c04-8c3d-6321d7a97d78
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/1c67fd5e-4493-4811-b894-d45038e5cdb8
         method: GET
       response:
         proto: HTTP/2.0
@@ -1011,18 +1011,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 601
+        content_length: 953
         uncompressed: false
-        body: '{"created_at":"2025-06-11T12:01:11.009723Z","description":"","environment_variables":{},"error_message":null,"id":"d2d2f713-994c-4c04-8c3d-6321d7a97d78","name":"tf-ns-festive-merkle","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsfestivemerkle1qlua5qo","registry_namespace_id":"6e61270a-e1ce-438e-a954-88838f63def7","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-11T12:01:12.975036Z","vpc_integration_activated":false}'
+        body: '{"args":[],"command":[],"cpu_limit":70,"created_at":"2025-08-27T15:05:57.067522Z","description":"","domain_name":"tfnsquizzicalptolemyco2lwtn7-my-container-tf.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"1c67fd5e-4493-4811-b894-d45038e5cdb8","local_storage_limit":1000,"max_concurrency":50,"max_scale":20,"memory_limit":128,"min_scale":0,"name":"my-container-tf","namespace_id":"f3c8d254-0d74-4372-96a4-ea1855c38342","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsquizzicalptolemyco2lwtn7/my-container-tf:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":["tag"],"timeout":"300s","updated_at":"2025-08-27T15:05:57.067522Z"}'
         headers:
             Content-Length:
-                - "601"
+                - "953"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:01:20 GMT
+                - Wed, 27 Aug 2025 15:05:57 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -1032,10 +1032,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 93580776-e1cc-4cce-b4c6-f741319324ab
+                - 24e5e362-55e2-4d23-81ef-848dde7958da
         status: 200 OK
         code: 200
-        duration: 83.123625ms
+        duration: 162.290572ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1051,8 +1051,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/28d4e293-cab9-4340-951f-d14accf668c8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/f3c8d254-0d74-4372-96a4-ea1855c38342
         method: GET
       response:
         proto: HTTP/2.0
@@ -1060,18 +1060,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 980
+        content_length: 591
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":70,"created_at":"2025-06-11T12:01:19.142183Z","description":"","domain_name":"tfnsfestivemerkle1qlua5qo-my-container-tf.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"28d4e293-cab9-4340-951f-d14accf668c8","local_storage_limit":1000,"max_concurrency":50,"max_scale":20,"memory_limit":128,"min_scale":0,"name":"my-container-tf","namespace_id":"d2d2f713-994c-4c04-8c3d-6321d7a97d78","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsfestivemerkle1qlua5qo/my-container-tf:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":["tag"],"timeout":"300s","updated_at":"2025-06-11T12:01:19.142183Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.107749Z","description":"","environment_variables":{},"error_message":null,"id":"f3c8d254-0d74-4372-96a4-ea1855c38342","name":"tf-ns-quizzical-ptolemy","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsquizzicalptolemyco2lwtn7","registry_namespace_id":"dfe94e06-48b4-4c0d-9a59-f8b63baf222d","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:47.985407Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "980"
+                - "591"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:01:20 GMT
+                - Wed, 27 Aug 2025 15:05:58 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -1081,10 +1081,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 266de912-bbce-4db9-93cc-84a2a7362b7a
+                - 16d3895f-bc82-4397-a887-9f5a59826334
         status: 200 OK
         code: 200
-        duration: 91.454125ms
+        duration: 90.030148ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1100,8 +1100,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d2d2f713-994c-4c04-8c3d-6321d7a97d78
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/1c67fd5e-4493-4811-b894-d45038e5cdb8
         method: GET
       response:
         proto: HTTP/2.0
@@ -1109,18 +1109,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 601
+        content_length: 953
         uncompressed: false
-        body: '{"created_at":"2025-06-11T12:01:11.009723Z","description":"","environment_variables":{},"error_message":null,"id":"d2d2f713-994c-4c04-8c3d-6321d7a97d78","name":"tf-ns-festive-merkle","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsfestivemerkle1qlua5qo","registry_namespace_id":"6e61270a-e1ce-438e-a954-88838f63def7","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-11T12:01:12.975036Z","vpc_integration_activated":false}'
+        body: '{"args":[],"command":[],"cpu_limit":70,"created_at":"2025-08-27T15:05:57.067522Z","description":"","domain_name":"tfnsquizzicalptolemyco2lwtn7-my-container-tf.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"1c67fd5e-4493-4811-b894-d45038e5cdb8","local_storage_limit":1000,"max_concurrency":50,"max_scale":20,"memory_limit":128,"min_scale":0,"name":"my-container-tf","namespace_id":"f3c8d254-0d74-4372-96a4-ea1855c38342","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsquizzicalptolemyco2lwtn7/my-container-tf:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":["tag"],"timeout":"300s","updated_at":"2025-08-27T15:05:57.067522Z"}'
         headers:
             Content-Length:
-                - "601"
+                - "953"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:01:20 GMT
+                - Wed, 27 Aug 2025 15:05:58 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -1130,10 +1130,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e2686c51-98dd-4e5d-b76b-37a8cdbaa424
+                - bada67f0-a6ee-4f03-8eef-311c84cb3720
         status: 200 OK
         code: 200
-        duration: 72.142ms
+        duration: 96.092393ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1149,8 +1149,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/28d4e293-cab9-4340-951f-d14accf668c8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/f3c8d254-0d74-4372-96a4-ea1855c38342
         method: GET
       response:
         proto: HTTP/2.0
@@ -1158,18 +1158,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 980
+        content_length: 591
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":70,"created_at":"2025-06-11T12:01:19.142183Z","description":"","domain_name":"tfnsfestivemerkle1qlua5qo-my-container-tf.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"28d4e293-cab9-4340-951f-d14accf668c8","local_storage_limit":1000,"max_concurrency":50,"max_scale":20,"memory_limit":128,"min_scale":0,"name":"my-container-tf","namespace_id":"d2d2f713-994c-4c04-8c3d-6321d7a97d78","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsfestivemerkle1qlua5qo/my-container-tf:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":["tag"],"timeout":"300s","updated_at":"2025-06-11T12:01:19.142183Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.107749Z","description":"","environment_variables":{},"error_message":null,"id":"f3c8d254-0d74-4372-96a4-ea1855c38342","name":"tf-ns-quizzical-ptolemy","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsquizzicalptolemyco2lwtn7","registry_namespace_id":"dfe94e06-48b4-4c0d-9a59-f8b63baf222d","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:47.985407Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "980"
+                - "591"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:01:20 GMT
+                - Wed, 27 Aug 2025 15:05:59 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -1179,11 +1179,60 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1b574281-c0a7-453a-b417-a454676d4c26
+                - 17823be6-58d9-4766-b11e-624b0669d7a0
         status: 200 OK
         code: 200
-        duration: 96.356666ms
+        duration: 108.056684ms
     - id: 24
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/1c67fd5e-4493-4811-b894-d45038e5cdb8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 953
+        uncompressed: false
+        body: '{"args":[],"command":[],"cpu_limit":70,"created_at":"2025-08-27T15:05:57.067522Z","description":"","domain_name":"tfnsquizzicalptolemyco2lwtn7-my-container-tf.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"1c67fd5e-4493-4811-b894-d45038e5cdb8","local_storage_limit":1000,"max_concurrency":50,"max_scale":20,"memory_limit":128,"min_scale":0,"name":"my-container-tf","namespace_id":"f3c8d254-0d74-4372-96a4-ea1855c38342","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsquizzicalptolemyco2lwtn7/my-container-tf:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":["tag"],"timeout":"300s","updated_at":"2025-08-27T15:05:57.067522Z"}'
+        headers:
+            Content-Length:
+                - "953"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:05:59 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 709ffdb1-138f-4e5e-95ab-52e06378e66d
+        status: 200 OK
+        code: 200
+        duration: 92.35979ms
+    - id: 25
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1200,8 +1249,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/28d4e293-cab9-4340-951f-d14accf668c8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/1c67fd5e-4493-4811-b894-d45038e5cdb8
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -1209,18 +1258,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 979
+        content_length: 952
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":280,"created_at":"2025-06-11T12:01:19.142183Z","description":"","domain_name":"tfnsfestivemerkle1qlua5qo-my-container-tf.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"28d4e293-cab9-4340-951f-d14accf668c8","local_storage_limit":1500,"max_concurrency":80,"max_scale":2,"memory_limit":1120,"min_scale":1,"name":"my-container-tf","namespace_id":"d2d2f713-994c-4c04-8c3d-6321d7a97d78","port":5000,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsfestivemerkle1qlua5qo/my-container-tf:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":80},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-06-11T12:01:20.645103206Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":280,"created_at":"2025-08-27T15:05:57.067522Z","description":"","domain_name":"tfnsquizzicalptolemyco2lwtn7-my-container-tf.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"1c67fd5e-4493-4811-b894-d45038e5cdb8","local_storage_limit":1500,"max_concurrency":80,"max_scale":2,"memory_limit":1120,"min_scale":1,"name":"my-container-tf","namespace_id":"f3c8d254-0d74-4372-96a4-ea1855c38342","port":5000,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsquizzicalptolemyco2lwtn7/my-container-tf:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":80},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:59.283196104Z"}'
         headers:
             Content-Length:
-                - "979"
+                - "952"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:01:20 GMT
+                - Wed, 27 Aug 2025 15:05:59 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -1230,59 +1279,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 82291775-0554-40c6-b907-cc213d1926e4
+                - 4d15b20f-6165-4584-8fd2-b5db814e37c6
         status: 200 OK
         code: 200
-        duration: 96.243417ms
-    - id: 25
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/28d4e293-cab9-4340-951f-d14accf668c8
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 976
-        uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":280,"created_at":"2025-06-11T12:01:19.142183Z","description":"","domain_name":"tfnsfestivemerkle1qlua5qo-my-container-tf.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"28d4e293-cab9-4340-951f-d14accf668c8","local_storage_limit":1500,"max_concurrency":80,"max_scale":2,"memory_limit":1120,"min_scale":1,"name":"my-container-tf","namespace_id":"d2d2f713-994c-4c04-8c3d-6321d7a97d78","port":5000,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsfestivemerkle1qlua5qo/my-container-tf:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":80},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-06-11T12:01:20.645103Z"}'
-        headers:
-            Content-Length:
-                - "976"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 11 Jun 2025 12:01:20 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 0a823a25-6889-475d-9e23-cafaffd00b15
-        status: 200 OK
-        code: 200
-        duration: 85.289042ms
+        duration: 106.452274ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1298,8 +1298,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/28d4e293-cab9-4340-951f-d14accf668c8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/1c67fd5e-4493-4811-b894-d45038e5cdb8
         method: GET
       response:
         proto: HTTP/2.0
@@ -1307,18 +1307,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 976
+        content_length: 949
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":280,"created_at":"2025-06-11T12:01:19.142183Z","description":"","domain_name":"tfnsfestivemerkle1qlua5qo-my-container-tf.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"28d4e293-cab9-4340-951f-d14accf668c8","local_storage_limit":1500,"max_concurrency":80,"max_scale":2,"memory_limit":1120,"min_scale":1,"name":"my-container-tf","namespace_id":"d2d2f713-994c-4c04-8c3d-6321d7a97d78","port":5000,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsfestivemerkle1qlua5qo/my-container-tf:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":80},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-06-11T12:01:20.645103Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":280,"created_at":"2025-08-27T15:05:57.067522Z","description":"","domain_name":"tfnsquizzicalptolemyco2lwtn7-my-container-tf.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"1c67fd5e-4493-4811-b894-d45038e5cdb8","local_storage_limit":1500,"max_concurrency":80,"max_scale":2,"memory_limit":1120,"min_scale":1,"name":"my-container-tf","namespace_id":"f3c8d254-0d74-4372-96a4-ea1855c38342","port":5000,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsquizzicalptolemyco2lwtn7/my-container-tf:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":80},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:59.283196Z"}'
         headers:
             Content-Length:
-                - "976"
+                - "949"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:01:25 GMT
+                - Wed, 27 Aug 2025 15:05:59 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -1328,10 +1328,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 288266df-da78-4b7c-9954-2bfacf7385fe
+                - f4c0877a-6de3-4b97-8c9e-736cad0b8a59
         status: 200 OK
         code: 200
-        duration: 88.334625ms
+        duration: 98.026533ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1347,8 +1347,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/28d4e293-cab9-4340-951f-d14accf668c8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/1c67fd5e-4493-4811-b894-d45038e5cdb8
         method: GET
       response:
         proto: HTTP/2.0
@@ -1356,18 +1356,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1014
+        content_length: 949
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":280,"created_at":"2025-06-11T12:01:19.142183Z","description":"","domain_name":"tfnsfestivemerkle1qlua5qo-my-container-tf.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"28d4e293-cab9-4340-951f-d14accf668c8","local_storage_limit":1500,"max_concurrency":80,"max_scale":2,"memory_limit":1120,"min_scale":1,"name":"my-container-tf","namespace_id":"d2d2f713-994c-4c04-8c3d-6321d7a97d78","port":5000,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsfestivemerkle1qlua5qo/my-container-tf:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":80},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-06-11T12:01:27.146177Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":280,"created_at":"2025-08-27T15:05:57.067522Z","description":"","domain_name":"tfnsquizzicalptolemyco2lwtn7-my-container-tf.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"1c67fd5e-4493-4811-b894-d45038e5cdb8","local_storage_limit":1500,"max_concurrency":80,"max_scale":2,"memory_limit":1120,"min_scale":1,"name":"my-container-tf","namespace_id":"f3c8d254-0d74-4372-96a4-ea1855c38342","port":5000,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsquizzicalptolemyco2lwtn7/my-container-tf:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":80},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:59.283196Z"}'
         headers:
             Content-Length:
-                - "1014"
+                - "949"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:01:30 GMT
+                - Wed, 27 Aug 2025 15:06:04 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -1377,10 +1377,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6f12fa7c-a479-47cd-a239-cfa3242c34fa
+                - 9a1f3d24-b07a-4a4e-b751-9118ee59dab2
         status: 200 OK
         code: 200
-        duration: 85.852833ms
+        duration: 81.037475ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1396,8 +1396,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/28d4e293-cab9-4340-951f-d14accf668c8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/1c67fd5e-4493-4811-b894-d45038e5cdb8
         method: GET
       response:
         proto: HTTP/2.0
@@ -1405,18 +1405,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1014
+        content_length: 949
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":280,"created_at":"2025-06-11T12:01:19.142183Z","description":"","domain_name":"tfnsfestivemerkle1qlua5qo-my-container-tf.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"28d4e293-cab9-4340-951f-d14accf668c8","local_storage_limit":1500,"max_concurrency":80,"max_scale":2,"memory_limit":1120,"min_scale":1,"name":"my-container-tf","namespace_id":"d2d2f713-994c-4c04-8c3d-6321d7a97d78","port":5000,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsfestivemerkle1qlua5qo/my-container-tf:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":80},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-06-11T12:01:27.146177Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":280,"created_at":"2025-08-27T15:05:57.067522Z","description":"","domain_name":"tfnsquizzicalptolemyco2lwtn7-my-container-tf.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"1c67fd5e-4493-4811-b894-d45038e5cdb8","local_storage_limit":1500,"max_concurrency":80,"max_scale":2,"memory_limit":1120,"min_scale":1,"name":"my-container-tf","namespace_id":"f3c8d254-0d74-4372-96a4-ea1855c38342","port":5000,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsquizzicalptolemyco2lwtn7/my-container-tf:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":80},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:59.283196Z"}'
         headers:
             Content-Length:
-                - "1014"
+                - "949"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:01:31 GMT
+                - Wed, 27 Aug 2025 15:06:09 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -1426,10 +1426,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 588f8193-7fc1-4d28-8fde-01279b39965a
+                - a888369a-78a0-410d-ba8a-032fc31e15fd
         status: 200 OK
         code: 200
-        duration: 84.49375ms
+        duration: 92.008884ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1445,8 +1445,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/28d4e293-cab9-4340-951f-d14accf668c8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/1c67fd5e-4493-4811-b894-d45038e5cdb8
         method: GET
       response:
         proto: HTTP/2.0
@@ -1454,18 +1454,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1014
+        content_length: 987
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":280,"created_at":"2025-06-11T12:01:19.142183Z","description":"","domain_name":"tfnsfestivemerkle1qlua5qo-my-container-tf.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"28d4e293-cab9-4340-951f-d14accf668c8","local_storage_limit":1500,"max_concurrency":80,"max_scale":2,"memory_limit":1120,"min_scale":1,"name":"my-container-tf","namespace_id":"d2d2f713-994c-4c04-8c3d-6321d7a97d78","port":5000,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsfestivemerkle1qlua5qo/my-container-tf:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":80},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-06-11T12:01:27.146177Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":280,"created_at":"2025-08-27T15:05:57.067522Z","description":"","domain_name":"tfnsquizzicalptolemyco2lwtn7-my-container-tf.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"1c67fd5e-4493-4811-b894-d45038e5cdb8","local_storage_limit":1500,"max_concurrency":80,"max_scale":2,"memory_limit":1120,"min_scale":1,"name":"my-container-tf","namespace_id":"f3c8d254-0d74-4372-96a4-ea1855c38342","port":5000,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsquizzicalptolemyco2lwtn7/my-container-tf:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":80},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:10.893727Z"}'
         headers:
             Content-Length:
-                - "1014"
+                - "987"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:01:31 GMT
+                - Wed, 27 Aug 2025 15:06:14 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -1475,10 +1475,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 54042c0f-ed70-44db-bce5-ee246e1be558
+                - f39eb645-e740-4a0b-bb34-e00635816d41
         status: 200 OK
         code: 200
-        duration: 84.91175ms
+        duration: 96.512055ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1494,8 +1494,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d2d2f713-994c-4c04-8c3d-6321d7a97d78
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/1c67fd5e-4493-4811-b894-d45038e5cdb8
         method: GET
       response:
         proto: HTTP/2.0
@@ -1503,18 +1503,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 601
+        content_length: 987
         uncompressed: false
-        body: '{"created_at":"2025-06-11T12:01:11.009723Z","description":"","environment_variables":{},"error_message":null,"id":"d2d2f713-994c-4c04-8c3d-6321d7a97d78","name":"tf-ns-festive-merkle","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsfestivemerkle1qlua5qo","registry_namespace_id":"6e61270a-e1ce-438e-a954-88838f63def7","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-11T12:01:12.975036Z","vpc_integration_activated":false}'
+        body: '{"args":[],"command":[],"cpu_limit":280,"created_at":"2025-08-27T15:05:57.067522Z","description":"","domain_name":"tfnsquizzicalptolemyco2lwtn7-my-container-tf.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"1c67fd5e-4493-4811-b894-d45038e5cdb8","local_storage_limit":1500,"max_concurrency":80,"max_scale":2,"memory_limit":1120,"min_scale":1,"name":"my-container-tf","namespace_id":"f3c8d254-0d74-4372-96a4-ea1855c38342","port":5000,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsquizzicalptolemyco2lwtn7/my-container-tf:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":80},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:10.893727Z"}'
         headers:
             Content-Length:
-                - "601"
+                - "987"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:01:31 GMT
+                - Wed, 27 Aug 2025 15:06:14 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -1524,10 +1524,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 87ffaf65-fac5-4126-952b-67222b68270c
+                - 7e4520de-a511-4812-bf7e-16bfb72944fa
         status: 200 OK
         code: 200
-        duration: 89.918416ms
+        duration: 88.987325ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1543,8 +1543,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/28d4e293-cab9-4340-951f-d14accf668c8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/1c67fd5e-4493-4811-b894-d45038e5cdb8
         method: GET
       response:
         proto: HTTP/2.0
@@ -1552,18 +1552,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1014
+        content_length: 987
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":280,"created_at":"2025-06-11T12:01:19.142183Z","description":"","domain_name":"tfnsfestivemerkle1qlua5qo-my-container-tf.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"28d4e293-cab9-4340-951f-d14accf668c8","local_storage_limit":1500,"max_concurrency":80,"max_scale":2,"memory_limit":1120,"min_scale":1,"name":"my-container-tf","namespace_id":"d2d2f713-994c-4c04-8c3d-6321d7a97d78","port":5000,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsfestivemerkle1qlua5qo/my-container-tf:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":80},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-06-11T12:01:27.146177Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":280,"created_at":"2025-08-27T15:05:57.067522Z","description":"","domain_name":"tfnsquizzicalptolemyco2lwtn7-my-container-tf.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"1c67fd5e-4493-4811-b894-d45038e5cdb8","local_storage_limit":1500,"max_concurrency":80,"max_scale":2,"memory_limit":1120,"min_scale":1,"name":"my-container-tf","namespace_id":"f3c8d254-0d74-4372-96a4-ea1855c38342","port":5000,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsquizzicalptolemyco2lwtn7/my-container-tf:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":80},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:10.893727Z"}'
         headers:
             Content-Length:
-                - "1014"
+                - "987"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:01:31 GMT
+                - Wed, 27 Aug 2025 15:06:14 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -1573,10 +1573,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d3267327-35e7-4a1f-a839-f310634a60e3
+                - 1c283712-552b-477c-9ea2-f187c2f65ff0
         status: 200 OK
         code: 200
-        duration: 92.917833ms
+        duration: 84.707485ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1592,8 +1592,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/28d4e293-cab9-4340-951f-d14accf668c8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/f3c8d254-0d74-4372-96a4-ea1855c38342
         method: GET
       response:
         proto: HTTP/2.0
@@ -1601,18 +1601,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1014
+        content_length: 591
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":280,"created_at":"2025-06-11T12:01:19.142183Z","description":"","domain_name":"tfnsfestivemerkle1qlua5qo-my-container-tf.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"28d4e293-cab9-4340-951f-d14accf668c8","local_storage_limit":1500,"max_concurrency":80,"max_scale":2,"memory_limit":1120,"min_scale":1,"name":"my-container-tf","namespace_id":"d2d2f713-994c-4c04-8c3d-6321d7a97d78","port":5000,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsfestivemerkle1qlua5qo/my-container-tf:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":80},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-06-11T12:01:27.146177Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.107749Z","description":"","environment_variables":{},"error_message":null,"id":"f3c8d254-0d74-4372-96a4-ea1855c38342","name":"tf-ns-quizzical-ptolemy","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsquizzicalptolemyco2lwtn7","registry_namespace_id":"dfe94e06-48b4-4c0d-9a59-f8b63baf222d","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:47.985407Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "1014"
+                - "591"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:01:31 GMT
+                - Wed, 27 Aug 2025 15:06:15 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -1622,10 +1622,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ea60ed07-d2b5-4824-a2a3-51753d15db8b
+                - 667f40b5-aa5d-4fdb-a693-95b13aa5f672
         status: 200 OK
         code: 200
-        duration: 95.53975ms
+        duration: 70.792964ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1641,27 +1641,27 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/28d4e293-cab9-4340-951f-d14accf668c8
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/1c67fd5e-4493-4811-b894-d45038e5cdb8
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 980
+        content_length: 987
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":280,"created_at":"2025-06-11T12:01:19.142183Z","description":"","domain_name":"tfnsfestivemerkle1qlua5qo-my-container-tf.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"28d4e293-cab9-4340-951f-d14accf668c8","local_storage_limit":1500,"max_concurrency":80,"max_scale":2,"memory_limit":1120,"min_scale":1,"name":"my-container-tf","namespace_id":"d2d2f713-994c-4c04-8c3d-6321d7a97d78","port":5000,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsfestivemerkle1qlua5qo/my-container-tf:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":80},"secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2025-06-11T12:01:31.977676725Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":280,"created_at":"2025-08-27T15:05:57.067522Z","description":"","domain_name":"tfnsquizzicalptolemyco2lwtn7-my-container-tf.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"1c67fd5e-4493-4811-b894-d45038e5cdb8","local_storage_limit":1500,"max_concurrency":80,"max_scale":2,"memory_limit":1120,"min_scale":1,"name":"my-container-tf","namespace_id":"f3c8d254-0d74-4372-96a4-ea1855c38342","port":5000,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsquizzicalptolemyco2lwtn7/my-container-tf:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":80},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:10.893727Z"}'
         headers:
             Content-Length:
-                - "980"
+                - "987"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:01:32 GMT
+                - Wed, 27 Aug 2025 15:06:15 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -1671,10 +1671,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bc559251-ce26-4177-8df5-0efd2b8aa3e2
+                - 255f7e85-dd1b-4398-a48a-b2fa87988ca5
         status: 200 OK
         code: 200
-        duration: 134.666083ms
+        duration: 90.313885ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1690,8 +1690,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d2d2f713-994c-4c04-8c3d-6321d7a97d78
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/1c67fd5e-4493-4811-b894-d45038e5cdb8
         method: GET
       response:
         proto: HTTP/2.0
@@ -1699,18 +1699,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 601
+        content_length: 987
         uncompressed: false
-        body: '{"created_at":"2025-06-11T12:01:11.009723Z","description":"","environment_variables":{},"error_message":null,"id":"d2d2f713-994c-4c04-8c3d-6321d7a97d78","name":"tf-ns-festive-merkle","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsfestivemerkle1qlua5qo","registry_namespace_id":"6e61270a-e1ce-438e-a954-88838f63def7","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-11T12:01:12.975036Z","vpc_integration_activated":false}'
+        body: '{"args":[],"command":[],"cpu_limit":280,"created_at":"2025-08-27T15:05:57.067522Z","description":"","domain_name":"tfnsquizzicalptolemyco2lwtn7-my-container-tf.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"1c67fd5e-4493-4811-b894-d45038e5cdb8","local_storage_limit":1500,"max_concurrency":80,"max_scale":2,"memory_limit":1120,"min_scale":1,"name":"my-container-tf","namespace_id":"f3c8d254-0d74-4372-96a4-ea1855c38342","port":5000,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsquizzicalptolemyco2lwtn7/my-container-tf:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":80},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:10.893727Z"}'
         headers:
             Content-Length:
-                - "601"
+                - "987"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:01:32 GMT
+                - Wed, 27 Aug 2025 15:06:15 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -1720,10 +1720,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 54051e89-a866-4a2f-8d86-2e403a703e6a
+                - c2693685-1fb9-470d-b74b-7a98388e17b9
         status: 200 OK
         code: 200
-        duration: 96.941042ms
+        duration: 90.465029ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1739,8 +1739,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d2d2f713-994c-4c04-8c3d-6321d7a97d78
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/1c67fd5e-4493-4811-b894-d45038e5cdb8
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1748,18 +1748,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 607
+        content_length: 953
         uncompressed: false
-        body: '{"created_at":"2025-06-11T12:01:11.009723Z","description":"","environment_variables":{},"error_message":null,"id":"d2d2f713-994c-4c04-8c3d-6321d7a97d78","name":"tf-ns-festive-merkle","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsfestivemerkle1qlua5qo","registry_namespace_id":"6e61270a-e1ce-438e-a954-88838f63def7","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-06-11T12:01:32.233565432Z","vpc_integration_activated":false}'
+        body: '{"args":[],"command":[],"cpu_limit":280,"created_at":"2025-08-27T15:05:57.067522Z","description":"","domain_name":"tfnsquizzicalptolemyco2lwtn7-my-container-tf.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"1c67fd5e-4493-4811-b894-d45038e5cdb8","local_storage_limit":1500,"max_concurrency":80,"max_scale":2,"memory_limit":1120,"min_scale":1,"name":"my-container-tf","namespace_id":"f3c8d254-0d74-4372-96a4-ea1855c38342","port":5000,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsquizzicalptolemyco2lwtn7/my-container-tf:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":80},"secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:16.018533584Z"}'
         headers:
             Content-Length:
-                - "607"
+                - "953"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:01:32 GMT
+                - Wed, 27 Aug 2025 15:06:16 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -1769,10 +1769,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fbde038d-01a6-4d47-aeb9-ec7efeb42531
+                - b8980fb8-7bd0-4ff8-a952-045a1e0a0762
         status: 200 OK
         code: 200
-        duration: 660.666459ms
+        duration: 358.539996ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1788,8 +1788,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d2d2f713-994c-4c04-8c3d-6321d7a97d78
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/f3c8d254-0d74-4372-96a4-ea1855c38342
         method: GET
       response:
         proto: HTTP/2.0
@@ -1797,18 +1797,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 604
+        content_length: 591
         uncompressed: false
-        body: '{"created_at":"2025-06-11T12:01:11.009723Z","description":"","environment_variables":{},"error_message":null,"id":"d2d2f713-994c-4c04-8c3d-6321d7a97d78","name":"tf-ns-festive-merkle","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsfestivemerkle1qlua5qo","registry_namespace_id":"6e61270a-e1ce-438e-a954-88838f63def7","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-06-11T12:01:32.233565Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2025-08-27T15:05:41.107749Z","description":"","environment_variables":{},"error_message":null,"id":"f3c8d254-0d74-4372-96a4-ea1855c38342","name":"tf-ns-quizzical-ptolemy","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsquizzicalptolemyco2lwtn7","registry_namespace_id":"dfe94e06-48b4-4c0d-9a59-f8b63baf222d","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:47.985407Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "604"
+                - "591"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:01:32 GMT
+                - Wed, 27 Aug 2025 15:06:16 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -1818,10 +1818,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 404d8a88-0a14-43f4-9f48-ed86247e7111
+                - e2153573-79fb-4468-8cd9-30122253f083
         status: 200 OK
         code: 200
-        duration: 91.115375ms
+        duration: 231.656417ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1837,8 +1837,400 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d2d2f713-994c-4c04-8c3d-6321d7a97d78
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/f3c8d254-0d74-4372-96a4-ea1855c38342
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 597
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:41.107749Z","description":"","environment_variables":{},"error_message":null,"id":"f3c8d254-0d74-4372-96a4-ea1855c38342","name":"tf-ns-quizzical-ptolemy","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsquizzicalptolemyco2lwtn7","registry_namespace_id":"dfe94e06-48b4-4c0d-9a59-f8b63baf222d","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:16.643526893Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "597"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:16 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f0e11d42-55b4-441b-ab71-5725093a1866
+        status: 200 OK
+        code: 200
+        duration: 369.007529ms
+    - id: 38
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/f3c8d254-0d74-4372-96a4-ea1855c38342
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 594
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:41.107749Z","description":"","environment_variables":{},"error_message":null,"id":"f3c8d254-0d74-4372-96a4-ea1855c38342","name":"tf-ns-quizzical-ptolemy","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsquizzicalptolemyco2lwtn7","registry_namespace_id":"dfe94e06-48b4-4c0d-9a59-f8b63baf222d","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:16.643527Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "594"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:17 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 737c4fb7-10cc-4b2e-8945-e387710ff8b2
+        status: 200 OK
+        code: 200
+        duration: 136.098381ms
+    - id: 39
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/f3c8d254-0d74-4372-96a4-ea1855c38342
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 594
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:41.107749Z","description":"","environment_variables":{},"error_message":null,"id":"f3c8d254-0d74-4372-96a4-ea1855c38342","name":"tf-ns-quizzical-ptolemy","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsquizzicalptolemyco2lwtn7","registry_namespace_id":"dfe94e06-48b4-4c0d-9a59-f8b63baf222d","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:16.643527Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "594"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:22 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - cc01e2d0-f48d-4a7e-955c-fe9041ecb305
+        status: 200 OK
+        code: 200
+        duration: 83.352093ms
+    - id: 40
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/f3c8d254-0d74-4372-96a4-ea1855c38342
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 594
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:41.107749Z","description":"","environment_variables":{},"error_message":null,"id":"f3c8d254-0d74-4372-96a4-ea1855c38342","name":"tf-ns-quizzical-ptolemy","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsquizzicalptolemyco2lwtn7","registry_namespace_id":"dfe94e06-48b4-4c0d-9a59-f8b63baf222d","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:16.643527Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "594"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:27 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 852dba59-0b9d-4978-9eba-86647016c96d
+        status: 200 OK
+        code: 200
+        duration: 86.774657ms
+    - id: 41
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/f3c8d254-0d74-4372-96a4-ea1855c38342
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 594
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:41.107749Z","description":"","environment_variables":{},"error_message":null,"id":"f3c8d254-0d74-4372-96a4-ea1855c38342","name":"tf-ns-quizzical-ptolemy","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsquizzicalptolemyco2lwtn7","registry_namespace_id":"dfe94e06-48b4-4c0d-9a59-f8b63baf222d","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:16.643527Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "594"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:32 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3c877b20-f8ae-42dd-8e81-3a72e5226c1e
+        status: 200 OK
+        code: 200
+        duration: 80.57801ms
+    - id: 42
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/f3c8d254-0d74-4372-96a4-ea1855c38342
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 594
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:41.107749Z","description":"","environment_variables":{},"error_message":null,"id":"f3c8d254-0d74-4372-96a4-ea1855c38342","name":"tf-ns-quizzical-ptolemy","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsquizzicalptolemyco2lwtn7","registry_namespace_id":"dfe94e06-48b4-4c0d-9a59-f8b63baf222d","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:16.643527Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "594"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:37 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - a47e4dfd-6a82-4f59-84e7-83eb63e13cd8
+        status: 200 OK
+        code: 200
+        duration: 89.284359ms
+    - id: 43
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/f3c8d254-0d74-4372-96a4-ea1855c38342
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 594
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:41.107749Z","description":"","environment_variables":{},"error_message":null,"id":"f3c8d254-0d74-4372-96a4-ea1855c38342","name":"tf-ns-quizzical-ptolemy","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsquizzicalptolemyco2lwtn7","registry_namespace_id":"dfe94e06-48b4-4c0d-9a59-f8b63baf222d","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:16.643527Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "594"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:42 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - de4f6383-ac1a-45d5-93c6-3e3e9a2f8c5f
+        status: 200 OK
+        code: 200
+        duration: 86.927357ms
+    - id: 44
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/f3c8d254-0d74-4372-96a4-ea1855c38342
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 594
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:41.107749Z","description":"","environment_variables":{},"error_message":null,"id":"f3c8d254-0d74-4372-96a4-ea1855c38342","name":"tf-ns-quizzical-ptolemy","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsquizzicalptolemyco2lwtn7","registry_namespace_id":"dfe94e06-48b4-4c0d-9a59-f8b63baf222d","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:16.643527Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "594"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:47 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 70580283-d478-478c-b549-3fb8d82497c8
+        status: 200 OK
+        code: 200
+        duration: 80.417101ms
+    - id: 45
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/f3c8d254-0d74-4372-96a4-ea1855c38342
         method: GET
       response:
         proto: HTTP/2.0
@@ -1857,7 +2249,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:01:37 GMT
+                - Wed, 27 Aug 2025 15:06:52 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -1867,11 +2259,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a8c8c7cf-9804-44f1-a2b6-5afbf9ea4bd2
+                - a69d889a-1d49-4719-a4d3-38438f3f853d
         status: 404 Not Found
         code: 404
-        duration: 26.487333ms
-    - id: 38
+        duration: 25.623345ms
+    - id: 46
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1886,8 +2278,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/d2d2f713-994c-4c04-8c3d-6321d7a97d78
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f3c8d254-0d74-4372-96a4-ea1855c38342
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1906,7 +2298,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:01:37 GMT
+                - Wed, 27 Aug 2025 15:06:52 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -1916,7 +2308,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5fa7df2d-2fde-4af5-a3f1-8c529d9b7b20
+                - 946a4d39-a4d2-45aa-a224-5251bbe8c467
         status: 404 Not Found
         code: 404
-        duration: 28.220917ms
+        duration: 26.748567ms

--- a/internal/services/container/testdata/container-command-and-args.cassette.yaml
+++ b/internal/services/container/testdata/container-command-and-args.cassette.yaml
@@ -6,13 +6,13 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 191
+        content_length: 189
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-ns-elegant-driscoll","environment_variables":{},"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","secret_environment_variables":[],"tags":null,"activate_vpc_integration":false}'
+        body: '{"name":"tf-ns-pensive-leavitt","environment_variables":{},"project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","secret_environment_variables":[],"tags":null,"activate_vpc_integration":true}'
         form: {}
         headers:
             Content-Type:
@@ -27,20 +27,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 523
+        content_length: 506
         uncompressed: false
-        body: '{"created_at":"2025-06-10T15:56:55.059877057Z","description":"","environment_variables":{},"error_message":null,"id":"ddbb61fa-0fa7-41f1-9ceb-928650aeb62c","name":"tf-ns-elegant-driscoll","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-06-10T15:56:55.059877057Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2025-08-27T15:05:41.451904711Z","description":"","environment_variables":{},"error_message":null,"id":"92f71c9d-d494-47a4-9428-790552451909","name":"tf-ns-pensive-leavitt","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:41.451904711Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "523"
+                - "506"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 10 Jun 2025 15:56:55 GMT
+                - Wed, 27 Aug 2025 15:05:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e7fc957e-68bc-4c53-9824-766535671713
+                - 9c639cab-5503-427d-bb95-b6fc0511fa51
         status: 200 OK
         code: 200
-        duration: 608.160123ms
+        duration: 5.500550878s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -68,7 +68,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/ddbb61fa-0fa7-41f1-9ceb-928650aeb62c
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/92f71c9d-d494-47a4-9428-790552451909
         method: GET
       response:
         proto: HTTP/2.0
@@ -76,20 +76,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 517
+        content_length: 500
         uncompressed: false
-        body: '{"created_at":"2025-06-10T15:56:55.059877Z","description":"","environment_variables":{},"error_message":null,"id":"ddbb61fa-0fa7-41f1-9ceb-928650aeb62c","name":"tf-ns-elegant-driscoll","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-06-10T15:56:55.059877Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2025-08-27T15:05:41.451905Z","description":"","environment_variables":{},"error_message":null,"id":"92f71c9d-d494-47a4-9428-790552451909","name":"tf-ns-pensive-leavitt","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:41.451905Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "517"
+                - "500"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 10 Jun 2025 15:56:55 GMT
+                - Wed, 27 Aug 2025 15:05:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e6b6dd79-41d8-416f-bc94-add8d36164fd
+                - 9e89e7a9-3fc8-425c-ad46-2ceabd069e9e
         status: 200 OK
         code: 200
-        duration: 47.847985ms
+        duration: 75.759605ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -117,7 +117,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/ddbb61fa-0fa7-41f1-9ceb-928650aeb62c
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/92f71c9d-d494-47a4-9428-790552451909
         method: GET
       response:
         proto: HTTP/2.0
@@ -125,20 +125,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 605
+        content_length: 589
         uncompressed: false
-        body: '{"created_at":"2025-06-10T15:56:55.059877Z","description":"","environment_variables":{},"error_message":null,"id":"ddbb61fa-0fa7-41f1-9ceb-928650aeb62c","name":"tf-ns-elegant-driscoll","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnselegantdriscollwnsj30w0","registry_namespace_id":"70c1fd08-c39a-4011-a782-4b53fe5b6d31","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-10T15:56:56.282684Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2025-08-27T15:05:41.451905Z","description":"","environment_variables":{},"error_message":null,"id":"92f71c9d-d494-47a4-9428-790552451909","name":"tf-ns-pensive-leavitt","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnspensiveleavittb7xontny","registry_namespace_id":"40f3a787-fff7-4ee8-9670-7ec701b43c59","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:44.549336Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "605"
+                - "589"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 10 Jun 2025 15:57:00 GMT
+                - Wed, 27 Aug 2025 15:05:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -146,10 +146,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0e2c7468-7cd8-4570-8911-8105a48096cd
+                - 192835b4-e1af-4489-8abb-4e24197e5c78
         status: 200 OK
         code: 200
-        duration: 55.547764ms
+        duration: 78.153728ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -166,7 +166,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/ddbb61fa-0fa7-41f1-9ceb-928650aeb62c
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/92f71c9d-d494-47a4-9428-790552451909
         method: GET
       response:
         proto: HTTP/2.0
@@ -174,20 +174,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 605
+        content_length: 589
         uncompressed: false
-        body: '{"created_at":"2025-06-10T15:56:55.059877Z","description":"","environment_variables":{},"error_message":null,"id":"ddbb61fa-0fa7-41f1-9ceb-928650aeb62c","name":"tf-ns-elegant-driscoll","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnselegantdriscollwnsj30w0","registry_namespace_id":"70c1fd08-c39a-4011-a782-4b53fe5b6d31","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-10T15:56:56.282684Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2025-08-27T15:05:41.451905Z","description":"","environment_variables":{},"error_message":null,"id":"92f71c9d-d494-47a4-9428-790552451909","name":"tf-ns-pensive-leavitt","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnspensiveleavittb7xontny","registry_namespace_id":"40f3a787-fff7-4ee8-9670-7ec701b43c59","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:44.549336Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "605"
+                - "589"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 10 Jun 2025 15:57:00 GMT
+                - Wed, 27 Aug 2025 15:05:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -195,10 +195,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 09a8f90f-6d1d-4211-a5b3-c2a69a0cedfe
+                - 077dbfd4-a3b8-4d08-a794-6be7c1136ece
         status: 200 OK
         code: 200
-        duration: 47.278187ms
+        duration: 144.226712ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -215,7 +215,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/ddbb61fa-0fa7-41f1-9ceb-928650aeb62c
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/92f71c9d-d494-47a4-9428-790552451909
         method: GET
       response:
         proto: HTTP/2.0
@@ -223,20 +223,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 605
+        content_length: 587
         uncompressed: false
-        body: '{"created_at":"2025-06-10T15:56:55.059877Z","description":"","environment_variables":{},"error_message":null,"id":"ddbb61fa-0fa7-41f1-9ceb-928650aeb62c","name":"tf-ns-elegant-driscoll","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnselegantdriscollwnsj30w0","registry_namespace_id":"70c1fd08-c39a-4011-a782-4b53fe5b6d31","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-10T15:56:56.282684Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2025-08-27T15:05:41.451905Z","description":"","environment_variables":{},"error_message":null,"id":"92f71c9d-d494-47a4-9428-790552451909","name":"tf-ns-pensive-leavitt","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnspensiveleavittb7xontny","registry_namespace_id":"40f3a787-fff7-4ee8-9670-7ec701b43c59","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:52.320939Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "605"
+                - "587"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 10 Jun 2025 15:57:00 GMT
+                - Wed, 27 Aug 2025 15:05:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -244,50 +244,48 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 52a42ed7-82ad-4aa9-863a-ffe7d6547a9d
+                - 44c81343-c466-4711-b23b-7c2ebbed5d79
         status: 200 OK
         code: 200
-        duration: 50.477877ms
+        duration: 78.63794ms
     - id: 5
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 282
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"namespace_id":"ddbb61fa-0fa7-41f1-9ceb-928650aeb62c","name":"tf-co-friendly-proskuriakova","privacy":"public","protocol":"http1","secret_environment_variables":null,"http_option":"enabled","sandbox":"unknown_sandbox","tags":null,"command":["bash","-c","my-script.sh"],"args":null}'
+        body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers
-        method: POST
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/92f71c9d-d494-47a4-9428-790552451909
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1054
+        content_length: 587
         uncompressed: false
-        body: '{"args":[],"command":["bash","-c","my-script.sh"],"cpu_limit":1000,"created_at":"2025-06-10T15:57:00.522363271Z","description":"","domain_name":"tfnselegantdriscollwnsj30w0-tf-co-friendly-proskuriakova.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"b7902931-c4d7-4d30-a86b-e11b0704c39f","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-friendly-proskuriakova","namespace_id":"ddbb61fa-0fa7-41f1-9ceb-928650aeb62c","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnselegantdriscollwnsj30w0/tf-co-friendly-proskuriakova:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-10T15:57:00.522363271Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.451905Z","description":"","environment_variables":{},"error_message":null,"id":"92f71c9d-d494-47a4-9428-790552451909","name":"tf-ns-pensive-leavitt","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnspensiveleavittb7xontny","registry_namespace_id":"40f3a787-fff7-4ee8-9670-7ec701b43c59","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:52.320939Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "1054"
+                - "587"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 10 Jun 2025 15:57:00 GMT
+                - Wed, 27 Aug 2025 15:05:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -295,10 +293,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fc6a4871-fb6c-4d6a-aff1-09a96c61f6da
+                - 93cef298-e1d2-4ec9-9362-20473c8a3917
         status: 200 OK
         code: 200
-        duration: 264.828881ms
+        duration: 68.495199ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -315,7 +313,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/b7902931-c4d7-4d30-a86b-e11b0704c39f
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/92f71c9d-d494-47a4-9428-790552451909
         method: GET
       response:
         proto: HTTP/2.0
@@ -323,20 +321,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1048
+        content_length: 587
         uncompressed: false
-        body: '{"args":[],"command":["bash","-c","my-script.sh"],"cpu_limit":1000,"created_at":"2025-06-10T15:57:00.522363Z","description":"","domain_name":"tfnselegantdriscollwnsj30w0-tf-co-friendly-proskuriakova.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"b7902931-c4d7-4d30-a86b-e11b0704c39f","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-friendly-proskuriakova","namespace_id":"ddbb61fa-0fa7-41f1-9ceb-928650aeb62c","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnselegantdriscollwnsj30w0/tf-co-friendly-proskuriakova:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-10T15:57:00.522363Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.451905Z","description":"","environment_variables":{},"error_message":null,"id":"92f71c9d-d494-47a4-9428-790552451909","name":"tf-ns-pensive-leavitt","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnspensiveleavittb7xontny","registry_namespace_id":"40f3a787-fff7-4ee8-9670-7ec701b43c59","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:52.320939Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "1048"
+                - "587"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 10 Jun 2025 15:57:00 GMT
+                - Wed, 27 Aug 2025 15:05:57 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -344,48 +342,50 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a8904b17-56e6-4f48-9584-be0c5a3d590d
+                - 636c54b4-5ac0-49c1-a4d9-351942ef383e
         status: 200 OK
         code: 200
-        duration: 55.594221ms
+        duration: 90.765968ms
     - id: 7
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 273
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"namespace_id":"92f71c9d-d494-47a4-9428-790552451909","name":"tf-co-serene-wright","privacy":"public","protocol":"http1","secret_environment_variables":null,"http_option":"enabled","sandbox":"unknown_sandbox","tags":null,"command":["bash","-c","my-script.sh"],"args":null}'
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/b7902931-c4d7-4d30-a86b-e11b0704c39f
-        method: GET
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1048
+        content_length: 990
         uncompressed: false
-        body: '{"args":[],"command":["bash","-c","my-script.sh"],"cpu_limit":1000,"created_at":"2025-06-10T15:57:00.522363Z","description":"","domain_name":"tfnselegantdriscollwnsj30w0-tf-co-friendly-proskuriakova.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"b7902931-c4d7-4d30-a86b-e11b0704c39f","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-friendly-proskuriakova","namespace_id":"ddbb61fa-0fa7-41f1-9ceb-928650aeb62c","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnselegantdriscollwnsj30w0/tf-co-friendly-proskuriakova:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-10T15:57:00.522363Z"}'
+        body: '{"args":[],"command":["bash","-c","my-script.sh"],"cpu_limit":1000,"created_at":"2025-08-27T15:05:59.280974739Z","description":"","domain_name":"tfnspensiveleavittb7xontny-tf-co-serene-wright.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a4a99426-67bb-4f51-9f6d-26cd59ca1ff0","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-serene-wright","namespace_id":"92f71c9d-d494-47a4-9428-790552451909","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnspensiveleavittb7xontny/tf-co-serene-wright:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:59.280974739Z"}'
         headers:
             Content-Length:
-                - "1048"
+                - "990"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 10 Jun 2025 15:57:00 GMT
+                - Wed, 27 Aug 2025 15:05:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -393,10 +393,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cea25177-e51e-4fe3-a03c-548da000b998
+                - f129aa74-b2f9-47aa-9b68-5acf8eced7ce
         status: 200 OK
         code: 200
-        duration: 52.517652ms
+        duration: 2.372417534s
     - id: 8
       request:
         proto: HTTP/1.1
@@ -413,7 +413,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/ddbb61fa-0fa7-41f1-9ceb-928650aeb62c
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a4a99426-67bb-4f51-9f6d-26cd59ca1ff0
         method: GET
       response:
         proto: HTTP/2.0
@@ -421,20 +421,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 605
+        content_length: 984
         uncompressed: false
-        body: '{"created_at":"2025-06-10T15:56:55.059877Z","description":"","environment_variables":{},"error_message":null,"id":"ddbb61fa-0fa7-41f1-9ceb-928650aeb62c","name":"tf-ns-elegant-driscoll","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnselegantdriscollwnsj30w0","registry_namespace_id":"70c1fd08-c39a-4011-a782-4b53fe5b6d31","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-10T15:56:56.282684Z","vpc_integration_activated":false}'
+        body: '{"args":[],"command":["bash","-c","my-script.sh"],"cpu_limit":1000,"created_at":"2025-08-27T15:05:59.280975Z","description":"","domain_name":"tfnspensiveleavittb7xontny-tf-co-serene-wright.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a4a99426-67bb-4f51-9f6d-26cd59ca1ff0","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-serene-wright","namespace_id":"92f71c9d-d494-47a4-9428-790552451909","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnspensiveleavittb7xontny/tf-co-serene-wright:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:59.280975Z"}'
         headers:
             Content-Length:
-                - "605"
+                - "984"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 10 Jun 2025 15:57:02 GMT
+                - Wed, 27 Aug 2025 15:05:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -442,10 +442,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a091f4db-9cd7-4816-ae04-6f6d15427aec
+                - ca24aac8-c89d-4610-ba53-ecaaea69662e
         status: 200 OK
         code: 200
-        duration: 47.02894ms
+        duration: 81.823839ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -462,7 +462,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/b7902931-c4d7-4d30-a86b-e11b0704c39f
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a4a99426-67bb-4f51-9f6d-26cd59ca1ff0
         method: GET
       response:
         proto: HTTP/2.0
@@ -470,20 +470,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1048
+        content_length: 984
         uncompressed: false
-        body: '{"args":[],"command":["bash","-c","my-script.sh"],"cpu_limit":1000,"created_at":"2025-06-10T15:57:00.522363Z","description":"","domain_name":"tfnselegantdriscollwnsj30w0-tf-co-friendly-proskuriakova.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"b7902931-c4d7-4d30-a86b-e11b0704c39f","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-friendly-proskuriakova","namespace_id":"ddbb61fa-0fa7-41f1-9ceb-928650aeb62c","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnselegantdriscollwnsj30w0/tf-co-friendly-proskuriakova:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-10T15:57:00.522363Z"}'
+        body: '{"args":[],"command":["bash","-c","my-script.sh"],"cpu_limit":1000,"created_at":"2025-08-27T15:05:59.280975Z","description":"","domain_name":"tfnspensiveleavittb7xontny-tf-co-serene-wright.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a4a99426-67bb-4f51-9f6d-26cd59ca1ff0","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-serene-wright","namespace_id":"92f71c9d-d494-47a4-9428-790552451909","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnspensiveleavittb7xontny/tf-co-serene-wright:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:59.280975Z"}'
         headers:
             Content-Length:
-                - "1048"
+                - "984"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 10 Jun 2025 15:57:02 GMT
+                - Wed, 27 Aug 2025 15:05:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -491,10 +491,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 42b22945-0c6d-4299-bc58-0c3adbe8f9d6
+                - e9b8b0ec-46e9-4652-9276-fec3a10e5e40
         status: 200 OK
         code: 200
-        duration: 46.825307ms
+        duration: 206.634662ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -511,7 +511,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/ddbb61fa-0fa7-41f1-9ceb-928650aeb62c
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/92f71c9d-d494-47a4-9428-790552451909
         method: GET
       response:
         proto: HTTP/2.0
@@ -519,20 +519,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 605
+        content_length: 587
         uncompressed: false
-        body: '{"created_at":"2025-06-10T15:56:55.059877Z","description":"","environment_variables":{},"error_message":null,"id":"ddbb61fa-0fa7-41f1-9ceb-928650aeb62c","name":"tf-ns-elegant-driscoll","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnselegantdriscollwnsj30w0","registry_namespace_id":"70c1fd08-c39a-4011-a782-4b53fe5b6d31","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-10T15:56:56.282684Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2025-08-27T15:05:41.451905Z","description":"","environment_variables":{},"error_message":null,"id":"92f71c9d-d494-47a4-9428-790552451909","name":"tf-ns-pensive-leavitt","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnspensiveleavittb7xontny","registry_namespace_id":"40f3a787-fff7-4ee8-9670-7ec701b43c59","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:52.320939Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "605"
+                - "587"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 10 Jun 2025 15:57:03 GMT
+                - Wed, 27 Aug 2025 15:06:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -540,10 +540,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b51fd505-5b23-4707-a50e-8c68cfe3317f
+                - a08a4211-891b-429e-bfdb-15e9700bc250
         status: 200 OK
         code: 200
-        duration: 50.917001ms
+        duration: 75.481108ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -560,7 +560,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/b7902931-c4d7-4d30-a86b-e11b0704c39f
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a4a99426-67bb-4f51-9f6d-26cd59ca1ff0
         method: GET
       response:
         proto: HTTP/2.0
@@ -568,20 +568,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1048
+        content_length: 984
         uncompressed: false
-        body: '{"args":[],"command":["bash","-c","my-script.sh"],"cpu_limit":1000,"created_at":"2025-06-10T15:57:00.522363Z","description":"","domain_name":"tfnselegantdriscollwnsj30w0-tf-co-friendly-proskuriakova.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"b7902931-c4d7-4d30-a86b-e11b0704c39f","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-friendly-proskuriakova","namespace_id":"ddbb61fa-0fa7-41f1-9ceb-928650aeb62c","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnselegantdriscollwnsj30w0/tf-co-friendly-proskuriakova:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-10T15:57:00.522363Z"}'
+        body: '{"args":[],"command":["bash","-c","my-script.sh"],"cpu_limit":1000,"created_at":"2025-08-27T15:05:59.280975Z","description":"","domain_name":"tfnspensiveleavittb7xontny-tf-co-serene-wright.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a4a99426-67bb-4f51-9f6d-26cd59ca1ff0","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-serene-wright","namespace_id":"92f71c9d-d494-47a4-9428-790552451909","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnspensiveleavittb7xontny/tf-co-serene-wright:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:59.280975Z"}'
         headers:
             Content-Length:
-                - "1048"
+                - "984"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 10 Jun 2025 15:57:03 GMT
+                - Wed, 27 Aug 2025 15:06:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -589,10 +589,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 72f8956c-d327-4b7e-b6d4-8309976577be
+                - 5cce10fa-1507-4102-a908-3cf1cb034a96
         status: 200 OK
         code: 200
-        duration: 50.428815ms
+        duration: 83.250045ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -609,7 +609,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/ddbb61fa-0fa7-41f1-9ceb-928650aeb62c
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/92f71c9d-d494-47a4-9428-790552451909
         method: GET
       response:
         proto: HTTP/2.0
@@ -617,20 +617,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 605
+        content_length: 587
         uncompressed: false
-        body: '{"created_at":"2025-06-10T15:56:55.059877Z","description":"","environment_variables":{},"error_message":null,"id":"ddbb61fa-0fa7-41f1-9ceb-928650aeb62c","name":"tf-ns-elegant-driscoll","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnselegantdriscollwnsj30w0","registry_namespace_id":"70c1fd08-c39a-4011-a782-4b53fe5b6d31","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-10T15:56:56.282684Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2025-08-27T15:05:41.451905Z","description":"","environment_variables":{},"error_message":null,"id":"92f71c9d-d494-47a4-9428-790552451909","name":"tf-ns-pensive-leavitt","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnspensiveleavittb7xontny","registry_namespace_id":"40f3a787-fff7-4ee8-9670-7ec701b43c59","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:52.320939Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "605"
+                - "587"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 10 Jun 2025 15:57:04 GMT
+                - Wed, 27 Aug 2025 15:06:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -638,10 +638,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 68f078ca-56ee-4370-a2a7-834341072e26
+                - f1675acb-7f5c-4ace-a5ca-516cf7050a95
         status: 200 OK
         code: 200
-        duration: 57.725337ms
+        duration: 80.73153ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -658,7 +658,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/b7902931-c4d7-4d30-a86b-e11b0704c39f
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a4a99426-67bb-4f51-9f6d-26cd59ca1ff0
         method: GET
       response:
         proto: HTTP/2.0
@@ -666,20 +666,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1048
+        content_length: 984
         uncompressed: false
-        body: '{"args":[],"command":["bash","-c","my-script.sh"],"cpu_limit":1000,"created_at":"2025-06-10T15:57:00.522363Z","description":"","domain_name":"tfnselegantdriscollwnsj30w0-tf-co-friendly-proskuriakova.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"b7902931-c4d7-4d30-a86b-e11b0704c39f","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-friendly-proskuriakova","namespace_id":"ddbb61fa-0fa7-41f1-9ceb-928650aeb62c","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnselegantdriscollwnsj30w0/tf-co-friendly-proskuriakova:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-10T15:57:00.522363Z"}'
+        body: '{"args":[],"command":["bash","-c","my-script.sh"],"cpu_limit":1000,"created_at":"2025-08-27T15:05:59.280975Z","description":"","domain_name":"tfnspensiveleavittb7xontny-tf-co-serene-wright.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a4a99426-67bb-4f51-9f6d-26cd59ca1ff0","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-serene-wright","namespace_id":"92f71c9d-d494-47a4-9428-790552451909","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnspensiveleavittb7xontny/tf-co-serene-wright:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:59.280975Z"}'
         headers:
             Content-Length:
-                - "1048"
+                - "984"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 10 Jun 2025 15:57:04 GMT
+                - Wed, 27 Aug 2025 15:06:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -687,11 +687,109 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d390f6a2-ba95-456d-b83b-82fd96e064e5
+                - 0ff8e0b7-2f47-465c-8c9f-f46ba406c180
         status: 200 OK
         code: 200
-        duration: 52.27099ms
+        duration: 95.380899ms
     - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/92f71c9d-d494-47a4-9428-790552451909
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 587
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:41.451905Z","description":"","environment_variables":{},"error_message":null,"id":"92f71c9d-d494-47a4-9428-790552451909","name":"tf-ns-pensive-leavitt","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnspensiveleavittb7xontny","registry_namespace_id":"40f3a787-fff7-4ee8-9670-7ec701b43c59","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:52.320939Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "587"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:01 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 4cc4454a-2e69-4050-ae30-f6af67edb29d
+        status: 200 OK
+        code: 200
+        duration: 102.169658ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a4a99426-67bb-4f51-9f6d-26cd59ca1ff0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 984
+        uncompressed: false
+        body: '{"args":[],"command":["bash","-c","my-script.sh"],"cpu_limit":1000,"created_at":"2025-08-27T15:05:59.280975Z","description":"","domain_name":"tfnspensiveleavittb7xontny-tf-co-serene-wright.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a4a99426-67bb-4f51-9f6d-26cd59ca1ff0","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-serene-wright","namespace_id":"92f71c9d-d494-47a4-9428-790552451909","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnspensiveleavittb7xontny/tf-co-serene-wright:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:59.280975Z"}'
+        headers:
+            Content-Length:
+                - "984"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:01 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 8f690507-9659-41e9-bfd6-4e4d93ccef21
+        status: 200 OK
+        code: 200
+        duration: 86.26834ms
+    - id: 16
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -709,7 +807,7 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/b7902931-c4d7-4d30-a86b-e11b0704c39f
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a4a99426-67bb-4f51-9f6d-26cd59ca1ff0
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -717,20 +815,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1065
+        content_length: 1000
         uncompressed: false
-        body: '{"args":["some","args"],"command":["bash","-c","my-script.sh"],"cpu_limit":1000,"created_at":"2025-06-10T15:57:00.522363Z","description":"","domain_name":"tfnselegantdriscollwnsj30w0-tf-co-friendly-proskuriakova.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"b7902931-c4d7-4d30-a86b-e11b0704c39f","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-friendly-proskuriakova","namespace_id":"ddbb61fa-0fa7-41f1-9ceb-928650aeb62c","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnselegantdriscollwnsj30w0/tf-co-friendly-proskuriakova:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-06-10T15:57:04.848938538Z"}'
+        body: '{"args":["some","args"],"command":["bash","-c","my-script.sh"],"cpu_limit":1000,"created_at":"2025-08-27T15:05:59.280975Z","description":"","domain_name":"tfnspensiveleavittb7xontny-tf-co-serene-wright.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a4a99426-67bb-4f51-9f6d-26cd59ca1ff0","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-serene-wright","namespace_id":"92f71c9d-d494-47a4-9428-790552451909","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnspensiveleavittb7xontny/tf-co-serene-wright:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:01.380855398Z"}'
         headers:
             Content-Length:
-                - "1065"
+                - "1000"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 10 Jun 2025 15:57:04 GMT
+                - Wed, 27 Aug 2025 15:06:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -738,108 +836,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - adef868f-0021-47e7-a828-c530e5e28fec
+                - 7ea710ff-b8c5-4310-b2ac-069a94ff36ef
         status: 200 OK
         code: 200
-        duration: 118.857664ms
-    - id: 15
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/b7902931-c4d7-4d30-a86b-e11b0704c39f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 1062
-        uncompressed: false
-        body: '{"args":["some","args"],"command":["bash","-c","my-script.sh"],"cpu_limit":1000,"created_at":"2025-06-10T15:57:00.522363Z","description":"","domain_name":"tfnselegantdriscollwnsj30w0-tf-co-friendly-proskuriakova.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"b7902931-c4d7-4d30-a86b-e11b0704c39f","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-friendly-proskuriakova","namespace_id":"ddbb61fa-0fa7-41f1-9ceb-928650aeb62c","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnselegantdriscollwnsj30w0/tf-co-friendly-proskuriakova:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-06-10T15:57:04.848939Z"}'
-        headers:
-            Content-Length:
-                - "1062"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 10 Jun 2025 15:57:04 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - b5eab749-4677-4e83-930e-7e700a32f334
-        status: 200 OK
-        code: 200
-        duration: 58.43032ms
-    - id: 16
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/b7902931-c4d7-4d30-a86b-e11b0704c39f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 1062
-        uncompressed: false
-        body: '{"args":["some","args"],"command":["bash","-c","my-script.sh"],"cpu_limit":1000,"created_at":"2025-06-10T15:57:00.522363Z","description":"","domain_name":"tfnselegantdriscollwnsj30w0-tf-co-friendly-proskuriakova.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"b7902931-c4d7-4d30-a86b-e11b0704c39f","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-friendly-proskuriakova","namespace_id":"ddbb61fa-0fa7-41f1-9ceb-928650aeb62c","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnselegantdriscollwnsj30w0/tf-co-friendly-proskuriakova:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-06-10T15:57:04.848939Z"}'
-        headers:
-            Content-Length:
-                - "1062"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 10 Jun 2025 15:57:10 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 5eb439fd-9685-4395-bf24-a74992f1f5b4
-        status: 200 OK
-        code: 200
-        duration: 60.013438ms
+        duration: 115.604859ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -856,7 +856,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/b7902931-c4d7-4d30-a86b-e11b0704c39f
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a4a99426-67bb-4f51-9f6d-26cd59ca1ff0
         method: GET
       response:
         proto: HTTP/2.0
@@ -864,20 +864,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1100
+        content_length: 997
         uncompressed: false
-        body: '{"args":["some","args"],"command":["bash","-c","my-script.sh"],"cpu_limit":1000,"created_at":"2025-06-10T15:57:00.522363Z","description":"","domain_name":"tfnselegantdriscollwnsj30w0-tf-co-friendly-proskuriakova.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"b7902931-c4d7-4d30-a86b-e11b0704c39f","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-friendly-proskuriakova","namespace_id":"ddbb61fa-0fa7-41f1-9ceb-928650aeb62c","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnselegantdriscollwnsj30w0/tf-co-friendly-proskuriakova:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-06-10T15:57:11.234253Z"}'
+        body: '{"args":["some","args"],"command":["bash","-c","my-script.sh"],"cpu_limit":1000,"created_at":"2025-08-27T15:05:59.280975Z","description":"","domain_name":"tfnspensiveleavittb7xontny-tf-co-serene-wright.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a4a99426-67bb-4f51-9f6d-26cd59ca1ff0","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-serene-wright","namespace_id":"92f71c9d-d494-47a4-9428-790552451909","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnspensiveleavittb7xontny/tf-co-serene-wright:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:01.380855Z"}'
         headers:
             Content-Length:
-                - "1100"
+                - "997"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 10 Jun 2025 15:57:15 GMT
+                - Wed, 27 Aug 2025 15:06:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -885,10 +885,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9c5ccc9c-5c10-41fa-abe6-ef9fe3ac0354
+                - 026a3360-0a62-41e1-a25a-5797e56c6e83
         status: 200 OK
         code: 200
-        duration: 52.801955ms
+        duration: 85.219462ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -905,7 +905,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/b7902931-c4d7-4d30-a86b-e11b0704c39f
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a4a99426-67bb-4f51-9f6d-26cd59ca1ff0
         method: GET
       response:
         proto: HTTP/2.0
@@ -913,20 +913,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1100
+        content_length: 997
         uncompressed: false
-        body: '{"args":["some","args"],"command":["bash","-c","my-script.sh"],"cpu_limit":1000,"created_at":"2025-06-10T15:57:00.522363Z","description":"","domain_name":"tfnselegantdriscollwnsj30w0-tf-co-friendly-proskuriakova.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"b7902931-c4d7-4d30-a86b-e11b0704c39f","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-friendly-proskuriakova","namespace_id":"ddbb61fa-0fa7-41f1-9ceb-928650aeb62c","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnselegantdriscollwnsj30w0/tf-co-friendly-proskuriakova:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-06-10T15:57:11.234253Z"}'
+        body: '{"args":["some","args"],"command":["bash","-c","my-script.sh"],"cpu_limit":1000,"created_at":"2025-08-27T15:05:59.280975Z","description":"","domain_name":"tfnspensiveleavittb7xontny-tf-co-serene-wright.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a4a99426-67bb-4f51-9f6d-26cd59ca1ff0","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-serene-wright","namespace_id":"92f71c9d-d494-47a4-9428-790552451909","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnspensiveleavittb7xontny/tf-co-serene-wright:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:01.380855Z"}'
         headers:
             Content-Length:
-                - "1100"
+                - "997"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 10 Jun 2025 15:57:15 GMT
+                - Wed, 27 Aug 2025 15:06:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -934,10 +934,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d5f62d11-b090-4c24-8989-8996d041c5a3
+                - 8ace3d30-b8ae-41cc-9cb0-4e7508d0fefc
         status: 200 OK
         code: 200
-        duration: 66.118737ms
+        duration: 90.312721ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -954,7 +954,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/b7902931-c4d7-4d30-a86b-e11b0704c39f
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a4a99426-67bb-4f51-9f6d-26cd59ca1ff0
         method: GET
       response:
         proto: HTTP/2.0
@@ -962,20 +962,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1100
+        content_length: 1035
         uncompressed: false
-        body: '{"args":["some","args"],"command":["bash","-c","my-script.sh"],"cpu_limit":1000,"created_at":"2025-06-10T15:57:00.522363Z","description":"","domain_name":"tfnselegantdriscollwnsj30w0-tf-co-friendly-proskuriakova.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"b7902931-c4d7-4d30-a86b-e11b0704c39f","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-friendly-proskuriakova","namespace_id":"ddbb61fa-0fa7-41f1-9ceb-928650aeb62c","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnselegantdriscollwnsj30w0/tf-co-friendly-proskuriakova:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-06-10T15:57:11.234253Z"}'
+        body: '{"args":["some","args"],"command":["bash","-c","my-script.sh"],"cpu_limit":1000,"created_at":"2025-08-27T15:05:59.280975Z","description":"","domain_name":"tfnspensiveleavittb7xontny-tf-co-serene-wright.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a4a99426-67bb-4f51-9f6d-26cd59ca1ff0","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-serene-wright","namespace_id":"92f71c9d-d494-47a4-9428-790552451909","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnspensiveleavittb7xontny/tf-co-serene-wright:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:07.752956Z"}'
         headers:
             Content-Length:
-                - "1100"
+                - "1035"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 10 Jun 2025 15:57:15 GMT
+                - Wed, 27 Aug 2025 15:06:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -983,10 +983,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1b816575-cb7f-4c7e-ad09-eb1cbf792e1d
+                - 72e964c5-24b4-4726-91b9-e3af8e199f16
         status: 200 OK
         code: 200
-        duration: 53.405166ms
+        duration: 86.852348ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1003,7 +1003,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/ddbb61fa-0fa7-41f1-9ceb-928650aeb62c
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a4a99426-67bb-4f51-9f6d-26cd59ca1ff0
         method: GET
       response:
         proto: HTTP/2.0
@@ -1011,20 +1011,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 605
+        content_length: 1035
         uncompressed: false
-        body: '{"created_at":"2025-06-10T15:56:55.059877Z","description":"","environment_variables":{},"error_message":null,"id":"ddbb61fa-0fa7-41f1-9ceb-928650aeb62c","name":"tf-ns-elegant-driscoll","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnselegantdriscollwnsj30w0","registry_namespace_id":"70c1fd08-c39a-4011-a782-4b53fe5b6d31","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-10T15:56:56.282684Z","vpc_integration_activated":false}'
+        body: '{"args":["some","args"],"command":["bash","-c","my-script.sh"],"cpu_limit":1000,"created_at":"2025-08-27T15:05:59.280975Z","description":"","domain_name":"tfnspensiveleavittb7xontny-tf-co-serene-wright.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a4a99426-67bb-4f51-9f6d-26cd59ca1ff0","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-serene-wright","namespace_id":"92f71c9d-d494-47a4-9428-790552451909","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnspensiveleavittb7xontny/tf-co-serene-wright:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:07.752956Z"}'
         headers:
             Content-Length:
-                - "605"
+                - "1035"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 10 Jun 2025 15:57:16 GMT
+                - Wed, 27 Aug 2025 15:06:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1032,10 +1032,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 565ab9ac-ec39-4ff1-b0fe-183e01a42dc0
+                - 43a62602-0faa-4b21-867e-788bc2753e26
         status: 200 OK
         code: 200
-        duration: 44.854241ms
+        duration: 88.852843ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1052,7 +1052,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/b7902931-c4d7-4d30-a86b-e11b0704c39f
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a4a99426-67bb-4f51-9f6d-26cd59ca1ff0
         method: GET
       response:
         proto: HTTP/2.0
@@ -1060,20 +1060,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1100
+        content_length: 1035
         uncompressed: false
-        body: '{"args":["some","args"],"command":["bash","-c","my-script.sh"],"cpu_limit":1000,"created_at":"2025-06-10T15:57:00.522363Z","description":"","domain_name":"tfnselegantdriscollwnsj30w0-tf-co-friendly-proskuriakova.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"b7902931-c4d7-4d30-a86b-e11b0704c39f","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-friendly-proskuriakova","namespace_id":"ddbb61fa-0fa7-41f1-9ceb-928650aeb62c","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnselegantdriscollwnsj30w0/tf-co-friendly-proskuriakova:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-06-10T15:57:11.234253Z"}'
+        body: '{"args":["some","args"],"command":["bash","-c","my-script.sh"],"cpu_limit":1000,"created_at":"2025-08-27T15:05:59.280975Z","description":"","domain_name":"tfnspensiveleavittb7xontny-tf-co-serene-wright.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a4a99426-67bb-4f51-9f6d-26cd59ca1ff0","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-serene-wright","namespace_id":"92f71c9d-d494-47a4-9428-790552451909","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnspensiveleavittb7xontny/tf-co-serene-wright:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:07.752956Z"}'
         headers:
             Content-Length:
-                - "1100"
+                - "1035"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 10 Jun 2025 15:57:16 GMT
+                - Wed, 27 Aug 2025 15:06:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1081,10 +1081,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5c2df5d5-7456-4a43-9908-9fde258b62d1
+                - 2f519648-e819-4e43-98c3-ba826255b209
         status: 200 OK
         code: 200
-        duration: 59.161822ms
+        duration: 180.990509ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1101,7 +1101,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/ddbb61fa-0fa7-41f1-9ceb-928650aeb62c
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/92f71c9d-d494-47a4-9428-790552451909
         method: GET
       response:
         proto: HTTP/2.0
@@ -1109,20 +1109,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 605
+        content_length: 587
         uncompressed: false
-        body: '{"created_at":"2025-06-10T15:56:55.059877Z","description":"","environment_variables":{},"error_message":null,"id":"ddbb61fa-0fa7-41f1-9ceb-928650aeb62c","name":"tf-ns-elegant-driscoll","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnselegantdriscollwnsj30w0","registry_namespace_id":"70c1fd08-c39a-4011-a782-4b53fe5b6d31","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-10T15:56:56.282684Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2025-08-27T15:05:41.451905Z","description":"","environment_variables":{},"error_message":null,"id":"92f71c9d-d494-47a4-9428-790552451909","name":"tf-ns-pensive-leavitt","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnspensiveleavittb7xontny","registry_namespace_id":"40f3a787-fff7-4ee8-9670-7ec701b43c59","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:52.320939Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "605"
+                - "587"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 10 Jun 2025 15:57:17 GMT
+                - Wed, 27 Aug 2025 15:06:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1130,10 +1130,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 72299c05-775e-4ec0-83b3-7142d74e19be
+                - ab9e749c-997c-4d7b-b6e5-7a5ab1f6ca6b
         status: 200 OK
         code: 200
-        duration: 47.356224ms
+        duration: 201.175076ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1150,7 +1150,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/b7902931-c4d7-4d30-a86b-e11b0704c39f
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a4a99426-67bb-4f51-9f6d-26cd59ca1ff0
         method: GET
       response:
         proto: HTTP/2.0
@@ -1158,20 +1158,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1100
+        content_length: 1035
         uncompressed: false
-        body: '{"args":["some","args"],"command":["bash","-c","my-script.sh"],"cpu_limit":1000,"created_at":"2025-06-10T15:57:00.522363Z","description":"","domain_name":"tfnselegantdriscollwnsj30w0-tf-co-friendly-proskuriakova.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"b7902931-c4d7-4d30-a86b-e11b0704c39f","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-friendly-proskuriakova","namespace_id":"ddbb61fa-0fa7-41f1-9ceb-928650aeb62c","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnselegantdriscollwnsj30w0/tf-co-friendly-proskuriakova:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-06-10T15:57:11.234253Z"}'
+        body: '{"args":["some","args"],"command":["bash","-c","my-script.sh"],"cpu_limit":1000,"created_at":"2025-08-27T15:05:59.280975Z","description":"","domain_name":"tfnspensiveleavittb7xontny-tf-co-serene-wright.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a4a99426-67bb-4f51-9f6d-26cd59ca1ff0","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-serene-wright","namespace_id":"92f71c9d-d494-47a4-9428-790552451909","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnspensiveleavittb7xontny/tf-co-serene-wright:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:07.752956Z"}'
         headers:
             Content-Length:
-                - "1100"
+                - "1035"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 10 Jun 2025 15:57:17 GMT
+                - Wed, 27 Aug 2025 15:06:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1179,10 +1179,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b8d8b5e7-75cd-4c00-9594-740dd6c061eb
+                - f9037ba7-1b70-4c8e-988e-aaa54d5a6a30
         status: 200 OK
         code: 200
-        duration: 59.33176ms
+        duration: 91.781789ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1199,7 +1199,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/ddbb61fa-0fa7-41f1-9ceb-928650aeb62c
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/92f71c9d-d494-47a4-9428-790552451909
         method: GET
       response:
         proto: HTTP/2.0
@@ -1207,20 +1207,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 605
+        content_length: 587
         uncompressed: false
-        body: '{"created_at":"2025-06-10T15:56:55.059877Z","description":"","environment_variables":{},"error_message":null,"id":"ddbb61fa-0fa7-41f1-9ceb-928650aeb62c","name":"tf-ns-elegant-driscoll","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnselegantdriscollwnsj30w0","registry_namespace_id":"70c1fd08-c39a-4011-a782-4b53fe5b6d31","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-10T15:56:56.282684Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2025-08-27T15:05:41.451905Z","description":"","environment_variables":{},"error_message":null,"id":"92f71c9d-d494-47a4-9428-790552451909","name":"tf-ns-pensive-leavitt","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnspensiveleavittb7xontny","registry_namespace_id":"40f3a787-fff7-4ee8-9670-7ec701b43c59","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:52.320939Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "605"
+                - "587"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 10 Jun 2025 15:57:19 GMT
+                - Wed, 27 Aug 2025 15:06:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1228,10 +1228,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b290bf47-2b2a-441d-9b8a-8129f8fff23a
+                - 015688c9-c4d3-41e2-90e2-c16caaf6e884
         status: 200 OK
         code: 200
-        duration: 57.399887ms
+        duration: 88.065315ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1248,7 +1248,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/b7902931-c4d7-4d30-a86b-e11b0704c39f
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a4a99426-67bb-4f51-9f6d-26cd59ca1ff0
         method: GET
       response:
         proto: HTTP/2.0
@@ -1256,20 +1256,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1100
+        content_length: 1035
         uncompressed: false
-        body: '{"args":["some","args"],"command":["bash","-c","my-script.sh"],"cpu_limit":1000,"created_at":"2025-06-10T15:57:00.522363Z","description":"","domain_name":"tfnselegantdriscollwnsj30w0-tf-co-friendly-proskuriakova.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"b7902931-c4d7-4d30-a86b-e11b0704c39f","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-friendly-proskuriakova","namespace_id":"ddbb61fa-0fa7-41f1-9ceb-928650aeb62c","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnselegantdriscollwnsj30w0/tf-co-friendly-proskuriakova:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-06-10T15:57:11.234253Z"}'
+        body: '{"args":["some","args"],"command":["bash","-c","my-script.sh"],"cpu_limit":1000,"created_at":"2025-08-27T15:05:59.280975Z","description":"","domain_name":"tfnspensiveleavittb7xontny-tf-co-serene-wright.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a4a99426-67bb-4f51-9f6d-26cd59ca1ff0","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-serene-wright","namespace_id":"92f71c9d-d494-47a4-9428-790552451909","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnspensiveleavittb7xontny/tf-co-serene-wright:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:07.752956Z"}'
         headers:
             Content-Length:
-                - "1100"
+                - "1035"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 10 Jun 2025 15:57:19 GMT
+                - Wed, 27 Aug 2025 15:06:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1277,11 +1277,109 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7a07082c-a37d-434d-a446-56dc782876fa
+                - bb534a4e-392b-470a-a92f-a17597815527
         status: 200 OK
         code: 200
-        duration: 73.726634ms
+        duration: 83.249698ms
     - id: 26
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/92f71c9d-d494-47a4-9428-790552451909
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 587
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:41.451905Z","description":"","environment_variables":{},"error_message":null,"id":"92f71c9d-d494-47a4-9428-790552451909","name":"tf-ns-pensive-leavitt","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnspensiveleavittb7xontny","registry_namespace_id":"40f3a787-fff7-4ee8-9670-7ec701b43c59","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:52.320939Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "587"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:13 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 324bc61c-efe3-4699-9d60-bab10d03fb42
+        status: 200 OK
+        code: 200
+        duration: 81.71561ms
+    - id: 27
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a4a99426-67bb-4f51-9f6d-26cd59ca1ff0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1035
+        uncompressed: false
+        body: '{"args":["some","args"],"command":["bash","-c","my-script.sh"],"cpu_limit":1000,"created_at":"2025-08-27T15:05:59.280975Z","description":"","domain_name":"tfnspensiveleavittb7xontny-tf-co-serene-wright.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a4a99426-67bb-4f51-9f6d-26cd59ca1ff0","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-serene-wright","namespace_id":"92f71c9d-d494-47a4-9428-790552451909","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnspensiveleavittb7xontny/tf-co-serene-wright:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:07.752956Z"}'
+        headers:
+            Content-Length:
+                - "1035"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:13 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - a3c80d2c-78e4-4cd7-8580-8dd296fe5f08
+        status: 200 OK
+        code: 200
+        duration: 117.88403ms
+    - id: 28
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1299,7 +1397,7 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/b7902931-c4d7-4d30-a86b-e11b0704c39f
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a4a99426-67bb-4f51-9f6d-26cd59ca1ff0
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -1307,20 +1405,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1037
+        content_length: 974
         uncompressed: false
-        body: '{"args":["some","args"],"command":[],"cpu_limit":1000,"created_at":"2025-06-10T15:57:00.522363Z","description":"","domain_name":"tfnselegantdriscollwnsj30w0-tf-co-friendly-proskuriakova.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"b7902931-c4d7-4d30-a86b-e11b0704c39f","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-friendly-proskuriakova","namespace_id":"ddbb61fa-0fa7-41f1-9ceb-928650aeb62c","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnselegantdriscollwnsj30w0/tf-co-friendly-proskuriakova:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-06-10T15:57:19.390936292Z"}'
+        body: '{"args":["some","args"],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:59.280975Z","description":"","domain_name":"tfnspensiveleavittb7xontny-tf-co-serene-wright.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a4a99426-67bb-4f51-9f6d-26cd59ca1ff0","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-serene-wright","namespace_id":"92f71c9d-d494-47a4-9428-790552451909","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnspensiveleavittb7xontny/tf-co-serene-wright:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:13.734892350Z"}'
         headers:
             Content-Length:
-                - "1037"
+                - "974"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 10 Jun 2025 15:57:19 GMT
+                - Wed, 27 Aug 2025 15:06:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1328,108 +1426,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e050fd5e-8473-40f9-9a5a-a6f48d87955b
+                - 487220f9-4250-41af-abab-ea7a7f5ba5e8
         status: 200 OK
         code: 200
-        duration: 100.202652ms
-    - id: 27
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/b7902931-c4d7-4d30-a86b-e11b0704c39f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 1034
-        uncompressed: false
-        body: '{"args":["some","args"],"command":[],"cpu_limit":1000,"created_at":"2025-06-10T15:57:00.522363Z","description":"","domain_name":"tfnselegantdriscollwnsj30w0-tf-co-friendly-proskuriakova.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"b7902931-c4d7-4d30-a86b-e11b0704c39f","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-friendly-proskuriakova","namespace_id":"ddbb61fa-0fa7-41f1-9ceb-928650aeb62c","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnselegantdriscollwnsj30w0/tf-co-friendly-proskuriakova:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-06-10T15:57:19.390936Z"}'
-        headers:
-            Content-Length:
-                - "1034"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 10 Jun 2025 15:57:19 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 1761c096-28da-4d27-837c-563f13c9f0fa
-        status: 200 OK
-        code: 200
-        duration: 53.16226ms
-    - id: 28
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/b7902931-c4d7-4d30-a86b-e11b0704c39f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 1034
-        uncompressed: false
-        body: '{"args":["some","args"],"command":[],"cpu_limit":1000,"created_at":"2025-06-10T15:57:00.522363Z","description":"","domain_name":"tfnselegantdriscollwnsj30w0-tf-co-friendly-proskuriakova.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"b7902931-c4d7-4d30-a86b-e11b0704c39f","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-friendly-proskuriakova","namespace_id":"ddbb61fa-0fa7-41f1-9ceb-928650aeb62c","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnselegantdriscollwnsj30w0/tf-co-friendly-proskuriakova:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-06-10T15:57:19.390936Z"}'
-        headers:
-            Content-Length:
-                - "1034"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 10 Jun 2025 15:57:24 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 81d29e8d-a7d9-4938-a8e6-742d8e346fdf
-        status: 200 OK
-        code: 200
-        duration: 54.993334ms
+        duration: 142.398972ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1446,7 +1446,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/b7902931-c4d7-4d30-a86b-e11b0704c39f
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a4a99426-67bb-4f51-9f6d-26cd59ca1ff0
         method: GET
       response:
         proto: HTTP/2.0
@@ -1454,20 +1454,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1072
+        content_length: 971
         uncompressed: false
-        body: '{"args":["some","args"],"command":[],"cpu_limit":1000,"created_at":"2025-06-10T15:57:00.522363Z","description":"","domain_name":"tfnselegantdriscollwnsj30w0-tf-co-friendly-proskuriakova.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"b7902931-c4d7-4d30-a86b-e11b0704c39f","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-friendly-proskuriakova","namespace_id":"ddbb61fa-0fa7-41f1-9ceb-928650aeb62c","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnselegantdriscollwnsj30w0/tf-co-friendly-proskuriakova:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-06-10T15:57:25.718328Z"}'
+        body: '{"args":["some","args"],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:59.280975Z","description":"","domain_name":"tfnspensiveleavittb7xontny-tf-co-serene-wright.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a4a99426-67bb-4f51-9f6d-26cd59ca1ff0","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-serene-wright","namespace_id":"92f71c9d-d494-47a4-9428-790552451909","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnspensiveleavittb7xontny/tf-co-serene-wright:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:13.734892Z"}'
         headers:
             Content-Length:
-                - "1072"
+                - "971"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 10 Jun 2025 15:57:29 GMT
+                - Wed, 27 Aug 2025 15:06:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1475,10 +1475,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 74630cf1-2ea5-4e78-a24b-a93378fc3c80
+                - be6332e8-fc57-4540-94c4-207774e9d2ad
         status: 200 OK
         code: 200
-        duration: 51.682887ms
+        duration: 95.426518ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1495,7 +1495,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/b7902931-c4d7-4d30-a86b-e11b0704c39f
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a4a99426-67bb-4f51-9f6d-26cd59ca1ff0
         method: GET
       response:
         proto: HTTP/2.0
@@ -1503,20 +1503,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1072
+        content_length: 971
         uncompressed: false
-        body: '{"args":["some","args"],"command":[],"cpu_limit":1000,"created_at":"2025-06-10T15:57:00.522363Z","description":"","domain_name":"tfnselegantdriscollwnsj30w0-tf-co-friendly-proskuriakova.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"b7902931-c4d7-4d30-a86b-e11b0704c39f","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-friendly-proskuriakova","namespace_id":"ddbb61fa-0fa7-41f1-9ceb-928650aeb62c","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnselegantdriscollwnsj30w0/tf-co-friendly-proskuriakova:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-06-10T15:57:25.718328Z"}'
+        body: '{"args":["some","args"],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:59.280975Z","description":"","domain_name":"tfnspensiveleavittb7xontny-tf-co-serene-wright.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a4a99426-67bb-4f51-9f6d-26cd59ca1ff0","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-serene-wright","namespace_id":"92f71c9d-d494-47a4-9428-790552451909","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnspensiveleavittb7xontny/tf-co-serene-wright:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:13.734892Z"}'
         headers:
             Content-Length:
-                - "1072"
+                - "971"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 10 Jun 2025 15:57:29 GMT
+                - Wed, 27 Aug 2025 15:06:18 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1524,10 +1524,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 14fbef0b-018b-4905-900d-8e3d11f75638
+                - ae53727e-cee8-4e1c-a83e-62cf3ec8933a
         status: 200 OK
         code: 200
-        duration: 69.972203ms
+        duration: 86.324931ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1544,7 +1544,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/b7902931-c4d7-4d30-a86b-e11b0704c39f
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a4a99426-67bb-4f51-9f6d-26cd59ca1ff0
         method: GET
       response:
         proto: HTTP/2.0
@@ -1552,20 +1552,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1072
+        content_length: 1009
         uncompressed: false
-        body: '{"args":["some","args"],"command":[],"cpu_limit":1000,"created_at":"2025-06-10T15:57:00.522363Z","description":"","domain_name":"tfnselegantdriscollwnsj30w0-tf-co-friendly-proskuriakova.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"b7902931-c4d7-4d30-a86b-e11b0704c39f","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-friendly-proskuriakova","namespace_id":"ddbb61fa-0fa7-41f1-9ceb-928650aeb62c","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnselegantdriscollwnsj30w0/tf-co-friendly-proskuriakova:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-06-10T15:57:25.718328Z"}'
+        body: '{"args":["some","args"],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:59.280975Z","description":"","domain_name":"tfnspensiveleavittb7xontny-tf-co-serene-wright.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a4a99426-67bb-4f51-9f6d-26cd59ca1ff0","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-serene-wright","namespace_id":"92f71c9d-d494-47a4-9428-790552451909","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnspensiveleavittb7xontny/tf-co-serene-wright:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:20.159094Z"}'
         headers:
             Content-Length:
-                - "1072"
+                - "1009"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 10 Jun 2025 15:57:30 GMT
+                - Wed, 27 Aug 2025 15:06:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1573,10 +1573,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0696218e-3837-438d-9ab5-c7174d374c2f
+                - 0738645d-799d-4428-99bf-3124c252c4ad
         status: 200 OK
         code: 200
-        duration: 69.311093ms
+        duration: 89.241445ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1593,7 +1593,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/ddbb61fa-0fa7-41f1-9ceb-928650aeb62c
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a4a99426-67bb-4f51-9f6d-26cd59ca1ff0
         method: GET
       response:
         proto: HTTP/2.0
@@ -1601,20 +1601,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 605
+        content_length: 1009
         uncompressed: false
-        body: '{"created_at":"2025-06-10T15:56:55.059877Z","description":"","environment_variables":{},"error_message":null,"id":"ddbb61fa-0fa7-41f1-9ceb-928650aeb62c","name":"tf-ns-elegant-driscoll","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnselegantdriscollwnsj30w0","registry_namespace_id":"70c1fd08-c39a-4011-a782-4b53fe5b6d31","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-10T15:56:56.282684Z","vpc_integration_activated":false}'
+        body: '{"args":["some","args"],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:59.280975Z","description":"","domain_name":"tfnspensiveleavittb7xontny-tf-co-serene-wright.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a4a99426-67bb-4f51-9f6d-26cd59ca1ff0","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-serene-wright","namespace_id":"92f71c9d-d494-47a4-9428-790552451909","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnspensiveleavittb7xontny/tf-co-serene-wright:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:20.159094Z"}'
         headers:
             Content-Length:
-                - "605"
+                - "1009"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 10 Jun 2025 15:57:31 GMT
+                - Wed, 27 Aug 2025 15:06:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1622,10 +1622,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8d07436e-96be-478d-aba5-42887176232d
+                - 7db51d48-9067-437b-a45c-0f40801821cb
         status: 200 OK
         code: 200
-        duration: 43.741906ms
+        duration: 85.763118ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1642,7 +1642,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/b7902931-c4d7-4d30-a86b-e11b0704c39f
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a4a99426-67bb-4f51-9f6d-26cd59ca1ff0
         method: GET
       response:
         proto: HTTP/2.0
@@ -1650,20 +1650,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1072
+        content_length: 1009
         uncompressed: false
-        body: '{"args":["some","args"],"command":[],"cpu_limit":1000,"created_at":"2025-06-10T15:57:00.522363Z","description":"","domain_name":"tfnselegantdriscollwnsj30w0-tf-co-friendly-proskuriakova.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"b7902931-c4d7-4d30-a86b-e11b0704c39f","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-friendly-proskuriakova","namespace_id":"ddbb61fa-0fa7-41f1-9ceb-928650aeb62c","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnselegantdriscollwnsj30w0/tf-co-friendly-proskuriakova:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-06-10T15:57:25.718328Z"}'
+        body: '{"args":["some","args"],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:59.280975Z","description":"","domain_name":"tfnspensiveleavittb7xontny-tf-co-serene-wright.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a4a99426-67bb-4f51-9f6d-26cd59ca1ff0","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-serene-wright","namespace_id":"92f71c9d-d494-47a4-9428-790552451909","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnspensiveleavittb7xontny/tf-co-serene-wright:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:20.159094Z"}'
         headers:
             Content-Length:
-                - "1072"
+                - "1009"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 10 Jun 2025 15:57:31 GMT
+                - Wed, 27 Aug 2025 15:06:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1671,10 +1671,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 88df18b1-90c1-4e43-885f-220c3a72df9d
+                - 5fc65bc6-8e38-47cb-84bd-613c73b5ac18
         status: 200 OK
         code: 200
-        duration: 59.628426ms
+        duration: 105.639036ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1691,7 +1691,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/ddbb61fa-0fa7-41f1-9ceb-928650aeb62c
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/92f71c9d-d494-47a4-9428-790552451909
         method: GET
       response:
         proto: HTTP/2.0
@@ -1699,20 +1699,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 605
+        content_length: 587
         uncompressed: false
-        body: '{"created_at":"2025-06-10T15:56:55.059877Z","description":"","environment_variables":{},"error_message":null,"id":"ddbb61fa-0fa7-41f1-9ceb-928650aeb62c","name":"tf-ns-elegant-driscoll","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnselegantdriscollwnsj30w0","registry_namespace_id":"70c1fd08-c39a-4011-a782-4b53fe5b6d31","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-10T15:56:56.282684Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2025-08-27T15:05:41.451905Z","description":"","environment_variables":{},"error_message":null,"id":"92f71c9d-d494-47a4-9428-790552451909","name":"tf-ns-pensive-leavitt","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnspensiveleavittb7xontny","registry_namespace_id":"40f3a787-fff7-4ee8-9670-7ec701b43c59","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:52.320939Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "605"
+                - "587"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 10 Jun 2025 15:57:32 GMT
+                - Wed, 27 Aug 2025 15:06:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1720,10 +1720,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 008aa2c2-7829-4fee-91ec-f552d198b6b9
+                - d08773d1-2c92-4304-ad1b-ab26898b0913
         status: 200 OK
         code: 200
-        duration: 55.393294ms
+        duration: 83.033285ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1740,7 +1740,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/b7902931-c4d7-4d30-a86b-e11b0704c39f
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a4a99426-67bb-4f51-9f6d-26cd59ca1ff0
         method: GET
       response:
         proto: HTTP/2.0
@@ -1748,20 +1748,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1072
+        content_length: 1009
         uncompressed: false
-        body: '{"args":["some","args"],"command":[],"cpu_limit":1000,"created_at":"2025-06-10T15:57:00.522363Z","description":"","domain_name":"tfnselegantdriscollwnsj30w0-tf-co-friendly-proskuriakova.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"b7902931-c4d7-4d30-a86b-e11b0704c39f","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-friendly-proskuriakova","namespace_id":"ddbb61fa-0fa7-41f1-9ceb-928650aeb62c","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnselegantdriscollwnsj30w0/tf-co-friendly-proskuriakova:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-06-10T15:57:25.718328Z"}'
+        body: '{"args":["some","args"],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:59.280975Z","description":"","domain_name":"tfnspensiveleavittb7xontny-tf-co-serene-wright.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a4a99426-67bb-4f51-9f6d-26cd59ca1ff0","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-serene-wright","namespace_id":"92f71c9d-d494-47a4-9428-790552451909","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnspensiveleavittb7xontny/tf-co-serene-wright:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:20.159094Z"}'
         headers:
             Content-Length:
-                - "1072"
+                - "1009"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 10 Jun 2025 15:57:32 GMT
+                - Wed, 27 Aug 2025 15:06:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1769,10 +1769,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a7e6d2e4-50d9-4155-8428-a493d2132db6
+                - 4d6e42bc-c1f3-43eb-9717-d436c1b35dfa
         status: 200 OK
         code: 200
-        duration: 46.637536ms
+        duration: 107.32511ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1789,7 +1789,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/ddbb61fa-0fa7-41f1-9ceb-928650aeb62c
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/92f71c9d-d494-47a4-9428-790552451909
         method: GET
       response:
         proto: HTTP/2.0
@@ -1797,20 +1797,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 605
+        content_length: 587
         uncompressed: false
-        body: '{"created_at":"2025-06-10T15:56:55.059877Z","description":"","environment_variables":{},"error_message":null,"id":"ddbb61fa-0fa7-41f1-9ceb-928650aeb62c","name":"tf-ns-elegant-driscoll","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnselegantdriscollwnsj30w0","registry_namespace_id":"70c1fd08-c39a-4011-a782-4b53fe5b6d31","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-10T15:56:56.282684Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2025-08-27T15:05:41.451905Z","description":"","environment_variables":{},"error_message":null,"id":"92f71c9d-d494-47a4-9428-790552451909","name":"tf-ns-pensive-leavitt","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnspensiveleavittb7xontny","registry_namespace_id":"40f3a787-fff7-4ee8-9670-7ec701b43c59","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:52.320939Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "605"
+                - "587"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 10 Jun 2025 15:57:33 GMT
+                - Wed, 27 Aug 2025 15:06:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1818,10 +1818,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 66adf866-6fd9-4aa3-af8d-337a60a1a04f
+                - c7be3f51-f4b0-401d-bde4-ad7eec277b40
         status: 200 OK
         code: 200
-        duration: 48.187713ms
+        duration: 80.748839ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1838,7 +1838,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/b7902931-c4d7-4d30-a86b-e11b0704c39f
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a4a99426-67bb-4f51-9f6d-26cd59ca1ff0
         method: GET
       response:
         proto: HTTP/2.0
@@ -1846,20 +1846,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1072
+        content_length: 1009
         uncompressed: false
-        body: '{"args":["some","args"],"command":[],"cpu_limit":1000,"created_at":"2025-06-10T15:57:00.522363Z","description":"","domain_name":"tfnselegantdriscollwnsj30w0-tf-co-friendly-proskuriakova.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"b7902931-c4d7-4d30-a86b-e11b0704c39f","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-friendly-proskuriakova","namespace_id":"ddbb61fa-0fa7-41f1-9ceb-928650aeb62c","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnselegantdriscollwnsj30w0/tf-co-friendly-proskuriakova:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-06-10T15:57:25.718328Z"}'
+        body: '{"args":["some","args"],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:59.280975Z","description":"","domain_name":"tfnspensiveleavittb7xontny-tf-co-serene-wright.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a4a99426-67bb-4f51-9f6d-26cd59ca1ff0","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-serene-wright","namespace_id":"92f71c9d-d494-47a4-9428-790552451909","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnspensiveleavittb7xontny/tf-co-serene-wright:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:20.159094Z"}'
         headers:
             Content-Length:
-                - "1072"
+                - "1009"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 10 Jun 2025 15:57:33 GMT
+                - Wed, 27 Aug 2025 15:06:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1867,11 +1867,109 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 829e4625-7cd0-4734-a9d5-7ebca179b142
+                - 8cf01624-e56a-411d-9ca7-7992f31b5b5c
         status: 200 OK
         code: 200
-        duration: 106.697501ms
+        duration: 81.408626ms
     - id: 38
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/92f71c9d-d494-47a4-9428-790552451909
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 587
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:41.451905Z","description":"","environment_variables":{},"error_message":null,"id":"92f71c9d-d494-47a4-9428-790552451909","name":"tf-ns-pensive-leavitt","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnspensiveleavittb7xontny","registry_namespace_id":"40f3a787-fff7-4ee8-9670-7ec701b43c59","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:52.320939Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "587"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:25 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 330a1ae2-89c5-4e88-a396-cab473eef97d
+        status: 200 OK
+        code: 200
+        duration: 74.617362ms
+    - id: 39
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a4a99426-67bb-4f51-9f6d-26cd59ca1ff0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1009
+        uncompressed: false
+        body: '{"args":["some","args"],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:59.280975Z","description":"","domain_name":"tfnspensiveleavittb7xontny-tf-co-serene-wright.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a4a99426-67bb-4f51-9f6d-26cd59ca1ff0","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-serene-wright","namespace_id":"92f71c9d-d494-47a4-9428-790552451909","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnspensiveleavittb7xontny/tf-co-serene-wright:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:20.159094Z"}'
+        headers:
+            Content-Length:
+                - "1009"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:25 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 705039c4-52f3-45e9-b497-b16c3125a9c5
+        status: 200 OK
+        code: 200
+        duration: 138.383764ms
+    - id: 40
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1889,7 +1987,7 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/b7902931-c4d7-4d30-a86b-e11b0704c39f
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a4a99426-67bb-4f51-9f6d-26cd59ca1ff0
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -1897,20 +1995,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1023
+        content_length: 961
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-10T15:57:00.522363Z","description":"","domain_name":"tfnselegantdriscollwnsj30w0-tf-co-friendly-proskuriakova.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"b7902931-c4d7-4d30-a86b-e11b0704c39f","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-friendly-proskuriakova","namespace_id":"ddbb61fa-0fa7-41f1-9ceb-928650aeb62c","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnselegantdriscollwnsj30w0/tf-co-friendly-proskuriakova:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-06-10T15:57:33.933357900Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:59.280975Z","description":"","domain_name":"tfnspensiveleavittb7xontny-tf-co-serene-wright.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a4a99426-67bb-4f51-9f6d-26cd59ca1ff0","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-serene-wright","namespace_id":"92f71c9d-d494-47a4-9428-790552451909","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnspensiveleavittb7xontny/tf-co-serene-wright:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:25.910131935Z"}'
         headers:
             Content-Length:
-                - "1023"
+                - "961"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 10 Jun 2025 15:57:33 GMT
+                - Wed, 27 Aug 2025 15:06:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1918,108 +2016,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - efe44252-d32f-4c54-8611-4d7779c660e9
+                - 2d8a179e-3562-400e-ae79-3898cda589b8
         status: 200 OK
         code: 200
-        duration: 71.473488ms
-    - id: 39
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/b7902931-c4d7-4d30-a86b-e11b0704c39f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 1020
-        uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-10T15:57:00.522363Z","description":"","domain_name":"tfnselegantdriscollwnsj30w0-tf-co-friendly-proskuriakova.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"b7902931-c4d7-4d30-a86b-e11b0704c39f","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-friendly-proskuriakova","namespace_id":"ddbb61fa-0fa7-41f1-9ceb-928650aeb62c","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnselegantdriscollwnsj30w0/tf-co-friendly-proskuriakova:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-06-10T15:57:33.933358Z"}'
-        headers:
-            Content-Length:
-                - "1020"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 10 Jun 2025 15:57:34 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 3596bc56-5c6f-4e87-b84f-b6681f8fd3a5
-        status: 200 OK
-        code: 200
-        duration: 56.965754ms
-    - id: 40
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/b7902931-c4d7-4d30-a86b-e11b0704c39f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 1020
-        uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-10T15:57:00.522363Z","description":"","domain_name":"tfnselegantdriscollwnsj30w0-tf-co-friendly-proskuriakova.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"b7902931-c4d7-4d30-a86b-e11b0704c39f","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-friendly-proskuriakova","namespace_id":"ddbb61fa-0fa7-41f1-9ceb-928650aeb62c","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnselegantdriscollwnsj30w0/tf-co-friendly-proskuriakova:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-06-10T15:57:33.933358Z"}'
-        headers:
-            Content-Length:
-                - "1020"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 10 Jun 2025 15:57:39 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 353c38a3-0b2a-4504-a30c-467a30feb5f8
-        status: 200 OK
-        code: 200
-        duration: 50.049855ms
+        duration: 128.03328ms
     - id: 41
       request:
         proto: HTTP/1.1
@@ -2036,7 +2036,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/b7902931-c4d7-4d30-a86b-e11b0704c39f
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a4a99426-67bb-4f51-9f6d-26cd59ca1ff0
         method: GET
       response:
         proto: HTTP/2.0
@@ -2044,20 +2044,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1058
+        content_length: 958
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-10T15:57:00.522363Z","description":"","domain_name":"tfnselegantdriscollwnsj30w0-tf-co-friendly-proskuriakova.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"b7902931-c4d7-4d30-a86b-e11b0704c39f","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-friendly-proskuriakova","namespace_id":"ddbb61fa-0fa7-41f1-9ceb-928650aeb62c","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnselegantdriscollwnsj30w0/tf-co-friendly-proskuriakova:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-06-10T15:57:40.351321Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:59.280975Z","description":"","domain_name":"tfnspensiveleavittb7xontny-tf-co-serene-wright.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a4a99426-67bb-4f51-9f6d-26cd59ca1ff0","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-serene-wright","namespace_id":"92f71c9d-d494-47a4-9428-790552451909","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnspensiveleavittb7xontny/tf-co-serene-wright:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:25.910132Z"}'
         headers:
             Content-Length:
-                - "1058"
+                - "958"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 10 Jun 2025 15:57:44 GMT
+                - Wed, 27 Aug 2025 15:06:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2065,10 +2065,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 68483be8-4747-454f-8ba8-80de78ed5e6e
+                - ce86c432-1e54-45c4-a993-76b06c682823
         status: 200 OK
         code: 200
-        duration: 52.109537ms
+        duration: 90.098625ms
     - id: 42
       request:
         proto: HTTP/1.1
@@ -2085,7 +2085,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/b7902931-c4d7-4d30-a86b-e11b0704c39f
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a4a99426-67bb-4f51-9f6d-26cd59ca1ff0
         method: GET
       response:
         proto: HTTP/2.0
@@ -2093,20 +2093,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1058
+        content_length: 958
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-10T15:57:00.522363Z","description":"","domain_name":"tfnselegantdriscollwnsj30w0-tf-co-friendly-proskuriakova.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"b7902931-c4d7-4d30-a86b-e11b0704c39f","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-friendly-proskuriakova","namespace_id":"ddbb61fa-0fa7-41f1-9ceb-928650aeb62c","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnselegantdriscollwnsj30w0/tf-co-friendly-proskuriakova:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-06-10T15:57:40.351321Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:59.280975Z","description":"","domain_name":"tfnspensiveleavittb7xontny-tf-co-serene-wright.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a4a99426-67bb-4f51-9f6d-26cd59ca1ff0","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-serene-wright","namespace_id":"92f71c9d-d494-47a4-9428-790552451909","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnspensiveleavittb7xontny/tf-co-serene-wright:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:25.910132Z"}'
         headers:
             Content-Length:
-                - "1058"
+                - "958"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 10 Jun 2025 15:57:44 GMT
+                - Wed, 27 Aug 2025 15:06:31 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2114,10 +2114,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f1689aae-d1aa-4474-b74a-536855c93f1a
+                - eab4342b-2c90-4acc-b4a0-bc0d8798735c
         status: 200 OK
         code: 200
-        duration: 50.695315ms
+        duration: 117.481482ms
     - id: 43
       request:
         proto: HTTP/1.1
@@ -2134,7 +2134,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/b7902931-c4d7-4d30-a86b-e11b0704c39f
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a4a99426-67bb-4f51-9f6d-26cd59ca1ff0
         method: GET
       response:
         proto: HTTP/2.0
@@ -2142,20 +2142,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1058
+        content_length: 996
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-10T15:57:00.522363Z","description":"","domain_name":"tfnselegantdriscollwnsj30w0-tf-co-friendly-proskuriakova.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"b7902931-c4d7-4d30-a86b-e11b0704c39f","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-friendly-proskuriakova","namespace_id":"ddbb61fa-0fa7-41f1-9ceb-928650aeb62c","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnselegantdriscollwnsj30w0/tf-co-friendly-proskuriakova:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-06-10T15:57:40.351321Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:59.280975Z","description":"","domain_name":"tfnspensiveleavittb7xontny-tf-co-serene-wright.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a4a99426-67bb-4f51-9f6d-26cd59ca1ff0","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-serene-wright","namespace_id":"92f71c9d-d494-47a4-9428-790552451909","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnspensiveleavittb7xontny/tf-co-serene-wright:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:32.198215Z"}'
         headers:
             Content-Length:
-                - "1058"
+                - "996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 10 Jun 2025 15:57:44 GMT
+                - Wed, 27 Aug 2025 15:06:36 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2163,10 +2163,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bf9f29f3-7af1-47b2-9fed-0ace8acc5824
+                - 8abfd115-4d09-48a4-b24b-182da1c6d9b9
         status: 200 OK
         code: 200
-        duration: 73.082616ms
+        duration: 92.703915ms
     - id: 44
       request:
         proto: HTTP/1.1
@@ -2183,7 +2183,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/ddbb61fa-0fa7-41f1-9ceb-928650aeb62c
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a4a99426-67bb-4f51-9f6d-26cd59ca1ff0
         method: GET
       response:
         proto: HTTP/2.0
@@ -2191,20 +2191,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 605
+        content_length: 996
         uncompressed: false
-        body: '{"created_at":"2025-06-10T15:56:55.059877Z","description":"","environment_variables":{},"error_message":null,"id":"ddbb61fa-0fa7-41f1-9ceb-928650aeb62c","name":"tf-ns-elegant-driscoll","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnselegantdriscollwnsj30w0","registry_namespace_id":"70c1fd08-c39a-4011-a782-4b53fe5b6d31","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-10T15:56:56.282684Z","vpc_integration_activated":false}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:59.280975Z","description":"","domain_name":"tfnspensiveleavittb7xontny-tf-co-serene-wright.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a4a99426-67bb-4f51-9f6d-26cd59ca1ff0","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-serene-wright","namespace_id":"92f71c9d-d494-47a4-9428-790552451909","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnspensiveleavittb7xontny/tf-co-serene-wright:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:32.198215Z"}'
         headers:
             Content-Length:
-                - "605"
+                - "996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 10 Jun 2025 15:57:45 GMT
+                - Wed, 27 Aug 2025 15:06:36 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2212,10 +2212,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4ab0618a-1ce1-40ff-8f93-848864fca92c
+                - 9f66af63-be33-4d89-b7ec-f548ea0428cb
         status: 200 OK
         code: 200
-        duration: 53.164354ms
+        duration: 86.42889ms
     - id: 45
       request:
         proto: HTTP/1.1
@@ -2232,7 +2232,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/b7902931-c4d7-4d30-a86b-e11b0704c39f
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a4a99426-67bb-4f51-9f6d-26cd59ca1ff0
         method: GET
       response:
         proto: HTTP/2.0
@@ -2240,20 +2240,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1058
+        content_length: 996
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-10T15:57:00.522363Z","description":"","domain_name":"tfnselegantdriscollwnsj30w0-tf-co-friendly-proskuriakova.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"b7902931-c4d7-4d30-a86b-e11b0704c39f","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-friendly-proskuriakova","namespace_id":"ddbb61fa-0fa7-41f1-9ceb-928650aeb62c","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnselegantdriscollwnsj30w0/tf-co-friendly-proskuriakova:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-06-10T15:57:40.351321Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:59.280975Z","description":"","domain_name":"tfnspensiveleavittb7xontny-tf-co-serene-wright.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a4a99426-67bb-4f51-9f6d-26cd59ca1ff0","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-serene-wright","namespace_id":"92f71c9d-d494-47a4-9428-790552451909","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnspensiveleavittb7xontny/tf-co-serene-wright:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:32.198215Z"}'
         headers:
             Content-Length:
-                - "1058"
+                - "996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 10 Jun 2025 15:57:45 GMT
+                - Wed, 27 Aug 2025 15:06:36 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2261,10 +2261,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f13de539-e331-4217-92a2-5a6093789706
+                - e162caab-8608-4676-919c-488f03d682c7
         status: 200 OK
         code: 200
-        duration: 57.695011ms
+        duration: 77.280884ms
     - id: 46
       request:
         proto: HTTP/1.1
@@ -2281,7 +2281,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/b7902931-c4d7-4d30-a86b-e11b0704c39f
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/92f71c9d-d494-47a4-9428-790552451909
         method: GET
       response:
         proto: HTTP/2.0
@@ -2289,20 +2289,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1058
+        content_length: 587
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-10T15:57:00.522363Z","description":"","domain_name":"tfnselegantdriscollwnsj30w0-tf-co-friendly-proskuriakova.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"b7902931-c4d7-4d30-a86b-e11b0704c39f","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-friendly-proskuriakova","namespace_id":"ddbb61fa-0fa7-41f1-9ceb-928650aeb62c","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnselegantdriscollwnsj30w0/tf-co-friendly-proskuriakova:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-06-10T15:57:40.351321Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.451905Z","description":"","environment_variables":{},"error_message":null,"id":"92f71c9d-d494-47a4-9428-790552451909","name":"tf-ns-pensive-leavitt","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnspensiveleavittb7xontny","registry_namespace_id":"40f3a787-fff7-4ee8-9670-7ec701b43c59","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:52.320939Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "1058"
+                - "587"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 10 Jun 2025 15:57:46 GMT
+                - Wed, 27 Aug 2025 15:06:36 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2310,10 +2310,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d690546e-9d9d-4b6a-ae19-f1941397ead0
+                - fbdf3e7b-d8b7-4f76-861a-c984283d2a91
         status: 200 OK
         code: 200
-        duration: 55.193289ms
+        duration: 83.7913ms
     - id: 47
       request:
         proto: HTTP/1.1
@@ -2330,28 +2330,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/b7902931-c4d7-4d30-a86b-e11b0704c39f
-        method: DELETE
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a4a99426-67bb-4f51-9f6d-26cd59ca1ff0
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1024
+        content_length: 996
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-10T15:57:00.522363Z","description":"","domain_name":"tfnselegantdriscollwnsj30w0-tf-co-friendly-proskuriakova.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"b7902931-c4d7-4d30-a86b-e11b0704c39f","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-friendly-proskuriakova","namespace_id":"ddbb61fa-0fa7-41f1-9ceb-928650aeb62c","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnselegantdriscollwnsj30w0/tf-co-friendly-proskuriakova:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2025-06-10T15:57:46.736723140Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:59.280975Z","description":"","domain_name":"tfnspensiveleavittb7xontny-tf-co-serene-wright.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a4a99426-67bb-4f51-9f6d-26cd59ca1ff0","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-serene-wright","namespace_id":"92f71c9d-d494-47a4-9428-790552451909","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnspensiveleavittb7xontny/tf-co-serene-wright:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:32.198215Z"}'
         headers:
             Content-Length:
-                - "1024"
+                - "996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 10 Jun 2025 15:57:46 GMT
+                - Wed, 27 Aug 2025 15:06:36 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2359,10 +2359,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7fbddac7-8a8b-4064-9c13-04cea57c004e
+                - 3cf877bd-65c5-460b-b28a-df9a117c65c3
         status: 200 OK
         code: 200
-        duration: 113.464851ms
+        duration: 101.874305ms
     - id: 48
       request:
         proto: HTTP/1.1
@@ -2379,7 +2379,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/ddbb61fa-0fa7-41f1-9ceb-928650aeb62c
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a4a99426-67bb-4f51-9f6d-26cd59ca1ff0
         method: GET
       response:
         proto: HTTP/2.0
@@ -2387,20 +2387,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 605
+        content_length: 996
         uncompressed: false
-        body: '{"created_at":"2025-06-10T15:56:55.059877Z","description":"","environment_variables":{},"error_message":null,"id":"ddbb61fa-0fa7-41f1-9ceb-928650aeb62c","name":"tf-ns-elegant-driscoll","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnselegantdriscollwnsj30w0","registry_namespace_id":"70c1fd08-c39a-4011-a782-4b53fe5b6d31","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-10T15:56:56.282684Z","vpc_integration_activated":false}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:59.280975Z","description":"","domain_name":"tfnspensiveleavittb7xontny-tf-co-serene-wright.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a4a99426-67bb-4f51-9f6d-26cd59ca1ff0","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-serene-wright","namespace_id":"92f71c9d-d494-47a4-9428-790552451909","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnspensiveleavittb7xontny/tf-co-serene-wright:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:32.198215Z"}'
         headers:
             Content-Length:
-                - "605"
+                - "996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 10 Jun 2025 15:57:46 GMT
+                - Wed, 27 Aug 2025 15:06:37 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2408,10 +2408,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a28a965b-3926-4305-8fb0-6d5df0bf9cd3
+                - f225575e-4878-48a4-b152-0f4d0a949e36
         status: 200 OK
         code: 200
-        duration: 51.326218ms
+        duration: 98.188709ms
     - id: 49
       request:
         proto: HTTP/1.1
@@ -2428,7 +2428,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/ddbb61fa-0fa7-41f1-9ceb-928650aeb62c
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a4a99426-67bb-4f51-9f6d-26cd59ca1ff0
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -2436,20 +2436,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 611
+        content_length: 962
         uncompressed: false
-        body: '{"created_at":"2025-06-10T15:56:55.059877Z","description":"","environment_variables":{},"error_message":null,"id":"ddbb61fa-0fa7-41f1-9ceb-928650aeb62c","name":"tf-ns-elegant-driscoll","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnselegantdriscollwnsj30w0","registry_namespace_id":"70c1fd08-c39a-4011-a782-4b53fe5b6d31","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-06-10T15:57:46.885921129Z","vpc_integration_activated":false}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:59.280975Z","description":"","domain_name":"tfnspensiveleavittb7xontny-tf-co-serene-wright.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a4a99426-67bb-4f51-9f6d-26cd59ca1ff0","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-serene-wright","namespace_id":"92f71c9d-d494-47a4-9428-790552451909","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnspensiveleavittb7xontny/tf-co-serene-wright:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:37.559377397Z"}'
         headers:
             Content-Length:
-                - "611"
+                - "962"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 10 Jun 2025 15:57:47 GMT
+                - Wed, 27 Aug 2025 15:06:37 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2457,10 +2457,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 592be7aa-4b90-436c-8a48-ee8b0dc286b1
+                - 8f746a95-0dae-4790-a245-baeacc964022
         status: 200 OK
         code: 200
-        duration: 168.248512ms
+        duration: 157.304414ms
     - id: 50
       request:
         proto: HTTP/1.1
@@ -2477,7 +2477,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/ddbb61fa-0fa7-41f1-9ceb-928650aeb62c
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/92f71c9d-d494-47a4-9428-790552451909
         method: GET
       response:
         proto: HTTP/2.0
@@ -2485,20 +2485,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 608
+        content_length: 587
         uncompressed: false
-        body: '{"created_at":"2025-06-10T15:56:55.059877Z","description":"","environment_variables":{},"error_message":null,"id":"ddbb61fa-0fa7-41f1-9ceb-928650aeb62c","name":"tf-ns-elegant-driscoll","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnselegantdriscollwnsj30w0","registry_namespace_id":"70c1fd08-c39a-4011-a782-4b53fe5b6d31","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-06-10T15:57:46.885921Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2025-08-27T15:05:41.451905Z","description":"","environment_variables":{},"error_message":null,"id":"92f71c9d-d494-47a4-9428-790552451909","name":"tf-ns-pensive-leavitt","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnspensiveleavittb7xontny","registry_namespace_id":"40f3a787-fff7-4ee8-9670-7ec701b43c59","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:52.320939Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "608"
+                - "587"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 10 Jun 2025 15:57:47 GMT
+                - Wed, 27 Aug 2025 15:06:37 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2506,10 +2506,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e5decab3-112b-45b2-993e-302599312132
+                - df4d22cf-6c1c-4a52-86cc-20df8d3d2bdb
         status: 200 OK
         code: 200
-        duration: 57.242402ms
+        duration: 107.402588ms
     - id: 51
       request:
         proto: HTTP/1.1
@@ -2526,28 +2526,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/ddbb61fa-0fa7-41f1-9ceb-928650aeb62c
-        method: GET
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/92f71c9d-d494-47a4-9428-790552451909
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 608
+        content_length: 593
         uncompressed: false
-        body: '{"created_at":"2025-06-10T15:56:55.059877Z","description":"","environment_variables":{},"error_message":null,"id":"ddbb61fa-0fa7-41f1-9ceb-928650aeb62c","name":"tf-ns-elegant-driscoll","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnselegantdriscollwnsj30w0","registry_namespace_id":"70c1fd08-c39a-4011-a782-4b53fe5b6d31","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-06-10T15:57:46.885921Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2025-08-27T15:05:41.451905Z","description":"","environment_variables":{},"error_message":null,"id":"92f71c9d-d494-47a4-9428-790552451909","name":"tf-ns-pensive-leavitt","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnspensiveleavittb7xontny","registry_namespace_id":"40f3a787-fff7-4ee8-9670-7ec701b43c59","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:37.771022281Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "608"
+                - "593"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 10 Jun 2025 15:57:52 GMT
+                - Wed, 27 Aug 2025 15:06:38 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2555,10 +2555,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8ed95781-d823-47ca-b313-071b920dfd5c
+                - 454c0484-18d4-4124-ad1e-74964fca9e09
         status: 200 OK
         code: 200
-        duration: 52.200827ms
+        duration: 324.424268ms
     - id: 52
       request:
         proto: HTTP/1.1
@@ -2575,7 +2575,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/ddbb61fa-0fa7-41f1-9ceb-928650aeb62c
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/92f71c9d-d494-47a4-9428-790552451909
         method: GET
       response:
         proto: HTTP/2.0
@@ -2583,20 +2583,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 608
+        content_length: 590
         uncompressed: false
-        body: '{"created_at":"2025-06-10T15:56:55.059877Z","description":"","environment_variables":{},"error_message":null,"id":"ddbb61fa-0fa7-41f1-9ceb-928650aeb62c","name":"tf-ns-elegant-driscoll","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnselegantdriscollwnsj30w0","registry_namespace_id":"70c1fd08-c39a-4011-a782-4b53fe5b6d31","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-06-10T15:57:46.885921Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2025-08-27T15:05:41.451905Z","description":"","environment_variables":{},"error_message":null,"id":"92f71c9d-d494-47a4-9428-790552451909","name":"tf-ns-pensive-leavitt","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnspensiveleavittb7xontny","registry_namespace_id":"40f3a787-fff7-4ee8-9670-7ec701b43c59","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:37.771022Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "608"
+                - "590"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 10 Jun 2025 15:57:57 GMT
+                - Wed, 27 Aug 2025 15:06:38 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2604,10 +2604,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0b6ff9ba-615c-46d3-94a1-f98dabed29be
+                - fe43d456-2ed6-4d3b-98dd-3be7582bdbdd
         status: 200 OK
         code: 200
-        duration: 49.90891ms
+        duration: 77.460511ms
     - id: 53
       request:
         proto: HTTP/1.1
@@ -2624,154 +2624,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/ddbb61fa-0fa7-41f1-9ceb-928650aeb62c
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 608
-        uncompressed: false
-        body: '{"created_at":"2025-06-10T15:56:55.059877Z","description":"","environment_variables":{},"error_message":null,"id":"ddbb61fa-0fa7-41f1-9ceb-928650aeb62c","name":"tf-ns-elegant-driscoll","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnselegantdriscollwnsj30w0","registry_namespace_id":"70c1fd08-c39a-4011-a782-4b53fe5b6d31","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-06-10T15:57:46.885921Z","vpc_integration_activated":false}'
-        headers:
-            Content-Length:
-                - "608"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 10 Jun 2025 15:58:02 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 65d84aa7-2843-4fd4-a24b-76af909c793d
-        status: 200 OK
-        code: 200
-        duration: 51.400347ms
-    - id: 54
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/ddbb61fa-0fa7-41f1-9ceb-928650aeb62c
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 608
-        uncompressed: false
-        body: '{"created_at":"2025-06-10T15:56:55.059877Z","description":"","environment_variables":{},"error_message":null,"id":"ddbb61fa-0fa7-41f1-9ceb-928650aeb62c","name":"tf-ns-elegant-driscoll","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnselegantdriscollwnsj30w0","registry_namespace_id":"70c1fd08-c39a-4011-a782-4b53fe5b6d31","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-06-10T15:57:46.885921Z","vpc_integration_activated":false}'
-        headers:
-            Content-Length:
-                - "608"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 10 Jun 2025 15:58:07 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 877c126c-30da-4856-b1b5-84a8e082bc85
-        status: 200 OK
-        code: 200
-        duration: 52.079741ms
-    - id: 55
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/ddbb61fa-0fa7-41f1-9ceb-928650aeb62c
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 608
-        uncompressed: false
-        body: '{"created_at":"2025-06-10T15:56:55.059877Z","description":"","environment_variables":{},"error_message":null,"id":"ddbb61fa-0fa7-41f1-9ceb-928650aeb62c","name":"tf-ns-elegant-driscoll","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnselegantdriscollwnsj30w0","registry_namespace_id":"70c1fd08-c39a-4011-a782-4b53fe5b6d31","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-06-10T15:57:46.885921Z","vpc_integration_activated":false}'
-        headers:
-            Content-Length:
-                - "608"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 10 Jun 2025 15:58:12 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - cf925443-b910-48fc-a79b-34eb2fcda795
-        status: 200 OK
-        code: 200
-        duration: 46.663003ms
-    - id: 56
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/ddbb61fa-0fa7-41f1-9ceb-928650aeb62c
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/92f71c9d-d494-47a4-9428-790552451909
         method: GET
       response:
         proto: HTTP/2.0
@@ -2790,9 +2643,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 10 Jun 2025 15:58:17 GMT
+                - Wed, 27 Aug 2025 15:06:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2800,11 +2653,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5efe357d-f013-4c1d-9564-f58eee0c19f7
+                - ccb70e23-2d57-41f5-a3be-baa219cae341
         status: 404 Not Found
         code: 404
-        duration: 28.845001ms
-    - id: 57
+        duration: 19.349911ms
+    - id: 54
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2820,7 +2673,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/ddbb61fa-0fa7-41f1-9ceb-928650aeb62c
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/92f71c9d-d494-47a4-9428-790552451909
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -2839,9 +2692,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 10 Jun 2025 15:58:17 GMT
+                - Wed, 27 Aug 2025 15:06:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2849,7 +2702,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4fd64d84-52d8-40a2-9c77-2b8e0e299a7c
+                - 9a77fd50-9e93-48ed-be32-1b154ef09ac8
         status: 404 Not Found
         code: 404
-        duration: 27.284855ms
+        duration: 24.923492ms

--- a/internal/services/container/testdata/container-env.cassette.yaml
+++ b/internal/services/container/testdata/container-env.cassette.yaml
@@ -6,19 +6,19 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 157
+        content_length: 185
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-ns-objective-haibt","environment_variables":{},"project_id":"6867048b-fe12-4e96-835e-41c79a39604b","secret_environment_variables":[],"tags":null}'
+        body: '{"name":"tf-ns-epic-curran","environment_variables":{},"project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","secret_environment_variables":[],"tags":null,"activate_vpc_integration":true}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces
         method: POST
       response:
@@ -27,20 +27,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 473
+        content_length: 502
         uncompressed: false
-        body: '{"created_at":"2025-04-17T11:42:04.084993889Z","description":"","environment_variables":{},"error_message":null,"id":"8a9798e3-ed28-49a0-8e23-149ed68fd3a0","name":"tf-ns-objective-haibt","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-04-17T11:42:04.084993889Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.431613964Z","description":"","environment_variables":{},"error_message":null,"id":"97c8830e-6d1b-42c0-8ce3-7230e241dd40","name":"tf-ns-epic-curran","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:41.431613964Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "473"
+                - "502"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 17 Apr 2025 11:42:04 GMT
+                - Wed, 27 Aug 2025 15:05:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 68933cd1-3718-4ac9-bc4f-188452feea31
+                - cf10d583-3e42-4b26-89fd-57403f70e098
         status: 200 OK
         code: 200
-        duration: 792.301417ms
+        duration: 5.477515374s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -67,8 +67,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/8a9798e3-ed28-49a0-8e23-149ed68fd3a0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/97c8830e-6d1b-42c0-8ce3-7230e241dd40
         method: GET
       response:
         proto: HTTP/2.0
@@ -76,20 +76,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 467
+        content_length: 496
         uncompressed: false
-        body: '{"created_at":"2025-04-17T11:42:04.084994Z","description":"","environment_variables":{},"error_message":null,"id":"8a9798e3-ed28-49a0-8e23-149ed68fd3a0","name":"tf-ns-objective-haibt","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-04-17T11:42:04.084994Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.431614Z","description":"","environment_variables":{},"error_message":null,"id":"97c8830e-6d1b-42c0-8ce3-7230e241dd40","name":"tf-ns-epic-curran","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:41.431614Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "467"
+                - "496"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 17 Apr 2025 11:42:04 GMT
+                - Wed, 27 Aug 2025 15:05:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 57adcd4e-72f8-40e8-b9e8-97e446da882f
+                - 4b801fb7-a2e1-40f0-bbab-193dcdcc44ac
         status: 200 OK
         code: 200
-        duration: 47.828ms
+        duration: 82.971759ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -116,8 +116,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/8a9798e3-ed28-49a0-8e23-149ed68fd3a0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/97c8830e-6d1b-42c0-8ce3-7230e241dd40
         method: GET
       response:
         proto: HTTP/2.0
@@ -125,20 +125,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 554
+        content_length: 581
         uncompressed: false
-        body: '{"created_at":"2025-04-17T11:42:04.084994Z","description":"","environment_variables":{},"error_message":null,"id":"8a9798e3-ed28-49a0-8e23-149ed68fd3a0","name":"tf-ns-objective-haibt","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsobjectivehaibtcrvvgesx","registry_namespace_id":"efa49832-146a-4b51-a49a-7a8e0dbd49b2","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-17T11:42:05.435732Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.431614Z","description":"","environment_variables":{},"error_message":null,"id":"97c8830e-6d1b-42c0-8ce3-7230e241dd40","name":"tf-ns-epic-curran","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsepiccurransflacvv1","registry_namespace_id":"2bc65664-8e71-49f3-aaf8-10d6f5313c42","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:46.029240Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "554"
+                - "581"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 17 Apr 2025 11:42:09 GMT
+                - Wed, 27 Aug 2025 15:05:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -146,10 +146,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b5af5198-8c20-4616-b178-ec23a4fa81f7
+                - 080763d9-31ca-4deb-96fb-fb5a304e6243
         status: 200 OK
         code: 200
-        duration: 49.672959ms
+        duration: 94.026883ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -165,8 +165,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/8a9798e3-ed28-49a0-8e23-149ed68fd3a0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/97c8830e-6d1b-42c0-8ce3-7230e241dd40
         method: GET
       response:
         proto: HTTP/2.0
@@ -174,20 +174,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 554
+        content_length: 579
         uncompressed: false
-        body: '{"created_at":"2025-04-17T11:42:04.084994Z","description":"","environment_variables":{},"error_message":null,"id":"8a9798e3-ed28-49a0-8e23-149ed68fd3a0","name":"tf-ns-objective-haibt","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsobjectivehaibtcrvvgesx","registry_namespace_id":"efa49832-146a-4b51-a49a-7a8e0dbd49b2","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-17T11:42:05.435732Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.431614Z","description":"","environment_variables":{},"error_message":null,"id":"97c8830e-6d1b-42c0-8ce3-7230e241dd40","name":"tf-ns-epic-curran","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsepiccurransflacvv1","registry_namespace_id":"2bc65664-8e71-49f3-aaf8-10d6f5313c42","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:46.545571Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "554"
+                - "579"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 17 Apr 2025 11:42:09 GMT
+                - Wed, 27 Aug 2025 15:05:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -195,10 +195,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1478df24-d451-4ef2-b0f9-20a9ccbaa2f7
+                - c4d38022-648b-4ae0-89d7-923ff81c1701
         status: 200 OK
         code: 200
-        duration: 48.780208ms
+        duration: 141.57698ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -214,8 +214,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/8a9798e3-ed28-49a0-8e23-149ed68fd3a0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/97c8830e-6d1b-42c0-8ce3-7230e241dd40
         method: GET
       response:
         proto: HTTP/2.0
@@ -223,20 +223,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 554
+        content_length: 579
         uncompressed: false
-        body: '{"created_at":"2025-04-17T11:42:04.084994Z","description":"","environment_variables":{},"error_message":null,"id":"8a9798e3-ed28-49a0-8e23-149ed68fd3a0","name":"tf-ns-objective-haibt","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsobjectivehaibtcrvvgesx","registry_namespace_id":"efa49832-146a-4b51-a49a-7a8e0dbd49b2","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-17T11:42:05.435732Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.431614Z","description":"","environment_variables":{},"error_message":null,"id":"97c8830e-6d1b-42c0-8ce3-7230e241dd40","name":"tf-ns-epic-curran","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsepiccurransflacvv1","registry_namespace_id":"2bc65664-8e71-49f3-aaf8-10d6f5313c42","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:46.545571Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "554"
+                - "579"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 17 Apr 2025 11:42:09 GMT
+                - Wed, 27 Aug 2025 15:05:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -244,62 +244,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3c775e71-f099-4c5e-b8a8-5a810b5c9c94
+                - a3ac2175-678e-474f-b408-30d8a0415853
         status: 200 OK
         code: 200
-        duration: 48.176625ms
+        duration: 84.171934ms
     - id: 5
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 341
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"namespace_id":"8a9798e3-ed28-49a0-8e23-149ed68fd3a0","name":"tf-co-peaceful-meninsky","environment_variables":{"test":"test"},"privacy":"public","protocol":"http1","secret_environment_variables":[{"key":"first_secret","value":"first_secret"},{"key":"test_secret","value":"test_secret"}],"http_option":"enabled","sandbox":"unknown_sandbox"}'
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 1204
-        uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-04-17T11:42:10.039194046Z","description":"","domain_name":"tfnsobjectivehaibtcrvvgesx-tf-co-peaceful-meninsky.functions.fnc.fr-par.scw.cloud","environment_variables":{"test":"test"},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"5553d036-eed1-49d6-a81e-85f41cf83bb4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-peaceful-meninsky","namespace_id":"8a9798e3-ed28-49a0-8e23-149ed68fd3a0","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsobjectivehaibtcrvvgesx/tf-co-peaceful-meninsky:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$06vLAUfpxNMaD0Dkful3Vg$U2pI9ovP3fVTc7JUgcJcqHXKAwUGmHDBWcOWRn+YNBU","key":"first_secret"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$zGcj87kpSi69SupEBJMN3g$nG+5QgfeRmgxY49JIExjzIci4ezmHUxsjfKEbld0EwA","key":"test_secret"}],"status":"created","timeout":"300s","updated_at":"2025-04-17T11:42:10.039194046Z"}'
-        headers:
-            Content-Length:
-                - "1204"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Thu, 17 Apr 2025 11:42:10 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 26f75a6a-95e6-4365-9c09-c63ed159278a
-        status: 200 OK
-        code: 200
-        duration: 718.734958ms
-    - id: 6
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -314,8 +263,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/5553d036-eed1-49d6-a81e-85f41cf83bb4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/97c8830e-6d1b-42c0-8ce3-7230e241dd40
         method: GET
       response:
         proto: HTTP/2.0
@@ -323,20 +272,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1198
+        content_length: 579
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-04-17T11:42:10.039194Z","description":"","domain_name":"tfnsobjectivehaibtcrvvgesx-tf-co-peaceful-meninsky.functions.fnc.fr-par.scw.cloud","environment_variables":{"test":"test"},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"5553d036-eed1-49d6-a81e-85f41cf83bb4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-peaceful-meninsky","namespace_id":"8a9798e3-ed28-49a0-8e23-149ed68fd3a0","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsobjectivehaibtcrvvgesx/tf-co-peaceful-meninsky:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$06vLAUfpxNMaD0Dkful3Vg$U2pI9ovP3fVTc7JUgcJcqHXKAwUGmHDBWcOWRn+YNBU","key":"first_secret"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$zGcj87kpSi69SupEBJMN3g$nG+5QgfeRmgxY49JIExjzIci4ezmHUxsjfKEbld0EwA","key":"test_secret"}],"status":"created","timeout":"300s","updated_at":"2025-04-17T11:42:10.039194Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.431614Z","description":"","environment_variables":{},"error_message":null,"id":"97c8830e-6d1b-42c0-8ce3-7230e241dd40","name":"tf-ns-epic-curran","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsepiccurransflacvv1","registry_namespace_id":"2bc65664-8e71-49f3-aaf8-10d6f5313c42","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:46.545571Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "1198"
+                - "579"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 17 Apr 2025 11:42:10 GMT
+                - Wed, 27 Aug 2025 15:05:52 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -344,10 +293,61 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 400f3ebd-2ebd-4f81-bc22-7102d9bfeacb
+                - fc377220-c381-40d0-943d-af816b42cfdb
         status: 200 OK
         code: 200
-        duration: 61.285875ms
+        duration: 233.00511ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 375
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"namespace_id":"97c8830e-6d1b-42c0-8ce3-7230e241dd40","name":"tf-co-confident-tu","environment_variables":{"test":"test"},"privacy":"public","protocol":"http1","secret_environment_variables":[{"key":"first_secret","value":"first_secret"},{"key":"test_secret","value":"test_secret"}],"http_option":"enabled","sandbox":"unknown_sandbox","tags":null,"command":null,"args":null}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1240
+        uncompressed: false
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:54.308424894Z","description":"","domain_name":"tfnsepiccurransflacvv1-tf-co-confident-tu.functions.fnc.fr-par.scw.cloud","environment_variables":{"test":"test"},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"0b6ea900-e5ac-4145-947b-785fe8f7143b","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-confident-tu","namespace_id":"97c8830e-6d1b-42c0-8ce3-7230e241dd40","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsepiccurransflacvv1/tf-co-confident-tu:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$xV25hSvhb8ynFb4GTTSVJQ$aQe1AfGWkSRQqKfDWoyGjrNipWD0LD/Zj0pGv2uABWI","key":"first_secret"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$imNLN12H3zoKm8ptBqS87Q$jRQyWWEjcrg29UUzfq4PUVTVtYOC4Ok/+i7ccSCfJ80","key":"test_secret"}],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:54.308424894Z"}'
+        headers:
+            Content-Length:
+                - "1240"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:05:54 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 25fbf18a-8e37-489d-99b0-d41f47f57a72
+        status: 200 OK
+        code: 200
+        duration: 2.31318506s
     - id: 7
       request:
         proto: HTTP/1.1
@@ -363,8 +363,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/5553d036-eed1-49d6-a81e-85f41cf83bb4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/0b6ea900-e5ac-4145-947b-785fe8f7143b
         method: GET
       response:
         proto: HTTP/2.0
@@ -372,20 +372,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1198
+        content_length: 1234
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-04-17T11:42:10.039194Z","description":"","domain_name":"tfnsobjectivehaibtcrvvgesx-tf-co-peaceful-meninsky.functions.fnc.fr-par.scw.cloud","environment_variables":{"test":"test"},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"5553d036-eed1-49d6-a81e-85f41cf83bb4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-peaceful-meninsky","namespace_id":"8a9798e3-ed28-49a0-8e23-149ed68fd3a0","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsobjectivehaibtcrvvgesx/tf-co-peaceful-meninsky:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$06vLAUfpxNMaD0Dkful3Vg$U2pI9ovP3fVTc7JUgcJcqHXKAwUGmHDBWcOWRn+YNBU","key":"first_secret"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$zGcj87kpSi69SupEBJMN3g$nG+5QgfeRmgxY49JIExjzIci4ezmHUxsjfKEbld0EwA","key":"test_secret"}],"status":"created","timeout":"300s","updated_at":"2025-04-17T11:42:10.039194Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:54.308425Z","description":"","domain_name":"tfnsepiccurransflacvv1-tf-co-confident-tu.functions.fnc.fr-par.scw.cloud","environment_variables":{"test":"test"},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"0b6ea900-e5ac-4145-947b-785fe8f7143b","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-confident-tu","namespace_id":"97c8830e-6d1b-42c0-8ce3-7230e241dd40","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsepiccurransflacvv1/tf-co-confident-tu:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$xV25hSvhb8ynFb4GTTSVJQ$aQe1AfGWkSRQqKfDWoyGjrNipWD0LD/Zj0pGv2uABWI","key":"first_secret"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$imNLN12H3zoKm8ptBqS87Q$jRQyWWEjcrg29UUzfq4PUVTVtYOC4Ok/+i7ccSCfJ80","key":"test_secret"}],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:54.308425Z"}'
         headers:
             Content-Length:
-                - "1198"
+                - "1234"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 17 Apr 2025 11:42:10 GMT
+                - Wed, 27 Aug 2025 15:05:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -393,10 +393,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d703657d-8d19-4299-b20e-ef2f010de26a
+                - e4047f58-1f73-4637-8bc2-dcb24921f03c
         status: 200 OK
         code: 200
-        duration: 55.927ms
+        duration: 121.022873ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -412,8 +412,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/8a9798e3-ed28-49a0-8e23-149ed68fd3a0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/0b6ea900-e5ac-4145-947b-785fe8f7143b
         method: GET
       response:
         proto: HTTP/2.0
@@ -421,20 +421,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 554
+        content_length: 1234
         uncompressed: false
-        body: '{"created_at":"2025-04-17T11:42:04.084994Z","description":"","environment_variables":{},"error_message":null,"id":"8a9798e3-ed28-49a0-8e23-149ed68fd3a0","name":"tf-ns-objective-haibt","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsobjectivehaibtcrvvgesx","registry_namespace_id":"efa49832-146a-4b51-a49a-7a8e0dbd49b2","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-17T11:42:05.435732Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:54.308425Z","description":"","domain_name":"tfnsepiccurransflacvv1-tf-co-confident-tu.functions.fnc.fr-par.scw.cloud","environment_variables":{"test":"test"},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"0b6ea900-e5ac-4145-947b-785fe8f7143b","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-confident-tu","namespace_id":"97c8830e-6d1b-42c0-8ce3-7230e241dd40","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsepiccurransflacvv1/tf-co-confident-tu:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$xV25hSvhb8ynFb4GTTSVJQ$aQe1AfGWkSRQqKfDWoyGjrNipWD0LD/Zj0pGv2uABWI","key":"first_secret"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$imNLN12H3zoKm8ptBqS87Q$jRQyWWEjcrg29UUzfq4PUVTVtYOC4Ok/+i7ccSCfJ80","key":"test_secret"}],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:54.308425Z"}'
         headers:
             Content-Length:
-                - "554"
+                - "1234"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 17 Apr 2025 11:42:10 GMT
+                - Wed, 27 Aug 2025 15:05:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -442,10 +442,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 81379323-34ea-4a62-aa17-3cf4ecc7010a
+                - 7d866981-74c0-4553-bca6-1dd076982923
         status: 200 OK
         code: 200
-        duration: 45.311834ms
+        duration: 90.987423ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -461,8 +461,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/5553d036-eed1-49d6-a81e-85f41cf83bb4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/97c8830e-6d1b-42c0-8ce3-7230e241dd40
         method: GET
       response:
         proto: HTTP/2.0
@@ -470,20 +470,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1198
+        content_length: 579
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-04-17T11:42:10.039194Z","description":"","domain_name":"tfnsobjectivehaibtcrvvgesx-tf-co-peaceful-meninsky.functions.fnc.fr-par.scw.cloud","environment_variables":{"test":"test"},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"5553d036-eed1-49d6-a81e-85f41cf83bb4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-peaceful-meninsky","namespace_id":"8a9798e3-ed28-49a0-8e23-149ed68fd3a0","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsobjectivehaibtcrvvgesx/tf-co-peaceful-meninsky:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$06vLAUfpxNMaD0Dkful3Vg$U2pI9ovP3fVTc7JUgcJcqHXKAwUGmHDBWcOWRn+YNBU","key":"first_secret"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$zGcj87kpSi69SupEBJMN3g$nG+5QgfeRmgxY49JIExjzIci4ezmHUxsjfKEbld0EwA","key":"test_secret"}],"status":"created","timeout":"300s","updated_at":"2025-04-17T11:42:10.039194Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.431614Z","description":"","environment_variables":{},"error_message":null,"id":"97c8830e-6d1b-42c0-8ce3-7230e241dd40","name":"tf-ns-epic-curran","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsepiccurransflacvv1","registry_namespace_id":"2bc65664-8e71-49f3-aaf8-10d6f5313c42","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:46.545571Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "1198"
+                - "579"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 17 Apr 2025 11:42:10 GMT
+                - Wed, 27 Aug 2025 15:05:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -491,10 +491,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bb9f31e7-e4d2-4b92-ac4d-ac61f1f4f06f
+                - d7578348-14cd-487e-99c1-ad9106cab456
         status: 200 OK
         code: 200
-        duration: 57.420666ms
+        duration: 81.838456ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -510,8 +510,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/8a9798e3-ed28-49a0-8e23-149ed68fd3a0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/0b6ea900-e5ac-4145-947b-785fe8f7143b
         method: GET
       response:
         proto: HTTP/2.0
@@ -519,20 +519,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 554
+        content_length: 1234
         uncompressed: false
-        body: '{"created_at":"2025-04-17T11:42:04.084994Z","description":"","environment_variables":{},"error_message":null,"id":"8a9798e3-ed28-49a0-8e23-149ed68fd3a0","name":"tf-ns-objective-haibt","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsobjectivehaibtcrvvgesx","registry_namespace_id":"efa49832-146a-4b51-a49a-7a8e0dbd49b2","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-17T11:42:05.435732Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:54.308425Z","description":"","domain_name":"tfnsepiccurransflacvv1-tf-co-confident-tu.functions.fnc.fr-par.scw.cloud","environment_variables":{"test":"test"},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"0b6ea900-e5ac-4145-947b-785fe8f7143b","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-confident-tu","namespace_id":"97c8830e-6d1b-42c0-8ce3-7230e241dd40","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsepiccurransflacvv1/tf-co-confident-tu:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$xV25hSvhb8ynFb4GTTSVJQ$aQe1AfGWkSRQqKfDWoyGjrNipWD0LD/Zj0pGv2uABWI","key":"first_secret"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$imNLN12H3zoKm8ptBqS87Q$jRQyWWEjcrg29UUzfq4PUVTVtYOC4Ok/+i7ccSCfJ80","key":"test_secret"}],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:54.308425Z"}'
         headers:
             Content-Length:
-                - "554"
+                - "1234"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 17 Apr 2025 11:42:11 GMT
+                - Wed, 27 Aug 2025 15:05:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -540,10 +540,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0fee990c-1252-4519-85f5-690026806771
+                - 06661f2e-3036-4bdf-8c4b-5b97c601e352
         status: 200 OK
         code: 200
-        duration: 53.191625ms
+        duration: 89.855128ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -559,8 +559,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/5553d036-eed1-49d6-a81e-85f41cf83bb4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/97c8830e-6d1b-42c0-8ce3-7230e241dd40
         method: GET
       response:
         proto: HTTP/2.0
@@ -568,20 +568,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1198
+        content_length: 579
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-04-17T11:42:10.039194Z","description":"","domain_name":"tfnsobjectivehaibtcrvvgesx-tf-co-peaceful-meninsky.functions.fnc.fr-par.scw.cloud","environment_variables":{"test":"test"},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"5553d036-eed1-49d6-a81e-85f41cf83bb4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-peaceful-meninsky","namespace_id":"8a9798e3-ed28-49a0-8e23-149ed68fd3a0","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsobjectivehaibtcrvvgesx/tf-co-peaceful-meninsky:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$06vLAUfpxNMaD0Dkful3Vg$U2pI9ovP3fVTc7JUgcJcqHXKAwUGmHDBWcOWRn+YNBU","key":"first_secret"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$zGcj87kpSi69SupEBJMN3g$nG+5QgfeRmgxY49JIExjzIci4ezmHUxsjfKEbld0EwA","key":"test_secret"}],"status":"created","timeout":"300s","updated_at":"2025-04-17T11:42:10.039194Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.431614Z","description":"","environment_variables":{},"error_message":null,"id":"97c8830e-6d1b-42c0-8ce3-7230e241dd40","name":"tf-ns-epic-curran","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsepiccurransflacvv1","registry_namespace_id":"2bc65664-8e71-49f3-aaf8-10d6f5313c42","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:46.545571Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "1198"
+                - "579"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 17 Apr 2025 11:42:11 GMT
+                - Wed, 27 Aug 2025 15:05:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -589,10 +589,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a4d237d6-40ed-43af-8691-1cd961690caf
+                - 1666d247-38b0-4986-91fd-c0cbba0df3f7
         status: 200 OK
         code: 200
-        duration: 65.630125ms
+        duration: 84.198694ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -608,8 +608,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/8a9798e3-ed28-49a0-8e23-149ed68fd3a0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/0b6ea900-e5ac-4145-947b-785fe8f7143b
         method: GET
       response:
         proto: HTTP/2.0
@@ -617,20 +617,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 554
+        content_length: 1234
         uncompressed: false
-        body: '{"created_at":"2025-04-17T11:42:04.084994Z","description":"","environment_variables":{},"error_message":null,"id":"8a9798e3-ed28-49a0-8e23-149ed68fd3a0","name":"tf-ns-objective-haibt","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsobjectivehaibtcrvvgesx","registry_namespace_id":"efa49832-146a-4b51-a49a-7a8e0dbd49b2","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-17T11:42:05.435732Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:54.308425Z","description":"","domain_name":"tfnsepiccurransflacvv1-tf-co-confident-tu.functions.fnc.fr-par.scw.cloud","environment_variables":{"test":"test"},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"0b6ea900-e5ac-4145-947b-785fe8f7143b","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-confident-tu","namespace_id":"97c8830e-6d1b-42c0-8ce3-7230e241dd40","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsepiccurransflacvv1/tf-co-confident-tu:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$xV25hSvhb8ynFb4GTTSVJQ$aQe1AfGWkSRQqKfDWoyGjrNipWD0LD/Zj0pGv2uABWI","key":"first_secret"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$imNLN12H3zoKm8ptBqS87Q$jRQyWWEjcrg29UUzfq4PUVTVtYOC4Ok/+i7ccSCfJ80","key":"test_secret"}],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:54.308425Z"}'
         headers:
             Content-Length:
-                - "554"
+                - "1234"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 17 Apr 2025 11:42:11 GMT
+                - Wed, 27 Aug 2025 15:05:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -638,10 +638,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 245474b4-098d-4578-901f-e02773e9c473
+                - 238d0d2d-95d1-4efb-8e4b-3df05295b3e2
         status: 200 OK
         code: 200
-        duration: 41.959417ms
+        duration: 83.891389ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -657,8 +657,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/5553d036-eed1-49d6-a81e-85f41cf83bb4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/97c8830e-6d1b-42c0-8ce3-7230e241dd40
         method: GET
       response:
         proto: HTTP/2.0
@@ -666,20 +666,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1198
+        content_length: 579
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-04-17T11:42:10.039194Z","description":"","domain_name":"tfnsobjectivehaibtcrvvgesx-tf-co-peaceful-meninsky.functions.fnc.fr-par.scw.cloud","environment_variables":{"test":"test"},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"5553d036-eed1-49d6-a81e-85f41cf83bb4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-peaceful-meninsky","namespace_id":"8a9798e3-ed28-49a0-8e23-149ed68fd3a0","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsobjectivehaibtcrvvgesx/tf-co-peaceful-meninsky:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$06vLAUfpxNMaD0Dkful3Vg$U2pI9ovP3fVTc7JUgcJcqHXKAwUGmHDBWcOWRn+YNBU","key":"first_secret"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$zGcj87kpSi69SupEBJMN3g$nG+5QgfeRmgxY49JIExjzIci4ezmHUxsjfKEbld0EwA","key":"test_secret"}],"status":"created","timeout":"300s","updated_at":"2025-04-17T11:42:10.039194Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.431614Z","description":"","environment_variables":{},"error_message":null,"id":"97c8830e-6d1b-42c0-8ce3-7230e241dd40","name":"tf-ns-epic-curran","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsepiccurransflacvv1","registry_namespace_id":"2bc65664-8e71-49f3-aaf8-10d6f5313c42","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:46.545571Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "1198"
+                - "579"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 17 Apr 2025 11:42:11 GMT
+                - Wed, 27 Aug 2025 15:05:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -687,11 +687,60 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c046cf8f-e436-47bf-b855-1f78b564021c
+                - 4da4b4e4-fe9d-43a7-ab84-eb1d43bc04e7
         status: 200 OK
         code: 200
-        duration: 53.608125ms
+        duration: 76.034685ms
     - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/0b6ea900-e5ac-4145-947b-785fe8f7143b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1234
+        uncompressed: false
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:54.308425Z","description":"","domain_name":"tfnsepiccurransflacvv1-tf-co-confident-tu.functions.fnc.fr-par.scw.cloud","environment_variables":{"test":"test"},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"0b6ea900-e5ac-4145-947b-785fe8f7143b","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-confident-tu","namespace_id":"97c8830e-6d1b-42c0-8ce3-7230e241dd40","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsepiccurransflacvv1/tf-co-confident-tu:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$xV25hSvhb8ynFb4GTTSVJQ$aQe1AfGWkSRQqKfDWoyGjrNipWD0LD/Zj0pGv2uABWI","key":"first_secret"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$imNLN12H3zoKm8ptBqS87Q$jRQyWWEjcrg29UUzfq4PUVTVtYOC4Ok/+i7ccSCfJ80","key":"test_secret"}],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:54.308425Z"}'
+        headers:
+            Content-Length:
+                - "1234"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:05:56 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - d3c218bf-fc73-42b5-8f76-3065c30d3c3c
+        status: 200 OK
+        code: 200
+        duration: 83.865199ms
+    - id: 15
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -708,8 +757,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/5553d036-eed1-49d6-a81e-85f41cf83bb4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/0b6ea900-e5ac-4145-947b-785fe8f7143b
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -717,20 +766,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1197
+        content_length: 1233
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-04-17T11:42:10.039194Z","description":"","domain_name":"tfnsobjectivehaibtcrvvgesx-tf-co-peaceful-meninsky.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"bar"},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"5553d036-eed1-49d6-a81e-85f41cf83bb4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-peaceful-meninsky","namespace_id":"8a9798e3-ed28-49a0-8e23-149ed68fd3a0","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsobjectivehaibtcrvvgesx/tf-co-peaceful-meninsky:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$NpCnluDZQKZyiwwHb9O3xw$I/z9YnUN3fgbFPbCwyP2hU8C66swTA+Brw5+YtcHt4w","key":"test_secret"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$TpeT+ZJ0Q89hhlPN87y1DQ$03DMQJOegGex0ktXrrmSdT6IrPcGoyoZ9Go2VK/2KtM","key":"foo_secret"}],"status":"pending","timeout":"300s","updated_at":"2025-04-17T11:42:11.968427654Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:54.308425Z","description":"","domain_name":"tfnsepiccurransflacvv1-tf-co-confident-tu.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"bar"},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"0b6ea900-e5ac-4145-947b-785fe8f7143b","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-confident-tu","namespace_id":"97c8830e-6d1b-42c0-8ce3-7230e241dd40","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsepiccurransflacvv1/tf-co-confident-tu:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$aYkTZQirbRRHPceslkMOlQ$lm53jRjaxGV4wvQb8ab5FfS+UaZEoTiFZAaa21naUPY","key":"test_secret"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$xsL2VAueqzHwRHxiJv52uw$lNn6qqCg9nHl3iq/nwppRhUHKX45fmpmCq2irxfvAcg","key":"foo_secret"}],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:57.476513962Z"}'
         headers:
             Content-Length:
-                - "1197"
+                - "1233"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 17 Apr 2025 11:42:11 GMT
+                - Wed, 27 Aug 2025 15:05:57 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -738,59 +787,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e960899d-42dc-45e0-ab3f-649ddddacda7
+                - d083e56d-6183-47bc-9515-35bf4baf8e10
         status: 200 OK
         code: 200
-        duration: 457.2695ms
-    - id: 15
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/5553d036-eed1-49d6-a81e-85f41cf83bb4
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 1194
-        uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-04-17T11:42:10.039194Z","description":"","domain_name":"tfnsobjectivehaibtcrvvgesx-tf-co-peaceful-meninsky.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"bar"},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"5553d036-eed1-49d6-a81e-85f41cf83bb4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-peaceful-meninsky","namespace_id":"8a9798e3-ed28-49a0-8e23-149ed68fd3a0","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsobjectivehaibtcrvvgesx/tf-co-peaceful-meninsky:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$NpCnluDZQKZyiwwHb9O3xw$I/z9YnUN3fgbFPbCwyP2hU8C66swTA+Brw5+YtcHt4w","key":"test_secret"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$TpeT+ZJ0Q89hhlPN87y1DQ$03DMQJOegGex0ktXrrmSdT6IrPcGoyoZ9Go2VK/2KtM","key":"foo_secret"}],"status":"pending","timeout":"300s","updated_at":"2025-04-17T11:42:11.968428Z"}'
-        headers:
-            Content-Length:
-                - "1194"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Thu, 17 Apr 2025 11:42:12 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 3448a24f-6cca-4ee1-aa58-bc1c1e56e61a
-        status: 200 OK
-        code: 200
-        duration: 52.602ms
+        duration: 514.776866ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -806,8 +806,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/5553d036-eed1-49d6-a81e-85f41cf83bb4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/0b6ea900-e5ac-4145-947b-785fe8f7143b
         method: GET
       response:
         proto: HTTP/2.0
@@ -815,20 +815,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1194
+        content_length: 1230
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-04-17T11:42:10.039194Z","description":"","domain_name":"tfnsobjectivehaibtcrvvgesx-tf-co-peaceful-meninsky.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"bar"},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"5553d036-eed1-49d6-a81e-85f41cf83bb4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-peaceful-meninsky","namespace_id":"8a9798e3-ed28-49a0-8e23-149ed68fd3a0","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsobjectivehaibtcrvvgesx/tf-co-peaceful-meninsky:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$NpCnluDZQKZyiwwHb9O3xw$I/z9YnUN3fgbFPbCwyP2hU8C66swTA+Brw5+YtcHt4w","key":"test_secret"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$TpeT+ZJ0Q89hhlPN87y1DQ$03DMQJOegGex0ktXrrmSdT6IrPcGoyoZ9Go2VK/2KtM","key":"foo_secret"}],"status":"pending","timeout":"300s","updated_at":"2025-04-17T11:42:11.968428Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:54.308425Z","description":"","domain_name":"tfnsepiccurransflacvv1-tf-co-confident-tu.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"bar"},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"0b6ea900-e5ac-4145-947b-785fe8f7143b","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-confident-tu","namespace_id":"97c8830e-6d1b-42c0-8ce3-7230e241dd40","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsepiccurransflacvv1/tf-co-confident-tu:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$aYkTZQirbRRHPceslkMOlQ$lm53jRjaxGV4wvQb8ab5FfS+UaZEoTiFZAaa21naUPY","key":"test_secret"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$xsL2VAueqzHwRHxiJv52uw$lNn6qqCg9nHl3iq/nwppRhUHKX45fmpmCq2irxfvAcg","key":"foo_secret"}],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:57.476514Z"}'
         headers:
             Content-Length:
-                - "1194"
+                - "1230"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 17 Apr 2025 11:42:17 GMT
+                - Wed, 27 Aug 2025 15:05:57 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -836,10 +836,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f7ba0a06-cbb0-4913-bb65-c92967dfdbfc
+                - 3550d89d-7caa-4b37-82ed-93c8232bc725
         status: 200 OK
         code: 200
-        duration: 63.311833ms
+        duration: 108.49193ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -855,8 +855,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/5553d036-eed1-49d6-a81e-85f41cf83bb4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/0b6ea900-e5ac-4145-947b-785fe8f7143b
         method: GET
       response:
         proto: HTTP/2.0
@@ -864,20 +864,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1232
+        content_length: 1230
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-04-17T11:42:10.039194Z","description":"","domain_name":"tfnsobjectivehaibtcrvvgesx-tf-co-peaceful-meninsky.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"bar"},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"5553d036-eed1-49d6-a81e-85f41cf83bb4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-peaceful-meninsky","namespace_id":"8a9798e3-ed28-49a0-8e23-149ed68fd3a0","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsobjectivehaibtcrvvgesx/tf-co-peaceful-meninsky:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$NpCnluDZQKZyiwwHb9O3xw$I/z9YnUN3fgbFPbCwyP2hU8C66swTA+Brw5+YtcHt4w","key":"test_secret"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$TpeT+ZJ0Q89hhlPN87y1DQ$03DMQJOegGex0ktXrrmSdT6IrPcGoyoZ9Go2VK/2KtM","key":"foo_secret"}],"status":"error","timeout":"300s","updated_at":"2025-04-17T11:42:18.505209Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:54.308425Z","description":"","domain_name":"tfnsepiccurransflacvv1-tf-co-confident-tu.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"bar"},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"0b6ea900-e5ac-4145-947b-785fe8f7143b","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-confident-tu","namespace_id":"97c8830e-6d1b-42c0-8ce3-7230e241dd40","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsepiccurransflacvv1/tf-co-confident-tu:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$aYkTZQirbRRHPceslkMOlQ$lm53jRjaxGV4wvQb8ab5FfS+UaZEoTiFZAaa21naUPY","key":"test_secret"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$xsL2VAueqzHwRHxiJv52uw$lNn6qqCg9nHl3iq/nwppRhUHKX45fmpmCq2irxfvAcg","key":"foo_secret"}],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:57.476514Z"}'
         headers:
             Content-Length:
-                - "1232"
+                - "1230"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 17 Apr 2025 11:42:22 GMT
+                - Wed, 27 Aug 2025 15:06:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -885,10 +885,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 125ade38-c844-4c8f-84ff-32936d0ce7d0
+                - bbcf310b-7ab8-430b-b019-68546798b10b
         status: 200 OK
         code: 200
-        duration: 60.959625ms
+        duration: 104.423939ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -904,8 +904,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/5553d036-eed1-49d6-a81e-85f41cf83bb4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/0b6ea900-e5ac-4145-947b-785fe8f7143b
         method: GET
       response:
         proto: HTTP/2.0
@@ -913,20 +913,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1232
+        content_length: 1230
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-04-17T11:42:10.039194Z","description":"","domain_name":"tfnsobjectivehaibtcrvvgesx-tf-co-peaceful-meninsky.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"bar"},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"5553d036-eed1-49d6-a81e-85f41cf83bb4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-peaceful-meninsky","namespace_id":"8a9798e3-ed28-49a0-8e23-149ed68fd3a0","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsobjectivehaibtcrvvgesx/tf-co-peaceful-meninsky:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$NpCnluDZQKZyiwwHb9O3xw$I/z9YnUN3fgbFPbCwyP2hU8C66swTA+Brw5+YtcHt4w","key":"test_secret"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$TpeT+ZJ0Q89hhlPN87y1DQ$03DMQJOegGex0ktXrrmSdT6IrPcGoyoZ9Go2VK/2KtM","key":"foo_secret"}],"status":"error","timeout":"300s","updated_at":"2025-04-17T11:42:18.505209Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:54.308425Z","description":"","domain_name":"tfnsepiccurransflacvv1-tf-co-confident-tu.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"bar"},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"0b6ea900-e5ac-4145-947b-785fe8f7143b","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-confident-tu","namespace_id":"97c8830e-6d1b-42c0-8ce3-7230e241dd40","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsepiccurransflacvv1/tf-co-confident-tu:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$aYkTZQirbRRHPceslkMOlQ$lm53jRjaxGV4wvQb8ab5FfS+UaZEoTiFZAaa21naUPY","key":"test_secret"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$xsL2VAueqzHwRHxiJv52uw$lNn6qqCg9nHl3iq/nwppRhUHKX45fmpmCq2irxfvAcg","key":"foo_secret"}],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:57.476514Z"}'
         headers:
             Content-Length:
-                - "1232"
+                - "1230"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 17 Apr 2025 11:42:22 GMT
+                - Wed, 27 Aug 2025 15:06:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -934,10 +934,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6c641445-b94d-45bc-82b5-05fbd37c87c6
+                - 0ffba431-7297-439a-8a0a-5de6fb78c027
         status: 200 OK
         code: 200
-        duration: 56.02575ms
+        duration: 92.355654ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -953,8 +953,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/5553d036-eed1-49d6-a81e-85f41cf83bb4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/0b6ea900-e5ac-4145-947b-785fe8f7143b
         method: GET
       response:
         proto: HTTP/2.0
@@ -962,20 +962,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1232
+        content_length: 1230
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-04-17T11:42:10.039194Z","description":"","domain_name":"tfnsobjectivehaibtcrvvgesx-tf-co-peaceful-meninsky.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"bar"},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"5553d036-eed1-49d6-a81e-85f41cf83bb4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-peaceful-meninsky","namespace_id":"8a9798e3-ed28-49a0-8e23-149ed68fd3a0","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsobjectivehaibtcrvvgesx/tf-co-peaceful-meninsky:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$NpCnluDZQKZyiwwHb9O3xw$I/z9YnUN3fgbFPbCwyP2hU8C66swTA+Brw5+YtcHt4w","key":"test_secret"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$TpeT+ZJ0Q89hhlPN87y1DQ$03DMQJOegGex0ktXrrmSdT6IrPcGoyoZ9Go2VK/2KtM","key":"foo_secret"}],"status":"error","timeout":"300s","updated_at":"2025-04-17T11:42:18.505209Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:54.308425Z","description":"","domain_name":"tfnsepiccurransflacvv1-tf-co-confident-tu.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"bar"},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"0b6ea900-e5ac-4145-947b-785fe8f7143b","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-confident-tu","namespace_id":"97c8830e-6d1b-42c0-8ce3-7230e241dd40","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsepiccurransflacvv1/tf-co-confident-tu:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$aYkTZQirbRRHPceslkMOlQ$lm53jRjaxGV4wvQb8ab5FfS+UaZEoTiFZAaa21naUPY","key":"test_secret"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$xsL2VAueqzHwRHxiJv52uw$lNn6qqCg9nHl3iq/nwppRhUHKX45fmpmCq2irxfvAcg","key":"foo_secret"}],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:57.476514Z"}'
         headers:
             Content-Length:
-                - "1232"
+                - "1230"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 17 Apr 2025 11:42:22 GMT
+                - Wed, 27 Aug 2025 15:06:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -983,10 +983,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 580180d9-bc2e-4e30-a270-69edea5a001d
+                - 15d7a2e2-3fdc-49cc-9abf-6aaa50bcbe72
         status: 200 OK
         code: 200
-        duration: 55.1ms
+        duration: 163.818416ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1002,8 +1002,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/8a9798e3-ed28-49a0-8e23-149ed68fd3a0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/0b6ea900-e5ac-4145-947b-785fe8f7143b
         method: GET
       response:
         proto: HTTP/2.0
@@ -1011,20 +1011,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 554
+        content_length: 1230
         uncompressed: false
-        body: '{"created_at":"2025-04-17T11:42:04.084994Z","description":"","environment_variables":{},"error_message":null,"id":"8a9798e3-ed28-49a0-8e23-149ed68fd3a0","name":"tf-ns-objective-haibt","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsobjectivehaibtcrvvgesx","registry_namespace_id":"efa49832-146a-4b51-a49a-7a8e0dbd49b2","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-17T11:42:05.435732Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:54.308425Z","description":"","domain_name":"tfnsepiccurransflacvv1-tf-co-confident-tu.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"bar"},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"0b6ea900-e5ac-4145-947b-785fe8f7143b","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-confident-tu","namespace_id":"97c8830e-6d1b-42c0-8ce3-7230e241dd40","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsepiccurransflacvv1/tf-co-confident-tu:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$aYkTZQirbRRHPceslkMOlQ$lm53jRjaxGV4wvQb8ab5FfS+UaZEoTiFZAaa21naUPY","key":"test_secret"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$xsL2VAueqzHwRHxiJv52uw$lNn6qqCg9nHl3iq/nwppRhUHKX45fmpmCq2irxfvAcg","key":"foo_secret"}],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:57.476514Z"}'
         headers:
             Content-Length:
-                - "554"
+                - "1230"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 17 Apr 2025 11:42:22 GMT
+                - Wed, 27 Aug 2025 15:06:18 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1032,10 +1032,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 39cb644e-7db8-4b04-9d50-f62a49b4261d
+                - 7f293b1f-e397-4f2e-961b-b14885a8a3d9
         status: 200 OK
         code: 200
-        duration: 44.430416ms
+        duration: 99.054267ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1051,8 +1051,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/5553d036-eed1-49d6-a81e-85f41cf83bb4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/0b6ea900-e5ac-4145-947b-785fe8f7143b
         method: GET
       response:
         proto: HTTP/2.0
@@ -1060,20 +1060,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1232
+        content_length: 1230
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-04-17T11:42:10.039194Z","description":"","domain_name":"tfnsobjectivehaibtcrvvgesx-tf-co-peaceful-meninsky.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"bar"},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"5553d036-eed1-49d6-a81e-85f41cf83bb4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-peaceful-meninsky","namespace_id":"8a9798e3-ed28-49a0-8e23-149ed68fd3a0","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsobjectivehaibtcrvvgesx/tf-co-peaceful-meninsky:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$NpCnluDZQKZyiwwHb9O3xw$I/z9YnUN3fgbFPbCwyP2hU8C66swTA+Brw5+YtcHt4w","key":"test_secret"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$TpeT+ZJ0Q89hhlPN87y1DQ$03DMQJOegGex0ktXrrmSdT6IrPcGoyoZ9Go2VK/2KtM","key":"foo_secret"}],"status":"error","timeout":"300s","updated_at":"2025-04-17T11:42:18.505209Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:54.308425Z","description":"","domain_name":"tfnsepiccurransflacvv1-tf-co-confident-tu.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"bar"},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"0b6ea900-e5ac-4145-947b-785fe8f7143b","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-confident-tu","namespace_id":"97c8830e-6d1b-42c0-8ce3-7230e241dd40","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsepiccurransflacvv1/tf-co-confident-tu:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$aYkTZQirbRRHPceslkMOlQ$lm53jRjaxGV4wvQb8ab5FfS+UaZEoTiFZAaa21naUPY","key":"test_secret"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$xsL2VAueqzHwRHxiJv52uw$lNn6qqCg9nHl3iq/nwppRhUHKX45fmpmCq2irxfvAcg","key":"foo_secret"}],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:57.476514Z"}'
         headers:
             Content-Length:
-                - "1232"
+                - "1230"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 17 Apr 2025 11:42:22 GMT
+                - Wed, 27 Aug 2025 15:06:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1081,10 +1081,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9384ca65-2922-4dc2-8d33-b80fa083a9f1
+                - 2800e7cf-c621-45c2-adb3-9dd8174b786d
         status: 200 OK
         code: 200
-        duration: 57.597333ms
+        duration: 135.85087ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1100,8 +1100,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/8a9798e3-ed28-49a0-8e23-149ed68fd3a0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/0b6ea900-e5ac-4145-947b-785fe8f7143b
         method: GET
       response:
         proto: HTTP/2.0
@@ -1109,20 +1109,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 554
+        content_length: 1268
         uncompressed: false
-        body: '{"created_at":"2025-04-17T11:42:04.084994Z","description":"","environment_variables":{},"error_message":null,"id":"8a9798e3-ed28-49a0-8e23-149ed68fd3a0","name":"tf-ns-objective-haibt","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsobjectivehaibtcrvvgesx","registry_namespace_id":"efa49832-146a-4b51-a49a-7a8e0dbd49b2","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-17T11:42:05.435732Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:54.308425Z","description":"","domain_name":"tfnsepiccurransflacvv1-tf-co-confident-tu.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"bar"},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"0b6ea900-e5ac-4145-947b-785fe8f7143b","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-confident-tu","namespace_id":"97c8830e-6d1b-42c0-8ce3-7230e241dd40","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsepiccurransflacvv1/tf-co-confident-tu:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$aYkTZQirbRRHPceslkMOlQ$lm53jRjaxGV4wvQb8ab5FfS+UaZEoTiFZAaa21naUPY","key":"test_secret"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$xsL2VAueqzHwRHxiJv52uw$lNn6qqCg9nHl3iq/nwppRhUHKX45fmpmCq2irxfvAcg","key":"foo_secret"}],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:25.107484Z"}'
         headers:
             Content-Length:
-                - "554"
+                - "1268"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 17 Apr 2025 11:42:23 GMT
+                - Wed, 27 Aug 2025 15:06:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1130,10 +1130,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1a34eb89-6042-4def-8b25-566b085f93b4
+                - ca0ed4ce-6f95-40b6-994a-cbb2bbc6a9f2
         status: 200 OK
         code: 200
-        duration: 44.781625ms
+        duration: 81.882557ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1149,8 +1149,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/5553d036-eed1-49d6-a81e-85f41cf83bb4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/0b6ea900-e5ac-4145-947b-785fe8f7143b
         method: GET
       response:
         proto: HTTP/2.0
@@ -1158,20 +1158,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1232
+        content_length: 1268
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-04-17T11:42:10.039194Z","description":"","domain_name":"tfnsobjectivehaibtcrvvgesx-tf-co-peaceful-meninsky.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"bar"},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"5553d036-eed1-49d6-a81e-85f41cf83bb4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-peaceful-meninsky","namespace_id":"8a9798e3-ed28-49a0-8e23-149ed68fd3a0","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsobjectivehaibtcrvvgesx/tf-co-peaceful-meninsky:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$NpCnluDZQKZyiwwHb9O3xw$I/z9YnUN3fgbFPbCwyP2hU8C66swTA+Brw5+YtcHt4w","key":"test_secret"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$TpeT+ZJ0Q89hhlPN87y1DQ$03DMQJOegGex0ktXrrmSdT6IrPcGoyoZ9Go2VK/2KtM","key":"foo_secret"}],"status":"error","timeout":"300s","updated_at":"2025-04-17T11:42:18.505209Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:54.308425Z","description":"","domain_name":"tfnsepiccurransflacvv1-tf-co-confident-tu.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"bar"},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"0b6ea900-e5ac-4145-947b-785fe8f7143b","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-confident-tu","namespace_id":"97c8830e-6d1b-42c0-8ce3-7230e241dd40","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsepiccurransflacvv1/tf-co-confident-tu:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$aYkTZQirbRRHPceslkMOlQ$lm53jRjaxGV4wvQb8ab5FfS+UaZEoTiFZAaa21naUPY","key":"test_secret"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$xsL2VAueqzHwRHxiJv52uw$lNn6qqCg9nHl3iq/nwppRhUHKX45fmpmCq2irxfvAcg","key":"foo_secret"}],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:25.107484Z"}'
         headers:
             Content-Length:
-                - "1232"
+                - "1268"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 17 Apr 2025 11:42:23 GMT
+                - Wed, 27 Aug 2025 15:06:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1179,10 +1179,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fd4dd5b8-9f18-43b0-ba6f-2ec8ed33477e
+                - 42ff3929-8df4-4e70-bf93-08eb7e60f557
         status: 200 OK
         code: 200
-        duration: 51.740084ms
+        duration: 86.984731ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1198,8 +1198,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/8a9798e3-ed28-49a0-8e23-149ed68fd3a0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/0b6ea900-e5ac-4145-947b-785fe8f7143b
         method: GET
       response:
         proto: HTTP/2.0
@@ -1207,20 +1207,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 554
+        content_length: 1268
         uncompressed: false
-        body: '{"created_at":"2025-04-17T11:42:04.084994Z","description":"","environment_variables":{},"error_message":null,"id":"8a9798e3-ed28-49a0-8e23-149ed68fd3a0","name":"tf-ns-objective-haibt","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsobjectivehaibtcrvvgesx","registry_namespace_id":"efa49832-146a-4b51-a49a-7a8e0dbd49b2","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-17T11:42:05.435732Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:54.308425Z","description":"","domain_name":"tfnsepiccurransflacvv1-tf-co-confident-tu.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"bar"},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"0b6ea900-e5ac-4145-947b-785fe8f7143b","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-confident-tu","namespace_id":"97c8830e-6d1b-42c0-8ce3-7230e241dd40","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsepiccurransflacvv1/tf-co-confident-tu:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$aYkTZQirbRRHPceslkMOlQ$lm53jRjaxGV4wvQb8ab5FfS+UaZEoTiFZAaa21naUPY","key":"test_secret"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$xsL2VAueqzHwRHxiJv52uw$lNn6qqCg9nHl3iq/nwppRhUHKX45fmpmCq2irxfvAcg","key":"foo_secret"}],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:25.107484Z"}'
         headers:
             Content-Length:
-                - "554"
+                - "1268"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 17 Apr 2025 11:42:23 GMT
+                - Wed, 27 Aug 2025 15:06:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1228,10 +1228,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b7a31528-25c5-493e-a3db-659e4e164e69
+                - fbd380a0-1693-4f5b-8659-92ddccf6a730
         status: 200 OK
         code: 200
-        duration: 43.060959ms
+        duration: 85.255728ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1247,8 +1247,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/5553d036-eed1-49d6-a81e-85f41cf83bb4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/97c8830e-6d1b-42c0-8ce3-7230e241dd40
         method: GET
       response:
         proto: HTTP/2.0
@@ -1256,20 +1256,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1232
+        content_length: 579
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-04-17T11:42:10.039194Z","description":"","domain_name":"tfnsobjectivehaibtcrvvgesx-tf-co-peaceful-meninsky.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"bar"},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"5553d036-eed1-49d6-a81e-85f41cf83bb4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-peaceful-meninsky","namespace_id":"8a9798e3-ed28-49a0-8e23-149ed68fd3a0","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsobjectivehaibtcrvvgesx/tf-co-peaceful-meninsky:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$NpCnluDZQKZyiwwHb9O3xw$I/z9YnUN3fgbFPbCwyP2hU8C66swTA+Brw5+YtcHt4w","key":"test_secret"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$TpeT+ZJ0Q89hhlPN87y1DQ$03DMQJOegGex0ktXrrmSdT6IrPcGoyoZ9Go2VK/2KtM","key":"foo_secret"}],"status":"error","timeout":"300s","updated_at":"2025-04-17T11:42:18.505209Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.431614Z","description":"","environment_variables":{},"error_message":null,"id":"97c8830e-6d1b-42c0-8ce3-7230e241dd40","name":"tf-ns-epic-curran","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsepiccurransflacvv1","registry_namespace_id":"2bc65664-8e71-49f3-aaf8-10d6f5313c42","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:46.545571Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "1232"
+                - "579"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 17 Apr 2025 11:42:23 GMT
+                - Wed, 27 Aug 2025 15:06:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1277,50 +1277,48 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cca103f8-fa3c-4726-9ba9-398fe8213d54
+                - a47ecd20-fbd0-458b-a71f-337a57dccdd8
         status: 200 OK
         code: 200
-        duration: 56.427292ms
+        duration: 94.058997ms
     - id: 26
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 252
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"environment_variables":{},"privacy":"unknown_privacy","protocol":"unknown_protocol","secret_environment_variables":[{"key":"foo_secret","value":null},{"key":"test_secret","value":null}],"http_option":"unknown_http_option","sandbox":"unknown_sandbox"}'
+        body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/5553d036-eed1-49d6-a81e-85f41cf83bb4
-        method: PATCH
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/0b6ea900-e5ac-4145-947b-785fe8f7143b
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 914
+        content_length: 1268
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-04-17T11:42:10.039194Z","description":"","domain_name":"tfnsobjectivehaibtcrvvgesx-tf-co-peaceful-meninsky.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"5553d036-eed1-49d6-a81e-85f41cf83bb4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-peaceful-meninsky","namespace_id":"8a9798e3-ed28-49a0-8e23-149ed68fd3a0","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsobjectivehaibtcrvvgesx/tf-co-peaceful-meninsky:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","timeout":"300s","updated_at":"2025-04-17T11:42:23.761003961Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:54.308425Z","description":"","domain_name":"tfnsepiccurransflacvv1-tf-co-confident-tu.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"bar"},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"0b6ea900-e5ac-4145-947b-785fe8f7143b","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-confident-tu","namespace_id":"97c8830e-6d1b-42c0-8ce3-7230e241dd40","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsepiccurransflacvv1/tf-co-confident-tu:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$aYkTZQirbRRHPceslkMOlQ$lm53jRjaxGV4wvQb8ab5FfS+UaZEoTiFZAaa21naUPY","key":"test_secret"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$xsL2VAueqzHwRHxiJv52uw$lNn6qqCg9nHl3iq/nwppRhUHKX45fmpmCq2irxfvAcg","key":"foo_secret"}],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:25.107484Z"}'
         headers:
             Content-Length:
-                - "914"
+                - "1268"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 17 Apr 2025 11:42:23 GMT
+                - Wed, 27 Aug 2025 15:06:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1328,10 +1326,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f4e197d9-3eab-4ee7-a857-8873ef440c78
+                - bc94077a-374a-43f7-8b6f-40c217171d06
         status: 200 OK
         code: 200
-        duration: 92.056375ms
+        duration: 104.709062ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1347,8 +1345,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/5553d036-eed1-49d6-a81e-85f41cf83bb4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/97c8830e-6d1b-42c0-8ce3-7230e241dd40
         method: GET
       response:
         proto: HTTP/2.0
@@ -1356,20 +1354,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 911
+        content_length: 579
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-04-17T11:42:10.039194Z","description":"","domain_name":"tfnsobjectivehaibtcrvvgesx-tf-co-peaceful-meninsky.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"5553d036-eed1-49d6-a81e-85f41cf83bb4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-peaceful-meninsky","namespace_id":"8a9798e3-ed28-49a0-8e23-149ed68fd3a0","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsobjectivehaibtcrvvgesx/tf-co-peaceful-meninsky:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","timeout":"300s","updated_at":"2025-04-17T11:42:23.761004Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.431614Z","description":"","environment_variables":{},"error_message":null,"id":"97c8830e-6d1b-42c0-8ce3-7230e241dd40","name":"tf-ns-epic-curran","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsepiccurransflacvv1","registry_namespace_id":"2bc65664-8e71-49f3-aaf8-10d6f5313c42","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:46.545571Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "911"
+                - "579"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 17 Apr 2025 11:42:23 GMT
+                - Wed, 27 Aug 2025 15:06:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1377,10 +1375,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1dcd4fc4-e898-45ee-aac9-de76a58cb39c
+                - 131e6f4c-672d-4044-a91e-f8b07d13fea4
         status: 200 OK
         code: 200
-        duration: 52.137833ms
+        duration: 90.936998ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1396,8 +1394,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/5553d036-eed1-49d6-a81e-85f41cf83bb4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/0b6ea900-e5ac-4145-947b-785fe8f7143b
         method: GET
       response:
         proto: HTTP/2.0
@@ -1405,20 +1403,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 911
+        content_length: 1268
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-04-17T11:42:10.039194Z","description":"","domain_name":"tfnsobjectivehaibtcrvvgesx-tf-co-peaceful-meninsky.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"5553d036-eed1-49d6-a81e-85f41cf83bb4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-peaceful-meninsky","namespace_id":"8a9798e3-ed28-49a0-8e23-149ed68fd3a0","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsobjectivehaibtcrvvgesx/tf-co-peaceful-meninsky:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","timeout":"300s","updated_at":"2025-04-17T11:42:23.761004Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:54.308425Z","description":"","domain_name":"tfnsepiccurransflacvv1-tf-co-confident-tu.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"bar"},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"0b6ea900-e5ac-4145-947b-785fe8f7143b","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-confident-tu","namespace_id":"97c8830e-6d1b-42c0-8ce3-7230e241dd40","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsepiccurransflacvv1/tf-co-confident-tu:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$aYkTZQirbRRHPceslkMOlQ$lm53jRjaxGV4wvQb8ab5FfS+UaZEoTiFZAaa21naUPY","key":"test_secret"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$xsL2VAueqzHwRHxiJv52uw$lNn6qqCg9nHl3iq/nwppRhUHKX45fmpmCq2irxfvAcg","key":"foo_secret"}],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:25.107484Z"}'
         headers:
             Content-Length:
-                - "911"
+                - "1268"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 17 Apr 2025 11:42:28 GMT
+                - Wed, 27 Aug 2025 15:06:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1426,10 +1424,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cbe17ade-3fd9-4332-9515-603ba359533c
+                - 4e55e881-9fd1-40c6-99a4-a089e71d92e0
         status: 200 OK
         code: 200
-        duration: 54.527833ms
+        duration: 102.860594ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1445,8 +1443,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/5553d036-eed1-49d6-a81e-85f41cf83bb4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/97c8830e-6d1b-42c0-8ce3-7230e241dd40
         method: GET
       response:
         proto: HTTP/2.0
@@ -1454,20 +1452,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 949
+        content_length: 579
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-04-17T11:42:10.039194Z","description":"","domain_name":"tfnsobjectivehaibtcrvvgesx-tf-co-peaceful-meninsky.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"5553d036-eed1-49d6-a81e-85f41cf83bb4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-peaceful-meninsky","namespace_id":"8a9798e3-ed28-49a0-8e23-149ed68fd3a0","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsobjectivehaibtcrvvgesx/tf-co-peaceful-meninsky:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-04-17T11:42:30.299895Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.431614Z","description":"","environment_variables":{},"error_message":null,"id":"97c8830e-6d1b-42c0-8ce3-7230e241dd40","name":"tf-ns-epic-curran","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsepiccurransflacvv1","registry_namespace_id":"2bc65664-8e71-49f3-aaf8-10d6f5313c42","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:46.545571Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "949"
+                - "579"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 17 Apr 2025 11:42:33 GMT
+                - Wed, 27 Aug 2025 15:06:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1475,10 +1473,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 65c83e1b-6586-44e0-ba3d-9b0bc6076bc6
+                - b80921cf-c209-42f3-b85e-9eeabd2ff9e8
         status: 200 OK
         code: 200
-        duration: 60.374292ms
+        duration: 82.684022ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1494,8 +1492,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/5553d036-eed1-49d6-a81e-85f41cf83bb4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/0b6ea900-e5ac-4145-947b-785fe8f7143b
         method: GET
       response:
         proto: HTTP/2.0
@@ -1503,20 +1501,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 949
+        content_length: 1268
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-04-17T11:42:10.039194Z","description":"","domain_name":"tfnsobjectivehaibtcrvvgesx-tf-co-peaceful-meninsky.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"5553d036-eed1-49d6-a81e-85f41cf83bb4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-peaceful-meninsky","namespace_id":"8a9798e3-ed28-49a0-8e23-149ed68fd3a0","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsobjectivehaibtcrvvgesx/tf-co-peaceful-meninsky:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-04-17T11:42:30.299895Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:54.308425Z","description":"","domain_name":"tfnsepiccurransflacvv1-tf-co-confident-tu.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"bar"},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"0b6ea900-e5ac-4145-947b-785fe8f7143b","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-confident-tu","namespace_id":"97c8830e-6d1b-42c0-8ce3-7230e241dd40","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsepiccurransflacvv1/tf-co-confident-tu:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$aYkTZQirbRRHPceslkMOlQ$lm53jRjaxGV4wvQb8ab5FfS+UaZEoTiFZAaa21naUPY","key":"test_secret"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$xsL2VAueqzHwRHxiJv52uw$lNn6qqCg9nHl3iq/nwppRhUHKX45fmpmCq2irxfvAcg","key":"foo_secret"}],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:25.107484Z"}'
         headers:
             Content-Length:
-                - "949"
+                - "1268"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 17 Apr 2025 11:42:34 GMT
+                - Wed, 27 Aug 2025 15:06:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1524,48 +1522,50 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - aef0a799-b771-4206-bdff-9d67d791f817
+                - fd4289a9-9319-4d76-8dc8-0e1b69738ab9
         status: 200 OK
         code: 200
-        duration: 58.226334ms
+        duration: 112.16771ms
     - id: 31
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 252
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"environment_variables":{},"privacy":"unknown_privacy","protocol":"unknown_protocol","secret_environment_variables":[{"key":"test_secret","value":null},{"key":"foo_secret","value":null}],"http_option":"unknown_http_option","sandbox":"unknown_sandbox"}'
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/5553d036-eed1-49d6-a81e-85f41cf83bb4
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/0b6ea900-e5ac-4145-947b-785fe8f7143b
+        method: PATCH
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 949
+        content_length: 950
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-04-17T11:42:10.039194Z","description":"","domain_name":"tfnsobjectivehaibtcrvvgesx-tf-co-peaceful-meninsky.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"5553d036-eed1-49d6-a81e-85f41cf83bb4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-peaceful-meninsky","namespace_id":"8a9798e3-ed28-49a0-8e23-149ed68fd3a0","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsobjectivehaibtcrvvgesx/tf-co-peaceful-meninsky:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-04-17T11:42:30.299895Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:54.308425Z","description":"","domain_name":"tfnsepiccurransflacvv1-tf-co-confident-tu.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"0b6ea900-e5ac-4145-947b-785fe8f7143b","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-confident-tu","namespace_id":"97c8830e-6d1b-42c0-8ce3-7230e241dd40","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsepiccurransflacvv1/tf-co-confident-tu:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:30.936110961Z"}'
         headers:
             Content-Length:
-                - "949"
+                - "950"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 17 Apr 2025 11:42:34 GMT
+                - Wed, 27 Aug 2025 15:06:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1573,10 +1573,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a4895cc8-6818-4c57-926d-0f85bd9e28d6
+                - c2047f2a-d2d0-4cad-9443-016b4f0395d1
         status: 200 OK
         code: 200
-        duration: 54.101458ms
+        duration: 116.016452ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1592,8 +1592,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/8a9798e3-ed28-49a0-8e23-149ed68fd3a0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/0b6ea900-e5ac-4145-947b-785fe8f7143b
         method: GET
       response:
         proto: HTTP/2.0
@@ -1601,20 +1601,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 554
+        content_length: 947
         uncompressed: false
-        body: '{"created_at":"2025-04-17T11:42:04.084994Z","description":"","environment_variables":{},"error_message":null,"id":"8a9798e3-ed28-49a0-8e23-149ed68fd3a0","name":"tf-ns-objective-haibt","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsobjectivehaibtcrvvgesx","registry_namespace_id":"efa49832-146a-4b51-a49a-7a8e0dbd49b2","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-17T11:42:05.435732Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:54.308425Z","description":"","domain_name":"tfnsepiccurransflacvv1-tf-co-confident-tu.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"0b6ea900-e5ac-4145-947b-785fe8f7143b","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-confident-tu","namespace_id":"97c8830e-6d1b-42c0-8ce3-7230e241dd40","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsepiccurransflacvv1/tf-co-confident-tu:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:30.936111Z"}'
         headers:
             Content-Length:
-                - "554"
+                - "947"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 17 Apr 2025 11:42:34 GMT
+                - Wed, 27 Aug 2025 15:06:31 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1622,10 +1622,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b1e2ebd5-f11a-4346-bbd1-9f5dc2d16c3f
+                - a72c47db-7505-4a68-b062-f1c0f1c088b7
         status: 200 OK
         code: 200
-        duration: 45.318167ms
+        duration: 113.316846ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1641,8 +1641,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/5553d036-eed1-49d6-a81e-85f41cf83bb4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/0b6ea900-e5ac-4145-947b-785fe8f7143b
         method: GET
       response:
         proto: HTTP/2.0
@@ -1650,20 +1650,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 949
+        content_length: 947
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-04-17T11:42:10.039194Z","description":"","domain_name":"tfnsobjectivehaibtcrvvgesx-tf-co-peaceful-meninsky.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"5553d036-eed1-49d6-a81e-85f41cf83bb4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-peaceful-meninsky","namespace_id":"8a9798e3-ed28-49a0-8e23-149ed68fd3a0","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsobjectivehaibtcrvvgesx/tf-co-peaceful-meninsky:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-04-17T11:42:30.299895Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:54.308425Z","description":"","domain_name":"tfnsepiccurransflacvv1-tf-co-confident-tu.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"0b6ea900-e5ac-4145-947b-785fe8f7143b","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-confident-tu","namespace_id":"97c8830e-6d1b-42c0-8ce3-7230e241dd40","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsepiccurransflacvv1/tf-co-confident-tu:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:30.936111Z"}'
         headers:
             Content-Length:
-                - "949"
+                - "947"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 17 Apr 2025 11:42:34 GMT
+                - Wed, 27 Aug 2025 15:06:36 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1671,10 +1671,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fe0d61d9-be65-4824-8ab7-28cc02b1ba4a
+                - 50eee5e5-2db5-472c-babb-d508ac8a0ad3
         status: 200 OK
         code: 200
-        duration: 56.149458ms
+        duration: 122.247868ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1690,8 +1690,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/5553d036-eed1-49d6-a81e-85f41cf83bb4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/0b6ea900-e5ac-4145-947b-785fe8f7143b
         method: GET
       response:
         proto: HTTP/2.0
@@ -1699,20 +1699,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 949
+        content_length: 947
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-04-17T11:42:10.039194Z","description":"","domain_name":"tfnsobjectivehaibtcrvvgesx-tf-co-peaceful-meninsky.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"5553d036-eed1-49d6-a81e-85f41cf83bb4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-peaceful-meninsky","namespace_id":"8a9798e3-ed28-49a0-8e23-149ed68fd3a0","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsobjectivehaibtcrvvgesx/tf-co-peaceful-meninsky:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-04-17T11:42:30.299895Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:54.308425Z","description":"","domain_name":"tfnsepiccurransflacvv1-tf-co-confident-tu.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"0b6ea900-e5ac-4145-947b-785fe8f7143b","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-confident-tu","namespace_id":"97c8830e-6d1b-42c0-8ce3-7230e241dd40","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsepiccurransflacvv1/tf-co-confident-tu:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:30.936111Z"}'
         headers:
             Content-Length:
-                - "949"
+                - "947"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 17 Apr 2025 11:42:34 GMT
+                - Wed, 27 Aug 2025 15:06:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1720,10 +1720,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 27daf533-625e-411e-b227-605ecb7e7275
+                - 0a2d96e4-9ab4-469f-b66e-6ea45b669fe3
         status: 200 OK
         code: 200
-        duration: 65.176917ms
+        duration: 90.995281ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1739,29 +1739,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/5553d036-eed1-49d6-a81e-85f41cf83bb4
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/0b6ea900-e5ac-4145-947b-785fe8f7143b
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 915
+        content_length: 947
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-04-17T11:42:10.039194Z","description":"","domain_name":"tfnsobjectivehaibtcrvvgesx-tf-co-peaceful-meninsky.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"5553d036-eed1-49d6-a81e-85f41cf83bb4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-peaceful-meninsky","namespace_id":"8a9798e3-ed28-49a0-8e23-149ed68fd3a0","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsobjectivehaibtcrvvgesx/tf-co-peaceful-meninsky:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"deleting","timeout":"300s","updated_at":"2025-04-17T11:42:34.790545923Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:54.308425Z","description":"","domain_name":"tfnsepiccurransflacvv1-tf-co-confident-tu.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"0b6ea900-e5ac-4145-947b-785fe8f7143b","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-confident-tu","namespace_id":"97c8830e-6d1b-42c0-8ce3-7230e241dd40","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsepiccurransflacvv1/tf-co-confident-tu:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:30.936111Z"}'
         headers:
             Content-Length:
-                - "915"
+                - "947"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 17 Apr 2025 11:42:34 GMT
+                - Wed, 27 Aug 2025 15:06:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1769,10 +1769,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 67d31d36-f27d-472b-9295-e7329321382d
+                - 08a8c555-6f2a-42e5-bd20-299228ea0ec8
         status: 200 OK
         code: 200
-        duration: 163.367917ms
+        duration: 90.656406ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1788,8 +1788,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/8a9798e3-ed28-49a0-8e23-149ed68fd3a0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/0b6ea900-e5ac-4145-947b-785fe8f7143b
         method: GET
       response:
         proto: HTTP/2.0
@@ -1797,20 +1797,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 554
+        content_length: 947
         uncompressed: false
-        body: '{"created_at":"2025-04-17T11:42:04.084994Z","description":"","environment_variables":{},"error_message":null,"id":"8a9798e3-ed28-49a0-8e23-149ed68fd3a0","name":"tf-ns-objective-haibt","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsobjectivehaibtcrvvgesx","registry_namespace_id":"efa49832-146a-4b51-a49a-7a8e0dbd49b2","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-17T11:42:05.435732Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:54.308425Z","description":"","domain_name":"tfnsepiccurransflacvv1-tf-co-confident-tu.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"0b6ea900-e5ac-4145-947b-785fe8f7143b","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-confident-tu","namespace_id":"97c8830e-6d1b-42c0-8ce3-7230e241dd40","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsepiccurransflacvv1/tf-co-confident-tu:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:30.936111Z"}'
         headers:
             Content-Length:
-                - "554"
+                - "947"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 17 Apr 2025 11:42:34 GMT
+                - Wed, 27 Aug 2025 15:06:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1818,10 +1818,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7ef07c5f-6b37-4764-b28d-f472e6640f9d
+                - 98c3b2eb-7df0-46d2-a915-a6cd6e15fefe
         status: 200 OK
         code: 200
-        duration: 39.053208ms
+        duration: 90.341627ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1837,29 +1837,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/8a9798e3-ed28-49a0-8e23-149ed68fd3a0
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/0b6ea900-e5ac-4145-947b-785fe8f7143b
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 560
+        content_length: 947
         uncompressed: false
-        body: '{"created_at":"2025-04-17T11:42:04.084994Z","description":"","environment_variables":{},"error_message":null,"id":"8a9798e3-ed28-49a0-8e23-149ed68fd3a0","name":"tf-ns-objective-haibt","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsobjectivehaibtcrvvgesx","registry_namespace_id":"efa49832-146a-4b51-a49a-7a8e0dbd49b2","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-04-17T11:42:34.981890950Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:54.308425Z","description":"","domain_name":"tfnsepiccurransflacvv1-tf-co-confident-tu.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"0b6ea900-e5ac-4145-947b-785fe8f7143b","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-confident-tu","namespace_id":"97c8830e-6d1b-42c0-8ce3-7230e241dd40","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsepiccurransflacvv1/tf-co-confident-tu:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:30.936111Z"}'
         headers:
             Content-Length:
-                - "560"
+                - "947"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 17 Apr 2025 11:42:35 GMT
+                - Wed, 27 Aug 2025 15:06:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1867,10 +1867,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b2d7455b-fb2e-42f4-bb16-754ef072fea5
+                - b8f9c32f-914d-485f-bb1b-c98a9e9cb447
         status: 200 OK
         code: 200
-        duration: 214.111792ms
+        duration: 98.544572ms
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1886,8 +1886,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/8a9798e3-ed28-49a0-8e23-149ed68fd3a0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/0b6ea900-e5ac-4145-947b-785fe8f7143b
         method: GET
       response:
         proto: HTTP/2.0
@@ -1895,20 +1895,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 557
+        content_length: 947
         uncompressed: false
-        body: '{"created_at":"2025-04-17T11:42:04.084994Z","description":"","environment_variables":{},"error_message":null,"id":"8a9798e3-ed28-49a0-8e23-149ed68fd3a0","name":"tf-ns-objective-haibt","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsobjectivehaibtcrvvgesx","registry_namespace_id":"efa49832-146a-4b51-a49a-7a8e0dbd49b2","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-04-17T11:42:34.981891Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:54.308425Z","description":"","domain_name":"tfnsepiccurransflacvv1-tf-co-confident-tu.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"0b6ea900-e5ac-4145-947b-785fe8f7143b","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-confident-tu","namespace_id":"97c8830e-6d1b-42c0-8ce3-7230e241dd40","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsepiccurransflacvv1/tf-co-confident-tu:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:30.936111Z"}'
         headers:
             Content-Length:
-                - "557"
+                - "947"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 17 Apr 2025 11:42:35 GMT
+                - Wed, 27 Aug 2025 15:07:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1916,10 +1916,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6523da6d-48d9-468a-b4ca-f7713365119d
+                - 9c27f33f-8c00-407d-bc9a-9f2a839cb5b2
         status: 200 OK
         code: 200
-        duration: 138.313958ms
+        duration: 109.064195ms
     - id: 39
       request:
         proto: HTTP/1.1
@@ -1935,8 +1935,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/8a9798e3-ed28-49a0-8e23-149ed68fd3a0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/0b6ea900-e5ac-4145-947b-785fe8f7143b
         method: GET
       response:
         proto: HTTP/2.0
@@ -1944,20 +1944,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 557
+        content_length: 947
         uncompressed: false
-        body: '{"created_at":"2025-04-17T11:42:04.084994Z","description":"","environment_variables":{},"error_message":null,"id":"8a9798e3-ed28-49a0-8e23-149ed68fd3a0","name":"tf-ns-objective-haibt","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsobjectivehaibtcrvvgesx","registry_namespace_id":"efa49832-146a-4b51-a49a-7a8e0dbd49b2","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-04-17T11:42:34.981891Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:54.308425Z","description":"","domain_name":"tfnsepiccurransflacvv1-tf-co-confident-tu.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"0b6ea900-e5ac-4145-947b-785fe8f7143b","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-confident-tu","namespace_id":"97c8830e-6d1b-42c0-8ce3-7230e241dd40","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsepiccurransflacvv1/tf-co-confident-tu:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:30.936111Z"}'
         headers:
             Content-Length:
-                - "557"
+                - "947"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 17 Apr 2025 11:42:40 GMT
+                - Wed, 27 Aug 2025 15:07:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1965,10 +1965,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 66c2f33c-3889-4b7f-9d81-c7a0a0272ed0
+                - 74fb7a48-8e2b-4666-ad11-5589b559cbd5
         status: 200 OK
         code: 200
-        duration: 46.620167ms
+        duration: 83.508858ms
     - id: 40
       request:
         proto: HTTP/1.1
@@ -1984,8 +1984,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/8a9798e3-ed28-49a0-8e23-149ed68fd3a0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/0b6ea900-e5ac-4145-947b-785fe8f7143b
         method: GET
       response:
         proto: HTTP/2.0
@@ -1993,20 +1993,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 557
+        content_length: 947
         uncompressed: false
-        body: '{"created_at":"2025-04-17T11:42:04.084994Z","description":"","environment_variables":{},"error_message":null,"id":"8a9798e3-ed28-49a0-8e23-149ed68fd3a0","name":"tf-ns-objective-haibt","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsobjectivehaibtcrvvgesx","registry_namespace_id":"efa49832-146a-4b51-a49a-7a8e0dbd49b2","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-04-17T11:42:34.981891Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:54.308425Z","description":"","domain_name":"tfnsepiccurransflacvv1-tf-co-confident-tu.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"0b6ea900-e5ac-4145-947b-785fe8f7143b","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-confident-tu","namespace_id":"97c8830e-6d1b-42c0-8ce3-7230e241dd40","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsepiccurransflacvv1/tf-co-confident-tu:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:30.936111Z"}'
         headers:
             Content-Length:
-                - "557"
+                - "947"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 17 Apr 2025 11:42:45 GMT
+                - Wed, 27 Aug 2025 15:07:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2014,10 +2014,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 98b1c333-36ef-4395-91b9-4d383e6670cf
+                - c63cf7ea-ef62-482b-bbdf-ac8eef786326
         status: 200 OK
         code: 200
-        duration: 41.17225ms
+        duration: 106.578374ms
     - id: 41
       request:
         proto: HTTP/1.1
@@ -2033,8 +2033,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/8a9798e3-ed28-49a0-8e23-149ed68fd3a0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/0b6ea900-e5ac-4145-947b-785fe8f7143b
         method: GET
       response:
         proto: HTTP/2.0
@@ -2042,20 +2042,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 557
+        content_length: 947
         uncompressed: false
-        body: '{"created_at":"2025-04-17T11:42:04.084994Z","description":"","environment_variables":{},"error_message":null,"id":"8a9798e3-ed28-49a0-8e23-149ed68fd3a0","name":"tf-ns-objective-haibt","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsobjectivehaibtcrvvgesx","registry_namespace_id":"efa49832-146a-4b51-a49a-7a8e0dbd49b2","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-04-17T11:42:34.981891Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:54.308425Z","description":"","domain_name":"tfnsepiccurransflacvv1-tf-co-confident-tu.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"0b6ea900-e5ac-4145-947b-785fe8f7143b","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-confident-tu","namespace_id":"97c8830e-6d1b-42c0-8ce3-7230e241dd40","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsepiccurransflacvv1/tf-co-confident-tu:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:30.936111Z"}'
         headers:
             Content-Length:
-                - "557"
+                - "947"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 17 Apr 2025 11:42:50 GMT
+                - Wed, 27 Aug 2025 15:07:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2063,10 +2063,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7b8a2b94-a060-415d-82e3-65c862a7a5b6
+                - bd0e28ef-3f0f-4e9d-bf98-27154ccfbf1d
         status: 200 OK
         code: 200
-        duration: 41.450541ms
+        duration: 128.752077ms
     - id: 42
       request:
         proto: HTTP/1.1
@@ -2082,8 +2082,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/8a9798e3-ed28-49a0-8e23-149ed68fd3a0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/0b6ea900-e5ac-4145-947b-785fe8f7143b
         method: GET
       response:
         proto: HTTP/2.0
@@ -2091,20 +2091,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 557
+        content_length: 985
         uncompressed: false
-        body: '{"created_at":"2025-04-17T11:42:04.084994Z","description":"","environment_variables":{},"error_message":null,"id":"8a9798e3-ed28-49a0-8e23-149ed68fd3a0","name":"tf-ns-objective-haibt","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsobjectivehaibtcrvvgesx","registry_namespace_id":"efa49832-146a-4b51-a49a-7a8e0dbd49b2","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-04-17T11:42:34.981891Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:54.308425Z","description":"","domain_name":"tfnsepiccurransflacvv1-tf-co-confident-tu.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"0b6ea900-e5ac-4145-947b-785fe8f7143b","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-confident-tu","namespace_id":"97c8830e-6d1b-42c0-8ce3-7230e241dd40","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsepiccurransflacvv1/tf-co-confident-tu:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:07:19.488868Z"}'
         headers:
             Content-Length:
-                - "557"
+                - "985"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 17 Apr 2025 11:42:55 GMT
+                - Wed, 27 Aug 2025 15:07:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2112,10 +2112,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9943d9b3-f198-4a25-b547-685a59cf8ea2
+                - 0ff890ca-7175-4cb9-8cad-4832a231f4f7
         status: 200 OK
         code: 200
-        duration: 45.996041ms
+        duration: 90.53123ms
     - id: 43
       request:
         proto: HTTP/1.1
@@ -2131,8 +2131,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/8a9798e3-ed28-49a0-8e23-149ed68fd3a0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/0b6ea900-e5ac-4145-947b-785fe8f7143b
         method: GET
       response:
         proto: HTTP/2.0
@@ -2140,20 +2140,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 557
+        content_length: 985
         uncompressed: false
-        body: '{"created_at":"2025-04-17T11:42:04.084994Z","description":"","environment_variables":{},"error_message":null,"id":"8a9798e3-ed28-49a0-8e23-149ed68fd3a0","name":"tf-ns-objective-haibt","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsobjectivehaibtcrvvgesx","registry_namespace_id":"efa49832-146a-4b51-a49a-7a8e0dbd49b2","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-04-17T11:42:34.981891Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:54.308425Z","description":"","domain_name":"tfnsepiccurransflacvv1-tf-co-confident-tu.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"0b6ea900-e5ac-4145-947b-785fe8f7143b","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-confident-tu","namespace_id":"97c8830e-6d1b-42c0-8ce3-7230e241dd40","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsepiccurransflacvv1/tf-co-confident-tu:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:07:19.488868Z"}'
         headers:
             Content-Length:
-                - "557"
+                - "985"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 17 Apr 2025 11:43:00 GMT
+                - Wed, 27 Aug 2025 15:07:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2161,10 +2161,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 393b06ba-73ac-42a1-bbbb-37d54ae14a9b
+                - cb293f69-ab7c-4a60-a054-811752c836af
         status: 200 OK
         code: 200
-        duration: 83.130417ms
+        duration: 105.978401ms
     - id: 44
       request:
         proto: HTTP/1.1
@@ -2180,8 +2180,400 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/8a9798e3-ed28-49a0-8e23-149ed68fd3a0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/0b6ea900-e5ac-4145-947b-785fe8f7143b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 985
+        uncompressed: false
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:54.308425Z","description":"","domain_name":"tfnsepiccurransflacvv1-tf-co-confident-tu.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"0b6ea900-e5ac-4145-947b-785fe8f7143b","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-confident-tu","namespace_id":"97c8830e-6d1b-42c0-8ce3-7230e241dd40","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsepiccurransflacvv1/tf-co-confident-tu:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:07:19.488868Z"}'
+        headers:
+            Content-Length:
+                - "985"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:07:22 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 62decc10-af16-4862-b75c-fb83062e9999
+        status: 200 OK
+        code: 200
+        duration: 91.883809ms
+    - id: 45
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/97c8830e-6d1b-42c0-8ce3-7230e241dd40
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 579
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:41.431614Z","description":"","environment_variables":{},"error_message":null,"id":"97c8830e-6d1b-42c0-8ce3-7230e241dd40","name":"tf-ns-epic-curran","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsepiccurransflacvv1","registry_namespace_id":"2bc65664-8e71-49f3-aaf8-10d6f5313c42","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:46.545571Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "579"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:07:22 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - d75a8d40-521a-422d-9e7d-8ea981ef98fa
+        status: 200 OK
+        code: 200
+        duration: 82.35714ms
+    - id: 46
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/0b6ea900-e5ac-4145-947b-785fe8f7143b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 985
+        uncompressed: false
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:54.308425Z","description":"","domain_name":"tfnsepiccurransflacvv1-tf-co-confident-tu.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"0b6ea900-e5ac-4145-947b-785fe8f7143b","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-confident-tu","namespace_id":"97c8830e-6d1b-42c0-8ce3-7230e241dd40","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsepiccurransflacvv1/tf-co-confident-tu:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:07:19.488868Z"}'
+        headers:
+            Content-Length:
+                - "985"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:07:22 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 38c997a3-3537-4555-952b-5398dce3f8af
+        status: 200 OK
+        code: 200
+        duration: 96.535419ms
+    - id: 47
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/0b6ea900-e5ac-4145-947b-785fe8f7143b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 985
+        uncompressed: false
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:54.308425Z","description":"","domain_name":"tfnsepiccurransflacvv1-tf-co-confident-tu.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"0b6ea900-e5ac-4145-947b-785fe8f7143b","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-confident-tu","namespace_id":"97c8830e-6d1b-42c0-8ce3-7230e241dd40","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsepiccurransflacvv1/tf-co-confident-tu:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:07:19.488868Z"}'
+        headers:
+            Content-Length:
+                - "985"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:07:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - d4fb6255-c1cc-4e70-a3f6-b68e8387cb33
+        status: 200 OK
+        code: 200
+        duration: 98.382555ms
+    - id: 48
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/0b6ea900-e5ac-4145-947b-785fe8f7143b
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 951
+        uncompressed: false
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:54.308425Z","description":"","domain_name":"tfnsepiccurransflacvv1-tf-co-confident-tu.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"0b6ea900-e5ac-4145-947b-785fe8f7143b","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-confident-tu","namespace_id":"97c8830e-6d1b-42c0-8ce3-7230e241dd40","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsepiccurransflacvv1/tf-co-confident-tu:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:07:23.425085745Z"}'
+        headers:
+            Content-Length:
+                - "951"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:07:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 167a2156-4872-4d7a-a1dc-54461b513fa5
+        status: 200 OK
+        code: 200
+        duration: 205.293436ms
+    - id: 49
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/97c8830e-6d1b-42c0-8ce3-7230e241dd40
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 579
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:41.431614Z","description":"","environment_variables":{},"error_message":null,"id":"97c8830e-6d1b-42c0-8ce3-7230e241dd40","name":"tf-ns-epic-curran","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsepiccurransflacvv1","registry_namespace_id":"2bc65664-8e71-49f3-aaf8-10d6f5313c42","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:46.545571Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "579"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:07:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 989c482b-f75a-4bb0-8994-e8c672ee70ff
+        status: 200 OK
+        code: 200
+        duration: 70.734568ms
+    - id: 50
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/97c8830e-6d1b-42c0-8ce3-7230e241dd40
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 585
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:41.431614Z","description":"","environment_variables":{},"error_message":null,"id":"97c8830e-6d1b-42c0-8ce3-7230e241dd40","name":"tf-ns-epic-curran","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsepiccurransflacvv1","registry_namespace_id":"2bc65664-8e71-49f3-aaf8-10d6f5313c42","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:07:23.732417408Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "585"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:07:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - a6a94062-d960-4add-965b-602f825423cd
+        status: 200 OK
+        code: 200
+        duration: 211.733111ms
+    - id: 51
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/97c8830e-6d1b-42c0-8ce3-7230e241dd40
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 582
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:41.431614Z","description":"","environment_variables":{},"error_message":null,"id":"97c8830e-6d1b-42c0-8ce3-7230e241dd40","name":"tf-ns-epic-curran","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsepiccurransflacvv1","registry_namespace_id":"2bc65664-8e71-49f3-aaf8-10d6f5313c42","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:07:23.732417Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "582"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:07:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 5565c7c3-96ba-4970-a22e-231b04ec2bda
+        status: 200 OK
+        code: 200
+        duration: 76.633128ms
+    - id: 52
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/97c8830e-6d1b-42c0-8ce3-7230e241dd40
         method: GET
       response:
         proto: HTTP/2.0
@@ -2200,9 +2592,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 17 Apr 2025 11:43:05 GMT
+                - Wed, 27 Aug 2025 15:07:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2210,11 +2602,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 47e7bd54-4086-4a9a-841b-09a69599f169
+                - 2418b8a6-9057-47da-b35e-96e45c75ad8a
         status: 404 Not Found
         code: 404
-        duration: 28.011459ms
-    - id: 45
+        duration: 30.218754ms
+    - id: 53
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2229,8 +2621,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/8a9798e3-ed28-49a0-8e23-149ed68fd3a0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/97c8830e-6d1b-42c0-8ce3-7230e241dd40
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -2249,9 +2641,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 17 Apr 2025 11:43:05 GMT
+                - Wed, 27 Aug 2025 15:07:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2259,7 +2651,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4cfd0a4d-6e5c-4c07-9465-90995bb27fcc
+                - 52d87c13-1c97-419b-9e1b-56033b30e414
         status: 404 Not Found
         code: 404
-        duration: 26.641ms
+        duration: 21.330601ms

--- a/internal/services/container/testdata/container-health-check.cassette.yaml
+++ b/internal/services/container/testdata/container-health-check.cassette.yaml
@@ -6,19 +6,19 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 158
+        content_length: 190
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-ns-inspiring-mclean","environment_variables":{},"project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","secret_environment_variables":[],"tags":null}'
+        body: '{"name":"tf-ns-heuristic-sammet","environment_variables":{},"project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","secret_environment_variables":[],"tags":null,"activate_vpc_integration":true}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces
         method: POST
       response:
@@ -27,20 +27,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 488
+        content_length: 507
         uncompressed: false
-        body: '{"created_at":"2025-01-16T10:10:38.995185196Z","description":"","environment_variables":{},"error_message":null,"id":"d25385c3-2c74-4f72-ae77-4aadd7a28183","name":"tf-ns-inspiring-mclean","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-16T10:10:38.995185196Z"}'
+        body: '{"created_at":"2025-08-27T15:06:16.964906782Z","description":"","environment_variables":{},"error_message":null,"id":"0b830e97-cdcb-43db-a86f-4cb8727c5611","name":"tf-ns-heuristic-sammet","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:06:16.964906782Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "488"
+                - "507"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 16 Jan 2025 10:10:39 GMT
+                - Wed, 27 Aug 2025 15:06:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f42e7d3e-453f-4191-a31b-8aa638fb1f3f
+                - 3f7c51cf-3c9e-4738-9c69-1fe358d11212
         status: 200 OK
         code: 200
-        duration: 304.876958ms
+        duration: 1.540401407s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -67,8 +67,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d25385c3-2c74-4f72-ae77-4aadd7a28183
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/0b830e97-cdcb-43db-a86f-4cb8727c5611
         method: GET
       response:
         proto: HTTP/2.0
@@ -76,20 +76,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 482
+        content_length: 501
         uncompressed: false
-        body: '{"created_at":"2025-01-16T10:10:38.995185Z","description":"","environment_variables":{},"error_message":null,"id":"d25385c3-2c74-4f72-ae77-4aadd7a28183","name":"tf-ns-inspiring-mclean","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-16T10:10:38.995185Z"}'
+        body: '{"created_at":"2025-08-27T15:06:16.964907Z","description":"","environment_variables":{},"error_message":null,"id":"0b830e97-cdcb-43db-a86f-4cb8727c5611","name":"tf-ns-heuristic-sammet","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:06:16.964907Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "482"
+                - "501"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 16 Jan 2025 10:10:39 GMT
+                - Wed, 27 Aug 2025 15:06:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ec1207bd-caf5-4f0b-80b6-503b09e99463
+                - 8b07ccb0-b37f-4e2c-8fd1-d5f168dc9a8d
         status: 200 OK
         code: 200
-        duration: 47.923709ms
+        duration: 87.934831ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -116,8 +116,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d25385c3-2c74-4f72-ae77-4aadd7a28183
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/0b830e97-cdcb-43db-a86f-4cb8727c5611
         method: GET
       response:
         proto: HTTP/2.0
@@ -125,20 +125,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 570
+        content_length: 501
         uncompressed: false
-        body: '{"created_at":"2025-01-16T10:10:38.995185Z","description":"","environment_variables":{},"error_message":null,"id":"d25385c3-2c74-4f72-ae77-4aadd7a28183","name":"tf-ns-inspiring-mclean","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsinspiringmclean2azlpkfl","registry_namespace_id":"4249c607-4ab4-460e-b3ee-f56bb0be043f","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-16T10:10:41.728349Z"}'
+        body: '{"created_at":"2025-08-27T15:06:16.964907Z","description":"","environment_variables":{},"error_message":null,"id":"0b830e97-cdcb-43db-a86f-4cb8727c5611","name":"tf-ns-heuristic-sammet","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:06:17.634290Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "570"
+                - "501"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 16 Jan 2025 10:10:44 GMT
+                - Wed, 27 Aug 2025 15:06:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -146,10 +146,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1affe9b3-6e6c-4166-949e-fbdd1ef1ed51
+                - 48a0325d-d323-466b-bc30-3d22ef690aa4
         status: 200 OK
         code: 200
-        duration: 50.605083ms
+        duration: 97.639703ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -165,8 +165,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d25385c3-2c74-4f72-ae77-4aadd7a28183
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/0b830e97-cdcb-43db-a86f-4cb8727c5611
         method: GET
       response:
         proto: HTTP/2.0
@@ -174,20 +174,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 570
+        content_length: 589
         uncompressed: false
-        body: '{"created_at":"2025-01-16T10:10:38.995185Z","description":"","environment_variables":{},"error_message":null,"id":"d25385c3-2c74-4f72-ae77-4aadd7a28183","name":"tf-ns-inspiring-mclean","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsinspiringmclean2azlpkfl","registry_namespace_id":"4249c607-4ab4-460e-b3ee-f56bb0be043f","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-16T10:10:41.728349Z"}'
+        body: '{"created_at":"2025-08-27T15:06:16.964907Z","description":"","environment_variables":{},"error_message":null,"id":"0b830e97-cdcb-43db-a86f-4cb8727c5611","name":"tf-ns-heuristic-sammet","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsheuristicsammetwk0agki7","registry_namespace_id":"88d0e960-ff06-4ea3-b377-8616f04eb28d","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:27.032007Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "570"
+                - "589"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 16 Jan 2025 10:10:44 GMT
+                - Wed, 27 Aug 2025 15:06:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -195,10 +195,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 606d4e39-ccc2-40fa-b6d6-ec9ab20dbb22
+                - f53781d4-8135-45c4-961b-bf09cb06e587
         status: 200 OK
         code: 200
-        duration: 55.564333ms
+        duration: 86.734272ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -214,8 +214,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d25385c3-2c74-4f72-ae77-4aadd7a28183
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/0b830e97-cdcb-43db-a86f-4cb8727c5611
         method: GET
       response:
         proto: HTTP/2.0
@@ -223,20 +223,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 570
+        content_length: 589
         uncompressed: false
-        body: '{"created_at":"2025-01-16T10:10:38.995185Z","description":"","environment_variables":{},"error_message":null,"id":"d25385c3-2c74-4f72-ae77-4aadd7a28183","name":"tf-ns-inspiring-mclean","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsinspiringmclean2azlpkfl","registry_namespace_id":"4249c607-4ab4-460e-b3ee-f56bb0be043f","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-16T10:10:41.728349Z"}'
+        body: '{"created_at":"2025-08-27T15:06:16.964907Z","description":"","environment_variables":{},"error_message":null,"id":"0b830e97-cdcb-43db-a86f-4cb8727c5611","name":"tf-ns-heuristic-sammet","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsheuristicsammetwk0agki7","registry_namespace_id":"88d0e960-ff06-4ea3-b377-8616f04eb28d","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:27.032007Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "570"
+                - "589"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 16 Jan 2025 10:10:44 GMT
+                - Wed, 27 Aug 2025 15:06:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -244,62 +244,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f0e5cc60-8c55-410b-a9bc-8b3acd9c38d6
+                - 91829ab6-cf28-40e8-8b71-ec058549de39
         status: 200 OK
         code: 200
-        duration: 51.52925ms
+        duration: 71.832146ms
     - id: 5
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 214
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"namespace_id":"d25385c3-2c74-4f72-ae77-4aadd7a28183","name":"tf-co-inspiring-goodall","privacy":"public","protocol":"http1","secret_environment_variables":null,"http_option":"enabled","sandbox":"unknown_sandbox"}'
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 948
-        uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-16T10:10:44.459725160Z","description":"","domain_name":"tfnsinspiringmclean2azlpkfl-tf-co-inspiring-goodall.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"4e144a2b-ac2c-4c54-a008-43e95b784b21","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-inspiring-goodall","namespace_id":"d25385c3-2c74-4f72-ae77-4aadd7a28183","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsinspiringmclean2azlpkfl/tf-co-inspiring-goodall:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-16T10:10:44.459725160Z"}'
-        headers:
-            Content-Length:
-                - "948"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Thu, 16 Jan 2025 10:10:44 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 9688cb3d-60de-4bec-b3d8-88f16beb121d
-        status: 200 OK
-        code: 200
-        duration: 275.160916ms
-    - id: 6
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -314,8 +263,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/4e144a2b-ac2c-4c54-a008-43e95b784b21
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/0b830e97-cdcb-43db-a86f-4cb8727c5611
         method: GET
       response:
         proto: HTTP/2.0
@@ -323,20 +272,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 942
+        content_length: 589
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-16T10:10:44.459725Z","description":"","domain_name":"tfnsinspiringmclean2azlpkfl-tf-co-inspiring-goodall.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"4e144a2b-ac2c-4c54-a008-43e95b784b21","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-inspiring-goodall","namespace_id":"d25385c3-2c74-4f72-ae77-4aadd7a28183","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsinspiringmclean2azlpkfl/tf-co-inspiring-goodall:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-16T10:10:44.459725Z"}'
+        body: '{"created_at":"2025-08-27T15:06:16.964907Z","description":"","environment_variables":{},"error_message":null,"id":"0b830e97-cdcb-43db-a86f-4cb8727c5611","name":"tf-ns-heuristic-sammet","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsheuristicsammetwk0agki7","registry_namespace_id":"88d0e960-ff06-4ea3-b377-8616f04eb28d","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:27.032007Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "942"
+                - "589"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 16 Jan 2025 10:10:44 GMT
+                - Wed, 27 Aug 2025 15:06:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -344,10 +293,61 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2b07e95b-c09d-415c-b19f-77f58dfa5c9d
+                - 7d94f7c7-8478-4517-a525-f0abcbfbfd13
         status: 200 OK
         code: 200
-        duration: 56.6975ms
+        duration: 94.850081ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 250
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"namespace_id":"0b830e97-cdcb-43db-a86f-4cb8727c5611","name":"tf-co-eloquent-moore","privacy":"public","protocol":"http1","secret_environment_variables":null,"http_option":"enabled","sandbox":"unknown_sandbox","tags":null,"command":null,"args":null}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 969
+        uncompressed: false
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:28.506116283Z","description":"","domain_name":"tfnsheuristicsammetwk0agki7-tf-co-eloquent-moore.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"b1cef340-3301-441f-ab2e-7397cf47e5e6","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-eloquent-moore","namespace_id":"0b830e97-cdcb-43db-a86f-4cb8727c5611","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsheuristicsammetwk0agki7/tf-co-eloquent-moore:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:28.506116283Z"}'
+        headers:
+            Content-Length:
+                - "969"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:28 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 2fde747e-345b-4e9e-9ed4-074f8409f7bc
+        status: 200 OK
+        code: 200
+        duration: 1.00304669s
     - id: 7
       request:
         proto: HTTP/1.1
@@ -363,8 +363,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/4e144a2b-ac2c-4c54-a008-43e95b784b21
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/b1cef340-3301-441f-ab2e-7397cf47e5e6
         method: GET
       response:
         proto: HTTP/2.0
@@ -372,20 +372,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 942
+        content_length: 963
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-16T10:10:44.459725Z","description":"","domain_name":"tfnsinspiringmclean2azlpkfl-tf-co-inspiring-goodall.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"4e144a2b-ac2c-4c54-a008-43e95b784b21","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-inspiring-goodall","namespace_id":"d25385c3-2c74-4f72-ae77-4aadd7a28183","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsinspiringmclean2azlpkfl/tf-co-inspiring-goodall:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-16T10:10:44.459725Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:28.506116Z","description":"","domain_name":"tfnsheuristicsammetwk0agki7-tf-co-eloquent-moore.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"b1cef340-3301-441f-ab2e-7397cf47e5e6","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-eloquent-moore","namespace_id":"0b830e97-cdcb-43db-a86f-4cb8727c5611","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsheuristicsammetwk0agki7/tf-co-eloquent-moore:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:28.506116Z"}'
         headers:
             Content-Length:
-                - "942"
+                - "963"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 16 Jan 2025 10:10:44 GMT
+                - Wed, 27 Aug 2025 15:06:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -393,10 +393,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1eb1c347-e136-49da-b4be-662910429bae
+                - f91ef619-1164-4e34-899d-d8db0ffbb227
         status: 200 OK
         code: 200
-        duration: 47.00725ms
+        duration: 164.857654ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -412,8 +412,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d25385c3-2c74-4f72-ae77-4aadd7a28183
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/b1cef340-3301-441f-ab2e-7397cf47e5e6
         method: GET
       response:
         proto: HTTP/2.0
@@ -421,20 +421,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 570
+        content_length: 963
         uncompressed: false
-        body: '{"created_at":"2025-01-16T10:10:38.995185Z","description":"","environment_variables":{},"error_message":null,"id":"d25385c3-2c74-4f72-ae77-4aadd7a28183","name":"tf-ns-inspiring-mclean","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsinspiringmclean2azlpkfl","registry_namespace_id":"4249c607-4ab4-460e-b3ee-f56bb0be043f","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-16T10:10:41.728349Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:28.506116Z","description":"","domain_name":"tfnsheuristicsammetwk0agki7-tf-co-eloquent-moore.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"b1cef340-3301-441f-ab2e-7397cf47e5e6","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-eloquent-moore","namespace_id":"0b830e97-cdcb-43db-a86f-4cb8727c5611","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsheuristicsammetwk0agki7/tf-co-eloquent-moore:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:28.506116Z"}'
         headers:
             Content-Length:
-                - "570"
+                - "963"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 16 Jan 2025 10:10:44 GMT
+                - Wed, 27 Aug 2025 15:06:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -442,10 +442,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 95f673d2-9901-4a4b-9653-8f10f5e71cf4
+                - e1f04778-700b-44a6-ab5b-63eaa5c97951
         status: 200 OK
         code: 200
-        duration: 43.174584ms
+        duration: 93.081212ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -461,8 +461,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/4e144a2b-ac2c-4c54-a008-43e95b784b21
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/0b830e97-cdcb-43db-a86f-4cb8727c5611
         method: GET
       response:
         proto: HTTP/2.0
@@ -470,20 +470,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 942
+        content_length: 589
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-16T10:10:44.459725Z","description":"","domain_name":"tfnsinspiringmclean2azlpkfl-tf-co-inspiring-goodall.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"4e144a2b-ac2c-4c54-a008-43e95b784b21","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-inspiring-goodall","namespace_id":"d25385c3-2c74-4f72-ae77-4aadd7a28183","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsinspiringmclean2azlpkfl/tf-co-inspiring-goodall:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-16T10:10:44.459725Z"}'
+        body: '{"created_at":"2025-08-27T15:06:16.964907Z","description":"","environment_variables":{},"error_message":null,"id":"0b830e97-cdcb-43db-a86f-4cb8727c5611","name":"tf-ns-heuristic-sammet","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsheuristicsammetwk0agki7","registry_namespace_id":"88d0e960-ff06-4ea3-b377-8616f04eb28d","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:27.032007Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "942"
+                - "589"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 16 Jan 2025 10:10:44 GMT
+                - Wed, 27 Aug 2025 15:06:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -491,10 +491,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 96eea230-9e44-4496-85b1-79d52b1c23df
+                - 52915866-a40c-4db2-be42-e95045492eb4
         status: 200 OK
         code: 200
-        duration: 56.006584ms
+        duration: 85.021026ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -510,8 +510,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d25385c3-2c74-4f72-ae77-4aadd7a28183
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/b1cef340-3301-441f-ab2e-7397cf47e5e6
         method: GET
       response:
         proto: HTTP/2.0
@@ -519,20 +519,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 570
+        content_length: 963
         uncompressed: false
-        body: '{"created_at":"2025-01-16T10:10:38.995185Z","description":"","environment_variables":{},"error_message":null,"id":"d25385c3-2c74-4f72-ae77-4aadd7a28183","name":"tf-ns-inspiring-mclean","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsinspiringmclean2azlpkfl","registry_namespace_id":"4249c607-4ab4-460e-b3ee-f56bb0be043f","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-16T10:10:41.728349Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:28.506116Z","description":"","domain_name":"tfnsheuristicsammetwk0agki7-tf-co-eloquent-moore.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"b1cef340-3301-441f-ab2e-7397cf47e5e6","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-eloquent-moore","namespace_id":"0b830e97-cdcb-43db-a86f-4cb8727c5611","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsheuristicsammetwk0agki7/tf-co-eloquent-moore:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:28.506116Z"}'
         headers:
             Content-Length:
-                - "570"
+                - "963"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 16 Jan 2025 10:10:45 GMT
+                - Wed, 27 Aug 2025 15:06:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -540,10 +540,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4d25a90c-814a-4ad7-91e3-5931fd8a95d3
+                - 1e69332b-adb6-4ff7-87e4-e00284b614b1
         status: 200 OK
         code: 200
-        duration: 41.402209ms
+        duration: 97.773488ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -559,8 +559,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/4e144a2b-ac2c-4c54-a008-43e95b784b21
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/0b830e97-cdcb-43db-a86f-4cb8727c5611
         method: GET
       response:
         proto: HTTP/2.0
@@ -568,20 +568,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 942
+        content_length: 589
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-16T10:10:44.459725Z","description":"","domain_name":"tfnsinspiringmclean2azlpkfl-tf-co-inspiring-goodall.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"4e144a2b-ac2c-4c54-a008-43e95b784b21","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-inspiring-goodall","namespace_id":"d25385c3-2c74-4f72-ae77-4aadd7a28183","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsinspiringmclean2azlpkfl/tf-co-inspiring-goodall:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-16T10:10:44.459725Z"}'
+        body: '{"created_at":"2025-08-27T15:06:16.964907Z","description":"","environment_variables":{},"error_message":null,"id":"0b830e97-cdcb-43db-a86f-4cb8727c5611","name":"tf-ns-heuristic-sammet","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsheuristicsammetwk0agki7","registry_namespace_id":"88d0e960-ff06-4ea3-b377-8616f04eb28d","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:27.032007Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "942"
+                - "589"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 16 Jan 2025 10:10:45 GMT
+                - Wed, 27 Aug 2025 15:06:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -589,10 +589,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 20ccc43f-6d0d-4675-a529-44d4419f587a
+                - 87a8e383-f929-4624-aeac-16b3e27da16c
         status: 200 OK
         code: 200
-        duration: 61.719791ms
+        duration: 90.665258ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -608,8 +608,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d25385c3-2c74-4f72-ae77-4aadd7a28183
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/b1cef340-3301-441f-ab2e-7397cf47e5e6
         method: GET
       response:
         proto: HTTP/2.0
@@ -617,20 +617,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 570
+        content_length: 963
         uncompressed: false
-        body: '{"created_at":"2025-01-16T10:10:38.995185Z","description":"","environment_variables":{},"error_message":null,"id":"d25385c3-2c74-4f72-ae77-4aadd7a28183","name":"tf-ns-inspiring-mclean","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsinspiringmclean2azlpkfl","registry_namespace_id":"4249c607-4ab4-460e-b3ee-f56bb0be043f","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-16T10:10:41.728349Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:28.506116Z","description":"","domain_name":"tfnsheuristicsammetwk0agki7-tf-co-eloquent-moore.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"b1cef340-3301-441f-ab2e-7397cf47e5e6","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-eloquent-moore","namespace_id":"0b830e97-cdcb-43db-a86f-4cb8727c5611","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsheuristicsammetwk0agki7/tf-co-eloquent-moore:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:28.506116Z"}'
         headers:
             Content-Length:
-                - "570"
+                - "963"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 16 Jan 2025 10:10:45 GMT
+                - Wed, 27 Aug 2025 15:06:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -638,10 +638,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 61baf271-9b6d-4bc9-916a-18ea0ea43d0a
+                - 6d5cead9-75ad-43af-a187-bc67e8766218
         status: 200 OK
         code: 200
-        duration: 38.594417ms
+        duration: 87.28255ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -657,8 +657,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/4e144a2b-ac2c-4c54-a008-43e95b784b21
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/0b830e97-cdcb-43db-a86f-4cb8727c5611
         method: GET
       response:
         proto: HTTP/2.0
@@ -666,20 +666,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 942
+        content_length: 589
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-16T10:10:44.459725Z","description":"","domain_name":"tfnsinspiringmclean2azlpkfl-tf-co-inspiring-goodall.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"4e144a2b-ac2c-4c54-a008-43e95b784b21","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-inspiring-goodall","namespace_id":"d25385c3-2c74-4f72-ae77-4aadd7a28183","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsinspiringmclean2azlpkfl/tf-co-inspiring-goodall:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-16T10:10:44.459725Z"}'
+        body: '{"created_at":"2025-08-27T15:06:16.964907Z","description":"","environment_variables":{},"error_message":null,"id":"0b830e97-cdcb-43db-a86f-4cb8727c5611","name":"tf-ns-heuristic-sammet","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsheuristicsammetwk0agki7","registry_namespace_id":"88d0e960-ff06-4ea3-b377-8616f04eb28d","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:27.032007Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "942"
+                - "589"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 16 Jan 2025 10:10:45 GMT
+                - Wed, 27 Aug 2025 15:06:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -687,11 +687,60 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fab3e590-99e5-4114-a38e-4a4422f08817
+                - 6b1244fe-813a-42a9-a073-5c8a526cd3a8
         status: 200 OK
         code: 200
-        duration: 61.838166ms
+        duration: 75.006695ms
     - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/b1cef340-3301-441f-ab2e-7397cf47e5e6
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 963
+        uncompressed: false
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:28.506116Z","description":"","domain_name":"tfnsheuristicsammetwk0agki7-tf-co-eloquent-moore.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"b1cef340-3301-441f-ab2e-7397cf47e5e6","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-eloquent-moore","namespace_id":"0b830e97-cdcb-43db-a86f-4cb8727c5611","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsheuristicsammetwk0agki7/tf-co-eloquent-moore:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:28.506116Z"}'
+        headers:
+            Content-Length:
+                - "963"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:30 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 149a1974-5cfe-4b25-98a3-d9f8c9ae87fc
+        status: 200 OK
+        code: 200
+        duration: 97.798505ms
+    - id: 15
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -708,8 +757,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/4e144a2b-ac2c-4c54-a008-43e95b784b21
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/b1cef340-3301-441f-ab2e-7397cf47e5e6
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -717,20 +766,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 960
+        content_length: 981
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-16T10:10:44.459725Z","description":"","domain_name":"tfnsinspiringmclean2azlpkfl-tf-co-inspiring-goodall.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":40,"http":{"path":"/test"},"interval":"12s"},"http_option":"enabled","id":"4e144a2b-ac2c-4c54-a008-43e95b784b21","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-inspiring-goodall","namespace_id":"d25385c3-2c74-4f72-ae77-4aadd7a28183","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsinspiringmclean2azlpkfl/tf-co-inspiring-goodall:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","timeout":"300s","updated_at":"2025-01-16T10:10:45.483608760Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:28.506116Z","description":"","domain_name":"tfnsheuristicsammetwk0agki7-tf-co-eloquent-moore.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":40,"http":{"path":"/test"},"interval":"12s"},"http_option":"enabled","id":"b1cef340-3301-441f-ab2e-7397cf47e5e6","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-eloquent-moore","namespace_id":"0b830e97-cdcb-43db-a86f-4cb8727c5611","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsheuristicsammetwk0agki7/tf-co-eloquent-moore:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:30.454507476Z"}'
         headers:
             Content-Length:
-                - "960"
+                - "981"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 16 Jan 2025 10:10:45 GMT
+                - Wed, 27 Aug 2025 15:06:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -738,59 +787,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9820b9d7-2d31-4991-bebe-7228e336ebb5
+                - 2e925fd2-0fd1-4e81-9c14-6f5c26612fa1
         status: 200 OK
         code: 200
-        duration: 111.926666ms
-    - id: 15
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/4e144a2b-ac2c-4c54-a008-43e95b784b21
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 957
-        uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-16T10:10:44.459725Z","description":"","domain_name":"tfnsinspiringmclean2azlpkfl-tf-co-inspiring-goodall.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":40,"http":{"path":"/test"},"interval":"12s"},"http_option":"enabled","id":"4e144a2b-ac2c-4c54-a008-43e95b784b21","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-inspiring-goodall","namespace_id":"d25385c3-2c74-4f72-ae77-4aadd7a28183","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsinspiringmclean2azlpkfl/tf-co-inspiring-goodall:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","timeout":"300s","updated_at":"2025-01-16T10:10:45.483609Z"}'
-        headers:
-            Content-Length:
-                - "957"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Thu, 16 Jan 2025 10:10:45 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - f133edd0-d9fc-431c-b0f9-e4417321a3f6
-        status: 200 OK
-        code: 200
-        duration: 51.708542ms
+        duration: 96.829887ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -806,8 +806,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/4e144a2b-ac2c-4c54-a008-43e95b784b21
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/b1cef340-3301-441f-ab2e-7397cf47e5e6
         method: GET
       response:
         proto: HTTP/2.0
@@ -815,20 +815,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 957
+        content_length: 978
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-16T10:10:44.459725Z","description":"","domain_name":"tfnsinspiringmclean2azlpkfl-tf-co-inspiring-goodall.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":40,"http":{"path":"/test"},"interval":"12s"},"http_option":"enabled","id":"4e144a2b-ac2c-4c54-a008-43e95b784b21","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-inspiring-goodall","namespace_id":"d25385c3-2c74-4f72-ae77-4aadd7a28183","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsinspiringmclean2azlpkfl/tf-co-inspiring-goodall:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","timeout":"300s","updated_at":"2025-01-16T10:10:45.483609Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:28.506116Z","description":"","domain_name":"tfnsheuristicsammetwk0agki7-tf-co-eloquent-moore.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":40,"http":{"path":"/test"},"interval":"12s"},"http_option":"enabled","id":"b1cef340-3301-441f-ab2e-7397cf47e5e6","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-eloquent-moore","namespace_id":"0b830e97-cdcb-43db-a86f-4cb8727c5611","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsheuristicsammetwk0agki7/tf-co-eloquent-moore:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:30.454507Z"}'
         headers:
             Content-Length:
-                - "957"
+                - "978"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 16 Jan 2025 10:10:50 GMT
+                - Wed, 27 Aug 2025 15:06:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -836,10 +836,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - be9690d2-80b4-482e-8bae-c48943c7ff72
+                - 000c065d-e4e8-4744-9efb-8312f34e447b
         status: 200 OK
         code: 200
-        duration: 65.506125ms
+        duration: 91.797373ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -855,8 +855,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/4e144a2b-ac2c-4c54-a008-43e95b784b21
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/b1cef340-3301-441f-ab2e-7397cf47e5e6
         method: GET
       response:
         proto: HTTP/2.0
@@ -864,20 +864,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 995
+        content_length: 978
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-16T10:10:44.459725Z","description":"","domain_name":"tfnsinspiringmclean2azlpkfl-tf-co-inspiring-goodall.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":40,"http":{"path":"/test"},"interval":"12s"},"http_option":"enabled","id":"4e144a2b-ac2c-4c54-a008-43e95b784b21","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-inspiring-goodall","namespace_id":"d25385c3-2c74-4f72-ae77-4aadd7a28183","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsinspiringmclean2azlpkfl/tf-co-inspiring-goodall:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-16T10:10:51.957258Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:28.506116Z","description":"","domain_name":"tfnsheuristicsammetwk0agki7-tf-co-eloquent-moore.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":40,"http":{"path":"/test"},"interval":"12s"},"http_option":"enabled","id":"b1cef340-3301-441f-ab2e-7397cf47e5e6","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-eloquent-moore","namespace_id":"0b830e97-cdcb-43db-a86f-4cb8727c5611","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsheuristicsammetwk0agki7/tf-co-eloquent-moore:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:30.454507Z"}'
         headers:
             Content-Length:
-                - "995"
+                - "978"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 16 Jan 2025 10:10:55 GMT
+                - Wed, 27 Aug 2025 15:06:35 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -885,10 +885,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 932a530b-aaab-4fca-8108-1124397dea20
+                - 5cb2d422-d99c-4c4c-ac99-e0e9257ea72b
         status: 200 OK
         code: 200
-        duration: 53.724791ms
+        duration: 97.514494ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -904,8 +904,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/4e144a2b-ac2c-4c54-a008-43e95b784b21
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/b1cef340-3301-441f-ab2e-7397cf47e5e6
         method: GET
       response:
         proto: HTTP/2.0
@@ -913,20 +913,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 995
+        content_length: 978
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-16T10:10:44.459725Z","description":"","domain_name":"tfnsinspiringmclean2azlpkfl-tf-co-inspiring-goodall.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":40,"http":{"path":"/test"},"interval":"12s"},"http_option":"enabled","id":"4e144a2b-ac2c-4c54-a008-43e95b784b21","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-inspiring-goodall","namespace_id":"d25385c3-2c74-4f72-ae77-4aadd7a28183","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsinspiringmclean2azlpkfl/tf-co-inspiring-goodall:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-16T10:10:51.957258Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:28.506116Z","description":"","domain_name":"tfnsheuristicsammetwk0agki7-tf-co-eloquent-moore.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":40,"http":{"path":"/test"},"interval":"12s"},"http_option":"enabled","id":"b1cef340-3301-441f-ab2e-7397cf47e5e6","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-eloquent-moore","namespace_id":"0b830e97-cdcb-43db-a86f-4cb8727c5611","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsheuristicsammetwk0agki7/tf-co-eloquent-moore:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:30.454507Z"}'
         headers:
             Content-Length:
-                - "995"
+                - "978"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 16 Jan 2025 10:10:55 GMT
+                - Wed, 27 Aug 2025 15:06:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -934,10 +934,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 95b191cb-0310-4cb0-a530-75067ca528ce
+                - daa2ac67-4d22-4f78-850a-2de027a8c311
         status: 200 OK
         code: 200
-        duration: 59.917917ms
+        duration: 108.783652ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -953,8 +953,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/4e144a2b-ac2c-4c54-a008-43e95b784b21
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/b1cef340-3301-441f-ab2e-7397cf47e5e6
         method: GET
       response:
         proto: HTTP/2.0
@@ -962,20 +962,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 995
+        content_length: 978
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-16T10:10:44.459725Z","description":"","domain_name":"tfnsinspiringmclean2azlpkfl-tf-co-inspiring-goodall.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":40,"http":{"path":"/test"},"interval":"12s"},"http_option":"enabled","id":"4e144a2b-ac2c-4c54-a008-43e95b784b21","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-inspiring-goodall","namespace_id":"d25385c3-2c74-4f72-ae77-4aadd7a28183","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsinspiringmclean2azlpkfl/tf-co-inspiring-goodall:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-16T10:10:51.957258Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:28.506116Z","description":"","domain_name":"tfnsheuristicsammetwk0agki7-tf-co-eloquent-moore.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":40,"http":{"path":"/test"},"interval":"12s"},"http_option":"enabled","id":"b1cef340-3301-441f-ab2e-7397cf47e5e6","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-eloquent-moore","namespace_id":"0b830e97-cdcb-43db-a86f-4cb8727c5611","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsheuristicsammetwk0agki7/tf-co-eloquent-moore:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:30.454507Z"}'
         headers:
             Content-Length:
-                - "995"
+                - "978"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 16 Jan 2025 10:10:55 GMT
+                - Wed, 27 Aug 2025 15:06:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -983,10 +983,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 203579e7-79dd-4231-b1db-53c968a4130e
+                - aa59a9f3-a2ee-47c5-8b7a-a8f9dbdfebab
         status: 200 OK
         code: 200
-        duration: 68.484416ms
+        duration: 106.272011ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1002,8 +1002,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d25385c3-2c74-4f72-ae77-4aadd7a28183
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/b1cef340-3301-441f-ab2e-7397cf47e5e6
         method: GET
       response:
         proto: HTTP/2.0
@@ -1011,20 +1011,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 570
+        content_length: 978
         uncompressed: false
-        body: '{"created_at":"2025-01-16T10:10:38.995185Z","description":"","environment_variables":{},"error_message":null,"id":"d25385c3-2c74-4f72-ae77-4aadd7a28183","name":"tf-ns-inspiring-mclean","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsinspiringmclean2azlpkfl","registry_namespace_id":"4249c607-4ab4-460e-b3ee-f56bb0be043f","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-16T10:10:41.728349Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:28.506116Z","description":"","domain_name":"tfnsheuristicsammetwk0agki7-tf-co-eloquent-moore.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":40,"http":{"path":"/test"},"interval":"12s"},"http_option":"enabled","id":"b1cef340-3301-441f-ab2e-7397cf47e5e6","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-eloquent-moore","namespace_id":"0b830e97-cdcb-43db-a86f-4cb8727c5611","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsheuristicsammetwk0agki7/tf-co-eloquent-moore:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:30.454507Z"}'
         headers:
             Content-Length:
-                - "570"
+                - "978"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 16 Jan 2025 10:10:56 GMT
+                - Wed, 27 Aug 2025 15:06:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1032,10 +1032,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e25f2895-7db2-4a23-b914-66096a717a10
+                - 6d8bac81-77cb-46c5-84a6-36d11a79c3f0
         status: 200 OK
         code: 200
-        duration: 41.338333ms
+        duration: 90.291854ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1051,8 +1051,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/4e144a2b-ac2c-4c54-a008-43e95b784b21
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/b1cef340-3301-441f-ab2e-7397cf47e5e6
         method: GET
       response:
         proto: HTTP/2.0
@@ -1060,20 +1060,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 995
+        content_length: 1016
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-16T10:10:44.459725Z","description":"","domain_name":"tfnsinspiringmclean2azlpkfl-tf-co-inspiring-goodall.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":40,"http":{"path":"/test"},"interval":"12s"},"http_option":"enabled","id":"4e144a2b-ac2c-4c54-a008-43e95b784b21","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-inspiring-goodall","namespace_id":"d25385c3-2c74-4f72-ae77-4aadd7a28183","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsinspiringmclean2azlpkfl/tf-co-inspiring-goodall:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-16T10:10:51.957258Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:28.506116Z","description":"","domain_name":"tfnsheuristicsammetwk0agki7-tf-co-eloquent-moore.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":40,"http":{"path":"/test"},"interval":"12s"},"http_option":"enabled","id":"b1cef340-3301-441f-ab2e-7397cf47e5e6","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-eloquent-moore","namespace_id":"0b830e97-cdcb-43db-a86f-4cb8727c5611","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsheuristicsammetwk0agki7/tf-co-eloquent-moore:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:52.519125Z"}'
         headers:
             Content-Length:
-                - "995"
+                - "1016"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 16 Jan 2025 10:10:56 GMT
+                - Wed, 27 Aug 2025 15:06:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1081,10 +1081,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 378a60a6-4bd4-43fb-9dd7-955236592fd0
+                - d543486d-80c7-4904-9c67-27d6063c8482
         status: 200 OK
         code: 200
-        duration: 61.717916ms
+        duration: 82.794054ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1100,8 +1100,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/4e144a2b-ac2c-4c54-a008-43e95b784b21
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/b1cef340-3301-441f-ab2e-7397cf47e5e6
         method: GET
       response:
         proto: HTTP/2.0
@@ -1109,20 +1109,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 995
+        content_length: 1016
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-16T10:10:44.459725Z","description":"","domain_name":"tfnsinspiringmclean2azlpkfl-tf-co-inspiring-goodall.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":40,"http":{"path":"/test"},"interval":"12s"},"http_option":"enabled","id":"4e144a2b-ac2c-4c54-a008-43e95b784b21","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-inspiring-goodall","namespace_id":"d25385c3-2c74-4f72-ae77-4aadd7a28183","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsinspiringmclean2azlpkfl/tf-co-inspiring-goodall:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-16T10:10:51.957258Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:28.506116Z","description":"","domain_name":"tfnsheuristicsammetwk0agki7-tf-co-eloquent-moore.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":40,"http":{"path":"/test"},"interval":"12s"},"http_option":"enabled","id":"b1cef340-3301-441f-ab2e-7397cf47e5e6","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-eloquent-moore","namespace_id":"0b830e97-cdcb-43db-a86f-4cb8727c5611","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsheuristicsammetwk0agki7/tf-co-eloquent-moore:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:52.519125Z"}'
         headers:
             Content-Length:
-                - "995"
+                - "1016"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 16 Jan 2025 10:10:56 GMT
+                - Wed, 27 Aug 2025 15:06:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1130,10 +1130,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3f8076b9-3304-4da4-9511-dd6caaa9477d
+                - ed4ce827-5b10-4cf8-828b-279686310b3b
         status: 200 OK
         code: 200
-        duration: 52.092291ms
+        duration: 99.137354ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1149,29 +1149,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/4e144a2b-ac2c-4c54-a008-43e95b784b21
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/b1cef340-3301-441f-ab2e-7397cf47e5e6
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 961
+        content_length: 1016
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-16T10:10:44.459725Z","description":"","domain_name":"tfnsinspiringmclean2azlpkfl-tf-co-inspiring-goodall.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":40,"http":{"path":"/test"},"interval":"12s"},"http_option":"enabled","id":"4e144a2b-ac2c-4c54-a008-43e95b784b21","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-inspiring-goodall","namespace_id":"d25385c3-2c74-4f72-ae77-4aadd7a28183","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsinspiringmclean2azlpkfl/tf-co-inspiring-goodall:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"deleting","timeout":"300s","updated_at":"2025-01-16T10:10:56.385200251Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:28.506116Z","description":"","domain_name":"tfnsheuristicsammetwk0agki7-tf-co-eloquent-moore.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":40,"http":{"path":"/test"},"interval":"12s"},"http_option":"enabled","id":"b1cef340-3301-441f-ab2e-7397cf47e5e6","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-eloquent-moore","namespace_id":"0b830e97-cdcb-43db-a86f-4cb8727c5611","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsheuristicsammetwk0agki7/tf-co-eloquent-moore:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:52.519125Z"}'
         headers:
             Content-Length:
-                - "961"
+                - "1016"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 16 Jan 2025 10:10:56 GMT
+                - Wed, 27 Aug 2025 15:06:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1179,10 +1179,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 13c2fb83-86d9-4dbb-a055-41cc2117737e
+                - c7b8d807-17a1-40ed-8b6f-fc23628cf888
         status: 200 OK
         code: 200
-        duration: 118.760875ms
+        duration: 94.395484ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1198,8 +1198,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d25385c3-2c74-4f72-ae77-4aadd7a28183
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/0b830e97-cdcb-43db-a86f-4cb8727c5611
         method: GET
       response:
         proto: HTTP/2.0
@@ -1207,20 +1207,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 570
+        content_length: 589
         uncompressed: false
-        body: '{"created_at":"2025-01-16T10:10:38.995185Z","description":"","environment_variables":{},"error_message":null,"id":"d25385c3-2c74-4f72-ae77-4aadd7a28183","name":"tf-ns-inspiring-mclean","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsinspiringmclean2azlpkfl","registry_namespace_id":"4249c607-4ab4-460e-b3ee-f56bb0be043f","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-16T10:10:41.728349Z"}'
+        body: '{"created_at":"2025-08-27T15:06:16.964907Z","description":"","environment_variables":{},"error_message":null,"id":"0b830e97-cdcb-43db-a86f-4cb8727c5611","name":"tf-ns-heuristic-sammet","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsheuristicsammetwk0agki7","registry_namespace_id":"88d0e960-ff06-4ea3-b377-8616f04eb28d","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:27.032007Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "570"
+                - "589"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 16 Jan 2025 10:10:56 GMT
+                - Wed, 27 Aug 2025 15:06:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1228,10 +1228,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 36a5d2b5-27ce-455d-a647-ec57a8c19f7d
+                - a200926f-ff5c-4a08-a347-346e8c7cdfb4
         status: 200 OK
         code: 200
-        duration: 41.015291ms
+        duration: 78.547606ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1247,29 +1247,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d25385c3-2c74-4f72-ae77-4aadd7a28183
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/b1cef340-3301-441f-ab2e-7397cf47e5e6
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 576
+        content_length: 1016
         uncompressed: false
-        body: '{"created_at":"2025-01-16T10:10:38.995185Z","description":"","environment_variables":{},"error_message":null,"id":"d25385c3-2c74-4f72-ae77-4aadd7a28183","name":"tf-ns-inspiring-mclean","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsinspiringmclean2azlpkfl","registry_namespace_id":"4249c607-4ab4-460e-b3ee-f56bb0be043f","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-16T10:10:56.539546271Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:28.506116Z","description":"","domain_name":"tfnsheuristicsammetwk0agki7-tf-co-eloquent-moore.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":40,"http":{"path":"/test"},"interval":"12s"},"http_option":"enabled","id":"b1cef340-3301-441f-ab2e-7397cf47e5e6","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-eloquent-moore","namespace_id":"0b830e97-cdcb-43db-a86f-4cb8727c5611","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsheuristicsammetwk0agki7/tf-co-eloquent-moore:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:52.519125Z"}'
         headers:
             Content-Length:
-                - "576"
+                - "1016"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 16 Jan 2025 10:10:56 GMT
+                - Wed, 27 Aug 2025 15:06:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1277,10 +1277,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7334bf0e-19ce-4ece-b2a9-1593cea56292
+                - 03cb4970-c9fe-4ece-a1e2-e05839bab7f2
         status: 200 OK
         code: 200
-        duration: 161.450458ms
+        duration: 95.53283ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1296,8 +1296,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d25385c3-2c74-4f72-ae77-4aadd7a28183
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/b1cef340-3301-441f-ab2e-7397cf47e5e6
         method: GET
       response:
         proto: HTTP/2.0
@@ -1305,20 +1305,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 573
+        content_length: 1016
         uncompressed: false
-        body: '{"created_at":"2025-01-16T10:10:38.995185Z","description":"","environment_variables":{},"error_message":null,"id":"d25385c3-2c74-4f72-ae77-4aadd7a28183","name":"tf-ns-inspiring-mclean","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsinspiringmclean2azlpkfl","registry_namespace_id":"4249c607-4ab4-460e-b3ee-f56bb0be043f","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-16T10:10:56.539546Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:28.506116Z","description":"","domain_name":"tfnsheuristicsammetwk0agki7-tf-co-eloquent-moore.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":40,"http":{"path":"/test"},"interval":"12s"},"http_option":"enabled","id":"b1cef340-3301-441f-ab2e-7397cf47e5e6","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-eloquent-moore","namespace_id":"0b830e97-cdcb-43db-a86f-4cb8727c5611","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsheuristicsammetwk0agki7/tf-co-eloquent-moore:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:52.519125Z"}'
         headers:
             Content-Length:
-                - "573"
+                - "1016"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 16 Jan 2025 10:10:56 GMT
+                - Wed, 27 Aug 2025 15:06:57 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1326,10 +1326,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 045a0f03-4c6a-49f3-9d33-44d44410f994
+                - d88f1dae-8b2c-4610-960d-5bf1968a1a12
         status: 200 OK
         code: 200
-        duration: 55.0205ms
+        duration: 90.554468ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1345,29 +1345,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d25385c3-2c74-4f72-ae77-4aadd7a28183
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/b1cef340-3301-441f-ab2e-7397cf47e5e6
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 573
+        content_length: 982
         uncompressed: false
-        body: '{"created_at":"2025-01-16T10:10:38.995185Z","description":"","environment_variables":{},"error_message":null,"id":"d25385c3-2c74-4f72-ae77-4aadd7a28183","name":"tf-ns-inspiring-mclean","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsinspiringmclean2azlpkfl","registry_namespace_id":"4249c607-4ab4-460e-b3ee-f56bb0be043f","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-16T10:10:56.539546Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:28.506116Z","description":"","domain_name":"tfnsheuristicsammetwk0agki7-tf-co-eloquent-moore.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":40,"http":{"path":"/test"},"interval":"12s"},"http_option":"enabled","id":"b1cef340-3301-441f-ab2e-7397cf47e5e6","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-eloquent-moore","namespace_id":"0b830e97-cdcb-43db-a86f-4cb8727c5611","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsheuristicsammetwk0agki7/tf-co-eloquent-moore:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:57.292833006Z"}'
         headers:
             Content-Length:
-                - "573"
+                - "982"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 16 Jan 2025 10:11:01 GMT
+                - Wed, 27 Aug 2025 15:06:57 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1375,10 +1375,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ed7684fd-f8df-48e2-9f60-ee50b2ccc4df
+                - 2b555944-dadc-4599-8d6b-fcd6200e4f99
         status: 200 OK
         code: 200
-        duration: 42.096458ms
+        duration: 220.370486ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1394,8 +1394,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d25385c3-2c74-4f72-ae77-4aadd7a28183
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/0b830e97-cdcb-43db-a86f-4cb8727c5611
         method: GET
       response:
         proto: HTTP/2.0
@@ -1403,20 +1403,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 573
+        content_length: 589
         uncompressed: false
-        body: '{"created_at":"2025-01-16T10:10:38.995185Z","description":"","environment_variables":{},"error_message":null,"id":"d25385c3-2c74-4f72-ae77-4aadd7a28183","name":"tf-ns-inspiring-mclean","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsinspiringmclean2azlpkfl","registry_namespace_id":"4249c607-4ab4-460e-b3ee-f56bb0be043f","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-16T10:10:56.539546Z"}'
+        body: '{"created_at":"2025-08-27T15:06:16.964907Z","description":"","environment_variables":{},"error_message":null,"id":"0b830e97-cdcb-43db-a86f-4cb8727c5611","name":"tf-ns-heuristic-sammet","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsheuristicsammetwk0agki7","registry_namespace_id":"88d0e960-ff06-4ea3-b377-8616f04eb28d","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:27.032007Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "573"
+                - "589"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 16 Jan 2025 10:11:06 GMT
+                - Wed, 27 Aug 2025 15:06:57 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1424,10 +1424,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c0efd5d0-a345-4a24-b192-25c984a7a694
+                - 9ef56288-2a39-4769-9ffe-a298faa2ab56
         status: 200 OK
         code: 200
-        duration: 43.330708ms
+        duration: 78.750282ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1443,29 +1443,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d25385c3-2c74-4f72-ae77-4aadd7a28183
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/0b830e97-cdcb-43db-a86f-4cb8727c5611
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 573
+        content_length: 595
         uncompressed: false
-        body: '{"created_at":"2025-01-16T10:10:38.995185Z","description":"","environment_variables":{},"error_message":null,"id":"d25385c3-2c74-4f72-ae77-4aadd7a28183","name":"tf-ns-inspiring-mclean","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsinspiringmclean2azlpkfl","registry_namespace_id":"4249c607-4ab4-460e-b3ee-f56bb0be043f","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-16T10:10:56.539546Z"}'
+        body: '{"created_at":"2025-08-27T15:06:16.964907Z","description":"","environment_variables":{},"error_message":null,"id":"0b830e97-cdcb-43db-a86f-4cb8727c5611","name":"tf-ns-heuristic-sammet","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsheuristicsammetwk0agki7","registry_namespace_id":"88d0e960-ff06-4ea3-b377-8616f04eb28d","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:57.631442793Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "573"
+                - "595"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 16 Jan 2025 10:11:11 GMT
+                - Wed, 27 Aug 2025 15:06:57 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1473,10 +1473,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cc3628cd-abb6-43ae-a0ca-078f9f29b694
+                - 79506e89-26fb-4213-98d6-34be187dd084
         status: 200 OK
         code: 200
-        duration: 52.753959ms
+        duration: 212.526125ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1492,8 +1492,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d25385c3-2c74-4f72-ae77-4aadd7a28183
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/0b830e97-cdcb-43db-a86f-4cb8727c5611
         method: GET
       response:
         proto: HTTP/2.0
@@ -1501,20 +1501,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 573
+        content_length: 592
         uncompressed: false
-        body: '{"created_at":"2025-01-16T10:10:38.995185Z","description":"","environment_variables":{},"error_message":null,"id":"d25385c3-2c74-4f72-ae77-4aadd7a28183","name":"tf-ns-inspiring-mclean","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsinspiringmclean2azlpkfl","registry_namespace_id":"4249c607-4ab4-460e-b3ee-f56bb0be043f","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-16T10:10:56.539546Z"}'
+        body: '{"created_at":"2025-08-27T15:06:16.964907Z","description":"","environment_variables":{},"error_message":null,"id":"0b830e97-cdcb-43db-a86f-4cb8727c5611","name":"tf-ns-heuristic-sammet","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsheuristicsammetwk0agki7","registry_namespace_id":"88d0e960-ff06-4ea3-b377-8616f04eb28d","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:57.631443Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "573"
+                - "592"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 16 Jan 2025 10:11:16 GMT
+                - Wed, 27 Aug 2025 15:06:57 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1522,10 +1522,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 37db673e-15c4-4e44-af35-f2a53df8d1b2
+                - 079a5a1c-1bed-45b7-b404-f78067bfca3f
         status: 200 OK
         code: 200
-        duration: 43.945958ms
+        duration: 73.977138ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1541,8 +1541,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d25385c3-2c74-4f72-ae77-4aadd7a28183
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/0b830e97-cdcb-43db-a86f-4cb8727c5611
         method: GET
       response:
         proto: HTTP/2.0
@@ -1550,20 +1550,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 573
+        content_length: 592
         uncompressed: false
-        body: '{"created_at":"2025-01-16T10:10:38.995185Z","description":"","environment_variables":{},"error_message":null,"id":"d25385c3-2c74-4f72-ae77-4aadd7a28183","name":"tf-ns-inspiring-mclean","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsinspiringmclean2azlpkfl","registry_namespace_id":"4249c607-4ab4-460e-b3ee-f56bb0be043f","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-16T10:10:56.539546Z"}'
+        body: '{"created_at":"2025-08-27T15:06:16.964907Z","description":"","environment_variables":{},"error_message":null,"id":"0b830e97-cdcb-43db-a86f-4cb8727c5611","name":"tf-ns-heuristic-sammet","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsheuristicsammetwk0agki7","registry_namespace_id":"88d0e960-ff06-4ea3-b377-8616f04eb28d","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:57.631443Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "573"
+                - "592"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 16 Jan 2025 10:11:21 GMT
+                - Wed, 27 Aug 2025 15:07:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1571,10 +1571,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b5832fd1-2c82-4066-a3cf-63628d080560
+                - dcc3be45-8b2b-4fdf-aec9-0707a36f0f36
         status: 200 OK
         code: 200
-        duration: 48.840208ms
+        duration: 104.438785ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1590,8 +1590,253 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d25385c3-2c74-4f72-ae77-4aadd7a28183
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/0b830e97-cdcb-43db-a86f-4cb8727c5611
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 592
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:06:16.964907Z","description":"","environment_variables":{},"error_message":null,"id":"0b830e97-cdcb-43db-a86f-4cb8727c5611","name":"tf-ns-heuristic-sammet","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsheuristicsammetwk0agki7","registry_namespace_id":"88d0e960-ff06-4ea3-b377-8616f04eb28d","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:57.631443Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "592"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:07:07 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 8a6ee480-0edc-4da2-860e-140c3c6123b5
+        status: 200 OK
+        code: 200
+        duration: 82.586437ms
+    - id: 33
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/0b830e97-cdcb-43db-a86f-4cb8727c5611
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 592
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:06:16.964907Z","description":"","environment_variables":{},"error_message":null,"id":"0b830e97-cdcb-43db-a86f-4cb8727c5611","name":"tf-ns-heuristic-sammet","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsheuristicsammetwk0agki7","registry_namespace_id":"88d0e960-ff06-4ea3-b377-8616f04eb28d","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:57.631443Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "592"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:07:13 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 5879071d-855f-4b78-87f5-ff235cd487fb
+        status: 200 OK
+        code: 200
+        duration: 99.347384ms
+    - id: 34
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/0b830e97-cdcb-43db-a86f-4cb8727c5611
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 592
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:06:16.964907Z","description":"","environment_variables":{},"error_message":null,"id":"0b830e97-cdcb-43db-a86f-4cb8727c5611","name":"tf-ns-heuristic-sammet","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsheuristicsammetwk0agki7","registry_namespace_id":"88d0e960-ff06-4ea3-b377-8616f04eb28d","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:57.631443Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "592"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:07:18 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - a6f15c98-4ba0-4595-9081-e4ddb93b1754
+        status: 200 OK
+        code: 200
+        duration: 79.721904ms
+    - id: 35
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/0b830e97-cdcb-43db-a86f-4cb8727c5611
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 592
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:06:16.964907Z","description":"","environment_variables":{},"error_message":null,"id":"0b830e97-cdcb-43db-a86f-4cb8727c5611","name":"tf-ns-heuristic-sammet","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsheuristicsammetwk0agki7","registry_namespace_id":"88d0e960-ff06-4ea3-b377-8616f04eb28d","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:57.631443Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "592"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:07:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 44cea580-a610-4d0e-ba86-495b7f0e2762
+        status: 200 OK
+        code: 200
+        duration: 92.239998ms
+    - id: 36
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/0b830e97-cdcb-43db-a86f-4cb8727c5611
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 592
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:06:16.964907Z","description":"","environment_variables":{},"error_message":null,"id":"0b830e97-cdcb-43db-a86f-4cb8727c5611","name":"tf-ns-heuristic-sammet","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsheuristicsammetwk0agki7","registry_namespace_id":"88d0e960-ff06-4ea3-b377-8616f04eb28d","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:57.631443Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "592"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:07:28 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 54492628-152d-4750-956e-ca189c892f77
+        status: 200 OK
+        code: 200
+        duration: 82.810933ms
+    - id: 37
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/0b830e97-cdcb-43db-a86f-4cb8727c5611
         method: GET
       response:
         proto: HTTP/2.0
@@ -1610,9 +1855,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 16 Jan 2025 10:11:26 GMT
+                - Wed, 27 Aug 2025 15:07:33 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1620,11 +1865,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2b7073c6-9b07-44cf-ba40-3661da102e08
+                - 3cb556c3-76e4-4629-a2c4-40c68d15cba2
         status: 404 Not Found
         code: 404
-        duration: 28.005583ms
-    - id: 33
+        duration: 23.200561ms
+    - id: 38
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1639,8 +1884,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/d25385c3-2c74-4f72-ae77-4aadd7a28183
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/0b830e97-cdcb-43db-a86f-4cb8727c5611
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1659,9 +1904,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 16 Jan 2025 10:11:27 GMT
+                - Wed, 27 Aug 2025 15:07:33 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1669,7 +1914,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 97cbd868-a78b-489e-9b71-ce3b82bedaa9
+                - c28e8229-3013-43d8-9c99-fe6fc16cc0c5
         status: 404 Not Found
         code: 404
-        duration: 33.204458ms
+        duration: 18.741833ms

--- a/internal/services/container/testdata/container-http-option.cassette.yaml
+++ b/internal/services/container/testdata/container-http-option.cassette.yaml
@@ -6,19 +6,19 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 159
+        content_length: 186
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-ns-confident-ganguly","environment_variables":{},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","secret_environment_variables":[],"tags":null}'
+        body: '{"name":"tf-ns-elegant-saha","environment_variables":{},"project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","secret_environment_variables":[],"tags":null,"activate_vpc_integration":true}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces
         method: POST
       response:
@@ -27,20 +27,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 475
+        content_length: 503
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.284598044Z","description":"","environment_variables":{},"error_message":null,"id":"2ff1ee02-3bdd-4ced-93e4-769d7a3c6bec","name":"tf-ns-confident-ganguly","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:37:49.284598044Z"}'
+        body: '{"created_at":"2025-08-27T15:06:23.658292362Z","description":"","environment_variables":{},"error_message":null,"id":"403178d9-4dc5-4643-8837-b01ed9991cb1","name":"tf-ns-elegant-saha","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:06:23.658292362Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "475"
+                - "503"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:37:49 GMT
+                - Wed, 27 Aug 2025 15:06:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5c9dc324-4661-46f7-ba08-64bf462c19cb
+                - 285205f3-e652-41ff-a5b8-c4fa7ed02736
         status: 200 OK
         code: 200
-        duration: 939.608583ms
+        duration: 671.482211ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -67,8 +67,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2ff1ee02-3bdd-4ced-93e4-769d7a3c6bec
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/403178d9-4dc5-4643-8837-b01ed9991cb1
         method: GET
       response:
         proto: HTTP/2.0
@@ -76,20 +76,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 469
+        content_length: 497
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.284598Z","description":"","environment_variables":{},"error_message":null,"id":"2ff1ee02-3bdd-4ced-93e4-769d7a3c6bec","name":"tf-ns-confident-ganguly","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:37:49.284598Z"}'
+        body: '{"created_at":"2025-08-27T15:06:23.658292Z","description":"","environment_variables":{},"error_message":null,"id":"403178d9-4dc5-4643-8837-b01ed9991cb1","name":"tf-ns-elegant-saha","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:06:23.658292Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "469"
+                - "497"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:37:49 GMT
+                - Wed, 27 Aug 2025 15:06:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 182e0ad0-2da0-4d73-9883-9dfc5432956c
+                - e225c900-fa41-4b63-a9a7-c78521c12a92
         status: 200 OK
         code: 200
-        duration: 62.16625ms
+        duration: 82.461021ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -116,8 +116,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2ff1ee02-3bdd-4ced-93e4-769d7a3c6bec
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/403178d9-4dc5-4643-8837-b01ed9991cb1
         method: GET
       response:
         proto: HTTP/2.0
@@ -125,20 +125,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 469
+        content_length: 581
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.284598Z","description":"","environment_variables":{},"error_message":null,"id":"2ff1ee02-3bdd-4ced-93e4-769d7a3c6bec","name":"tf-ns-confident-ganguly","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:37:49.284598Z"}'
+        body: '{"created_at":"2025-08-27T15:06:23.658292Z","description":"","environment_variables":{},"error_message":null,"id":"403178d9-4dc5-4643-8837-b01ed9991cb1","name":"tf-ns-elegant-saha","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnselegantsahaaebozhcd","registry_namespace_id":"0552de53-7c26-4b6f-89dd-3edeb13145cb","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:25.257483Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "469"
+                - "581"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:37:54 GMT
+                - Wed, 27 Aug 2025 15:06:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -146,10 +146,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5151bf4c-b9b8-4816-87f5-ba65d706bd24
+                - 1f100bd6-0ced-41c9-bcbf-f4dc42b1c3da
         status: 200 OK
         code: 200
-        duration: 61.631792ms
+        duration: 95.015642ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -165,8 +165,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2ff1ee02-3bdd-4ced-93e4-769d7a3c6bec
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/403178d9-4dc5-4643-8837-b01ed9991cb1
         method: GET
       response:
         proto: HTTP/2.0
@@ -174,20 +174,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 469
+        content_length: 581
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.284598Z","description":"","environment_variables":{},"error_message":null,"id":"2ff1ee02-3bdd-4ced-93e4-769d7a3c6bec","name":"tf-ns-confident-ganguly","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:37:49.284598Z"}'
+        body: '{"created_at":"2025-08-27T15:06:23.658292Z","description":"","environment_variables":{},"error_message":null,"id":"403178d9-4dc5-4643-8837-b01ed9991cb1","name":"tf-ns-elegant-saha","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnselegantsahaaebozhcd","registry_namespace_id":"0552de53-7c26-4b6f-89dd-3edeb13145cb","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:25.257483Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "469"
+                - "581"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:37:59 GMT
+                - Wed, 27 Aug 2025 15:06:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -195,10 +195,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - da47f6b4-f403-4133-804a-127f4987bf1c
+                - bb85321b-e683-4176-80bb-1cf0c1154a11
         status: 200 OK
         code: 200
-        duration: 70.277584ms
+        duration: 81.935106ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -214,8 +214,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2ff1ee02-3bdd-4ced-93e4-769d7a3c6bec
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/403178d9-4dc5-4643-8837-b01ed9991cb1
         method: GET
       response:
         proto: HTTP/2.0
@@ -223,20 +223,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 469
+        content_length: 581
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.284598Z","description":"","environment_variables":{},"error_message":null,"id":"2ff1ee02-3bdd-4ced-93e4-769d7a3c6bec","name":"tf-ns-confident-ganguly","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:37:49.284598Z"}'
+        body: '{"created_at":"2025-08-27T15:06:23.658292Z","description":"","environment_variables":{},"error_message":null,"id":"403178d9-4dc5-4643-8837-b01ed9991cb1","name":"tf-ns-elegant-saha","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnselegantsahaaebozhcd","registry_namespace_id":"0552de53-7c26-4b6f-89dd-3edeb13145cb","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:25.257483Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "469"
+                - "581"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:04 GMT
+                - Wed, 27 Aug 2025 15:06:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -244,48 +244,50 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c70f9cd2-c22a-4f79-bea1-b628f5bca19c
+                - 4dd1df41-d44e-49ea-8dd2-4dc2b9c5d83d
         status: 200 OK
         code: 200
-        duration: 71.812334ms
+        duration: 89.923265ms
     - id: 5
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 253
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"namespace_id":"403178d9-4dc5-4643-8837-b01ed9991cb1","name":"tf-co-unruffled-faraday","privacy":"public","protocol":"http1","secret_environment_variables":null,"http_option":"enabled","sandbox":"unknown_sandbox","tags":null,"command":null,"args":null}'
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2ff1ee02-3bdd-4ced-93e4-769d7a3c6bec
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 469
+        content_length: 970
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.284598Z","description":"","environment_variables":{},"error_message":null,"id":"2ff1ee02-3bdd-4ced-93e4-769d7a3c6bec","name":"tf-ns-confident-ganguly","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:37:49.284598Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:30.000844978Z","description":"","domain_name":"tfnselegantsahaaebozhcd-tf-co-unruffled-faraday.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"17498702-1c35-4fff-80fc-b4989bfc5b08","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-unruffled-faraday","namespace_id":"403178d9-4dc5-4643-8837-b01ed9991cb1","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnselegantsahaaebozhcd/tf-co-unruffled-faraday:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:30.000844978Z"}'
         headers:
             Content-Length:
-                - "469"
+                - "970"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:09 GMT
+                - Wed, 27 Aug 2025 15:06:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -293,10 +295,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e7074bc9-bf95-4459-b8bc-9de83ea2e86d
+                - babd6bba-3c10-4575-bef2-ddbee69c1676
         status: 200 OK
         code: 200
-        duration: 66.605667ms
+        duration: 995.488099ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -312,8 +314,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2ff1ee02-3bdd-4ced-93e4-769d7a3c6bec
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/17498702-1c35-4fff-80fc-b4989bfc5b08
         method: GET
       response:
         proto: HTTP/2.0
@@ -321,20 +323,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 469
+        content_length: 964
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.284598Z","description":"","environment_variables":{},"error_message":null,"id":"2ff1ee02-3bdd-4ced-93e4-769d7a3c6bec","name":"tf-ns-confident-ganguly","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:37:49.284598Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:30.000845Z","description":"","domain_name":"tfnselegantsahaaebozhcd-tf-co-unruffled-faraday.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"17498702-1c35-4fff-80fc-b4989bfc5b08","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-unruffled-faraday","namespace_id":"403178d9-4dc5-4643-8837-b01ed9991cb1","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnselegantsahaaebozhcd/tf-co-unruffled-faraday:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:30.000845Z"}'
         headers:
             Content-Length:
-                - "469"
+                - "964"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:14 GMT
+                - Wed, 27 Aug 2025 15:06:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -342,10 +344,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cae3651d-5e65-4372-884e-48055700097d
+                - 39329430-a53c-40e2-a6f6-a60a03353458
         status: 200 OK
         code: 200
-        duration: 91.53225ms
+        duration: 88.637223ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -361,8 +363,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2ff1ee02-3bdd-4ced-93e4-769d7a3c6bec
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/17498702-1c35-4fff-80fc-b4989bfc5b08
         method: GET
       response:
         proto: HTTP/2.0
@@ -370,20 +372,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 558
+        content_length: 964
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.284598Z","description":"","environment_variables":{},"error_message":null,"id":"2ff1ee02-3bdd-4ced-93e4-769d7a3c6bec","name":"tf-ns-confident-ganguly","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsconfidentgangulybfsoc9rs","registry_namespace_id":"5a78cf28-f399-4a9b-9a30-73f46fddf650","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:38:19.416967Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:30.000845Z","description":"","domain_name":"tfnselegantsahaaebozhcd-tf-co-unruffled-faraday.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"17498702-1c35-4fff-80fc-b4989bfc5b08","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-unruffled-faraday","namespace_id":"403178d9-4dc5-4643-8837-b01ed9991cb1","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnselegantsahaaebozhcd/tf-co-unruffled-faraday:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:30.000845Z"}'
         headers:
             Content-Length:
-                - "558"
+                - "964"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:19 GMT
+                - Wed, 27 Aug 2025 15:06:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -391,10 +393,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5b1945f6-387a-41ac-bb63-a73ad9b9a0a2
+                - 1d595055-580d-428c-a4de-fc58c5dee832
         status: 200 OK
         code: 200
-        duration: 64.9915ms
+        duration: 81.693051ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -410,8 +412,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2ff1ee02-3bdd-4ced-93e4-769d7a3c6bec
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/403178d9-4dc5-4643-8837-b01ed9991cb1
         method: GET
       response:
         proto: HTTP/2.0
@@ -419,20 +421,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 558
+        content_length: 581
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.284598Z","description":"","environment_variables":{},"error_message":null,"id":"2ff1ee02-3bdd-4ced-93e4-769d7a3c6bec","name":"tf-ns-confident-ganguly","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsconfidentgangulybfsoc9rs","registry_namespace_id":"5a78cf28-f399-4a9b-9a30-73f46fddf650","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:38:19.416967Z"}'
+        body: '{"created_at":"2025-08-27T15:06:23.658292Z","description":"","environment_variables":{},"error_message":null,"id":"403178d9-4dc5-4643-8837-b01ed9991cb1","name":"tf-ns-elegant-saha","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnselegantsahaaebozhcd","registry_namespace_id":"0552de53-7c26-4b6f-89dd-3edeb13145cb","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:25.257483Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "558"
+                - "581"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:19 GMT
+                - Wed, 27 Aug 2025 15:06:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -440,10 +442,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b7578ab4-aa98-4c65-be42-9e84750e2854
+                - dd0d5cd0-347e-4d0a-a2b3-a00ecd6d649f
         status: 200 OK
         code: 200
-        duration: 67.570292ms
+        duration: 71.8394ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -459,8 +461,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2ff1ee02-3bdd-4ced-93e4-769d7a3c6bec
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/17498702-1c35-4fff-80fc-b4989bfc5b08
         method: GET
       response:
         proto: HTTP/2.0
@@ -468,20 +470,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 558
+        content_length: 964
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.284598Z","description":"","environment_variables":{},"error_message":null,"id":"2ff1ee02-3bdd-4ced-93e4-769d7a3c6bec","name":"tf-ns-confident-ganguly","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsconfidentgangulybfsoc9rs","registry_namespace_id":"5a78cf28-f399-4a9b-9a30-73f46fddf650","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:38:19.416967Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:30.000845Z","description":"","domain_name":"tfnselegantsahaaebozhcd-tf-co-unruffled-faraday.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"17498702-1c35-4fff-80fc-b4989bfc5b08","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-unruffled-faraday","namespace_id":"403178d9-4dc5-4643-8837-b01ed9991cb1","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnselegantsahaaebozhcd/tf-co-unruffled-faraday:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:30.000845Z"}'
         headers:
             Content-Length:
-                - "558"
+                - "964"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:19 GMT
+                - Wed, 27 Aug 2025 15:06:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -489,50 +491,48 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 492bc64c-620e-493c-a43a-dcc8abc38376
+                - 29c7d85b-d96b-4852-bb74-b838c59d3f68
         status: 200 OK
         code: 200
-        duration: 72.938959ms
+        duration: 96.71443ms
     - id: 10
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 213
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"namespace_id":"2ff1ee02-3bdd-4ced-93e4-769d7a3c6bec","name":"tf-co-recursing-beaver","privacy":"public","protocol":"http1","secret_environment_variables":null,"http_option":"enabled","sandbox":"unknown_sandbox"}'
+        body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers
-        method: POST
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/403178d9-4dc5-4643-8837-b01ed9991cb1
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 918
+        content_length: 581
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:20.870030381Z","description":"","domain_name":"tfnsconfidentgangulybfsoc9rs-tf-co-recursing-beaver.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"9367846c-5762-4eea-b4d1-9dcc46f4251d","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-recursing-beaver","namespace_id":"2ff1ee02-3bdd-4ced-93e4-769d7a3c6bec","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsconfidentgangulybfsoc9rs/tf-co-recursing-beaver:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:38:20.870030381Z"}'
+        body: '{"created_at":"2025-08-27T15:06:23.658292Z","description":"","environment_variables":{},"error_message":null,"id":"403178d9-4dc5-4643-8837-b01ed9991cb1","name":"tf-ns-elegant-saha","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnselegantsahaaebozhcd","registry_namespace_id":"0552de53-7c26-4b6f-89dd-3edeb13145cb","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:25.257483Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "918"
+                - "581"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:20 GMT
+                - Wed, 27 Aug 2025 15:06:31 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -540,10 +540,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 387ac54b-ea87-40f0-8433-9c8766fb5b23
+                - 51e5bb8e-8b31-40a4-be08-72596db4d598
         status: 200 OK
         code: 200
-        duration: 949.496625ms
+        duration: 90.807706ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -559,8 +559,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/9367846c-5762-4eea-b4d1-9dcc46f4251d
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/17498702-1c35-4fff-80fc-b4989bfc5b08
         method: GET
       response:
         proto: HTTP/2.0
@@ -568,20 +568,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 912
+        content_length: 964
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:20.870030Z","description":"","domain_name":"tfnsconfidentgangulybfsoc9rs-tf-co-recursing-beaver.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"9367846c-5762-4eea-b4d1-9dcc46f4251d","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-recursing-beaver","namespace_id":"2ff1ee02-3bdd-4ced-93e4-769d7a3c6bec","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsconfidentgangulybfsoc9rs/tf-co-recursing-beaver:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:38:20.870030Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:30.000845Z","description":"","domain_name":"tfnselegantsahaaebozhcd-tf-co-unruffled-faraday.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"17498702-1c35-4fff-80fc-b4989bfc5b08","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-unruffled-faraday","namespace_id":"403178d9-4dc5-4643-8837-b01ed9991cb1","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnselegantsahaaebozhcd/tf-co-unruffled-faraday:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:30.000845Z"}'
         headers:
             Content-Length:
-                - "912"
+                - "964"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:20 GMT
+                - Wed, 27 Aug 2025 15:06:31 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -589,10 +589,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e6d7455f-2f51-4097-ac18-0dd2d37049b7
+                - fbab9a68-25bc-4747-9b0e-a4b1ee7255ce
         status: 200 OK
         code: 200
-        duration: 80.16275ms
+        duration: 107.498658ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -608,8 +608,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/9367846c-5762-4eea-b4d1-9dcc46f4251d
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/403178d9-4dc5-4643-8837-b01ed9991cb1
         method: GET
       response:
         proto: HTTP/2.0
@@ -617,20 +617,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 912
+        content_length: 581
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:20.870030Z","description":"","domain_name":"tfnsconfidentgangulybfsoc9rs-tf-co-recursing-beaver.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"9367846c-5762-4eea-b4d1-9dcc46f4251d","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-recursing-beaver","namespace_id":"2ff1ee02-3bdd-4ced-93e4-769d7a3c6bec","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsconfidentgangulybfsoc9rs/tf-co-recursing-beaver:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:38:20.870030Z"}'
+        body: '{"created_at":"2025-08-27T15:06:23.658292Z","description":"","environment_variables":{},"error_message":null,"id":"403178d9-4dc5-4643-8837-b01ed9991cb1","name":"tf-ns-elegant-saha","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnselegantsahaaebozhcd","registry_namespace_id":"0552de53-7c26-4b6f-89dd-3edeb13145cb","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:25.257483Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "912"
+                - "581"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:21 GMT
+                - Wed, 27 Aug 2025 15:06:31 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -638,10 +638,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ed73f2bb-bac6-477c-ac3c-6ecb84fefcc2
+                - 06e81b7b-61dc-4fe5-8769-cfec9a1f3edc
         status: 200 OK
         code: 200
-        duration: 65.064917ms
+        duration: 76.675206ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -657,8 +657,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2ff1ee02-3bdd-4ced-93e4-769d7a3c6bec
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/17498702-1c35-4fff-80fc-b4989bfc5b08
         method: GET
       response:
         proto: HTTP/2.0
@@ -666,20 +666,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 558
+        content_length: 964
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.284598Z","description":"","environment_variables":{},"error_message":null,"id":"2ff1ee02-3bdd-4ced-93e4-769d7a3c6bec","name":"tf-ns-confident-ganguly","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsconfidentgangulybfsoc9rs","registry_namespace_id":"5a78cf28-f399-4a9b-9a30-73f46fddf650","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:38:19.416967Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:30.000845Z","description":"","domain_name":"tfnselegantsahaaebozhcd-tf-co-unruffled-faraday.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"17498702-1c35-4fff-80fc-b4989bfc5b08","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-unruffled-faraday","namespace_id":"403178d9-4dc5-4643-8837-b01ed9991cb1","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnselegantsahaaebozhcd/tf-co-unruffled-faraday:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:30.000845Z"}'
         headers:
             Content-Length:
-                - "558"
+                - "964"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:21 GMT
+                - Wed, 27 Aug 2025 15:06:31 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -687,256 +687,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 83641c5d-6017-4900-9910-eac8c12f75a4
+                - 9f69ab8a-5cdb-4ac8-ac9d-00f9c54eb7a9
         status: 200 OK
         code: 200
-        duration: 69.831792ms
+        duration: 128.841289ms
     - id: 14
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/9367846c-5762-4eea-b4d1-9dcc46f4251d
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 912
-        uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:20.870030Z","description":"","domain_name":"tfnsconfidentgangulybfsoc9rs-tf-co-recursing-beaver.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"9367846c-5762-4eea-b4d1-9dcc46f4251d","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-recursing-beaver","namespace_id":"2ff1ee02-3bdd-4ced-93e4-769d7a3c6bec","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsconfidentgangulybfsoc9rs/tf-co-recursing-beaver:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:38:20.870030Z"}'
-        headers:
-            Content-Length:
-                - "912"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:38:22 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - baaf3bbe-68e2-499d-97e7-1b81901f8d37
-        status: 200 OK
-        code: 200
-        duration: 79.161625ms
-    - id: 15
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2ff1ee02-3bdd-4ced-93e4-769d7a3c6bec
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 558
-        uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.284598Z","description":"","environment_variables":{},"error_message":null,"id":"2ff1ee02-3bdd-4ced-93e4-769d7a3c6bec","name":"tf-ns-confident-ganguly","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsconfidentgangulybfsoc9rs","registry_namespace_id":"5a78cf28-f399-4a9b-9a30-73f46fddf650","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:38:19.416967Z"}'
-        headers:
-            Content-Length:
-                - "558"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:38:22 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - ba90610c-119b-4c76-92e5-75bf74eced20
-        status: 200 OK
-        code: 200
-        duration: 67.435333ms
-    - id: 16
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/9367846c-5762-4eea-b4d1-9dcc46f4251d
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 912
-        uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:20.870030Z","description":"","domain_name":"tfnsconfidentgangulybfsoc9rs-tf-co-recursing-beaver.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"9367846c-5762-4eea-b4d1-9dcc46f4251d","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-recursing-beaver","namespace_id":"2ff1ee02-3bdd-4ced-93e4-769d7a3c6bec","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsconfidentgangulybfsoc9rs/tf-co-recursing-beaver:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:38:20.870030Z"}'
-        headers:
-            Content-Length:
-                - "912"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:38:22 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - eee5a32a-9cef-428f-a020-228f6d52733f
-        status: 200 OK
-        code: 200
-        duration: 75.014708ms
-    - id: 17
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2ff1ee02-3bdd-4ced-93e4-769d7a3c6bec
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 558
-        uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.284598Z","description":"","environment_variables":{},"error_message":null,"id":"2ff1ee02-3bdd-4ced-93e4-769d7a3c6bec","name":"tf-ns-confident-ganguly","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsconfidentgangulybfsoc9rs","registry_namespace_id":"5a78cf28-f399-4a9b-9a30-73f46fddf650","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:38:19.416967Z"}'
-        headers:
-            Content-Length:
-                - "558"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:38:23 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - d1e46eee-b427-4203-b61a-e20e5ec0752f
-        status: 200 OK
-        code: 200
-        duration: 66.287334ms
-    - id: 18
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/9367846c-5762-4eea-b4d1-9dcc46f4251d
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 912
-        uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:20.870030Z","description":"","domain_name":"tfnsconfidentgangulybfsoc9rs-tf-co-recursing-beaver.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"9367846c-5762-4eea-b4d1-9dcc46f4251d","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-recursing-beaver","namespace_id":"2ff1ee02-3bdd-4ced-93e4-769d7a3c6bec","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsconfidentgangulybfsoc9rs/tf-co-recursing-beaver:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:38:20.870030Z"}'
-        headers:
-            Content-Length:
-                - "912"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:38:23 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 472d0aec-9ea2-47db-be18-2aa9b2ac6f64
-        status: 200 OK
-        code: 200
-        duration: 72.894166ms
-    - id: 19
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -953,8 +708,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/9367846c-5762-4eea-b4d1-9dcc46f4251d
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/17498702-1c35-4fff-80fc-b4989bfc5b08
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -962,20 +717,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 918
+        content_length: 970
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:20.870030Z","description":"","domain_name":"tfnsconfidentgangulybfsoc9rs-tf-co-recursing-beaver.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"redirected","id":"9367846c-5762-4eea-b4d1-9dcc46f4251d","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-recursing-beaver","namespace_id":"2ff1ee02-3bdd-4ced-93e4-769d7a3c6bec","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsconfidentgangulybfsoc9rs/tf-co-recursing-beaver:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","timeout":"300s","updated_at":"2025-01-24T15:38:23.877264252Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:30.000845Z","description":"","domain_name":"tfnselegantsahaaebozhcd-tf-co-unruffled-faraday.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"redirected","id":"17498702-1c35-4fff-80fc-b4989bfc5b08","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-unruffled-faraday","namespace_id":"403178d9-4dc5-4643-8837-b01ed9991cb1","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnselegantsahaaebozhcd/tf-co-unruffled-faraday:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:31.936914682Z"}'
         headers:
             Content-Length:
-                - "918"
+                - "970"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:23 GMT
+                - Wed, 27 Aug 2025 15:06:31 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -983,10 +738,255 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9725c5b3-6c12-4a13-ad9d-ceed6c8dee47
+                - d04d1e0e-72fd-4730-8de7-2dc1c32f1939
         status: 200 OK
         code: 200
-        duration: 102.079ms
+        duration: 119.799903ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/17498702-1c35-4fff-80fc-b4989bfc5b08
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 967
+        uncompressed: false
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:30.000845Z","description":"","domain_name":"tfnselegantsahaaebozhcd-tf-co-unruffled-faraday.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"redirected","id":"17498702-1c35-4fff-80fc-b4989bfc5b08","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-unruffled-faraday","namespace_id":"403178d9-4dc5-4643-8837-b01ed9991cb1","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnselegantsahaaebozhcd/tf-co-unruffled-faraday:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:31.936915Z"}'
+        headers:
+            Content-Length:
+                - "967"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:32 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 9c7dcf02-707d-4208-8cff-8a7edd31345f
+        status: 200 OK
+        code: 200
+        duration: 108.843371ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/17498702-1c35-4fff-80fc-b4989bfc5b08
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 967
+        uncompressed: false
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:30.000845Z","description":"","domain_name":"tfnselegantsahaaebozhcd-tf-co-unruffled-faraday.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"redirected","id":"17498702-1c35-4fff-80fc-b4989bfc5b08","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-unruffled-faraday","namespace_id":"403178d9-4dc5-4643-8837-b01ed9991cb1","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnselegantsahaaebozhcd/tf-co-unruffled-faraday:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:31.936915Z"}'
+        headers:
+            Content-Length:
+                - "967"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:37 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 5f3277ec-cc59-400e-af0b-01beec64464d
+        status: 200 OK
+        code: 200
+        duration: 104.571026ms
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/17498702-1c35-4fff-80fc-b4989bfc5b08
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1005
+        uncompressed: false
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:30.000845Z","description":"","domain_name":"tfnselegantsahaaebozhcd-tf-co-unruffled-faraday.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"redirected","id":"17498702-1c35-4fff-80fc-b4989bfc5b08","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-unruffled-faraday","namespace_id":"403178d9-4dc5-4643-8837-b01ed9991cb1","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnselegantsahaaebozhcd/tf-co-unruffled-faraday:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:38.254405Z"}'
+        headers:
+            Content-Length:
+                - "1005"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:42 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 8ffb3650-7649-4a33-bd60-d489e330b853
+        status: 200 OK
+        code: 200
+        duration: 84.816416ms
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/17498702-1c35-4fff-80fc-b4989bfc5b08
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1005
+        uncompressed: false
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:30.000845Z","description":"","domain_name":"tfnselegantsahaaebozhcd-tf-co-unruffled-faraday.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"redirected","id":"17498702-1c35-4fff-80fc-b4989bfc5b08","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-unruffled-faraday","namespace_id":"403178d9-4dc5-4643-8837-b01ed9991cb1","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnselegantsahaaebozhcd/tf-co-unruffled-faraday:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:38.254405Z"}'
+        headers:
+            Content-Length:
+                - "1005"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:42 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 9a618d12-c400-496e-ae3f-ec824800306e
+        status: 200 OK
+        code: 200
+        duration: 93.174992ms
+    - id: 19
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/17498702-1c35-4fff-80fc-b4989bfc5b08
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1005
+        uncompressed: false
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:30.000845Z","description":"","domain_name":"tfnselegantsahaaebozhcd-tf-co-unruffled-faraday.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"redirected","id":"17498702-1c35-4fff-80fc-b4989bfc5b08","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-unruffled-faraday","namespace_id":"403178d9-4dc5-4643-8837-b01ed9991cb1","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnselegantsahaaebozhcd/tf-co-unruffled-faraday:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:38.254405Z"}'
+        headers:
+            Content-Length:
+                - "1005"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:42 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 56a0e6a9-b872-4442-b131-ff1d189e58da
+        status: 200 OK
+        code: 200
+        duration: 90.288395ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1002,8 +1002,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/9367846c-5762-4eea-b4d1-9dcc46f4251d
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/403178d9-4dc5-4643-8837-b01ed9991cb1
         method: GET
       response:
         proto: HTTP/2.0
@@ -1011,20 +1011,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 915
+        content_length: 581
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:20.870030Z","description":"","domain_name":"tfnsconfidentgangulybfsoc9rs-tf-co-recursing-beaver.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"redirected","id":"9367846c-5762-4eea-b4d1-9dcc46f4251d","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-recursing-beaver","namespace_id":"2ff1ee02-3bdd-4ced-93e4-769d7a3c6bec","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsconfidentgangulybfsoc9rs/tf-co-recursing-beaver:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","timeout":"300s","updated_at":"2025-01-24T15:38:23.877264Z"}'
+        body: '{"created_at":"2025-08-27T15:06:23.658292Z","description":"","environment_variables":{},"error_message":null,"id":"403178d9-4dc5-4643-8837-b01ed9991cb1","name":"tf-ns-elegant-saha","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnselegantsahaaebozhcd","registry_namespace_id":"0552de53-7c26-4b6f-89dd-3edeb13145cb","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:25.257483Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "915"
+                - "581"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:23 GMT
+                - Wed, 27 Aug 2025 15:06:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1032,10 +1032,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - dbb199b9-f717-412f-8a24-fb7ed6ec278b
+                - 90d857c7-c169-4b33-b9e9-4f2aa14595a7
         status: 200 OK
         code: 200
-        duration: 73.384042ms
+        duration: 98.203939ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1051,8 +1051,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/9367846c-5762-4eea-b4d1-9dcc46f4251d
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/17498702-1c35-4fff-80fc-b4989bfc5b08
         method: GET
       response:
         proto: HTTP/2.0
@@ -1060,20 +1060,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 915
+        content_length: 1005
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:20.870030Z","description":"","domain_name":"tfnsconfidentgangulybfsoc9rs-tf-co-recursing-beaver.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"redirected","id":"9367846c-5762-4eea-b4d1-9dcc46f4251d","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-recursing-beaver","namespace_id":"2ff1ee02-3bdd-4ced-93e4-769d7a3c6bec","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsconfidentgangulybfsoc9rs/tf-co-recursing-beaver:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","timeout":"300s","updated_at":"2025-01-24T15:38:23.877264Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:30.000845Z","description":"","domain_name":"tfnselegantsahaaebozhcd-tf-co-unruffled-faraday.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"redirected","id":"17498702-1c35-4fff-80fc-b4989bfc5b08","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-unruffled-faraday","namespace_id":"403178d9-4dc5-4643-8837-b01ed9991cb1","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnselegantsahaaebozhcd/tf-co-unruffled-faraday:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:38.254405Z"}'
         headers:
             Content-Length:
-                - "915"
+                - "1005"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:29 GMT
+                - Wed, 27 Aug 2025 15:06:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1081,10 +1081,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fd7496b5-4696-4bab-9550-29785e131b85
+                - bc808a97-fa8f-4c72-846b-f55c1fba6821
         status: 200 OK
         code: 200
-        duration: 97.802625ms
+        duration: 87.970394ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1100,8 +1100,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/9367846c-5762-4eea-b4d1-9dcc46f4251d
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/403178d9-4dc5-4643-8837-b01ed9991cb1
         method: GET
       response:
         proto: HTTP/2.0
@@ -1109,20 +1109,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 953
+        content_length: 581
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:20.870030Z","description":"","domain_name":"tfnsconfidentgangulybfsoc9rs-tf-co-recursing-beaver.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"redirected","id":"9367846c-5762-4eea-b4d1-9dcc46f4251d","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-recursing-beaver","namespace_id":"2ff1ee02-3bdd-4ced-93e4-769d7a3c6bec","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsconfidentgangulybfsoc9rs/tf-co-recursing-beaver:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-24T15:38:30.247305Z"}'
+        body: '{"created_at":"2025-08-27T15:06:23.658292Z","description":"","environment_variables":{},"error_message":null,"id":"403178d9-4dc5-4643-8837-b01ed9991cb1","name":"tf-ns-elegant-saha","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnselegantsahaaebozhcd","registry_namespace_id":"0552de53-7c26-4b6f-89dd-3edeb13145cb","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:25.257483Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "953"
+                - "581"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:34 GMT
+                - Wed, 27 Aug 2025 15:06:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1130,10 +1130,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ea795360-260c-474b-b0c5-a8ec04118a4e
+                - f73c9108-c537-4e4c-bf64-e546926bff9a
         status: 200 OK
         code: 200
-        duration: 78.822958ms
+        duration: 80.73706ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1149,8 +1149,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/9367846c-5762-4eea-b4d1-9dcc46f4251d
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/17498702-1c35-4fff-80fc-b4989bfc5b08
         method: GET
       response:
         proto: HTTP/2.0
@@ -1158,20 +1158,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 953
+        content_length: 1005
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:20.870030Z","description":"","domain_name":"tfnsconfidentgangulybfsoc9rs-tf-co-recursing-beaver.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"redirected","id":"9367846c-5762-4eea-b4d1-9dcc46f4251d","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-recursing-beaver","namespace_id":"2ff1ee02-3bdd-4ced-93e4-769d7a3c6bec","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsconfidentgangulybfsoc9rs/tf-co-recursing-beaver:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-24T15:38:30.247305Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:30.000845Z","description":"","domain_name":"tfnselegantsahaaebozhcd-tf-co-unruffled-faraday.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"redirected","id":"17498702-1c35-4fff-80fc-b4989bfc5b08","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-unruffled-faraday","namespace_id":"403178d9-4dc5-4643-8837-b01ed9991cb1","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnselegantsahaaebozhcd/tf-co-unruffled-faraday:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:38.254405Z"}'
         headers:
             Content-Length:
-                - "953"
+                - "1005"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:34 GMT
+                - Wed, 27 Aug 2025 15:06:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1179,10 +1179,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 32d18040-585a-465a-ba10-18e7e2020b3f
+                - d8ede0aa-1851-44c3-a1dc-df9893068df8
         status: 200 OK
         code: 200
-        duration: 71.591542ms
+        duration: 101.223216ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1198,8 +1198,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/9367846c-5762-4eea-b4d1-9dcc46f4251d
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/403178d9-4dc5-4643-8837-b01ed9991cb1
         method: GET
       response:
         proto: HTTP/2.0
@@ -1207,20 +1207,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 953
+        content_length: 581
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:20.870030Z","description":"","domain_name":"tfnsconfidentgangulybfsoc9rs-tf-co-recursing-beaver.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"redirected","id":"9367846c-5762-4eea-b4d1-9dcc46f4251d","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-recursing-beaver","namespace_id":"2ff1ee02-3bdd-4ced-93e4-769d7a3c6bec","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsconfidentgangulybfsoc9rs/tf-co-recursing-beaver:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-24T15:38:30.247305Z"}'
+        body: '{"created_at":"2025-08-27T15:06:23.658292Z","description":"","environment_variables":{},"error_message":null,"id":"403178d9-4dc5-4643-8837-b01ed9991cb1","name":"tf-ns-elegant-saha","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnselegantsahaaebozhcd","registry_namespace_id":"0552de53-7c26-4b6f-89dd-3edeb13145cb","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:25.257483Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "953"
+                - "581"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:34 GMT
+                - Wed, 27 Aug 2025 15:06:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1228,10 +1228,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6b1c3350-3a86-41e3-9e52-599633c707a3
+                - a8ef4691-3345-4dc6-ab5a-9b6963365edf
         status: 200 OK
         code: 200
-        duration: 70.552209ms
+        duration: 89.106557ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1247,8 +1247,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2ff1ee02-3bdd-4ced-93e4-769d7a3c6bec
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/17498702-1c35-4fff-80fc-b4989bfc5b08
         method: GET
       response:
         proto: HTTP/2.0
@@ -1256,20 +1256,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 558
+        content_length: 1005
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.284598Z","description":"","environment_variables":{},"error_message":null,"id":"2ff1ee02-3bdd-4ced-93e4-769d7a3c6bec","name":"tf-ns-confident-ganguly","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsconfidentgangulybfsoc9rs","registry_namespace_id":"5a78cf28-f399-4a9b-9a30-73f46fddf650","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:38:19.416967Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:30.000845Z","description":"","domain_name":"tfnselegantsahaaebozhcd-tf-co-unruffled-faraday.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"redirected","id":"17498702-1c35-4fff-80fc-b4989bfc5b08","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-unruffled-faraday","namespace_id":"403178d9-4dc5-4643-8837-b01ed9991cb1","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnselegantsahaaebozhcd/tf-co-unruffled-faraday:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:38.254405Z"}'
         headers:
             Content-Length:
-                - "558"
+                - "1005"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:35 GMT
+                - Wed, 27 Aug 2025 15:06:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1277,256 +1277,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 98a3a8e7-fed7-4adc-a1df-ab516a7e45d1
+                - a18031b4-2df7-4f12-8768-163cb7c98f7b
         status: 200 OK
         code: 200
-        duration: 110.992375ms
+        duration: 84.00345ms
     - id: 26
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/9367846c-5762-4eea-b4d1-9dcc46f4251d
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 953
-        uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:20.870030Z","description":"","domain_name":"tfnsconfidentgangulybfsoc9rs-tf-co-recursing-beaver.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"redirected","id":"9367846c-5762-4eea-b4d1-9dcc46f4251d","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-recursing-beaver","namespace_id":"2ff1ee02-3bdd-4ced-93e4-769d7a3c6bec","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsconfidentgangulybfsoc9rs/tf-co-recursing-beaver:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-24T15:38:30.247305Z"}'
-        headers:
-            Content-Length:
-                - "953"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:38:35 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - e243b53b-fcb5-4a9b-a7b2-9b2bcd22835d
-        status: 200 OK
-        code: 200
-        duration: 74.762791ms
-    - id: 27
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2ff1ee02-3bdd-4ced-93e4-769d7a3c6bec
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 558
-        uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.284598Z","description":"","environment_variables":{},"error_message":null,"id":"2ff1ee02-3bdd-4ced-93e4-769d7a3c6bec","name":"tf-ns-confident-ganguly","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsconfidentgangulybfsoc9rs","registry_namespace_id":"5a78cf28-f399-4a9b-9a30-73f46fddf650","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:38:19.416967Z"}'
-        headers:
-            Content-Length:
-                - "558"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:38:36 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 13f036c2-979a-464d-bc08-1509736dc172
-        status: 200 OK
-        code: 200
-        duration: 63.71375ms
-    - id: 28
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/9367846c-5762-4eea-b4d1-9dcc46f4251d
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 953
-        uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:20.870030Z","description":"","domain_name":"tfnsconfidentgangulybfsoc9rs-tf-co-recursing-beaver.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"redirected","id":"9367846c-5762-4eea-b4d1-9dcc46f4251d","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-recursing-beaver","namespace_id":"2ff1ee02-3bdd-4ced-93e4-769d7a3c6bec","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsconfidentgangulybfsoc9rs/tf-co-recursing-beaver:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-24T15:38:30.247305Z"}'
-        headers:
-            Content-Length:
-                - "953"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:38:36 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 14c2081e-3071-441a-b60e-d7211da218e7
-        status: 200 OK
-        code: 200
-        duration: 83.684833ms
-    - id: 29
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2ff1ee02-3bdd-4ced-93e4-769d7a3c6bec
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 558
-        uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.284598Z","description":"","environment_variables":{},"error_message":null,"id":"2ff1ee02-3bdd-4ced-93e4-769d7a3c6bec","name":"tf-ns-confident-ganguly","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsconfidentgangulybfsoc9rs","registry_namespace_id":"5a78cf28-f399-4a9b-9a30-73f46fddf650","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:38:19.416967Z"}'
-        headers:
-            Content-Length:
-                - "558"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:38:37 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - fc581c89-05fc-4cc0-b9bd-b03437d8d7b4
-        status: 200 OK
-        code: 200
-        duration: 72.97225ms
-    - id: 30
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/9367846c-5762-4eea-b4d1-9dcc46f4251d
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 953
-        uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:20.870030Z","description":"","domain_name":"tfnsconfidentgangulybfsoc9rs-tf-co-recursing-beaver.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"redirected","id":"9367846c-5762-4eea-b4d1-9dcc46f4251d","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-recursing-beaver","namespace_id":"2ff1ee02-3bdd-4ced-93e4-769d7a3c6bec","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsconfidentgangulybfsoc9rs/tf-co-recursing-beaver:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-24T15:38:30.247305Z"}'
-        headers:
-            Content-Length:
-                - "953"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:38:37 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 27cc0f72-2645-4bf9-869f-e0d2f2058cd2
-        status: 200 OK
-        code: 200
-        duration: 66.966209ms
-    - id: 31
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1543,8 +1298,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/9367846c-5762-4eea-b4d1-9dcc46f4251d
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/17498702-1c35-4fff-80fc-b4989bfc5b08
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -1552,20 +1307,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 915
+        content_length: 967
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:20.870030Z","description":"","domain_name":"tfnsconfidentgangulybfsoc9rs-tf-co-recursing-beaver.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"9367846c-5762-4eea-b4d1-9dcc46f4251d","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-recursing-beaver","namespace_id":"2ff1ee02-3bdd-4ced-93e4-769d7a3c6bec","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsconfidentgangulybfsoc9rs/tf-co-recursing-beaver:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","timeout":"300s","updated_at":"2025-01-24T15:38:37.300993149Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:30.000845Z","description":"","domain_name":"tfnselegantsahaaebozhcd-tf-co-unruffled-faraday.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"17498702-1c35-4fff-80fc-b4989bfc5b08","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-unruffled-faraday","namespace_id":"403178d9-4dc5-4643-8837-b01ed9991cb1","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnselegantsahaaebozhcd/tf-co-unruffled-faraday:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:44.062698509Z"}'
         headers:
             Content-Length:
-                - "915"
+                - "967"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:37 GMT
+                - Wed, 27 Aug 2025 15:06:44 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1573,10 +1328,255 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 25721fe0-d26b-4c08-af43-b6d4783d4e71
+                - 57da550d-c761-4ce1-9190-f43f40dbfcdf
         status: 200 OK
         code: 200
-        duration: 105.397875ms
+        duration: 167.190219ms
+    - id: 27
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/17498702-1c35-4fff-80fc-b4989bfc5b08
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 964
+        uncompressed: false
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:30.000845Z","description":"","domain_name":"tfnselegantsahaaebozhcd-tf-co-unruffled-faraday.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"17498702-1c35-4fff-80fc-b4989bfc5b08","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-unruffled-faraday","namespace_id":"403178d9-4dc5-4643-8837-b01ed9991cb1","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnselegantsahaaebozhcd/tf-co-unruffled-faraday:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:44.062699Z"}'
+        headers:
+            Content-Length:
+                - "964"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:44 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 1fc779a0-0983-46ea-972d-f8da9bfb643e
+        status: 200 OK
+        code: 200
+        duration: 89.322462ms
+    - id: 28
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/17498702-1c35-4fff-80fc-b4989bfc5b08
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 964
+        uncompressed: false
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:30.000845Z","description":"","domain_name":"tfnselegantsahaaebozhcd-tf-co-unruffled-faraday.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"17498702-1c35-4fff-80fc-b4989bfc5b08","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-unruffled-faraday","namespace_id":"403178d9-4dc5-4643-8837-b01ed9991cb1","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnselegantsahaaebozhcd/tf-co-unruffled-faraday:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:44.062699Z"}'
+        headers:
+            Content-Length:
+                - "964"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 0995250b-19fd-497f-b435-8a7da35c863b
+        status: 200 OK
+        code: 200
+        duration: 92.139221ms
+    - id: 29
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/17498702-1c35-4fff-80fc-b4989bfc5b08
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 964
+        uncompressed: false
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:30.000845Z","description":"","domain_name":"tfnselegantsahaaebozhcd-tf-co-unruffled-faraday.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"17498702-1c35-4fff-80fc-b4989bfc5b08","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-unruffled-faraday","namespace_id":"403178d9-4dc5-4643-8837-b01ed9991cb1","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnselegantsahaaebozhcd/tf-co-unruffled-faraday:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:44.062699Z"}'
+        headers:
+            Content-Length:
+                - "964"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:54 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 357f4a86-6aa9-4f0b-9e79-780a9e8e82ea
+        status: 200 OK
+        code: 200
+        duration: 89.109484ms
+    - id: 30
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/17498702-1c35-4fff-80fc-b4989bfc5b08
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1002
+        uncompressed: false
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:30.000845Z","description":"","domain_name":"tfnselegantsahaaebozhcd-tf-co-unruffled-faraday.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"17498702-1c35-4fff-80fc-b4989bfc5b08","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-unruffled-faraday","namespace_id":"403178d9-4dc5-4643-8837-b01ed9991cb1","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnselegantsahaaebozhcd/tf-co-unruffled-faraday:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:54.865819Z"}'
+        headers:
+            Content-Length:
+                - "1002"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:59 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 40f9bd65-5b6e-445d-af75-4558939e5133
+        status: 200 OK
+        code: 200
+        duration: 100.675954ms
+    - id: 31
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/17498702-1c35-4fff-80fc-b4989bfc5b08
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1002
+        uncompressed: false
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:30.000845Z","description":"","domain_name":"tfnselegantsahaaebozhcd-tf-co-unruffled-faraday.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"17498702-1c35-4fff-80fc-b4989bfc5b08","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-unruffled-faraday","namespace_id":"403178d9-4dc5-4643-8837-b01ed9991cb1","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnselegantsahaaebozhcd/tf-co-unruffled-faraday:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:54.865819Z"}'
+        headers:
+            Content-Length:
+                - "1002"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:59 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - a9a994de-84c5-44ff-8921-0c247e30cdea
+        status: 200 OK
+        code: 200
+        duration: 94.335183ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1592,8 +1592,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/9367846c-5762-4eea-b4d1-9dcc46f4251d
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/17498702-1c35-4fff-80fc-b4989bfc5b08
         method: GET
       response:
         proto: HTTP/2.0
@@ -1601,20 +1601,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 912
+        content_length: 1002
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:20.870030Z","description":"","domain_name":"tfnsconfidentgangulybfsoc9rs-tf-co-recursing-beaver.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"9367846c-5762-4eea-b4d1-9dcc46f4251d","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-recursing-beaver","namespace_id":"2ff1ee02-3bdd-4ced-93e4-769d7a3c6bec","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsconfidentgangulybfsoc9rs/tf-co-recursing-beaver:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","timeout":"300s","updated_at":"2025-01-24T15:38:37.300993Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:30.000845Z","description":"","domain_name":"tfnselegantsahaaebozhcd-tf-co-unruffled-faraday.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"17498702-1c35-4fff-80fc-b4989bfc5b08","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-unruffled-faraday","namespace_id":"403178d9-4dc5-4643-8837-b01ed9991cb1","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnselegantsahaaebozhcd/tf-co-unruffled-faraday:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:54.865819Z"}'
         headers:
             Content-Length:
-                - "912"
+                - "1002"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:37 GMT
+                - Wed, 27 Aug 2025 15:06:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1622,10 +1622,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2d0163a5-0639-448c-9628-b4cf4f081245
+                - f0d01aa5-dfeb-4fd3-ae76-4e95037789e1
         status: 200 OK
         code: 200
-        duration: 129.303084ms
+        duration: 102.646231ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1641,8 +1641,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/9367846c-5762-4eea-b4d1-9dcc46f4251d
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/403178d9-4dc5-4643-8837-b01ed9991cb1
         method: GET
       response:
         proto: HTTP/2.0
@@ -1650,20 +1650,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 912
+        content_length: 581
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:20.870030Z","description":"","domain_name":"tfnsconfidentgangulybfsoc9rs-tf-co-recursing-beaver.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"9367846c-5762-4eea-b4d1-9dcc46f4251d","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-recursing-beaver","namespace_id":"2ff1ee02-3bdd-4ced-93e4-769d7a3c6bec","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsconfidentgangulybfsoc9rs/tf-co-recursing-beaver:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","timeout":"300s","updated_at":"2025-01-24T15:38:37.300993Z"}'
+        body: '{"created_at":"2025-08-27T15:06:23.658292Z","description":"","environment_variables":{},"error_message":null,"id":"403178d9-4dc5-4643-8837-b01ed9991cb1","name":"tf-ns-elegant-saha","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnselegantsahaaebozhcd","registry_namespace_id":"0552de53-7c26-4b6f-89dd-3edeb13145cb","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:25.257483Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "912"
+                - "581"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:42 GMT
+                - Wed, 27 Aug 2025 15:07:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1671,10 +1671,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2adbeaf7-8449-438d-99ca-2b9071f7eba8
+                - cfc99ff3-f72b-4fe0-ab7a-4b307b6cba60
         status: 200 OK
         code: 200
-        duration: 85.142416ms
+        duration: 118.681042ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1690,8 +1690,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/9367846c-5762-4eea-b4d1-9dcc46f4251d
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/17498702-1c35-4fff-80fc-b4989bfc5b08
         method: GET
       response:
         proto: HTTP/2.0
@@ -1699,20 +1699,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 950
+        content_length: 1002
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:20.870030Z","description":"","domain_name":"tfnsconfidentgangulybfsoc9rs-tf-co-recursing-beaver.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"9367846c-5762-4eea-b4d1-9dcc46f4251d","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-recursing-beaver","namespace_id":"2ff1ee02-3bdd-4ced-93e4-769d7a3c6bec","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsconfidentgangulybfsoc9rs/tf-co-recursing-beaver:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-24T15:38:43.556656Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:30.000845Z","description":"","domain_name":"tfnselegantsahaaebozhcd-tf-co-unruffled-faraday.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"17498702-1c35-4fff-80fc-b4989bfc5b08","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-unruffled-faraday","namespace_id":"403178d9-4dc5-4643-8837-b01ed9991cb1","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnselegantsahaaebozhcd/tf-co-unruffled-faraday:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:54.865819Z"}'
         headers:
             Content-Length:
-                - "950"
+                - "1002"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:47 GMT
+                - Wed, 27 Aug 2025 15:07:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1720,10 +1720,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1ea8f9a7-58a7-404d-9962-8b055d1b2c61
+                - 13edc92e-bde2-4928-8b03-356e73743a82
         status: 200 OK
         code: 200
-        duration: 74.825334ms
+        duration: 101.819048ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1739,8 +1739,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/9367846c-5762-4eea-b4d1-9dcc46f4251d
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/17498702-1c35-4fff-80fc-b4989bfc5b08
         method: GET
       response:
         proto: HTTP/2.0
@@ -1748,20 +1748,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 950
+        content_length: 1002
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:20.870030Z","description":"","domain_name":"tfnsconfidentgangulybfsoc9rs-tf-co-recursing-beaver.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"9367846c-5762-4eea-b4d1-9dcc46f4251d","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-recursing-beaver","namespace_id":"2ff1ee02-3bdd-4ced-93e4-769d7a3c6bec","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsconfidentgangulybfsoc9rs/tf-co-recursing-beaver:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-24T15:38:43.556656Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:30.000845Z","description":"","domain_name":"tfnselegantsahaaebozhcd-tf-co-unruffled-faraday.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"17498702-1c35-4fff-80fc-b4989bfc5b08","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-unruffled-faraday","namespace_id":"403178d9-4dc5-4643-8837-b01ed9991cb1","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnselegantsahaaebozhcd/tf-co-unruffled-faraday:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:54.865819Z"}'
         headers:
             Content-Length:
-                - "950"
+                - "1002"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:47 GMT
+                - Wed, 27 Aug 2025 15:07:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1769,10 +1769,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 79990b26-b62d-4d38-8c2d-e10a7e359e66
+                - cdce2ec3-62f1-4c70-b3ed-31be47c8d9ce
         status: 200 OK
         code: 200
-        duration: 80.693542ms
+        duration: 91.880988ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1788,29 +1788,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/9367846c-5762-4eea-b4d1-9dcc46f4251d
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/17498702-1c35-4fff-80fc-b4989bfc5b08
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 950
+        content_length: 968
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:20.870030Z","description":"","domain_name":"tfnsconfidentgangulybfsoc9rs-tf-co-recursing-beaver.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"9367846c-5762-4eea-b4d1-9dcc46f4251d","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-recursing-beaver","namespace_id":"2ff1ee02-3bdd-4ced-93e4-769d7a3c6bec","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsconfidentgangulybfsoc9rs/tf-co-recursing-beaver:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-24T15:38:43.556656Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:30.000845Z","description":"","domain_name":"tfnselegantsahaaebozhcd-tf-co-unruffled-faraday.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"17498702-1c35-4fff-80fc-b4989bfc5b08","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-unruffled-faraday","namespace_id":"403178d9-4dc5-4643-8837-b01ed9991cb1","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnselegantsahaaebozhcd/tf-co-unruffled-faraday:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:07:00.813758857Z"}'
         headers:
             Content-Length:
-                - "950"
+                - "968"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:47 GMT
+                - Wed, 27 Aug 2025 15:07:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1818,10 +1818,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0f2ebe4f-8be4-4ee4-b175-0329d7abf465
+                - 3b0f829f-c7db-4c6b-9aeb-4231b4962beb
         status: 200 OK
         code: 200
-        duration: 79.343125ms
+        duration: 199.01412ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1837,8 +1837,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2ff1ee02-3bdd-4ced-93e4-769d7a3c6bec
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/403178d9-4dc5-4643-8837-b01ed9991cb1
         method: GET
       response:
         proto: HTTP/2.0
@@ -1846,20 +1846,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 558
+        content_length: 581
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.284598Z","description":"","environment_variables":{},"error_message":null,"id":"2ff1ee02-3bdd-4ced-93e4-769d7a3c6bec","name":"tf-ns-confident-ganguly","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsconfidentgangulybfsoc9rs","registry_namespace_id":"5a78cf28-f399-4a9b-9a30-73f46fddf650","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:38:19.416967Z"}'
+        body: '{"created_at":"2025-08-27T15:06:23.658292Z","description":"","environment_variables":{},"error_message":null,"id":"403178d9-4dc5-4643-8837-b01ed9991cb1","name":"tf-ns-elegant-saha","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnselegantsahaaebozhcd","registry_namespace_id":"0552de53-7c26-4b6f-89dd-3edeb13145cb","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:25.257483Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "558"
+                - "581"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:48 GMT
+                - Wed, 27 Aug 2025 15:07:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1867,10 +1867,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1bf58370-f92b-40f3-bbd5-cb573abc940f
+                - c865ce7b-4f2a-4c9a-942e-fc31fe9b5bc6
         status: 200 OK
         code: 200
-        duration: 85.3795ms
+        duration: 96.995519ms
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1886,29 +1886,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/9367846c-5762-4eea-b4d1-9dcc46f4251d
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/403178d9-4dc5-4643-8837-b01ed9991cb1
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 950
+        content_length: 587
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:20.870030Z","description":"","domain_name":"tfnsconfidentgangulybfsoc9rs-tf-co-recursing-beaver.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"9367846c-5762-4eea-b4d1-9dcc46f4251d","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-recursing-beaver","namespace_id":"2ff1ee02-3bdd-4ced-93e4-769d7a3c6bec","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsconfidentgangulybfsoc9rs/tf-co-recursing-beaver:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-24T15:38:43.556656Z"}'
+        body: '{"created_at":"2025-08-27T15:06:23.658292Z","description":"","environment_variables":{},"error_message":null,"id":"403178d9-4dc5-4643-8837-b01ed9991cb1","name":"tf-ns-elegant-saha","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnselegantsahaaebozhcd","registry_namespace_id":"0552de53-7c26-4b6f-89dd-3edeb13145cb","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:07:01.156000022Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "950"
+                - "587"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:48 GMT
+                - Wed, 27 Aug 2025 15:07:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1916,10 +1916,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c67b2b6a-363d-4ebb-bf07-caf8f2a7f807
+                - 2f18bcfa-973e-4ca8-b84c-dda76af5f6a1
         status: 200 OK
         code: 200
-        duration: 79.236875ms
+        duration: 225.588899ms
     - id: 39
       request:
         proto: HTTP/1.1
@@ -1935,8 +1935,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/9367846c-5762-4eea-b4d1-9dcc46f4251d
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/403178d9-4dc5-4643-8837-b01ed9991cb1
         method: GET
       response:
         proto: HTTP/2.0
@@ -1944,20 +1944,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 950
+        content_length: 581
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:20.870030Z","description":"","domain_name":"tfnsconfidentgangulybfsoc9rs-tf-co-recursing-beaver.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"9367846c-5762-4eea-b4d1-9dcc46f4251d","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-recursing-beaver","namespace_id":"2ff1ee02-3bdd-4ced-93e4-769d7a3c6bec","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsconfidentgangulybfsoc9rs/tf-co-recursing-beaver:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-24T15:38:43.556656Z"}'
+        body: '{"created_at":"2025-08-27T15:06:23.658292Z","description":"","environment_variables":{},"error_message":null,"id":"403178d9-4dc5-4643-8837-b01ed9991cb1","name":"tf-ns-elegant-saha","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnselegantsahaaebozhcd","registry_namespace_id":"0552de53-7c26-4b6f-89dd-3edeb13145cb","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:07:01.156Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "950"
+                - "581"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:49 GMT
+                - Wed, 27 Aug 2025 15:07:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1965,10 +1965,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b6a34004-533c-489f-9ec4-1185ec6b3019
+                - 81c45c6a-ef7d-4bd1-b80f-5805635a30ba
         status: 200 OK
         code: 200
-        duration: 86.260709ms
+        duration: 138.017349ms
     - id: 40
       request:
         proto: HTTP/1.1
@@ -1984,29 +1984,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/9367846c-5762-4eea-b4d1-9dcc46f4251d
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/403178d9-4dc5-4643-8837-b01ed9991cb1
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 916
+        content_length: 581
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:20.870030Z","description":"","domain_name":"tfnsconfidentgangulybfsoc9rs-tf-co-recursing-beaver.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"9367846c-5762-4eea-b4d1-9dcc46f4251d","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-recursing-beaver","namespace_id":"2ff1ee02-3bdd-4ced-93e4-769d7a3c6bec","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsconfidentgangulybfsoc9rs/tf-co-recursing-beaver:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"deleting","timeout":"300s","updated_at":"2025-01-24T15:38:49.793610222Z"}'
+        body: '{"created_at":"2025-08-27T15:06:23.658292Z","description":"","environment_variables":{},"error_message":null,"id":"403178d9-4dc5-4643-8837-b01ed9991cb1","name":"tf-ns-elegant-saha","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnselegantsahaaebozhcd","registry_namespace_id":"0552de53-7c26-4b6f-89dd-3edeb13145cb","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:07:01.156Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "916"
+                - "581"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:49 GMT
+                - Wed, 27 Aug 2025 15:07:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2014,10 +2014,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9d310108-e427-40a5-ad28-e88f5e2bc93a
+                - ba85ca46-1dd1-4891-baf9-0c3638258ddf
         status: 200 OK
         code: 200
-        duration: 158.011959ms
+        duration: 79.931334ms
     - id: 41
       request:
         proto: HTTP/1.1
@@ -2033,8 +2033,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2ff1ee02-3bdd-4ced-93e4-769d7a3c6bec
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/403178d9-4dc5-4643-8837-b01ed9991cb1
         method: GET
       response:
         proto: HTTP/2.0
@@ -2042,20 +2042,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 558
+        content_length: 581
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.284598Z","description":"","environment_variables":{},"error_message":null,"id":"2ff1ee02-3bdd-4ced-93e4-769d7a3c6bec","name":"tf-ns-confident-ganguly","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsconfidentgangulybfsoc9rs","registry_namespace_id":"5a78cf28-f399-4a9b-9a30-73f46fddf650","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:38:19.416967Z"}'
+        body: '{"created_at":"2025-08-27T15:06:23.658292Z","description":"","environment_variables":{},"error_message":null,"id":"403178d9-4dc5-4643-8837-b01ed9991cb1","name":"tf-ns-elegant-saha","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnselegantsahaaebozhcd","registry_namespace_id":"0552de53-7c26-4b6f-89dd-3edeb13145cb","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:07:01.156Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "558"
+                - "581"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:49 GMT
+                - Wed, 27 Aug 2025 15:07:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2063,10 +2063,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f2aa4d87-eb86-4e47-be59-948b2c3a6df1
+                - 979f0be9-f0ae-4b16-8acc-bff82c5550ad
         status: 200 OK
         code: 200
-        duration: 63.959917ms
+        duration: 78.339558ms
     - id: 42
       request:
         proto: HTTP/1.1
@@ -2082,29 +2082,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2ff1ee02-3bdd-4ced-93e4-769d7a3c6bec
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/403178d9-4dc5-4643-8837-b01ed9991cb1
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 564
+        content_length: 581
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.284598Z","description":"","environment_variables":{},"error_message":null,"id":"2ff1ee02-3bdd-4ced-93e4-769d7a3c6bec","name":"tf-ns-confident-ganguly","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsconfidentgangulybfsoc9rs","registry_namespace_id":"5a78cf28-f399-4a9b-9a30-73f46fddf650","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:38:49.999238553Z"}'
+        body: '{"created_at":"2025-08-27T15:06:23.658292Z","description":"","environment_variables":{},"error_message":null,"id":"403178d9-4dc5-4643-8837-b01ed9991cb1","name":"tf-ns-elegant-saha","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnselegantsahaaebozhcd","registry_namespace_id":"0552de53-7c26-4b6f-89dd-3edeb13145cb","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:07:01.156Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "564"
+                - "581"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:50 GMT
+                - Wed, 27 Aug 2025 15:07:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2112,10 +2112,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7371caf8-2046-4225-9e2a-b6df9eb18971
+                - 2b3f2ee3-957e-4f59-841c-d08c9c56022b
         status: 200 OK
         code: 200
-        duration: 229.209667ms
+        duration: 83.194461ms
     - id: 43
       request:
         proto: HTTP/1.1
@@ -2131,57 +2131,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2ff1ee02-3bdd-4ced-93e4-769d7a3c6bec
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 561
-        uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.284598Z","description":"","environment_variables":{},"error_message":null,"id":"2ff1ee02-3bdd-4ced-93e4-769d7a3c6bec","name":"tf-ns-confident-ganguly","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsconfidentgangulybfsoc9rs","registry_namespace_id":"5a78cf28-f399-4a9b-9a30-73f46fddf650","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:38:49.999239Z"}'
-        headers:
-            Content-Length:
-                - "561"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:38:50 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - d67c60fc-a7f3-4982-acb7-e17580a8338f
-        status: 200 OK
-        code: 200
-        duration: 68.142167ms
-    - id: 44
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2ff1ee02-3bdd-4ced-93e4-769d7a3c6bec
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/403178d9-4dc5-4643-8837-b01ed9991cb1
         method: GET
       response:
         proto: HTTP/2.0
@@ -2200,9 +2151,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:55 GMT
+                - Wed, 27 Aug 2025 15:07:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2210,11 +2161,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 46fe9391-cae5-4903-b5fd-a0f1b2e80c8c
+                - 48520a9c-2f1e-4b5d-9371-1bbac0d630a8
         status: 404 Not Found
         code: 404
-        duration: 24.659833ms
-    - id: 45
+        duration: 25.068847ms
+    - id: 44
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2229,8 +2180,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/2ff1ee02-3bdd-4ced-93e4-769d7a3c6bec
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/403178d9-4dc5-4643-8837-b01ed9991cb1
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -2249,9 +2200,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:55 GMT
+                - Wed, 27 Aug 2025 15:07:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2259,7 +2210,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8d611dfd-0ab5-4e4d-a961-7911bf854777
+                - 4051cc18-d1ec-4e57-bbb7-69d0dcb77574
         status: 404 Not Found
         code: 404
-        duration: 20.802916ms
+        duration: 37.913453ms

--- a/internal/services/container/testdata/container-private-network.cassette.yaml
+++ b/internal/services/container/testdata/container-private-network.cassette.yaml
@@ -6,20 +6,20 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 187
+        content_length: 156
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-ns-gallant-haibt","environment_variables":{},"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","secret_environment_variables":[],"tags":null,"activate_vpc_integration":true}'
+        body: '{"name":"test-acc-container-pn-pn00","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","tags":[],"subnets":null,"default_route_propagation_enabled":false}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
         method: POST
       response:
         proto: HTTP/2.0
@@ -27,20 +27,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 504
+        content_length: 1072
         uncompressed: false
-        body: '{"created_at":"2025-06-16T16:33:23.753071204Z","description":"","environment_variables":{},"error_message":null,"id":"36b36416-4c12-41cd-ba2b-52a002600f06","name":"tf-ns-gallant-haibt","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-06-16T16:33:23.753071204Z","vpc_integration_activated":true}'
+        body: '{"created_at":"2025-08-27T15:06:02.065728Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"932f31bb-f882-443f-be0e-9cc4f0bd70fa","name":"test-acc-container-pn-pn00","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","subnets":[{"created_at":"2025-08-27T15:06:02.065728Z","id":"0229a8c6-bc1d-4c1d-a39f-757914bf3e21","private_network_id":"932f31bb-f882-443f-be0e-9cc4f0bd70fa","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","subnet":"172.16.32.0/22","updated_at":"2025-08-27T15:06:02.065728Z","vpc_id":"bfef8344-f496-473e-af67-31ea9afc407c"},{"created_at":"2025-08-27T15:06:02.065728Z","id":"40f741ae-c39f-4f7f-a05c-440b603b61d7","private_network_id":"932f31bb-f882-443f-be0e-9cc4f0bd70fa","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","subnet":"fde7:767f:1bb5:e3b7::/64","updated_at":"2025-08-27T15:06:02.065728Z","vpc_id":"bfef8344-f496-473e-af67-31ea9afc407c"}],"tags":[],"updated_at":"2025-08-27T15:06:02.065728Z","vpc_id":"bfef8344-f496-473e-af67-31ea9afc407c"}'
         headers:
             Content-Length:
-                - "504"
+                - "1072"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:23 GMT
+                - Wed, 27 Aug 2025 15:06:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7be997da-de71-4737-b8f6-f0fdaadc68fd
+                - 363689d9-1642-494c-864a-a57492f2f164
         status: 200 OK
         code: 200
-        duration: 351.885337ms
+        duration: 923.829189ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -68,7 +68,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/36b36416-4c12-41cd-ba2b-52a002600f06
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/932f31bb-f882-443f-be0e-9cc4f0bd70fa
         method: GET
       response:
         proto: HTTP/2.0
@@ -76,20 +76,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 498
+        content_length: 1072
         uncompressed: false
-        body: '{"created_at":"2025-06-16T16:33:23.753071Z","description":"","environment_variables":{},"error_message":null,"id":"36b36416-4c12-41cd-ba2b-52a002600f06","name":"tf-ns-gallant-haibt","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-06-16T16:33:23.753071Z","vpc_integration_activated":true}'
+        body: '{"created_at":"2025-08-27T15:06:02.065728Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"932f31bb-f882-443f-be0e-9cc4f0bd70fa","name":"test-acc-container-pn-pn00","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","subnets":[{"created_at":"2025-08-27T15:06:02.065728Z","id":"0229a8c6-bc1d-4c1d-a39f-757914bf3e21","private_network_id":"932f31bb-f882-443f-be0e-9cc4f0bd70fa","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","subnet":"172.16.32.0/22","updated_at":"2025-08-27T15:06:02.065728Z","vpc_id":"bfef8344-f496-473e-af67-31ea9afc407c"},{"created_at":"2025-08-27T15:06:02.065728Z","id":"40f741ae-c39f-4f7f-a05c-440b603b61d7","private_network_id":"932f31bb-f882-443f-be0e-9cc4f0bd70fa","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","subnet":"fde7:767f:1bb5:e3b7::/64","updated_at":"2025-08-27T15:06:02.065728Z","vpc_id":"bfef8344-f496-473e-af67-31ea9afc407c"}],"tags":[],"updated_at":"2025-08-27T15:06:02.065728Z","vpc_id":"bfef8344-f496-473e-af67-31ea9afc407c"}'
         headers:
             Content-Length:
-                - "498"
+                - "1072"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:23 GMT
+                - Wed, 27 Aug 2025 15:06:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2a0965e3-2ec6-4a0a-99ca-d3cb247b46d7
+                - c970aa76-4bf7-484a-93ba-a340e1128213
         status: 200 OK
         code: 200
-        duration: 40.987187ms
+        duration: 19.316456ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -112,7 +112,7 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"test-acc-container-pn-pn01","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"subnets":null,"default_route_propagation_enabled":false}'
+        body: '{"name":"test-acc-container-pn-pn01","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","tags":[],"subnets":null,"default_route_propagation_enabled":false}'
         form: {}
         headers:
             Content-Type:
@@ -129,7 +129,7 @@ interactions:
         trailer: {}
         content_length: 1071
         uncompressed: false
-        body: '{"created_at":"2025-06-16T16:33:23.625701Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"c806474f-01fa-47a9-b59a-a57f0ddfce80","name":"test-acc-container-pn-pn01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-06-16T16:33:23.625701Z","id":"d2bc5535-6dc9-4782-bd4d-d36deb39b558","private_network_id":"c806474f-01fa-47a9-b59a-a57f0ddfce80","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.4.0/22","updated_at":"2025-06-16T16:33:23.625701Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-06-16T16:33:23.625701Z","id":"a38e59ef-cd3c-443f-ae15-6c0d8ff3508a","private_network_id":"c806474f-01fa-47a9-b59a-a57f0ddfce80","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:ce3b::/64","updated_at":"2025-06-16T16:33:23.625701Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-06-16T16:33:23.625701Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+        body: '{"created_at":"2025-08-27T15:06:02.345555Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"49592394-2619-4001-b8ab-cbb5017db9d9","name":"test-acc-container-pn-pn01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","subnets":[{"created_at":"2025-08-27T15:06:02.345555Z","id":"55b5c4c2-43a9-4d50-b6f8-c3207b0f9cb5","private_network_id":"49592394-2619-4001-b8ab-cbb5017db9d9","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","subnet":"172.16.4.0/22","updated_at":"2025-08-27T15:06:02.345555Z","vpc_id":"bfef8344-f496-473e-af67-31ea9afc407c"},{"created_at":"2025-08-27T15:06:02.345555Z","id":"2c9fda53-fa80-4dd7-977b-09d2e00670c1","private_network_id":"49592394-2619-4001-b8ab-cbb5017db9d9","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","subnet":"fde7:767f:1bb5:cd83::/64","updated_at":"2025-08-27T15:06:02.345555Z","vpc_id":"bfef8344-f496-473e-af67-31ea9afc407c"}],"tags":[],"updated_at":"2025-08-27T15:06:02.345555Z","vpc_id":"bfef8344-f496-473e-af67-31ea9afc407c"}'
         headers:
             Content-Length:
                 - "1071"
@@ -138,9 +138,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:24 GMT
+                - Wed, 27 Aug 2025 15:06:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -148,10 +148,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e4d73123-f498-4f1b-a4ef-eb5534e62dd2
+                - 944362e2-88fd-4085-9912-fe462663bb3f
         status: 200 OK
         code: 200
-        duration: 755.457175ms
+        duration: 1.08548959s
     - id: 3
       request:
         proto: HTTP/1.1
@@ -168,7 +168,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c806474f-01fa-47a9-b59a-a57f0ddfce80
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/49592394-2619-4001-b8ab-cbb5017db9d9
         method: GET
       response:
         proto: HTTP/2.0
@@ -178,7 +178,7 @@ interactions:
         trailer: {}
         content_length: 1071
         uncompressed: false
-        body: '{"created_at":"2025-06-16T16:33:23.625701Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"c806474f-01fa-47a9-b59a-a57f0ddfce80","name":"test-acc-container-pn-pn01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-06-16T16:33:23.625701Z","id":"d2bc5535-6dc9-4782-bd4d-d36deb39b558","private_network_id":"c806474f-01fa-47a9-b59a-a57f0ddfce80","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.4.0/22","updated_at":"2025-06-16T16:33:23.625701Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-06-16T16:33:23.625701Z","id":"a38e59ef-cd3c-443f-ae15-6c0d8ff3508a","private_network_id":"c806474f-01fa-47a9-b59a-a57f0ddfce80","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:ce3b::/64","updated_at":"2025-06-16T16:33:23.625701Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-06-16T16:33:23.625701Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+        body: '{"created_at":"2025-08-27T15:06:02.345555Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"49592394-2619-4001-b8ab-cbb5017db9d9","name":"test-acc-container-pn-pn01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","subnets":[{"created_at":"2025-08-27T15:06:02.345555Z","id":"55b5c4c2-43a9-4d50-b6f8-c3207b0f9cb5","private_network_id":"49592394-2619-4001-b8ab-cbb5017db9d9","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","subnet":"172.16.4.0/22","updated_at":"2025-08-27T15:06:02.345555Z","vpc_id":"bfef8344-f496-473e-af67-31ea9afc407c"},{"created_at":"2025-08-27T15:06:02.345555Z","id":"2c9fda53-fa80-4dd7-977b-09d2e00670c1","private_network_id":"49592394-2619-4001-b8ab-cbb5017db9d9","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","subnet":"fde7:767f:1bb5:cd83::/64","updated_at":"2025-08-27T15:06:02.345555Z","vpc_id":"bfef8344-f496-473e-af67-31ea9afc407c"}],"tags":[],"updated_at":"2025-08-27T15:06:02.345555Z","vpc_id":"bfef8344-f496-473e-af67-31ea9afc407c"}'
         headers:
             Content-Length:
                 - "1071"
@@ -187,9 +187,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:24 GMT
+                - Wed, 27 Aug 2025 15:06:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -197,29 +197,29 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7a7365e2-6f37-4ae0-884c-a27fb4823a92
+                - 76694206-4bfd-478c-bc1d-95d068326cf8
         status: 200 OK
         code: 200
-        duration: 26.619786ms
+        duration: 83.505336ms
     - id: 4
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 156
+        content_length: 192
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"test-acc-container-pn-pn00","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"subnets":null,"default_route_propagation_enabled":false}'
+        body: '{"name":"tf-ns-stoic-visvesvaraya","environment_variables":{},"project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","secret_environment_variables":[],"tags":null,"activate_vpc_integration":true}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces
         method: POST
       response:
         proto: HTTP/2.0
@@ -227,20 +227,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1072
+        content_length: 509
         uncompressed: false
-        body: '{"created_at":"2025-06-16T16:33:23.708187Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"8a415abf-00cd-4db2-bdc4-12408ad70c98","name":"test-acc-container-pn-pn00","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-06-16T16:33:23.708187Z","id":"15b4ea61-5306-454b-aa0e-bf9af4de300d","private_network_id":"8a415abf-00cd-4db2-bdc4-12408ad70c98","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.48.0/22","updated_at":"2025-06-16T16:33:23.708187Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-06-16T16:33:23.708187Z","id":"aa029065-1714-4b11-9d82-360ac03ac61c","private_network_id":"8a415abf-00cd-4db2-bdc4-12408ad70c98","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:e008::/64","updated_at":"2025-06-16T16:33:23.708187Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-06-16T16:33:23.708187Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+        body: '{"created_at":"2025-08-27T15:06:03.495906682Z","description":"","environment_variables":{},"error_message":null,"id":"627dd919-7422-43e4-bc7b-ce02de6605c9","name":"tf-ns-stoic-visvesvaraya","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:06:03.495906682Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "1072"
+                - "509"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:24 GMT
+                - Wed, 27 Aug 2025 15:06:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -248,10 +248,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a7e60a69-8de6-40a6-b81d-093b030cce3d
+                - 0ec0b3eb-38f3-4d83-b052-bd3b497394d2
         status: 200 OK
         code: 200
-        duration: 826.19513ms
+        duration: 1.521193308s
     - id: 5
       request:
         proto: HTTP/1.1
@@ -268,7 +268,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/8a415abf-00cd-4db2-bdc4-12408ad70c98
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/627dd919-7422-43e4-bc7b-ce02de6605c9
         method: GET
       response:
         proto: HTTP/2.0
@@ -276,20 +276,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1072
+        content_length: 503
         uncompressed: false
-        body: '{"created_at":"2025-06-16T16:33:23.708187Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"8a415abf-00cd-4db2-bdc4-12408ad70c98","name":"test-acc-container-pn-pn00","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-06-16T16:33:23.708187Z","id":"15b4ea61-5306-454b-aa0e-bf9af4de300d","private_network_id":"8a415abf-00cd-4db2-bdc4-12408ad70c98","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.48.0/22","updated_at":"2025-06-16T16:33:23.708187Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-06-16T16:33:23.708187Z","id":"aa029065-1714-4b11-9d82-360ac03ac61c","private_network_id":"8a415abf-00cd-4db2-bdc4-12408ad70c98","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:e008::/64","updated_at":"2025-06-16T16:33:23.708187Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-06-16T16:33:23.708187Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+        body: '{"created_at":"2025-08-27T15:06:03.495907Z","description":"","environment_variables":{},"error_message":null,"id":"627dd919-7422-43e4-bc7b-ce02de6605c9","name":"tf-ns-stoic-visvesvaraya","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:06:03.495907Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "1072"
+                - "503"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:24 GMT
+                - Wed, 27 Aug 2025 15:06:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -297,10 +297,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8151cdd9-40e3-4d40-81eb-d854afea5715
+                - aa5b2b46-aed9-4688-b3c9-bb06d29a6fe6
         status: 200 OK
         code: 200
-        duration: 68.537297ms
+        duration: 75.400688ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -317,7 +317,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/36b36416-4c12-41cd-ba2b-52a002600f06
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/627dd919-7422-43e4-bc7b-ce02de6605c9
         method: GET
       response:
         proto: HTTP/2.0
@@ -325,20 +325,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 583
+        content_length: 592
         uncompressed: false
-        body: '{"created_at":"2025-06-16T16:33:23.753071Z","description":"","environment_variables":{},"error_message":null,"id":"36b36416-4c12-41cd-ba2b-52a002600f06","name":"tf-ns-gallant-haibt","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsgallanthaibtku6hfpsd","registry_namespace_id":"a9a080da-7f15-4f03-adcf-9ab5d353fb37","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-16T16:33:24.797296Z","vpc_integration_activated":true}'
+        body: '{"created_at":"2025-08-27T15:06:03.495907Z","description":"","environment_variables":{},"error_message":null,"id":"627dd919-7422-43e4-bc7b-ce02de6605c9","name":"tf-ns-stoic-visvesvaraya","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsstoicvisvesvarayusdiiaiq","registry_namespace_id":"53f25a1b-bdfc-4c98-b9ea-30968c2ae2f1","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:06.063436Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "583"
+                - "592"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:28 GMT
+                - Wed, 27 Aug 2025 15:06:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -346,10 +346,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 55d7cf6f-a4ae-439c-a2d7-492a3815cdbb
+                - 03a185df-b9bd-47c4-8da5-d5d6effdf2aa
         status: 200 OK
         code: 200
-        duration: 59.161738ms
+        duration: 77.063249ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -366,7 +366,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/36b36416-4c12-41cd-ba2b-52a002600f06
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/627dd919-7422-43e4-bc7b-ce02de6605c9
         method: GET
       response:
         proto: HTTP/2.0
@@ -374,20 +374,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 583
+        content_length: 592
         uncompressed: false
-        body: '{"created_at":"2025-06-16T16:33:23.753071Z","description":"","environment_variables":{},"error_message":null,"id":"36b36416-4c12-41cd-ba2b-52a002600f06","name":"tf-ns-gallant-haibt","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsgallanthaibtku6hfpsd","registry_namespace_id":"a9a080da-7f15-4f03-adcf-9ab5d353fb37","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-16T16:33:24.797296Z","vpc_integration_activated":true}'
+        body: '{"created_at":"2025-08-27T15:06:03.495907Z","description":"","environment_variables":{},"error_message":null,"id":"627dd919-7422-43e4-bc7b-ce02de6605c9","name":"tf-ns-stoic-visvesvaraya","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsstoicvisvesvarayusdiiaiq","registry_namespace_id":"53f25a1b-bdfc-4c98-b9ea-30968c2ae2f1","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:06.063436Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "583"
+                - "592"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:28 GMT
+                - Wed, 27 Aug 2025 15:06:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -395,10 +395,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 05cbb4b0-dc0b-4bcc-9021-6663980f5f30
+                - df93ec6d-72c5-41b0-9df4-9fddf5259712
         status: 200 OK
         code: 200
-        duration: 86.374275ms
+        duration: 99.626429ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -415,7 +415,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/36b36416-4c12-41cd-ba2b-52a002600f06
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/627dd919-7422-43e4-bc7b-ce02de6605c9
         method: GET
       response:
         proto: HTTP/2.0
@@ -423,20 +423,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 583
+        content_length: 592
         uncompressed: false
-        body: '{"created_at":"2025-06-16T16:33:23.753071Z","description":"","environment_variables":{},"error_message":null,"id":"36b36416-4c12-41cd-ba2b-52a002600f06","name":"tf-ns-gallant-haibt","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsgallanthaibtku6hfpsd","registry_namespace_id":"a9a080da-7f15-4f03-adcf-9ab5d353fb37","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-16T16:33:24.797296Z","vpc_integration_activated":true}'
+        body: '{"created_at":"2025-08-27T15:06:03.495907Z","description":"","environment_variables":{},"error_message":null,"id":"627dd919-7422-43e4-bc7b-ce02de6605c9","name":"tf-ns-stoic-visvesvaraya","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsstoicvisvesvarayusdiiaiq","registry_namespace_id":"53f25a1b-bdfc-4c98-b9ea-30968c2ae2f1","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:06.063436Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "583"
+                - "592"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:29 GMT
+                - Wed, 27 Aug 2025 15:06:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -444,10 +444,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 45c01280-e312-4f30-863d-d51889ff7941
+                - 7daaebf8-9076-4452-a8ba-917eae62eb2f
         status: 200 OK
         code: 200
-        duration: 53.518484ms
+        duration: 80.370254ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -459,7 +459,7 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"namespace_id":"36b36416-4c12-41cd-ba2b-52a002600f06","name":"test-acc-container-pn-c00","privacy":"public","protocol":"http1","secret_environment_variables":null,"http_option":"enabled","sandbox":"v1","tags":null,"private_network_id":"8a415abf-00cd-4db2-bdc4-12408ad70c98","command":null,"args":null}'
+        body: '{"namespace_id":"627dd919-7422-43e4-bc7b-ce02de6605c9","name":"test-acc-container-pn-c00","privacy":"public","protocol":"http1","secret_environment_variables":null,"http_option":"enabled","sandbox":"v1","tags":null,"private_network_id":"932f31bb-f882-443f-be0e-9cc4f0bd70fa","command":null,"args":null}'
         form: {}
         headers:
             Content-Type:
@@ -474,20 +474,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1012
+        content_length: 1020
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-16T16:33:29.364422515Z","description":"","domain_name":"tfnsgallanthaibtku6hfpsd-test-acc-container-pn-c00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"aa1afb40-4da5-4bf9-a989-3cfb175fb432","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c00","namespace_id":"36b36416-4c12-41cd-ba2b-52a002600f06","port":8080,"privacy":"public","private_network_id":"8a415abf-00cd-4db2-bdc4-12408ad70c98","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsgallanthaibtku6hfpsd/test-acc-container-pn-c00:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:33:29.364422515Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:10.000783803Z","description":"","domain_name":"tfnsstoicvisvesvarayusdiiaiq-test-acc-container-pn-c00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a574568d-5c43-482b-9d82-513f27e7d2ad","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c00","namespace_id":"627dd919-7422-43e4-bc7b-ce02de6605c9","port":8080,"privacy":"public","private_network_id":"932f31bb-f882-443f-be0e-9cc4f0bd70fa","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsstoicvisvesvarayusdiiaiq/test-acc-container-pn-c00:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:10.000783803Z"}'
         headers:
             Content-Length:
-                - "1012"
+                - "1020"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:29 GMT
+                - Wed, 27 Aug 2025 15:06:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -495,10 +495,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - af780b53-5be9-41f1-9e31-643bcc3b620a
+                - f02c9e71-31d0-4bdb-9eef-1555e79606ec
         status: 200 OK
         code: 200
-        duration: 389.974478ms
+        duration: 1.246078881s
     - id: 10
       request:
         proto: HTTP/1.1
@@ -515,7 +515,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/aa1afb40-4da5-4bf9-a989-3cfb175fb432
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a574568d-5c43-482b-9d82-513f27e7d2ad
         method: GET
       response:
         proto: HTTP/2.0
@@ -523,20 +523,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1006
+        content_length: 1014
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-16T16:33:29.364423Z","description":"","domain_name":"tfnsgallanthaibtku6hfpsd-test-acc-container-pn-c00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"aa1afb40-4da5-4bf9-a989-3cfb175fb432","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c00","namespace_id":"36b36416-4c12-41cd-ba2b-52a002600f06","port":8080,"privacy":"public","private_network_id":"8a415abf-00cd-4db2-bdc4-12408ad70c98","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsgallanthaibtku6hfpsd/test-acc-container-pn-c00:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:33:29.364423Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:10.000784Z","description":"","domain_name":"tfnsstoicvisvesvarayusdiiaiq-test-acc-container-pn-c00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a574568d-5c43-482b-9d82-513f27e7d2ad","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c00","namespace_id":"627dd919-7422-43e4-bc7b-ce02de6605c9","port":8080,"privacy":"public","private_network_id":"932f31bb-f882-443f-be0e-9cc4f0bd70fa","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsstoicvisvesvarayusdiiaiq/test-acc-container-pn-c00:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:10.000784Z"}'
         headers:
             Content-Length:
-                - "1006"
+                - "1014"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:29 GMT
+                - Wed, 27 Aug 2025 15:06:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -544,10 +544,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a6406d0c-27be-48fc-988a-c83e43586d1e
+                - 363a4503-c652-4696-af89-e2b5e83a9d85
         status: 200 OK
         code: 200
-        duration: 60.399798ms
+        duration: 99.575764ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -564,7 +564,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/aa1afb40-4da5-4bf9-a989-3cfb175fb432
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a574568d-5c43-482b-9d82-513f27e7d2ad
         method: GET
       response:
         proto: HTTP/2.0
@@ -572,20 +572,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1006
+        content_length: 1014
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-16T16:33:29.364423Z","description":"","domain_name":"tfnsgallanthaibtku6hfpsd-test-acc-container-pn-c00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"aa1afb40-4da5-4bf9-a989-3cfb175fb432","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c00","namespace_id":"36b36416-4c12-41cd-ba2b-52a002600f06","port":8080,"privacy":"public","private_network_id":"8a415abf-00cd-4db2-bdc4-12408ad70c98","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsgallanthaibtku6hfpsd/test-acc-container-pn-c00:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:33:29.364423Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:10.000784Z","description":"","domain_name":"tfnsstoicvisvesvarayusdiiaiq-test-acc-container-pn-c00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a574568d-5c43-482b-9d82-513f27e7d2ad","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c00","namespace_id":"627dd919-7422-43e4-bc7b-ce02de6605c9","port":8080,"privacy":"public","private_network_id":"932f31bb-f882-443f-be0e-9cc4f0bd70fa","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsstoicvisvesvarayusdiiaiq/test-acc-container-pn-c00:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:10.000784Z"}'
         headers:
             Content-Length:
-                - "1006"
+                - "1014"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:29 GMT
+                - Wed, 27 Aug 2025 15:06:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -593,10 +593,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 495c54e8-f6a9-43df-bc13-116264a7f7aa
+                - d46c9429-d976-4f9d-81c0-e357ee471c91
         status: 200 OK
         code: 200
-        duration: 63.395456ms
+        duration: 107.796409ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -613,7 +613,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/8a415abf-00cd-4db2-bdc4-12408ad70c98
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/932f31bb-f882-443f-be0e-9cc4f0bd70fa
         method: GET
       response:
         proto: HTTP/2.0
@@ -623,7 +623,7 @@ interactions:
         trailer: {}
         content_length: 1072
         uncompressed: false
-        body: '{"created_at":"2025-06-16T16:33:23.708187Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"8a415abf-00cd-4db2-bdc4-12408ad70c98","name":"test-acc-container-pn-pn00","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-06-16T16:33:23.708187Z","id":"15b4ea61-5306-454b-aa0e-bf9af4de300d","private_network_id":"8a415abf-00cd-4db2-bdc4-12408ad70c98","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.48.0/22","updated_at":"2025-06-16T16:33:23.708187Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-06-16T16:33:23.708187Z","id":"aa029065-1714-4b11-9d82-360ac03ac61c","private_network_id":"8a415abf-00cd-4db2-bdc4-12408ad70c98","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:e008::/64","updated_at":"2025-06-16T16:33:23.708187Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-06-16T16:33:23.708187Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+        body: '{"created_at":"2025-08-27T15:06:02.065728Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"932f31bb-f882-443f-be0e-9cc4f0bd70fa","name":"test-acc-container-pn-pn00","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","subnets":[{"created_at":"2025-08-27T15:06:02.065728Z","id":"0229a8c6-bc1d-4c1d-a39f-757914bf3e21","private_network_id":"932f31bb-f882-443f-be0e-9cc4f0bd70fa","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","subnet":"172.16.32.0/22","updated_at":"2025-08-27T15:06:02.065728Z","vpc_id":"bfef8344-f496-473e-af67-31ea9afc407c"},{"created_at":"2025-08-27T15:06:02.065728Z","id":"40f741ae-c39f-4f7f-a05c-440b603b61d7","private_network_id":"932f31bb-f882-443f-be0e-9cc4f0bd70fa","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","subnet":"fde7:767f:1bb5:e3b7::/64","updated_at":"2025-08-27T15:06:02.065728Z","vpc_id":"bfef8344-f496-473e-af67-31ea9afc407c"}],"tags":[],"updated_at":"2025-08-27T15:06:02.065728Z","vpc_id":"bfef8344-f496-473e-af67-31ea9afc407c"}'
         headers:
             Content-Length:
                 - "1072"
@@ -632,9 +632,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:30 GMT
+                - Wed, 27 Aug 2025 15:06:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -642,10 +642,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 06410dbe-aa49-446f-a017-658eed162b9b
+                - faf67eb8-ec11-44d5-be89-08a1d74d9cd6
         status: 200 OK
         code: 200
-        duration: 29.717915ms
+        duration: 28.813579ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -662,7 +662,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c806474f-01fa-47a9-b59a-a57f0ddfce80
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/49592394-2619-4001-b8ab-cbb5017db9d9
         method: GET
       response:
         proto: HTTP/2.0
@@ -672,7 +672,7 @@ interactions:
         trailer: {}
         content_length: 1071
         uncompressed: false
-        body: '{"created_at":"2025-06-16T16:33:23.625701Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"c806474f-01fa-47a9-b59a-a57f0ddfce80","name":"test-acc-container-pn-pn01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-06-16T16:33:23.625701Z","id":"d2bc5535-6dc9-4782-bd4d-d36deb39b558","private_network_id":"c806474f-01fa-47a9-b59a-a57f0ddfce80","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.4.0/22","updated_at":"2025-06-16T16:33:23.625701Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-06-16T16:33:23.625701Z","id":"a38e59ef-cd3c-443f-ae15-6c0d8ff3508a","private_network_id":"c806474f-01fa-47a9-b59a-a57f0ddfce80","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:ce3b::/64","updated_at":"2025-06-16T16:33:23.625701Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-06-16T16:33:23.625701Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+        body: '{"created_at":"2025-08-27T15:06:02.345555Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"49592394-2619-4001-b8ab-cbb5017db9d9","name":"test-acc-container-pn-pn01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","subnets":[{"created_at":"2025-08-27T15:06:02.345555Z","id":"55b5c4c2-43a9-4d50-b6f8-c3207b0f9cb5","private_network_id":"49592394-2619-4001-b8ab-cbb5017db9d9","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","subnet":"172.16.4.0/22","updated_at":"2025-08-27T15:06:02.345555Z","vpc_id":"bfef8344-f496-473e-af67-31ea9afc407c"},{"created_at":"2025-08-27T15:06:02.345555Z","id":"2c9fda53-fa80-4dd7-977b-09d2e00670c1","private_network_id":"49592394-2619-4001-b8ab-cbb5017db9d9","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","subnet":"fde7:767f:1bb5:cd83::/64","updated_at":"2025-08-27T15:06:02.345555Z","vpc_id":"bfef8344-f496-473e-af67-31ea9afc407c"}],"tags":[],"updated_at":"2025-08-27T15:06:02.345555Z","vpc_id":"bfef8344-f496-473e-af67-31ea9afc407c"}'
         headers:
             Content-Length:
                 - "1071"
@@ -681,9 +681,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:30 GMT
+                - Wed, 27 Aug 2025 15:06:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -691,10 +691,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f260d6ed-76bf-49bb-9757-8a0d8b80a015
+                - a1cac893-b339-4096-92a2-2546e2be6b21
         status: 200 OK
         code: 200
-        duration: 38.820324ms
+        duration: 95.981109ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -711,7 +711,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/36b36416-4c12-41cd-ba2b-52a002600f06
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/627dd919-7422-43e4-bc7b-ce02de6605c9
         method: GET
       response:
         proto: HTTP/2.0
@@ -719,20 +719,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 583
+        content_length: 592
         uncompressed: false
-        body: '{"created_at":"2025-06-16T16:33:23.753071Z","description":"","environment_variables":{},"error_message":null,"id":"36b36416-4c12-41cd-ba2b-52a002600f06","name":"tf-ns-gallant-haibt","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsgallanthaibtku6hfpsd","registry_namespace_id":"a9a080da-7f15-4f03-adcf-9ab5d353fb37","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-16T16:33:24.797296Z","vpc_integration_activated":true}'
+        body: '{"created_at":"2025-08-27T15:06:03.495907Z","description":"","environment_variables":{},"error_message":null,"id":"627dd919-7422-43e4-bc7b-ce02de6605c9","name":"tf-ns-stoic-visvesvaraya","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsstoicvisvesvarayusdiiaiq","registry_namespace_id":"53f25a1b-bdfc-4c98-b9ea-30968c2ae2f1","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:06.063436Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "583"
+                - "592"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:30 GMT
+                - Wed, 27 Aug 2025 15:06:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -740,10 +740,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f988c6f0-b7c7-4e3f-abf3-7e20f4c7bc4d
+                - 19e025f1-d20d-443e-a66a-5a5c92582861
         status: 200 OK
         code: 200
-        duration: 46.035182ms
+        duration: 107.836865ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -760,7 +760,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/aa1afb40-4da5-4bf9-a989-3cfb175fb432
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a574568d-5c43-482b-9d82-513f27e7d2ad
         method: GET
       response:
         proto: HTTP/2.0
@@ -768,20 +768,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1006
+        content_length: 1014
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-16T16:33:29.364423Z","description":"","domain_name":"tfnsgallanthaibtku6hfpsd-test-acc-container-pn-c00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"aa1afb40-4da5-4bf9-a989-3cfb175fb432","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c00","namespace_id":"36b36416-4c12-41cd-ba2b-52a002600f06","port":8080,"privacy":"public","private_network_id":"8a415abf-00cd-4db2-bdc4-12408ad70c98","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsgallanthaibtku6hfpsd/test-acc-container-pn-c00:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:33:29.364423Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:10.000784Z","description":"","domain_name":"tfnsstoicvisvesvarayusdiiaiq-test-acc-container-pn-c00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a574568d-5c43-482b-9d82-513f27e7d2ad","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c00","namespace_id":"627dd919-7422-43e4-bc7b-ce02de6605c9","port":8080,"privacy":"public","private_network_id":"932f31bb-f882-443f-be0e-9cc4f0bd70fa","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsstoicvisvesvarayusdiiaiq/test-acc-container-pn-c00:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:10.000784Z"}'
         headers:
             Content-Length:
-                - "1006"
+                - "1014"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:30 GMT
+                - Wed, 27 Aug 2025 15:06:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -789,10 +789,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2486760a-8e64-4e01-892c-5820a22e1215
+                - 1de335a1-3df4-4b6b-a16b-f84a1f52d122
         status: 200 OK
         code: 200
-        duration: 102.068513ms
+        duration: 100.156162ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -809,7 +809,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/8a415abf-00cd-4db2-bdc4-12408ad70c98
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/49592394-2619-4001-b8ab-cbb5017db9d9
         method: GET
       response:
         proto: HTTP/2.0
@@ -817,20 +817,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1072
+        content_length: 1071
         uncompressed: false
-        body: '{"created_at":"2025-06-16T16:33:23.708187Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"8a415abf-00cd-4db2-bdc4-12408ad70c98","name":"test-acc-container-pn-pn00","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-06-16T16:33:23.708187Z","id":"15b4ea61-5306-454b-aa0e-bf9af4de300d","private_network_id":"8a415abf-00cd-4db2-bdc4-12408ad70c98","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.48.0/22","updated_at":"2025-06-16T16:33:23.708187Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-06-16T16:33:23.708187Z","id":"aa029065-1714-4b11-9d82-360ac03ac61c","private_network_id":"8a415abf-00cd-4db2-bdc4-12408ad70c98","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:e008::/64","updated_at":"2025-06-16T16:33:23.708187Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-06-16T16:33:23.708187Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+        body: '{"created_at":"2025-08-27T15:06:02.345555Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"49592394-2619-4001-b8ab-cbb5017db9d9","name":"test-acc-container-pn-pn01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","subnets":[{"created_at":"2025-08-27T15:06:02.345555Z","id":"55b5c4c2-43a9-4d50-b6f8-c3207b0f9cb5","private_network_id":"49592394-2619-4001-b8ab-cbb5017db9d9","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","subnet":"172.16.4.0/22","updated_at":"2025-08-27T15:06:02.345555Z","vpc_id":"bfef8344-f496-473e-af67-31ea9afc407c"},{"created_at":"2025-08-27T15:06:02.345555Z","id":"2c9fda53-fa80-4dd7-977b-09d2e00670c1","private_network_id":"49592394-2619-4001-b8ab-cbb5017db9d9","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","subnet":"fde7:767f:1bb5:cd83::/64","updated_at":"2025-08-27T15:06:02.345555Z","vpc_id":"bfef8344-f496-473e-af67-31ea9afc407c"}],"tags":[],"updated_at":"2025-08-27T15:06:02.345555Z","vpc_id":"bfef8344-f496-473e-af67-31ea9afc407c"}'
         headers:
             Content-Length:
-                - "1072"
+                - "1071"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:31 GMT
+                - Wed, 27 Aug 2025 15:06:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -838,10 +838,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 07d66516-1ba1-4cdd-a424-8f45f0f184d4
+                - e9ff2f3e-00f0-47a1-8f83-165ca26b0f06
         status: 200 OK
         code: 200
-        duration: 31.055554ms
+        duration: 34.197001ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -858,7 +858,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c806474f-01fa-47a9-b59a-a57f0ddfce80
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/932f31bb-f882-443f-be0e-9cc4f0bd70fa
         method: GET
       response:
         proto: HTTP/2.0
@@ -866,20 +866,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1071
+        content_length: 1072
         uncompressed: false
-        body: '{"created_at":"2025-06-16T16:33:23.625701Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"c806474f-01fa-47a9-b59a-a57f0ddfce80","name":"test-acc-container-pn-pn01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-06-16T16:33:23.625701Z","id":"d2bc5535-6dc9-4782-bd4d-d36deb39b558","private_network_id":"c806474f-01fa-47a9-b59a-a57f0ddfce80","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.4.0/22","updated_at":"2025-06-16T16:33:23.625701Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-06-16T16:33:23.625701Z","id":"a38e59ef-cd3c-443f-ae15-6c0d8ff3508a","private_network_id":"c806474f-01fa-47a9-b59a-a57f0ddfce80","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:ce3b::/64","updated_at":"2025-06-16T16:33:23.625701Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-06-16T16:33:23.625701Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+        body: '{"created_at":"2025-08-27T15:06:02.065728Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"932f31bb-f882-443f-be0e-9cc4f0bd70fa","name":"test-acc-container-pn-pn00","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","subnets":[{"created_at":"2025-08-27T15:06:02.065728Z","id":"0229a8c6-bc1d-4c1d-a39f-757914bf3e21","private_network_id":"932f31bb-f882-443f-be0e-9cc4f0bd70fa","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","subnet":"172.16.32.0/22","updated_at":"2025-08-27T15:06:02.065728Z","vpc_id":"bfef8344-f496-473e-af67-31ea9afc407c"},{"created_at":"2025-08-27T15:06:02.065728Z","id":"40f741ae-c39f-4f7f-a05c-440b603b61d7","private_network_id":"932f31bb-f882-443f-be0e-9cc4f0bd70fa","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","subnet":"fde7:767f:1bb5:e3b7::/64","updated_at":"2025-08-27T15:06:02.065728Z","vpc_id":"bfef8344-f496-473e-af67-31ea9afc407c"}],"tags":[],"updated_at":"2025-08-27T15:06:02.065728Z","vpc_id":"bfef8344-f496-473e-af67-31ea9afc407c"}'
         headers:
             Content-Length:
-                - "1071"
+                - "1072"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:31 GMT
+                - Wed, 27 Aug 2025 15:06:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -887,10 +887,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4814df52-259b-47b8-83f5-aea8ff29d6b0
+                - cd6294ba-952c-422c-a4df-4fec9c2a62d2
         status: 200 OK
         code: 200
-        duration: 33.604774ms
+        duration: 36.729653ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -907,7 +907,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/36b36416-4c12-41cd-ba2b-52a002600f06
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/627dd919-7422-43e4-bc7b-ce02de6605c9
         method: GET
       response:
         proto: HTTP/2.0
@@ -915,20 +915,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 583
+        content_length: 592
         uncompressed: false
-        body: '{"created_at":"2025-06-16T16:33:23.753071Z","description":"","environment_variables":{},"error_message":null,"id":"36b36416-4c12-41cd-ba2b-52a002600f06","name":"tf-ns-gallant-haibt","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsgallanthaibtku6hfpsd","registry_namespace_id":"a9a080da-7f15-4f03-adcf-9ab5d353fb37","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-16T16:33:24.797296Z","vpc_integration_activated":true}'
+        body: '{"created_at":"2025-08-27T15:06:03.495907Z","description":"","environment_variables":{},"error_message":null,"id":"627dd919-7422-43e4-bc7b-ce02de6605c9","name":"tf-ns-stoic-visvesvaraya","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsstoicvisvesvarayusdiiaiq","registry_namespace_id":"53f25a1b-bdfc-4c98-b9ea-30968c2ae2f1","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:06.063436Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "583"
+                - "592"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:31 GMT
+                - Wed, 27 Aug 2025 15:06:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -936,10 +936,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 751e2a25-9a1c-4e4c-b7b4-1da18c168923
+                - 74c92150-8dba-490d-9d08-e15900bdaffd
         status: 200 OK
         code: 200
-        duration: 38.39714ms
+        duration: 84.990635ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -956,7 +956,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/aa1afb40-4da5-4bf9-a989-3cfb175fb432
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a574568d-5c43-482b-9d82-513f27e7d2ad
         method: GET
       response:
         proto: HTTP/2.0
@@ -964,20 +964,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1006
+        content_length: 1014
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-16T16:33:29.364423Z","description":"","domain_name":"tfnsgallanthaibtku6hfpsd-test-acc-container-pn-c00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"aa1afb40-4da5-4bf9-a989-3cfb175fb432","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c00","namespace_id":"36b36416-4c12-41cd-ba2b-52a002600f06","port":8080,"privacy":"public","private_network_id":"8a415abf-00cd-4db2-bdc4-12408ad70c98","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsgallanthaibtku6hfpsd/test-acc-container-pn-c00:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:33:29.364423Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:10.000784Z","description":"","domain_name":"tfnsstoicvisvesvarayusdiiaiq-test-acc-container-pn-c00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a574568d-5c43-482b-9d82-513f27e7d2ad","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c00","namespace_id":"627dd919-7422-43e4-bc7b-ce02de6605c9","port":8080,"privacy":"public","private_network_id":"932f31bb-f882-443f-be0e-9cc4f0bd70fa","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsstoicvisvesvarayusdiiaiq/test-acc-container-pn-c00:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:10.000784Z"}'
         headers:
             Content-Length:
-                - "1006"
+                - "1014"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:31 GMT
+                - Wed, 27 Aug 2025 15:06:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -985,10 +985,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - eab8ee1b-5ee0-473d-ba1f-dda81be2a991
+                - 3468bee6-f90d-4112-9096-2fc6eb35d2af
         status: 200 OK
         code: 200
-        duration: 128.393966ms
+        duration: 102.166005ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1005,7 +1005,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/36b36416-4c12-41cd-ba2b-52a002600f06
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/627dd919-7422-43e4-bc7b-ce02de6605c9
         method: GET
       response:
         proto: HTTP/2.0
@@ -1013,20 +1013,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 583
+        content_length: 592
         uncompressed: false
-        body: '{"created_at":"2025-06-16T16:33:23.753071Z","description":"","environment_variables":{},"error_message":null,"id":"36b36416-4c12-41cd-ba2b-52a002600f06","name":"tf-ns-gallant-haibt","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsgallanthaibtku6hfpsd","registry_namespace_id":"a9a080da-7f15-4f03-adcf-9ab5d353fb37","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-16T16:33:24.797296Z","vpc_integration_activated":true}'
+        body: '{"created_at":"2025-08-27T15:06:03.495907Z","description":"","environment_variables":{},"error_message":null,"id":"627dd919-7422-43e4-bc7b-ce02de6605c9","name":"tf-ns-stoic-visvesvaraya","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsstoicvisvesvarayusdiiaiq","registry_namespace_id":"53f25a1b-bdfc-4c98-b9ea-30968c2ae2f1","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:06.063436Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "583"
+                - "592"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:32 GMT
+                - Wed, 27 Aug 2025 15:06:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1034,10 +1034,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - faf5c297-a0a9-4f58-af0a-83e9583f6750
+                - 9da8cf6e-c8ac-4ec3-ad97-62de5049bbd3
         status: 200 OK
         code: 200
-        duration: 43.86837ms
+        duration: 92.852248ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1054,7 +1054,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/36b36416-4c12-41cd-ba2b-52a002600f06
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/627dd919-7422-43e4-bc7b-ce02de6605c9
         method: GET
       response:
         proto: HTTP/2.0
@@ -1062,20 +1062,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 583
+        content_length: 592
         uncompressed: false
-        body: '{"created_at":"2025-06-16T16:33:23.753071Z","description":"","environment_variables":{},"error_message":null,"id":"36b36416-4c12-41cd-ba2b-52a002600f06","name":"tf-ns-gallant-haibt","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsgallanthaibtku6hfpsd","registry_namespace_id":"a9a080da-7f15-4f03-adcf-9ab5d353fb37","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-16T16:33:24.797296Z","vpc_integration_activated":true}'
+        body: '{"created_at":"2025-08-27T15:06:03.495907Z","description":"","environment_variables":{},"error_message":null,"id":"627dd919-7422-43e4-bc7b-ce02de6605c9","name":"tf-ns-stoic-visvesvaraya","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsstoicvisvesvarayusdiiaiq","registry_namespace_id":"53f25a1b-bdfc-4c98-b9ea-30968c2ae2f1","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:06.063436Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "583"
+                - "592"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:32 GMT
+                - Wed, 27 Aug 2025 15:06:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1083,10 +1083,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0b4103b8-eeb4-459b-a352-82fe3c4d6033
+                - 0473f626-2827-4f51-aefe-f67f927f52e0
         status: 200 OK
         code: 200
-        duration: 55.612501ms
+        duration: 94.981744ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1098,7 +1098,7 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"namespace_id":"36b36416-4c12-41cd-ba2b-52a002600f06","name":"test-acc-container-pn-c02","privacy":"public","protocol":"http1","secret_environment_variables":null,"http_option":"enabled","sandbox":"v1","tags":null,"private_network_id":"8a415abf-00cd-4db2-bdc4-12408ad70c98","command":null,"args":null}'
+        body: '{"namespace_id":"627dd919-7422-43e4-bc7b-ce02de6605c9","name":"test-acc-container-pn-c01","privacy":"public","protocol":"http1","secret_environment_variables":null,"http_option":"enabled","sandbox":"v1","tags":null,"private_network_id":"932f31bb-f882-443f-be0e-9cc4f0bd70fa","command":null,"args":null}'
         form: {}
         headers:
             Content-Type:
@@ -1113,20 +1113,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1012
+        content_length: 1020
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-16T16:33:33.320098169Z","description":"","domain_name":"tfnsgallanthaibtku6hfpsd-test-acc-container-pn-c02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a9e5fed6-13c0-4943-ae02-701b5bf3398b","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c02","namespace_id":"36b36416-4c12-41cd-ba2b-52a002600f06","port":8080,"privacy":"public","private_network_id":"8a415abf-00cd-4db2-bdc4-12408ad70c98","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsgallanthaibtku6hfpsd/test-acc-container-pn-c02:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:33:33.320098169Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:13.805947248Z","description":"","domain_name":"tfnsstoicvisvesvarayusdiiaiq-test-acc-container-pn-c01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"8a6e08c5-fc29-4bbe-af65-a749a99f7dc1","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c01","namespace_id":"627dd919-7422-43e4-bc7b-ce02de6605c9","port":8080,"privacy":"public","private_network_id":"932f31bb-f882-443f-be0e-9cc4f0bd70fa","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsstoicvisvesvarayusdiiaiq/test-acc-container-pn-c01:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:13.805947248Z"}'
         headers:
             Content-Length:
-                - "1012"
+                - "1020"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:33 GMT
+                - Wed, 27 Aug 2025 15:06:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1134,11 +1134,62 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 00f4414f-6324-4195-b4de-bb7aa468cd79
+                - 95c24bb2-49df-4358-b643-c6287394fe70
         status: 200 OK
         code: 200
-        duration: 768.504152ms
+        duration: 1.942257666s
     - id: 23
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 302
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"namespace_id":"627dd919-7422-43e4-bc7b-ce02de6605c9","name":"test-acc-container-pn-c02","privacy":"public","protocol":"http1","secret_environment_variables":null,"http_option":"enabled","sandbox":"v1","tags":null,"private_network_id":"932f31bb-f882-443f-be0e-9cc4f0bd70fa","command":null,"args":null}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1020
+        uncompressed: false
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:13.772340820Z","description":"","domain_name":"tfnsstoicvisvesvarayusdiiaiq-test-acc-container-pn-c02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"46867816-e5e1-47a4-993c-852289df4bae","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c02","namespace_id":"627dd919-7422-43e4-bc7b-ce02de6605c9","port":8080,"privacy":"public","private_network_id":"932f31bb-f882-443f-be0e-9cc4f0bd70fa","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsstoicvisvesvarayusdiiaiq/test-acc-container-pn-c02:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:13.772340820Z"}'
+        headers:
+            Content-Length:
+                - "1020"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:13 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 5c390651-f0d5-4e3d-908b-d499f9db1fc0
+        status: 200 OK
+        code: 200
+        duration: 1.987272537s
+    - id: 24
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1154,7 +1205,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a9e5fed6-13c0-4943-ae02-701b5bf3398b
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/8a6e08c5-fc29-4bbe-af65-a749a99f7dc1
         method: GET
       response:
         proto: HTTP/2.0
@@ -1162,20 +1213,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1006
+        content_length: 1014
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-16T16:33:33.320098Z","description":"","domain_name":"tfnsgallanthaibtku6hfpsd-test-acc-container-pn-c02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a9e5fed6-13c0-4943-ae02-701b5bf3398b","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c02","namespace_id":"36b36416-4c12-41cd-ba2b-52a002600f06","port":8080,"privacy":"public","private_network_id":"8a415abf-00cd-4db2-bdc4-12408ad70c98","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsgallanthaibtku6hfpsd/test-acc-container-pn-c02:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:33:33.320098Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:13.805947Z","description":"","domain_name":"tfnsstoicvisvesvarayusdiiaiq-test-acc-container-pn-c01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"8a6e08c5-fc29-4bbe-af65-a749a99f7dc1","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c01","namespace_id":"627dd919-7422-43e4-bc7b-ce02de6605c9","port":8080,"privacy":"public","private_network_id":"932f31bb-f882-443f-be0e-9cc4f0bd70fa","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsstoicvisvesvarayusdiiaiq/test-acc-container-pn-c01:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:13.805947Z"}'
         headers:
             Content-Length:
-                - "1006"
+                - "1014"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:33 GMT
+                - Wed, 27 Aug 2025 15:06:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1183,61 +1234,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3a173592-0b39-4498-b52c-8af4b0dab929
+                - 975bfab0-ee03-48b4-ba87-a01683603d8b
         status: 200 OK
         code: 200
-        duration: 60.267029ms
-    - id: 24
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 302
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"namespace_id":"36b36416-4c12-41cd-ba2b-52a002600f06","name":"test-acc-container-pn-c01","privacy":"public","protocol":"http1","secret_environment_variables":null,"http_option":"enabled","sandbox":"v1","tags":null,"private_network_id":"8a415abf-00cd-4db2-bdc4-12408ad70c98","command":null,"args":null}'
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 1012
-        uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-16T16:33:33.616540034Z","description":"","domain_name":"tfnsgallanthaibtku6hfpsd-test-acc-container-pn-c01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"1df2d836-32fe-4bf3-8a83-1fb38505f339","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c01","namespace_id":"36b36416-4c12-41cd-ba2b-52a002600f06","port":8080,"privacy":"public","private_network_id":"8a415abf-00cd-4db2-bdc4-12408ad70c98","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsgallanthaibtku6hfpsd/test-acc-container-pn-c01:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:33:33.616540034Z"}'
-        headers:
-            Content-Length:
-                - "1012"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 16 Jun 2025 16:33:33 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 1a29ea7a-01c3-43c6-bc3f-03ce8435e58b
-        status: 200 OK
-        code: 200
-        duration: 1.024760498s
+        duration: 94.221608ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1254,7 +1254,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/1df2d836-32fe-4bf3-8a83-1fb38505f339
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/46867816-e5e1-47a4-993c-852289df4bae
         method: GET
       response:
         proto: HTTP/2.0
@@ -1262,20 +1262,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1006
+        content_length: 1014
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-16T16:33:33.616540Z","description":"","domain_name":"tfnsgallanthaibtku6hfpsd-test-acc-container-pn-c01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"1df2d836-32fe-4bf3-8a83-1fb38505f339","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c01","namespace_id":"36b36416-4c12-41cd-ba2b-52a002600f06","port":8080,"privacy":"public","private_network_id":"8a415abf-00cd-4db2-bdc4-12408ad70c98","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsgallanthaibtku6hfpsd/test-acc-container-pn-c01:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:33:33.616540Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:13.772341Z","description":"","domain_name":"tfnsstoicvisvesvarayusdiiaiq-test-acc-container-pn-c02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"46867816-e5e1-47a4-993c-852289df4bae","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c02","namespace_id":"627dd919-7422-43e4-bc7b-ce02de6605c9","port":8080,"privacy":"public","private_network_id":"932f31bb-f882-443f-be0e-9cc4f0bd70fa","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsstoicvisvesvarayusdiiaiq/test-acc-container-pn-c02:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:13.772341Z"}'
         headers:
             Content-Length:
-                - "1006"
+                - "1014"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:33 GMT
+                - Wed, 27 Aug 2025 15:06:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1283,10 +1283,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e01c32c0-41fa-4c03-ae1a-e0ec5daed94f
+                - 7c5db306-d96b-4493-8dbb-1231c90bfc73
         status: 200 OK
         code: 200
-        duration: 83.963814ms
+        duration: 98.459249ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1303,7 +1303,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/aa1afb40-4da5-4bf9-a989-3cfb175fb432
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a574568d-5c43-482b-9d82-513f27e7d2ad
         method: GET
       response:
         proto: HTTP/2.0
@@ -1311,20 +1311,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1006
+        content_length: 1014
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-16T16:33:29.364423Z","description":"","domain_name":"tfnsgallanthaibtku6hfpsd-test-acc-container-pn-c00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"aa1afb40-4da5-4bf9-a989-3cfb175fb432","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c00","namespace_id":"36b36416-4c12-41cd-ba2b-52a002600f06","port":8080,"privacy":"public","private_network_id":"8a415abf-00cd-4db2-bdc4-12408ad70c98","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsgallanthaibtku6hfpsd/test-acc-container-pn-c00:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:33:29.364423Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:10.000784Z","description":"","domain_name":"tfnsstoicvisvesvarayusdiiaiq-test-acc-container-pn-c00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a574568d-5c43-482b-9d82-513f27e7d2ad","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c00","namespace_id":"627dd919-7422-43e4-bc7b-ce02de6605c9","port":8080,"privacy":"public","private_network_id":"932f31bb-f882-443f-be0e-9cc4f0bd70fa","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsstoicvisvesvarayusdiiaiq/test-acc-container-pn-c00:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:10.000784Z"}'
         headers:
             Content-Length:
-                - "1006"
+                - "1014"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:34 GMT
+                - Wed, 27 Aug 2025 15:06:14 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1332,10 +1332,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7f7f2995-f2bd-41ca-b0cf-20faef40f035
+                - b2e654c5-61ed-47cc-b276-182d8b9ad7fe
         status: 200 OK
         code: 200
-        duration: 56.589222ms
+        duration: 93.005656ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1352,7 +1352,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/1df2d836-32fe-4bf3-8a83-1fb38505f339
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/8a6e08c5-fc29-4bbe-af65-a749a99f7dc1
         method: GET
       response:
         proto: HTTP/2.0
@@ -1360,20 +1360,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1006
+        content_length: 1014
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-16T16:33:33.616540Z","description":"","domain_name":"tfnsgallanthaibtku6hfpsd-test-acc-container-pn-c01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"1df2d836-32fe-4bf3-8a83-1fb38505f339","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c01","namespace_id":"36b36416-4c12-41cd-ba2b-52a002600f06","port":8080,"privacy":"public","private_network_id":"8a415abf-00cd-4db2-bdc4-12408ad70c98","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsgallanthaibtku6hfpsd/test-acc-container-pn-c01:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:33:33.616540Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:13.805947Z","description":"","domain_name":"tfnsstoicvisvesvarayusdiiaiq-test-acc-container-pn-c01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"8a6e08c5-fc29-4bbe-af65-a749a99f7dc1","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c01","namespace_id":"627dd919-7422-43e4-bc7b-ce02de6605c9","port":8080,"privacy":"public","private_network_id":"932f31bb-f882-443f-be0e-9cc4f0bd70fa","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsstoicvisvesvarayusdiiaiq/test-acc-container-pn-c01:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:13.805947Z"}'
         headers:
             Content-Length:
-                - "1006"
+                - "1014"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:34 GMT
+                - Wed, 27 Aug 2025 15:06:14 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1381,10 +1381,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b338e776-ce6e-4940-9222-0ce6ad67782b
+                - 5ffeb977-f7b8-45de-9bd1-7b76e78bec22
         status: 200 OK
         code: 200
-        duration: 39.356018ms
+        duration: 109.920056ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1401,7 +1401,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a9e5fed6-13c0-4943-ae02-701b5bf3398b
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/46867816-e5e1-47a4-993c-852289df4bae
         method: GET
       response:
         proto: HTTP/2.0
@@ -1409,20 +1409,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1006
+        content_length: 1014
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-16T16:33:33.320098Z","description":"","domain_name":"tfnsgallanthaibtku6hfpsd-test-acc-container-pn-c02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a9e5fed6-13c0-4943-ae02-701b5bf3398b","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c02","namespace_id":"36b36416-4c12-41cd-ba2b-52a002600f06","port":8080,"privacy":"public","private_network_id":"8a415abf-00cd-4db2-bdc4-12408ad70c98","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsgallanthaibtku6hfpsd/test-acc-container-pn-c02:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:33:33.320098Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:13.772341Z","description":"","domain_name":"tfnsstoicvisvesvarayusdiiaiq-test-acc-container-pn-c02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"46867816-e5e1-47a4-993c-852289df4bae","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c02","namespace_id":"627dd919-7422-43e4-bc7b-ce02de6605c9","port":8080,"privacy":"public","private_network_id":"932f31bb-f882-443f-be0e-9cc4f0bd70fa","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsstoicvisvesvarayusdiiaiq/test-acc-container-pn-c02:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:13.772341Z"}'
         headers:
             Content-Length:
-                - "1006"
+                - "1014"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:34 GMT
+                - Wed, 27 Aug 2025 15:06:14 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1430,10 +1430,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 92fbf5d8-a8c1-492d-80b6-ebdbf547481d
+                - d8b166cd-a6c6-4cee-a260-e8f0a49c4a1f
         status: 200 OK
         code: 200
-        duration: 152.626235ms
+        duration: 93.011668ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1450,7 +1450,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/8a415abf-00cd-4db2-bdc4-12408ad70c98
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/932f31bb-f882-443f-be0e-9cc4f0bd70fa
         method: GET
       response:
         proto: HTTP/2.0
@@ -1460,7 +1460,7 @@ interactions:
         trailer: {}
         content_length: 1072
         uncompressed: false
-        body: '{"created_at":"2025-06-16T16:33:23.708187Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"8a415abf-00cd-4db2-bdc4-12408ad70c98","name":"test-acc-container-pn-pn00","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-06-16T16:33:23.708187Z","id":"15b4ea61-5306-454b-aa0e-bf9af4de300d","private_network_id":"8a415abf-00cd-4db2-bdc4-12408ad70c98","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.48.0/22","updated_at":"2025-06-16T16:33:23.708187Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-06-16T16:33:23.708187Z","id":"aa029065-1714-4b11-9d82-360ac03ac61c","private_network_id":"8a415abf-00cd-4db2-bdc4-12408ad70c98","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:e008::/64","updated_at":"2025-06-16T16:33:23.708187Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-06-16T16:33:23.708187Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+        body: '{"created_at":"2025-08-27T15:06:02.065728Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"932f31bb-f882-443f-be0e-9cc4f0bd70fa","name":"test-acc-container-pn-pn00","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","subnets":[{"created_at":"2025-08-27T15:06:02.065728Z","id":"0229a8c6-bc1d-4c1d-a39f-757914bf3e21","private_network_id":"932f31bb-f882-443f-be0e-9cc4f0bd70fa","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","subnet":"172.16.32.0/22","updated_at":"2025-08-27T15:06:02.065728Z","vpc_id":"bfef8344-f496-473e-af67-31ea9afc407c"},{"created_at":"2025-08-27T15:06:02.065728Z","id":"40f741ae-c39f-4f7f-a05c-440b603b61d7","private_network_id":"932f31bb-f882-443f-be0e-9cc4f0bd70fa","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","subnet":"fde7:767f:1bb5:e3b7::/64","updated_at":"2025-08-27T15:06:02.065728Z","vpc_id":"bfef8344-f496-473e-af67-31ea9afc407c"}],"tags":[],"updated_at":"2025-08-27T15:06:02.065728Z","vpc_id":"bfef8344-f496-473e-af67-31ea9afc407c"}'
         headers:
             Content-Length:
                 - "1072"
@@ -1469,9 +1469,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:35 GMT
+                - Wed, 27 Aug 2025 15:06:14 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1479,10 +1479,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 79ebc387-6696-48aa-ba31-3977e9a93de6
+                - 3546dba4-3fe6-4e71-9c3f-8cafbc8c5e63
         status: 200 OK
         code: 200
-        duration: 29.249356ms
+        duration: 29.838893ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1499,7 +1499,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c806474f-01fa-47a9-b59a-a57f0ddfce80
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/49592394-2619-4001-b8ab-cbb5017db9d9
         method: GET
       response:
         proto: HTTP/2.0
@@ -1509,7 +1509,7 @@ interactions:
         trailer: {}
         content_length: 1071
         uncompressed: false
-        body: '{"created_at":"2025-06-16T16:33:23.625701Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"c806474f-01fa-47a9-b59a-a57f0ddfce80","name":"test-acc-container-pn-pn01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-06-16T16:33:23.625701Z","id":"d2bc5535-6dc9-4782-bd4d-d36deb39b558","private_network_id":"c806474f-01fa-47a9-b59a-a57f0ddfce80","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.4.0/22","updated_at":"2025-06-16T16:33:23.625701Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-06-16T16:33:23.625701Z","id":"a38e59ef-cd3c-443f-ae15-6c0d8ff3508a","private_network_id":"c806474f-01fa-47a9-b59a-a57f0ddfce80","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:ce3b::/64","updated_at":"2025-06-16T16:33:23.625701Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-06-16T16:33:23.625701Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+        body: '{"created_at":"2025-08-27T15:06:02.345555Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"49592394-2619-4001-b8ab-cbb5017db9d9","name":"test-acc-container-pn-pn01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","subnets":[{"created_at":"2025-08-27T15:06:02.345555Z","id":"55b5c4c2-43a9-4d50-b6f8-c3207b0f9cb5","private_network_id":"49592394-2619-4001-b8ab-cbb5017db9d9","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","subnet":"172.16.4.0/22","updated_at":"2025-08-27T15:06:02.345555Z","vpc_id":"bfef8344-f496-473e-af67-31ea9afc407c"},{"created_at":"2025-08-27T15:06:02.345555Z","id":"2c9fda53-fa80-4dd7-977b-09d2e00670c1","private_network_id":"49592394-2619-4001-b8ab-cbb5017db9d9","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","subnet":"fde7:767f:1bb5:cd83::/64","updated_at":"2025-08-27T15:06:02.345555Z","vpc_id":"bfef8344-f496-473e-af67-31ea9afc407c"}],"tags":[],"updated_at":"2025-08-27T15:06:02.345555Z","vpc_id":"bfef8344-f496-473e-af67-31ea9afc407c"}'
         headers:
             Content-Length:
                 - "1071"
@@ -1518,9 +1518,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:35 GMT
+                - Wed, 27 Aug 2025 15:06:14 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1528,10 +1528,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 378842c7-b4ee-45a8-b56e-86da119b7705
+                - cb8519a1-f87c-4537-8720-0b006cec3d70
         status: 200 OK
         code: 200
-        duration: 29.172111ms
+        duration: 29.798277ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1548,7 +1548,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/36b36416-4c12-41cd-ba2b-52a002600f06
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/627dd919-7422-43e4-bc7b-ce02de6605c9
         method: GET
       response:
         proto: HTTP/2.0
@@ -1556,20 +1556,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 583
+        content_length: 592
         uncompressed: false
-        body: '{"created_at":"2025-06-16T16:33:23.753071Z","description":"","environment_variables":{},"error_message":null,"id":"36b36416-4c12-41cd-ba2b-52a002600f06","name":"tf-ns-gallant-haibt","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsgallanthaibtku6hfpsd","registry_namespace_id":"a9a080da-7f15-4f03-adcf-9ab5d353fb37","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-16T16:33:24.797296Z","vpc_integration_activated":true}'
+        body: '{"created_at":"2025-08-27T15:06:03.495907Z","description":"","environment_variables":{},"error_message":null,"id":"627dd919-7422-43e4-bc7b-ce02de6605c9","name":"tf-ns-stoic-visvesvaraya","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsstoicvisvesvarayusdiiaiq","registry_namespace_id":"53f25a1b-bdfc-4c98-b9ea-30968c2ae2f1","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:06.063436Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "583"
+                - "592"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:35 GMT
+                - Wed, 27 Aug 2025 15:06:14 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1577,10 +1577,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 271a8a75-fab0-48d9-ac7c-8a5dc17cd0f5
+                - 5b9c6cf6-b262-418f-9f01-cafa3f991d4e
         status: 200 OK
         code: 200
-        duration: 43.740189ms
+        duration: 90.244805ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1597,7 +1597,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/aa1afb40-4da5-4bf9-a989-3cfb175fb432
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a574568d-5c43-482b-9d82-513f27e7d2ad
         method: GET
       response:
         proto: HTTP/2.0
@@ -1605,20 +1605,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1006
+        content_length: 1014
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-16T16:33:29.364423Z","description":"","domain_name":"tfnsgallanthaibtku6hfpsd-test-acc-container-pn-c00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"aa1afb40-4da5-4bf9-a989-3cfb175fb432","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c00","namespace_id":"36b36416-4c12-41cd-ba2b-52a002600f06","port":8080,"privacy":"public","private_network_id":"8a415abf-00cd-4db2-bdc4-12408ad70c98","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsgallanthaibtku6hfpsd/test-acc-container-pn-c00:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:33:29.364423Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:10.000784Z","description":"","domain_name":"tfnsstoicvisvesvarayusdiiaiq-test-acc-container-pn-c00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a574568d-5c43-482b-9d82-513f27e7d2ad","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c00","namespace_id":"627dd919-7422-43e4-bc7b-ce02de6605c9","port":8080,"privacy":"public","private_network_id":"932f31bb-f882-443f-be0e-9cc4f0bd70fa","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsstoicvisvesvarayusdiiaiq/test-acc-container-pn-c00:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:10.000784Z"}'
         headers:
             Content-Length:
-                - "1006"
+                - "1014"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:35 GMT
+                - Wed, 27 Aug 2025 15:06:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1626,10 +1626,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0c4475d5-02d3-4e85-a410-99a58b9a56c2
+                - 1085bb64-ae4d-4a52-9ef1-1b3423ed7513
         status: 200 OK
         code: 200
-        duration: 56.680093ms
+        duration: 83.205997ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1646,7 +1646,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a9e5fed6-13c0-4943-ae02-701b5bf3398b
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/8a6e08c5-fc29-4bbe-af65-a749a99f7dc1
         method: GET
       response:
         proto: HTTP/2.0
@@ -1654,20 +1654,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1006
+        content_length: 1014
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-16T16:33:33.320098Z","description":"","domain_name":"tfnsgallanthaibtku6hfpsd-test-acc-container-pn-c02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a9e5fed6-13c0-4943-ae02-701b5bf3398b","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c02","namespace_id":"36b36416-4c12-41cd-ba2b-52a002600f06","port":8080,"privacy":"public","private_network_id":"8a415abf-00cd-4db2-bdc4-12408ad70c98","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsgallanthaibtku6hfpsd/test-acc-container-pn-c02:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:33:33.320098Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:13.805947Z","description":"","domain_name":"tfnsstoicvisvesvarayusdiiaiq-test-acc-container-pn-c01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"8a6e08c5-fc29-4bbe-af65-a749a99f7dc1","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c01","namespace_id":"627dd919-7422-43e4-bc7b-ce02de6605c9","port":8080,"privacy":"public","private_network_id":"932f31bb-f882-443f-be0e-9cc4f0bd70fa","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsstoicvisvesvarayusdiiaiq/test-acc-container-pn-c01:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:13.805947Z"}'
         headers:
             Content-Length:
-                - "1006"
+                - "1014"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:35 GMT
+                - Wed, 27 Aug 2025 15:06:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1675,10 +1675,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 742c6f23-9420-4a85-ac46-b482074998f4
+                - 3664c2bb-4343-43ca-99da-458cb1944b8d
         status: 200 OK
         code: 200
-        duration: 113.94903ms
+        duration: 96.755022ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1695,7 +1695,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/1df2d836-32fe-4bf3-8a83-1fb38505f339
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/46867816-e5e1-47a4-993c-852289df4bae
         method: GET
       response:
         proto: HTTP/2.0
@@ -1703,20 +1703,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1006
+        content_length: 1014
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-16T16:33:33.616540Z","description":"","domain_name":"tfnsgallanthaibtku6hfpsd-test-acc-container-pn-c01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"1df2d836-32fe-4bf3-8a83-1fb38505f339","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c01","namespace_id":"36b36416-4c12-41cd-ba2b-52a002600f06","port":8080,"privacy":"public","private_network_id":"8a415abf-00cd-4db2-bdc4-12408ad70c98","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsgallanthaibtku6hfpsd/test-acc-container-pn-c01:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:33:33.616540Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:13.772341Z","description":"","domain_name":"tfnsstoicvisvesvarayusdiiaiq-test-acc-container-pn-c02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"46867816-e5e1-47a4-993c-852289df4bae","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c02","namespace_id":"627dd919-7422-43e4-bc7b-ce02de6605c9","port":8080,"privacy":"public","private_network_id":"932f31bb-f882-443f-be0e-9cc4f0bd70fa","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsstoicvisvesvarayusdiiaiq/test-acc-container-pn-c02:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:13.772341Z"}'
         headers:
             Content-Length:
-                - "1006"
+                - "1014"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:35 GMT
+                - Wed, 27 Aug 2025 15:06:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1724,10 +1724,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1d82c188-c016-484d-8e3b-1f975faf5ac1
+                - e9bb7bf2-899a-4f09-9f75-5dfb76b0a738
         status: 200 OK
         code: 200
-        duration: 209.560053ms
+        duration: 118.99222ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1744,7 +1744,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c806474f-01fa-47a9-b59a-a57f0ddfce80
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/932f31bb-f882-443f-be0e-9cc4f0bd70fa
         method: GET
       response:
         proto: HTTP/2.0
@@ -1752,20 +1752,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1071
+        content_length: 1072
         uncompressed: false
-        body: '{"created_at":"2025-06-16T16:33:23.625701Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"c806474f-01fa-47a9-b59a-a57f0ddfce80","name":"test-acc-container-pn-pn01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-06-16T16:33:23.625701Z","id":"d2bc5535-6dc9-4782-bd4d-d36deb39b558","private_network_id":"c806474f-01fa-47a9-b59a-a57f0ddfce80","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.4.0/22","updated_at":"2025-06-16T16:33:23.625701Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-06-16T16:33:23.625701Z","id":"a38e59ef-cd3c-443f-ae15-6c0d8ff3508a","private_network_id":"c806474f-01fa-47a9-b59a-a57f0ddfce80","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:ce3b::/64","updated_at":"2025-06-16T16:33:23.625701Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-06-16T16:33:23.625701Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+        body: '{"created_at":"2025-08-27T15:06:02.065728Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"932f31bb-f882-443f-be0e-9cc4f0bd70fa","name":"test-acc-container-pn-pn00","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","subnets":[{"created_at":"2025-08-27T15:06:02.065728Z","id":"0229a8c6-bc1d-4c1d-a39f-757914bf3e21","private_network_id":"932f31bb-f882-443f-be0e-9cc4f0bd70fa","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","subnet":"172.16.32.0/22","updated_at":"2025-08-27T15:06:02.065728Z","vpc_id":"bfef8344-f496-473e-af67-31ea9afc407c"},{"created_at":"2025-08-27T15:06:02.065728Z","id":"40f741ae-c39f-4f7f-a05c-440b603b61d7","private_network_id":"932f31bb-f882-443f-be0e-9cc4f0bd70fa","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","subnet":"fde7:767f:1bb5:e3b7::/64","updated_at":"2025-08-27T15:06:02.065728Z","vpc_id":"bfef8344-f496-473e-af67-31ea9afc407c"}],"tags":[],"updated_at":"2025-08-27T15:06:02.065728Z","vpc_id":"bfef8344-f496-473e-af67-31ea9afc407c"}'
         headers:
             Content-Length:
-                - "1071"
+                - "1072"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:36 GMT
+                - Wed, 27 Aug 2025 15:06:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1773,10 +1773,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 545ff20c-5e09-4001-855e-ee6f20c6e826
+                - 26969540-4fc3-4de7-a10b-4ce974f8a23f
         status: 200 OK
         code: 200
-        duration: 33.617257ms
+        duration: 21.962012ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1793,7 +1793,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/8a415abf-00cd-4db2-bdc4-12408ad70c98
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/627dd919-7422-43e4-bc7b-ce02de6605c9
         method: GET
       response:
         proto: HTTP/2.0
@@ -1801,20 +1801,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1072
+        content_length: 592
         uncompressed: false
-        body: '{"created_at":"2025-06-16T16:33:23.708187Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"8a415abf-00cd-4db2-bdc4-12408ad70c98","name":"test-acc-container-pn-pn00","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-06-16T16:33:23.708187Z","id":"15b4ea61-5306-454b-aa0e-bf9af4de300d","private_network_id":"8a415abf-00cd-4db2-bdc4-12408ad70c98","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.48.0/22","updated_at":"2025-06-16T16:33:23.708187Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-06-16T16:33:23.708187Z","id":"aa029065-1714-4b11-9d82-360ac03ac61c","private_network_id":"8a415abf-00cd-4db2-bdc4-12408ad70c98","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:e008::/64","updated_at":"2025-06-16T16:33:23.708187Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-06-16T16:33:23.708187Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+        body: '{"created_at":"2025-08-27T15:06:03.495907Z","description":"","environment_variables":{},"error_message":null,"id":"627dd919-7422-43e4-bc7b-ce02de6605c9","name":"tf-ns-stoic-visvesvaraya","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsstoicvisvesvarayusdiiaiq","registry_namespace_id":"53f25a1b-bdfc-4c98-b9ea-30968c2ae2f1","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:06.063436Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "1072"
+                - "592"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:36 GMT
+                - Wed, 27 Aug 2025 15:06:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1822,10 +1822,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6fb3d050-fe08-42dd-8e26-aec0b2c6a721
+                - a8356983-9928-4450-b5e4-151e5f603c06
         status: 200 OK
         code: 200
-        duration: 33.489397ms
+        duration: 73.818742ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1842,7 +1842,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/36b36416-4c12-41cd-ba2b-52a002600f06
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/49592394-2619-4001-b8ab-cbb5017db9d9
         method: GET
       response:
         proto: HTTP/2.0
@@ -1850,20 +1850,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 583
+        content_length: 1071
         uncompressed: false
-        body: '{"created_at":"2025-06-16T16:33:23.753071Z","description":"","environment_variables":{},"error_message":null,"id":"36b36416-4c12-41cd-ba2b-52a002600f06","name":"tf-ns-gallant-haibt","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsgallanthaibtku6hfpsd","registry_namespace_id":"a9a080da-7f15-4f03-adcf-9ab5d353fb37","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-16T16:33:24.797296Z","vpc_integration_activated":true}'
+        body: '{"created_at":"2025-08-27T15:06:02.345555Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"49592394-2619-4001-b8ab-cbb5017db9d9","name":"test-acc-container-pn-pn01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","subnets":[{"created_at":"2025-08-27T15:06:02.345555Z","id":"55b5c4c2-43a9-4d50-b6f8-c3207b0f9cb5","private_network_id":"49592394-2619-4001-b8ab-cbb5017db9d9","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","subnet":"172.16.4.0/22","updated_at":"2025-08-27T15:06:02.345555Z","vpc_id":"bfef8344-f496-473e-af67-31ea9afc407c"},{"created_at":"2025-08-27T15:06:02.345555Z","id":"2c9fda53-fa80-4dd7-977b-09d2e00670c1","private_network_id":"49592394-2619-4001-b8ab-cbb5017db9d9","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","subnet":"fde7:767f:1bb5:cd83::/64","updated_at":"2025-08-27T15:06:02.345555Z","vpc_id":"bfef8344-f496-473e-af67-31ea9afc407c"}],"tags":[],"updated_at":"2025-08-27T15:06:02.345555Z","vpc_id":"bfef8344-f496-473e-af67-31ea9afc407c"}'
         headers:
             Content-Length:
-                - "583"
+                - "1071"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:36 GMT
+                - Wed, 27 Aug 2025 15:06:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1871,10 +1871,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a5491bf3-0a19-4321-ba28-92b48fab14b4
+                - 2a64c5f4-0d86-449a-aa4e-01c4f3011c8e
         status: 200 OK
         code: 200
-        duration: 41.269476ms
+        duration: 104.031947ms
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1891,7 +1891,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a9e5fed6-13c0-4943-ae02-701b5bf3398b
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/46867816-e5e1-47a4-993c-852289df4bae
         method: GET
       response:
         proto: HTTP/2.0
@@ -1899,20 +1899,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1006
+        content_length: 1014
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-16T16:33:33.320098Z","description":"","domain_name":"tfnsgallanthaibtku6hfpsd-test-acc-container-pn-c02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a9e5fed6-13c0-4943-ae02-701b5bf3398b","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c02","namespace_id":"36b36416-4c12-41cd-ba2b-52a002600f06","port":8080,"privacy":"public","private_network_id":"8a415abf-00cd-4db2-bdc4-12408ad70c98","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsgallanthaibtku6hfpsd/test-acc-container-pn-c02:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:33:33.320098Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:13.772341Z","description":"","domain_name":"tfnsstoicvisvesvarayusdiiaiq-test-acc-container-pn-c02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"46867816-e5e1-47a4-993c-852289df4bae","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c02","namespace_id":"627dd919-7422-43e4-bc7b-ce02de6605c9","port":8080,"privacy":"public","private_network_id":"932f31bb-f882-443f-be0e-9cc4f0bd70fa","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsstoicvisvesvarayusdiiaiq/test-acc-container-pn-c02:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:13.772341Z"}'
         headers:
             Content-Length:
-                - "1006"
+                - "1014"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:36 GMT
+                - Wed, 27 Aug 2025 15:06:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1920,10 +1920,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5491521b-15f4-471b-8ef1-abdcb8b7c415
+                - a784ab18-32d9-4d72-9d2b-3623becb3dd6
         status: 200 OK
         code: 200
-        duration: 87.113359ms
+        duration: 81.884698ms
     - id: 39
       request:
         proto: HTTP/1.1
@@ -1940,7 +1940,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/aa1afb40-4da5-4bf9-a989-3cfb175fb432
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a574568d-5c43-482b-9d82-513f27e7d2ad
         method: GET
       response:
         proto: HTTP/2.0
@@ -1948,20 +1948,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1006
+        content_length: 1014
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-16T16:33:29.364423Z","description":"","domain_name":"tfnsgallanthaibtku6hfpsd-test-acc-container-pn-c00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"aa1afb40-4da5-4bf9-a989-3cfb175fb432","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c00","namespace_id":"36b36416-4c12-41cd-ba2b-52a002600f06","port":8080,"privacy":"public","private_network_id":"8a415abf-00cd-4db2-bdc4-12408ad70c98","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsgallanthaibtku6hfpsd/test-acc-container-pn-c00:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:33:29.364423Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:10.000784Z","description":"","domain_name":"tfnsstoicvisvesvarayusdiiaiq-test-acc-container-pn-c00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a574568d-5c43-482b-9d82-513f27e7d2ad","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c00","namespace_id":"627dd919-7422-43e4-bc7b-ce02de6605c9","port":8080,"privacy":"public","private_network_id":"932f31bb-f882-443f-be0e-9cc4f0bd70fa","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsstoicvisvesvarayusdiiaiq/test-acc-container-pn-c00:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:10.000784Z"}'
         headers:
             Content-Length:
-                - "1006"
+                - "1014"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:36 GMT
+                - Wed, 27 Aug 2025 15:06:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1969,10 +1969,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 749157af-aa46-4871-bcfd-39265b6ee9a1
+                - 0ddc5ba9-30fc-48ca-96ce-b9c587ddb864
         status: 200 OK
         code: 200
-        duration: 105.785081ms
+        duration: 105.860008ms
     - id: 40
       request:
         proto: HTTP/1.1
@@ -1989,7 +1989,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/1df2d836-32fe-4bf3-8a83-1fb38505f339
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/8a6e08c5-fc29-4bbe-af65-a749a99f7dc1
         method: GET
       response:
         proto: HTTP/2.0
@@ -1997,20 +1997,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1006
+        content_length: 1014
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-16T16:33:33.616540Z","description":"","domain_name":"tfnsgallanthaibtku6hfpsd-test-acc-container-pn-c01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"1df2d836-32fe-4bf3-8a83-1fb38505f339","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c01","namespace_id":"36b36416-4c12-41cd-ba2b-52a002600f06","port":8080,"privacy":"public","private_network_id":"8a415abf-00cd-4db2-bdc4-12408ad70c98","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsgallanthaibtku6hfpsd/test-acc-container-pn-c01:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:33:33.616540Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:13.805947Z","description":"","domain_name":"tfnsstoicvisvesvarayusdiiaiq-test-acc-container-pn-c01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"8a6e08c5-fc29-4bbe-af65-a749a99f7dc1","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c01","namespace_id":"627dd919-7422-43e4-bc7b-ce02de6605c9","port":8080,"privacy":"public","private_network_id":"932f31bb-f882-443f-be0e-9cc4f0bd70fa","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsstoicvisvesvarayusdiiaiq/test-acc-container-pn-c01:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:13.805947Z"}'
         headers:
             Content-Length:
-                - "1006"
+                - "1014"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:36 GMT
+                - Wed, 27 Aug 2025 15:06:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2018,10 +2018,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 964ccb60-a406-4163-958e-cb16a5ba3cfb
+                - 56c3b336-4f5c-4883-8b1a-de837d878aa6
         status: 200 OK
         code: 200
-        duration: 105.223178ms
+        duration: 107.402553ms
     - id: 41
       request:
         proto: HTTP/1.1
@@ -2038,7 +2038,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/36b36416-4c12-41cd-ba2b-52a002600f06
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/627dd919-7422-43e4-bc7b-ce02de6605c9
         method: GET
       response:
         proto: HTTP/2.0
@@ -2046,20 +2046,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 583
+        content_length: 592
         uncompressed: false
-        body: '{"created_at":"2025-06-16T16:33:23.753071Z","description":"","environment_variables":{},"error_message":null,"id":"36b36416-4c12-41cd-ba2b-52a002600f06","name":"tf-ns-gallant-haibt","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsgallanthaibtku6hfpsd","registry_namespace_id":"a9a080da-7f15-4f03-adcf-9ab5d353fb37","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-16T16:33:24.797296Z","vpc_integration_activated":true}'
+        body: '{"created_at":"2025-08-27T15:06:03.495907Z","description":"","environment_variables":{},"error_message":null,"id":"627dd919-7422-43e4-bc7b-ce02de6605c9","name":"tf-ns-stoic-visvesvaraya","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsstoicvisvesvarayusdiiaiq","registry_namespace_id":"53f25a1b-bdfc-4c98-b9ea-30968c2ae2f1","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:06.063436Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "583"
+                - "592"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:37 GMT
+                - Wed, 27 Aug 2025 15:06:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2067,10 +2067,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 333eaa90-3fa4-4c72-8fac-e97e7f0e2da1
+                - 73e79f1d-efb0-4a43-95b6-7c16cade9e44
         status: 200 OK
         code: 200
-        duration: 39.348284ms
+        duration: 82.743059ms
     - id: 42
       request:
         proto: HTTP/1.1
@@ -2087,7 +2087,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/36b36416-4c12-41cd-ba2b-52a002600f06
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/627dd919-7422-43e4-bc7b-ce02de6605c9
         method: GET
       response:
         proto: HTTP/2.0
@@ -2095,20 +2095,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 583
+        content_length: 592
         uncompressed: false
-        body: '{"created_at":"2025-06-16T16:33:23.753071Z","description":"","environment_variables":{},"error_message":null,"id":"36b36416-4c12-41cd-ba2b-52a002600f06","name":"tf-ns-gallant-haibt","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsgallanthaibtku6hfpsd","registry_namespace_id":"a9a080da-7f15-4f03-adcf-9ab5d353fb37","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-16T16:33:24.797296Z","vpc_integration_activated":true}'
+        body: '{"created_at":"2025-08-27T15:06:03.495907Z","description":"","environment_variables":{},"error_message":null,"id":"627dd919-7422-43e4-bc7b-ce02de6605c9","name":"tf-ns-stoic-visvesvaraya","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsstoicvisvesvarayusdiiaiq","registry_namespace_id":"53f25a1b-bdfc-4c98-b9ea-30968c2ae2f1","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:06.063436Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "583"
+                - "592"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:37 GMT
+                - Wed, 27 Aug 2025 15:06:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2116,10 +2116,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 68b4aa04-1976-469b-9a39-9fdeef1195f2
+                - 884c856f-a65b-4438-a9b3-b63b231ef969
         status: 200 OK
         code: 200
-        duration: 51.392799ms
+        duration: 147.652693ms
     - id: 43
       request:
         proto: HTTP/1.1
@@ -2136,7 +2136,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/aa1afb40-4da5-4bf9-a989-3cfb175fb432
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a574568d-5c43-482b-9d82-513f27e7d2ad
         method: GET
       response:
         proto: HTTP/2.0
@@ -2144,20 +2144,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1006
+        content_length: 1014
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-16T16:33:29.364423Z","description":"","domain_name":"tfnsgallanthaibtku6hfpsd-test-acc-container-pn-c00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"aa1afb40-4da5-4bf9-a989-3cfb175fb432","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c00","namespace_id":"36b36416-4c12-41cd-ba2b-52a002600f06","port":8080,"privacy":"public","private_network_id":"8a415abf-00cd-4db2-bdc4-12408ad70c98","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsgallanthaibtku6hfpsd/test-acc-container-pn-c00:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:33:29.364423Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:10.000784Z","description":"","domain_name":"tfnsstoicvisvesvarayusdiiaiq-test-acc-container-pn-c00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a574568d-5c43-482b-9d82-513f27e7d2ad","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c00","namespace_id":"627dd919-7422-43e4-bc7b-ce02de6605c9","port":8080,"privacy":"public","private_network_id":"932f31bb-f882-443f-be0e-9cc4f0bd70fa","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsstoicvisvesvarayusdiiaiq/test-acc-container-pn-c00:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:10.000784Z"}'
         headers:
             Content-Length:
-                - "1006"
+                - "1014"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:37 GMT
+                - Wed, 27 Aug 2025 15:06:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2165,10 +2165,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e5df946b-ba48-4d1b-b556-f710d437c2a6
+                - b7d38047-8919-4e33-82ce-df3d385e7a38
         status: 200 OK
         code: 200
-        duration: 48.180415ms
+        duration: 83.993535ms
     - id: 44
       request:
         proto: HTTP/1.1
@@ -2185,7 +2185,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/1df2d836-32fe-4bf3-8a83-1fb38505f339
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/8a6e08c5-fc29-4bbe-af65-a749a99f7dc1
         method: GET
       response:
         proto: HTTP/2.0
@@ -2193,20 +2193,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1006
+        content_length: 1014
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-16T16:33:33.616540Z","description":"","domain_name":"tfnsgallanthaibtku6hfpsd-test-acc-container-pn-c01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"1df2d836-32fe-4bf3-8a83-1fb38505f339","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c01","namespace_id":"36b36416-4c12-41cd-ba2b-52a002600f06","port":8080,"privacy":"public","private_network_id":"8a415abf-00cd-4db2-bdc4-12408ad70c98","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsgallanthaibtku6hfpsd/test-acc-container-pn-c01:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:33:33.616540Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:13.805947Z","description":"","domain_name":"tfnsstoicvisvesvarayusdiiaiq-test-acc-container-pn-c01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"8a6e08c5-fc29-4bbe-af65-a749a99f7dc1","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c01","namespace_id":"627dd919-7422-43e4-bc7b-ce02de6605c9","port":8080,"privacy":"public","private_network_id":"932f31bb-f882-443f-be0e-9cc4f0bd70fa","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsstoicvisvesvarayusdiiaiq/test-acc-container-pn-c01:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:13.805947Z"}'
         headers:
             Content-Length:
-                - "1006"
+                - "1014"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:37 GMT
+                - Wed, 27 Aug 2025 15:06:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2214,11 +2214,62 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a22c59b8-27bc-41d9-afb1-f7b0c9c86264
+                - 9b5f0fdb-714b-4fae-a8b9-f66ae1214526
         status: 200 OK
         code: 200
-        duration: 93.873125ms
+        duration: 110.714959ms
     - id: 45
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 219
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"privacy":"unknown_privacy","protocol":"unknown_protocol","secret_environment_variables":null,"http_option":"unknown_http_option","sandbox":"unknown_sandbox","private_network_id":"49592394-2619-4001-b8ab-cbb5017db9d9"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/8a6e08c5-fc29-4bbe-af65-a749a99f7dc1
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1017
+        uncompressed: false
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:13.805947Z","description":"","domain_name":"tfnsstoicvisvesvarayusdiiaiq-test-acc-container-pn-c01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"8a6e08c5-fc29-4bbe-af65-a749a99f7dc1","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c01","namespace_id":"627dd919-7422-43e4-bc7b-ce02de6605c9","port":8080,"privacy":"public","private_network_id":"49592394-2619-4001-b8ab-cbb5017db9d9","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsstoicvisvesvarayusdiiaiq/test-acc-container-pn-c01:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:16.436529357Z"}'
+        headers:
+            Content-Length:
+                - "1017"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:16 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 5fb1c191-f311-4abb-9a1f-1caf1e22a927
+        status: 200 OK
+        code: 200
+        duration: 205.777635ms
+    - id: 46
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2236,7 +2287,7 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/aa1afb40-4da5-4bf9-a989-3cfb175fb432
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a574568d-5c43-482b-9d82-513f27e7d2ad
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -2244,20 +2295,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 975
+        content_length: 983
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-16T16:33:29.364423Z","description":"","domain_name":"tfnsgallanthaibtku6hfpsd-test-acc-container-pn-c00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"aa1afb40-4da5-4bf9-a989-3cfb175fb432","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c00","namespace_id":"36b36416-4c12-41cd-ba2b-52a002600f06","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsgallanthaibtku6hfpsd/test-acc-container-pn-c00:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:33:37.299854100Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:10.000784Z","description":"","domain_name":"tfnsstoicvisvesvarayusdiiaiq-test-acc-container-pn-c00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a574568d-5c43-482b-9d82-513f27e7d2ad","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c00","namespace_id":"627dd919-7422-43e4-bc7b-ce02de6605c9","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsstoicvisvesvarayusdiiaiq/test-acc-container-pn-c00:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:16.350038222Z"}'
         headers:
             Content-Length:
-                - "975"
+                - "983"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:37 GMT
+                - Wed, 27 Aug 2025 15:06:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2265,11 +2316,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6907febc-ff1a-4428-8dd6-dbebdd5c200f
+                - ddac11ab-b237-4694-8817-1faeb1e956db
         status: 200 OK
         code: 200
-        duration: 137.410012ms
-    - id: 46
+        duration: 346.678688ms
+    - id: 47
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2285,7 +2336,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/aa1afb40-4da5-4bf9-a989-3cfb175fb432
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/8a6e08c5-fc29-4bbe-af65-a749a99f7dc1
         method: GET
       response:
         proto: HTTP/2.0
@@ -2293,20 +2344,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 972
+        content_length: 1014
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-16T16:33:29.364423Z","description":"","domain_name":"tfnsgallanthaibtku6hfpsd-test-acc-container-pn-c00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"aa1afb40-4da5-4bf9-a989-3cfb175fb432","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c00","namespace_id":"36b36416-4c12-41cd-ba2b-52a002600f06","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsgallanthaibtku6hfpsd/test-acc-container-pn-c00:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:33:37.299854Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:13.805947Z","description":"","domain_name":"tfnsstoicvisvesvarayusdiiaiq-test-acc-container-pn-c01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"8a6e08c5-fc29-4bbe-af65-a749a99f7dc1","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c01","namespace_id":"627dd919-7422-43e4-bc7b-ce02de6605c9","port":8080,"privacy":"public","private_network_id":"49592394-2619-4001-b8ab-cbb5017db9d9","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsstoicvisvesvarayusdiiaiq/test-acc-container-pn-c01:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:16.436529Z"}'
         headers:
             Content-Length:
-                - "972"
+                - "1014"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:37 GMT
+                - Wed, 27 Aug 2025 15:06:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2314,61 +2365,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d4d88d1b-fe44-453a-abf2-1f8725cba744
+                - 0f5c36f3-bca0-4feb-89a3-5de430568b25
         status: 200 OK
         code: 200
-        duration: 57.397288ms
-    - id: 47
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 219
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"privacy":"unknown_privacy","protocol":"unknown_protocol","secret_environment_variables":null,"http_option":"unknown_http_option","sandbox":"unknown_sandbox","private_network_id":"c806474f-01fa-47a9-b59a-a57f0ddfce80"}'
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/1df2d836-32fe-4bf3-8a83-1fb38505f339
-        method: PATCH
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 1009
-        uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-16T16:33:33.616540Z","description":"","domain_name":"tfnsgallanthaibtku6hfpsd-test-acc-container-pn-c01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"1df2d836-32fe-4bf3-8a83-1fb38505f339","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c01","namespace_id":"36b36416-4c12-41cd-ba2b-52a002600f06","port":8080,"privacy":"public","private_network_id":"c806474f-01fa-47a9-b59a-a57f0ddfce80","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsgallanthaibtku6hfpsd/test-acc-container-pn-c01:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:33:37.362160416Z"}'
-        headers:
-            Content-Length:
-                - "1009"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 16 Jun 2025 16:33:37 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 8a28b6a0-1994-41c8-851f-7a09cf0dad92
-        status: 200 OK
-        code: 200
-        duration: 179.957835ms
+        duration: 110.208899ms
     - id: 48
       request:
         proto: HTTP/1.1
@@ -2385,7 +2385,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/1df2d836-32fe-4bf3-8a83-1fb38505f339
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a574568d-5c43-482b-9d82-513f27e7d2ad
         method: GET
       response:
         proto: HTTP/2.0
@@ -2393,20 +2393,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1006
+        content_length: 980
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-16T16:33:33.616540Z","description":"","domain_name":"tfnsgallanthaibtku6hfpsd-test-acc-container-pn-c01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"1df2d836-32fe-4bf3-8a83-1fb38505f339","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c01","namespace_id":"36b36416-4c12-41cd-ba2b-52a002600f06","port":8080,"privacy":"public","private_network_id":"c806474f-01fa-47a9-b59a-a57f0ddfce80","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsgallanthaibtku6hfpsd/test-acc-container-pn-c01:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:33:37.362160Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:10.000784Z","description":"","domain_name":"tfnsstoicvisvesvarayusdiiaiq-test-acc-container-pn-c00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a574568d-5c43-482b-9d82-513f27e7d2ad","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c00","namespace_id":"627dd919-7422-43e4-bc7b-ce02de6605c9","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsstoicvisvesvarayusdiiaiq/test-acc-container-pn-c00:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:16.350038Z"}'
         headers:
             Content-Length:
-                - "1006"
+                - "980"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:37 GMT
+                - Wed, 27 Aug 2025 15:06:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2414,10 +2414,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d390d719-e65e-4714-ae9c-d8c5e41e60d9
+                - 65b4d3a9-2438-448f-9efe-637537f49689
         status: 200 OK
         code: 200
-        duration: 61.782581ms
+        duration: 79.394245ms
     - id: 49
       request:
         proto: HTTP/1.1
@@ -2434,7 +2434,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/aa1afb40-4da5-4bf9-a989-3cfb175fb432
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/8a6e08c5-fc29-4bbe-af65-a749a99f7dc1
         method: GET
       response:
         proto: HTTP/2.0
@@ -2442,20 +2442,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 972
+        content_length: 1014
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-16T16:33:29.364423Z","description":"","domain_name":"tfnsgallanthaibtku6hfpsd-test-acc-container-pn-c00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"aa1afb40-4da5-4bf9-a989-3cfb175fb432","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c00","namespace_id":"36b36416-4c12-41cd-ba2b-52a002600f06","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsgallanthaibtku6hfpsd/test-acc-container-pn-c00:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:33:37.299854Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:13.805947Z","description":"","domain_name":"tfnsstoicvisvesvarayusdiiaiq-test-acc-container-pn-c01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"8a6e08c5-fc29-4bbe-af65-a749a99f7dc1","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c01","namespace_id":"627dd919-7422-43e4-bc7b-ce02de6605c9","port":8080,"privacy":"public","private_network_id":"49592394-2619-4001-b8ab-cbb5017db9d9","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsstoicvisvesvarayusdiiaiq/test-acc-container-pn-c01:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:16.436529Z"}'
         headers:
             Content-Length:
-                - "972"
+                - "1014"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:42 GMT
+                - Wed, 27 Aug 2025 15:06:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2463,10 +2463,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 598604c5-4889-4d99-a32c-c59ce280215c
+                - 7a71839a-1cd5-4b08-84b9-7eed6aab97c6
         status: 200 OK
         code: 200
-        duration: 60.251169ms
+        duration: 94.088108ms
     - id: 50
       request:
         proto: HTTP/1.1
@@ -2483,7 +2483,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/1df2d836-32fe-4bf3-8a83-1fb38505f339
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a574568d-5c43-482b-9d82-513f27e7d2ad
         method: GET
       response:
         proto: HTTP/2.0
@@ -2491,20 +2491,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1006
+        content_length: 980
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-16T16:33:33.616540Z","description":"","domain_name":"tfnsgallanthaibtku6hfpsd-test-acc-container-pn-c01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"1df2d836-32fe-4bf3-8a83-1fb38505f339","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c01","namespace_id":"36b36416-4c12-41cd-ba2b-52a002600f06","port":8080,"privacy":"public","private_network_id":"c806474f-01fa-47a9-b59a-a57f0ddfce80","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsgallanthaibtku6hfpsd/test-acc-container-pn-c01:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:33:37.362160Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:10.000784Z","description":"","domain_name":"tfnsstoicvisvesvarayusdiiaiq-test-acc-container-pn-c00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a574568d-5c43-482b-9d82-513f27e7d2ad","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c00","namespace_id":"627dd919-7422-43e4-bc7b-ce02de6605c9","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsstoicvisvesvarayusdiiaiq/test-acc-container-pn-c00:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:16.350038Z"}'
         headers:
             Content-Length:
-                - "1006"
+                - "980"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:42 GMT
+                - Wed, 27 Aug 2025 15:06:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2512,10 +2512,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8076ad29-ced1-4012-b8c1-9af0792ed8ce
+                - 2c0c1b17-c420-462d-9b64-edd5994cf72e
         status: 200 OK
         code: 200
-        duration: 53.472899ms
+        duration: 94.698043ms
     - id: 51
       request:
         proto: HTTP/1.1
@@ -2532,7 +2532,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/aa1afb40-4da5-4bf9-a989-3cfb175fb432
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/8a6e08c5-fc29-4bbe-af65-a749a99f7dc1
         method: GET
       response:
         proto: HTTP/2.0
@@ -2540,20 +2540,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1010
+        content_length: 1052
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-16T16:33:29.364423Z","description":"","domain_name":"tfnsgallanthaibtku6hfpsd-test-acc-container-pn-c00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"aa1afb40-4da5-4bf9-a989-3cfb175fb432","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c00","namespace_id":"36b36416-4c12-41cd-ba2b-52a002600f06","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsgallanthaibtku6hfpsd/test-acc-container-pn-c00:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:33:43.777804Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:13.805947Z","description":"","domain_name":"tfnsstoicvisvesvarayusdiiaiq-test-acc-container-pn-c01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"8a6e08c5-fc29-4bbe-af65-a749a99f7dc1","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c01","namespace_id":"627dd919-7422-43e4-bc7b-ce02de6605c9","port":8080,"privacy":"public","private_network_id":"49592394-2619-4001-b8ab-cbb5017db9d9","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsstoicvisvesvarayusdiiaiq/test-acc-container-pn-c01:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:22.766495Z"}'
         headers:
             Content-Length:
-                - "1010"
+                - "1052"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:47 GMT
+                - Wed, 27 Aug 2025 15:06:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2561,10 +2561,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5f06c56b-ef47-479e-bfce-0e0eaf92b076
+                - 20f7e780-6d14-4a33-98cf-9f5346060689
         status: 200 OK
         code: 200
-        duration: 50.999861ms
+        duration: 80.406106ms
     - id: 52
       request:
         proto: HTTP/1.1
@@ -2581,7 +2581,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/aa1afb40-4da5-4bf9-a989-3cfb175fb432
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a574568d-5c43-482b-9d82-513f27e7d2ad
         method: GET
       response:
         proto: HTTP/2.0
@@ -2589,20 +2589,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1010
+        content_length: 1018
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-16T16:33:29.364423Z","description":"","domain_name":"tfnsgallanthaibtku6hfpsd-test-acc-container-pn-c00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"aa1afb40-4da5-4bf9-a989-3cfb175fb432","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c00","namespace_id":"36b36416-4c12-41cd-ba2b-52a002600f06","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsgallanthaibtku6hfpsd/test-acc-container-pn-c00:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:33:43.777804Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:10.000784Z","description":"","domain_name":"tfnsstoicvisvesvarayusdiiaiq-test-acc-container-pn-c00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a574568d-5c43-482b-9d82-513f27e7d2ad","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c00","namespace_id":"627dd919-7422-43e4-bc7b-ce02de6605c9","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsstoicvisvesvarayusdiiaiq/test-acc-container-pn-c00:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:26.288370Z"}'
         headers:
             Content-Length:
-                - "1010"
+                - "1018"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:47 GMT
+                - Wed, 27 Aug 2025 15:06:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2610,10 +2610,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 42180881-4282-4c85-8eeb-795e7d6241c7
+                - ff205041-bf50-451c-beaa-38f54bf093df
         status: 200 OK
         code: 200
-        duration: 48.347748ms
+        duration: 86.841402ms
     - id: 53
       request:
         proto: HTTP/1.1
@@ -2630,7 +2630,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/1df2d836-32fe-4bf3-8a83-1fb38505f339
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/8a6e08c5-fc29-4bbe-af65-a749a99f7dc1
         method: GET
       response:
         proto: HTTP/2.0
@@ -2638,20 +2638,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1044
+        content_length: 1052
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-16T16:33:33.616540Z","description":"","domain_name":"tfnsgallanthaibtku6hfpsd-test-acc-container-pn-c01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"1df2d836-32fe-4bf3-8a83-1fb38505f339","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c01","namespace_id":"36b36416-4c12-41cd-ba2b-52a002600f06","port":8080,"privacy":"public","private_network_id":"c806474f-01fa-47a9-b59a-a57f0ddfce80","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsgallanthaibtku6hfpsd/test-acc-container-pn-c01:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:33:43.744515Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:13.805947Z","description":"","domain_name":"tfnsstoicvisvesvarayusdiiaiq-test-acc-container-pn-c01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"8a6e08c5-fc29-4bbe-af65-a749a99f7dc1","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c01","namespace_id":"627dd919-7422-43e4-bc7b-ce02de6605c9","port":8080,"privacy":"public","private_network_id":"49592394-2619-4001-b8ab-cbb5017db9d9","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsstoicvisvesvarayusdiiaiq/test-acc-container-pn-c01:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:22.766495Z"}'
         headers:
             Content-Length:
-                - "1044"
+                - "1052"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:47 GMT
+                - Wed, 27 Aug 2025 15:06:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2659,10 +2659,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 29a55009-7aa6-4c0c-aa2c-fc97d673b4b6
+                - 2b2b5013-7a7c-43c0-8430-f36fc739b71d
         status: 200 OK
         code: 200
-        duration: 62.435333ms
+        duration: 96.122579ms
     - id: 54
       request:
         proto: HTTP/1.1
@@ -2679,7 +2679,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/1df2d836-32fe-4bf3-8a83-1fb38505f339
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a574568d-5c43-482b-9d82-513f27e7d2ad
         method: GET
       response:
         proto: HTTP/2.0
@@ -2687,20 +2687,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1044
+        content_length: 1018
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-16T16:33:33.616540Z","description":"","domain_name":"tfnsgallanthaibtku6hfpsd-test-acc-container-pn-c01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"1df2d836-32fe-4bf3-8a83-1fb38505f339","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c01","namespace_id":"36b36416-4c12-41cd-ba2b-52a002600f06","port":8080,"privacy":"public","private_network_id":"c806474f-01fa-47a9-b59a-a57f0ddfce80","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsgallanthaibtku6hfpsd/test-acc-container-pn-c01:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:33:43.744515Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:10.000784Z","description":"","domain_name":"tfnsstoicvisvesvarayusdiiaiq-test-acc-container-pn-c00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a574568d-5c43-482b-9d82-513f27e7d2ad","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c00","namespace_id":"627dd919-7422-43e4-bc7b-ce02de6605c9","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsstoicvisvesvarayusdiiaiq/test-acc-container-pn-c00:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:26.288370Z"}'
         headers:
             Content-Length:
-                - "1044"
+                - "1018"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:47 GMT
+                - Wed, 27 Aug 2025 15:06:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2708,10 +2708,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 90869378-d7af-42cd-aa5b-207e4bb76a5f
+                - 878bf736-0ee8-472b-824b-12c2933d2cdf
         status: 200 OK
         code: 200
-        duration: 67.035169ms
+        duration: 72.742685ms
     - id: 55
       request:
         proto: HTTP/1.1
@@ -2728,7 +2728,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/aa1afb40-4da5-4bf9-a989-3cfb175fb432
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a574568d-5c43-482b-9d82-513f27e7d2ad
         method: GET
       response:
         proto: HTTP/2.0
@@ -2736,20 +2736,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1010
+        content_length: 1018
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-16T16:33:29.364423Z","description":"","domain_name":"tfnsgallanthaibtku6hfpsd-test-acc-container-pn-c00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"aa1afb40-4da5-4bf9-a989-3cfb175fb432","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c00","namespace_id":"36b36416-4c12-41cd-ba2b-52a002600f06","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsgallanthaibtku6hfpsd/test-acc-container-pn-c00:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:33:43.777804Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:10.000784Z","description":"","domain_name":"tfnsstoicvisvesvarayusdiiaiq-test-acc-container-pn-c00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a574568d-5c43-482b-9d82-513f27e7d2ad","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c00","namespace_id":"627dd919-7422-43e4-bc7b-ce02de6605c9","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsstoicvisvesvarayusdiiaiq/test-acc-container-pn-c00:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:26.288370Z"}'
         headers:
             Content-Length:
-                - "1010"
+                - "1018"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:47 GMT
+                - Wed, 27 Aug 2025 15:06:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2757,10 +2757,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f387f4ca-7b1c-4b1e-b5fa-ee155441e539
+                - 983bb97e-4127-4280-9fa8-b6b8600e5eeb
         status: 200 OK
         code: 200
-        duration: 46.666495ms
+        duration: 98.575342ms
     - id: 56
       request:
         proto: HTTP/1.1
@@ -2777,7 +2777,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/1df2d836-32fe-4bf3-8a83-1fb38505f339
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/8a6e08c5-fc29-4bbe-af65-a749a99f7dc1
         method: GET
       response:
         proto: HTTP/2.0
@@ -2785,20 +2785,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1044
+        content_length: 1052
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-16T16:33:33.616540Z","description":"","domain_name":"tfnsgallanthaibtku6hfpsd-test-acc-container-pn-c01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"1df2d836-32fe-4bf3-8a83-1fb38505f339","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c01","namespace_id":"36b36416-4c12-41cd-ba2b-52a002600f06","port":8080,"privacy":"public","private_network_id":"c806474f-01fa-47a9-b59a-a57f0ddfce80","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsgallanthaibtku6hfpsd/test-acc-container-pn-c01:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:33:43.744515Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:13.805947Z","description":"","domain_name":"tfnsstoicvisvesvarayusdiiaiq-test-acc-container-pn-c01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"8a6e08c5-fc29-4bbe-af65-a749a99f7dc1","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c01","namespace_id":"627dd919-7422-43e4-bc7b-ce02de6605c9","port":8080,"privacy":"public","private_network_id":"49592394-2619-4001-b8ab-cbb5017db9d9","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsstoicvisvesvarayusdiiaiq/test-acc-container-pn-c01:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:22.766495Z"}'
         headers:
             Content-Length:
-                - "1044"
+                - "1052"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:48 GMT
+                - Wed, 27 Aug 2025 15:06:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2806,10 +2806,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9bcaf9c0-8e15-4dd4-abf7-6ccd0c14d2ab
+                - c95159fd-89eb-4383-8642-96d12172c5ad
         status: 200 OK
         code: 200
-        duration: 52.646088ms
+        duration: 114.191807ms
     - id: 57
       request:
         proto: HTTP/1.1
@@ -2826,7 +2826,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a9e5fed6-13c0-4943-ae02-701b5bf3398b
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/46867816-e5e1-47a4-993c-852289df4bae
         method: GET
       response:
         proto: HTTP/2.0
@@ -2834,20 +2834,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1006
+        content_length: 1014
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-16T16:33:33.320098Z","description":"","domain_name":"tfnsgallanthaibtku6hfpsd-test-acc-container-pn-c02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a9e5fed6-13c0-4943-ae02-701b5bf3398b","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c02","namespace_id":"36b36416-4c12-41cd-ba2b-52a002600f06","port":8080,"privacy":"public","private_network_id":"8a415abf-00cd-4db2-bdc4-12408ad70c98","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsgallanthaibtku6hfpsd/test-acc-container-pn-c02:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:33:33.320098Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:13.772341Z","description":"","domain_name":"tfnsstoicvisvesvarayusdiiaiq-test-acc-container-pn-c02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"46867816-e5e1-47a4-993c-852289df4bae","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c02","namespace_id":"627dd919-7422-43e4-bc7b-ce02de6605c9","port":8080,"privacy":"public","private_network_id":"932f31bb-f882-443f-be0e-9cc4f0bd70fa","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsstoicvisvesvarayusdiiaiq/test-acc-container-pn-c02:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:13.772341Z"}'
         headers:
             Content-Length:
-                - "1006"
+                - "1014"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:48 GMT
+                - Wed, 27 Aug 2025 15:06:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2855,10 +2855,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ee9064d0-0886-443a-a3d6-c2991b94eeb5
+                - f1a723af-f78b-4c3b-9bf5-16aa5e1ead30
         status: 200 OK
         code: 200
-        duration: 55.770717ms
+        duration: 106.733211ms
     - id: 58
       request:
         proto: HTTP/1.1
@@ -2875,7 +2875,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/8a415abf-00cd-4db2-bdc4-12408ad70c98
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/49592394-2619-4001-b8ab-cbb5017db9d9
         method: GET
       response:
         proto: HTTP/2.0
@@ -2883,20 +2883,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1072
+        content_length: 1071
         uncompressed: false
-        body: '{"created_at":"2025-06-16T16:33:23.708187Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"8a415abf-00cd-4db2-bdc4-12408ad70c98","name":"test-acc-container-pn-pn00","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-06-16T16:33:23.708187Z","id":"15b4ea61-5306-454b-aa0e-bf9af4de300d","private_network_id":"8a415abf-00cd-4db2-bdc4-12408ad70c98","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.48.0/22","updated_at":"2025-06-16T16:33:23.708187Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-06-16T16:33:23.708187Z","id":"aa029065-1714-4b11-9d82-360ac03ac61c","private_network_id":"8a415abf-00cd-4db2-bdc4-12408ad70c98","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:e008::/64","updated_at":"2025-06-16T16:33:23.708187Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-06-16T16:33:23.708187Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+        body: '{"created_at":"2025-08-27T15:06:02.345555Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"49592394-2619-4001-b8ab-cbb5017db9d9","name":"test-acc-container-pn-pn01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","subnets":[{"created_at":"2025-08-27T15:06:02.345555Z","id":"55b5c4c2-43a9-4d50-b6f8-c3207b0f9cb5","private_network_id":"49592394-2619-4001-b8ab-cbb5017db9d9","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","subnet":"172.16.4.0/22","updated_at":"2025-08-27T15:06:02.345555Z","vpc_id":"bfef8344-f496-473e-af67-31ea9afc407c"},{"created_at":"2025-08-27T15:06:02.345555Z","id":"2c9fda53-fa80-4dd7-977b-09d2e00670c1","private_network_id":"49592394-2619-4001-b8ab-cbb5017db9d9","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","subnet":"fde7:767f:1bb5:cd83::/64","updated_at":"2025-08-27T15:06:02.345555Z","vpc_id":"bfef8344-f496-473e-af67-31ea9afc407c"}],"tags":[],"updated_at":"2025-08-27T15:06:02.345555Z","vpc_id":"bfef8344-f496-473e-af67-31ea9afc407c"}'
         headers:
             Content-Length:
-                - "1072"
+                - "1071"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:48 GMT
+                - Wed, 27 Aug 2025 15:06:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2904,10 +2904,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ae273580-3003-4b73-8d2a-110d8249db0d
+                - 0101e088-ed5d-44a2-bdb0-f6ca844973cd
         status: 200 OK
         code: 200
-        duration: 33.645499ms
+        duration: 23.662193ms
     - id: 59
       request:
         proto: HTTP/1.1
@@ -2924,7 +2924,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c806474f-01fa-47a9-b59a-a57f0ddfce80
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/932f31bb-f882-443f-be0e-9cc4f0bd70fa
         method: GET
       response:
         proto: HTTP/2.0
@@ -2932,20 +2932,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1071
+        content_length: 1072
         uncompressed: false
-        body: '{"created_at":"2025-06-16T16:33:23.625701Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"c806474f-01fa-47a9-b59a-a57f0ddfce80","name":"test-acc-container-pn-pn01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-06-16T16:33:23.625701Z","id":"d2bc5535-6dc9-4782-bd4d-d36deb39b558","private_network_id":"c806474f-01fa-47a9-b59a-a57f0ddfce80","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.4.0/22","updated_at":"2025-06-16T16:33:23.625701Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-06-16T16:33:23.625701Z","id":"a38e59ef-cd3c-443f-ae15-6c0d8ff3508a","private_network_id":"c806474f-01fa-47a9-b59a-a57f0ddfce80","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:ce3b::/64","updated_at":"2025-06-16T16:33:23.625701Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-06-16T16:33:23.625701Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+        body: '{"created_at":"2025-08-27T15:06:02.065728Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"932f31bb-f882-443f-be0e-9cc4f0bd70fa","name":"test-acc-container-pn-pn00","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","subnets":[{"created_at":"2025-08-27T15:06:02.065728Z","id":"0229a8c6-bc1d-4c1d-a39f-757914bf3e21","private_network_id":"932f31bb-f882-443f-be0e-9cc4f0bd70fa","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","subnet":"172.16.32.0/22","updated_at":"2025-08-27T15:06:02.065728Z","vpc_id":"bfef8344-f496-473e-af67-31ea9afc407c"},{"created_at":"2025-08-27T15:06:02.065728Z","id":"40f741ae-c39f-4f7f-a05c-440b603b61d7","private_network_id":"932f31bb-f882-443f-be0e-9cc4f0bd70fa","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","subnet":"fde7:767f:1bb5:e3b7::/64","updated_at":"2025-08-27T15:06:02.065728Z","vpc_id":"bfef8344-f496-473e-af67-31ea9afc407c"}],"tags":[],"updated_at":"2025-08-27T15:06:02.065728Z","vpc_id":"bfef8344-f496-473e-af67-31ea9afc407c"}'
         headers:
             Content-Length:
-                - "1071"
+                - "1072"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:48 GMT
+                - Wed, 27 Aug 2025 15:06:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2953,10 +2953,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f77e0cf9-c63c-423f-9056-81a2843cc174
+                - 4e009d4d-9a8a-43b0-bb65-b307437991c3
         status: 200 OK
         code: 200
-        duration: 35.692187ms
+        duration: 39.400356ms
     - id: 60
       request:
         proto: HTTP/1.1
@@ -2973,7 +2973,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/36b36416-4c12-41cd-ba2b-52a002600f06
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/627dd919-7422-43e4-bc7b-ce02de6605c9
         method: GET
       response:
         proto: HTTP/2.0
@@ -2981,20 +2981,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 583
+        content_length: 592
         uncompressed: false
-        body: '{"created_at":"2025-06-16T16:33:23.753071Z","description":"","environment_variables":{},"error_message":null,"id":"36b36416-4c12-41cd-ba2b-52a002600f06","name":"tf-ns-gallant-haibt","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsgallanthaibtku6hfpsd","registry_namespace_id":"a9a080da-7f15-4f03-adcf-9ab5d353fb37","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-16T16:33:24.797296Z","vpc_integration_activated":true}'
+        body: '{"created_at":"2025-08-27T15:06:03.495907Z","description":"","environment_variables":{},"error_message":null,"id":"627dd919-7422-43e4-bc7b-ce02de6605c9","name":"tf-ns-stoic-visvesvaraya","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsstoicvisvesvarayusdiiaiq","registry_namespace_id":"53f25a1b-bdfc-4c98-b9ea-30968c2ae2f1","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:06.063436Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "583"
+                - "592"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:48 GMT
+                - Wed, 27 Aug 2025 15:06:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3002,10 +3002,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a66e562a-8649-4093-9cc2-43be8e80876e
+                - 63b703f2-d248-47c7-bbee-6862ed48bb69
         status: 200 OK
         code: 200
-        duration: 40.717239ms
+        duration: 77.460178ms
     - id: 61
       request:
         proto: HTTP/1.1
@@ -3022,7 +3022,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/1df2d836-32fe-4bf3-8a83-1fb38505f339
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/46867816-e5e1-47a4-993c-852289df4bae
         method: GET
       response:
         proto: HTTP/2.0
@@ -3030,20 +3030,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1044
+        content_length: 1014
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-16T16:33:33.616540Z","description":"","domain_name":"tfnsgallanthaibtku6hfpsd-test-acc-container-pn-c01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"1df2d836-32fe-4bf3-8a83-1fb38505f339","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c01","namespace_id":"36b36416-4c12-41cd-ba2b-52a002600f06","port":8080,"privacy":"public","private_network_id":"c806474f-01fa-47a9-b59a-a57f0ddfce80","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsgallanthaibtku6hfpsd/test-acc-container-pn-c01:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:33:43.744515Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:13.772341Z","description":"","domain_name":"tfnsstoicvisvesvarayusdiiaiq-test-acc-container-pn-c02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"46867816-e5e1-47a4-993c-852289df4bae","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c02","namespace_id":"627dd919-7422-43e4-bc7b-ce02de6605c9","port":8080,"privacy":"public","private_network_id":"932f31bb-f882-443f-be0e-9cc4f0bd70fa","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsstoicvisvesvarayusdiiaiq/test-acc-container-pn-c02:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:13.772341Z"}'
         headers:
             Content-Length:
-                - "1044"
+                - "1014"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:48 GMT
+                - Wed, 27 Aug 2025 15:06:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3051,10 +3051,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d04be78e-cf45-4cb0-bc12-39534a56aea5
+                - 2f8c5cf6-a1a0-44b7-9a12-a08ff175dda2
         status: 200 OK
         code: 200
-        duration: 82.683542ms
+        duration: 100.704537ms
     - id: 62
       request:
         proto: HTTP/1.1
@@ -3071,7 +3071,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/aa1afb40-4da5-4bf9-a989-3cfb175fb432
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a574568d-5c43-482b-9d82-513f27e7d2ad
         method: GET
       response:
         proto: HTTP/2.0
@@ -3079,20 +3079,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1010
+        content_length: 1018
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-16T16:33:29.364423Z","description":"","domain_name":"tfnsgallanthaibtku6hfpsd-test-acc-container-pn-c00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"aa1afb40-4da5-4bf9-a989-3cfb175fb432","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c00","namespace_id":"36b36416-4c12-41cd-ba2b-52a002600f06","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsgallanthaibtku6hfpsd/test-acc-container-pn-c00:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:33:43.777804Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:10.000784Z","description":"","domain_name":"tfnsstoicvisvesvarayusdiiaiq-test-acc-container-pn-c00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a574568d-5c43-482b-9d82-513f27e7d2ad","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c00","namespace_id":"627dd919-7422-43e4-bc7b-ce02de6605c9","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsstoicvisvesvarayusdiiaiq/test-acc-container-pn-c00:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:26.288370Z"}'
         headers:
             Content-Length:
-                - "1010"
+                - "1018"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:48 GMT
+                - Wed, 27 Aug 2025 15:06:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3100,10 +3100,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1e780d75-20a7-452d-9a97-cf420b64a6b1
+                - e1aabe1c-7d2c-4666-9806-6c53ef088068
         status: 200 OK
         code: 200
-        duration: 86.142409ms
+        duration: 100.115812ms
     - id: 63
       request:
         proto: HTTP/1.1
@@ -3120,7 +3120,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a9e5fed6-13c0-4943-ae02-701b5bf3398b
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/8a6e08c5-fc29-4bbe-af65-a749a99f7dc1
         method: GET
       response:
         proto: HTTP/2.0
@@ -3128,20 +3128,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1006
+        content_length: 1052
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-16T16:33:33.320098Z","description":"","domain_name":"tfnsgallanthaibtku6hfpsd-test-acc-container-pn-c02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a9e5fed6-13c0-4943-ae02-701b5bf3398b","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c02","namespace_id":"36b36416-4c12-41cd-ba2b-52a002600f06","port":8080,"privacy":"public","private_network_id":"8a415abf-00cd-4db2-bdc4-12408ad70c98","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsgallanthaibtku6hfpsd/test-acc-container-pn-c02:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:33:33.320098Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:13.805947Z","description":"","domain_name":"tfnsstoicvisvesvarayusdiiaiq-test-acc-container-pn-c01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"8a6e08c5-fc29-4bbe-af65-a749a99f7dc1","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c01","namespace_id":"627dd919-7422-43e4-bc7b-ce02de6605c9","port":8080,"privacy":"public","private_network_id":"49592394-2619-4001-b8ab-cbb5017db9d9","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsstoicvisvesvarayusdiiaiq/test-acc-container-pn-c01:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:22.766495Z"}'
         headers:
             Content-Length:
-                - "1006"
+                - "1052"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:48 GMT
+                - Wed, 27 Aug 2025 15:06:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3149,10 +3149,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 93012706-a2ab-4483-b347-7070ecfe9bd8
+                - 03f73ba8-e6dd-4539-b14e-d126cc7e1eac
         status: 200 OK
         code: 200
-        duration: 85.128527ms
+        duration: 154.748874ms
     - id: 64
       request:
         proto: HTTP/1.1
@@ -3169,7 +3169,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a9e5fed6-13c0-4943-ae02-701b5bf3398b
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/46867816-e5e1-47a4-993c-852289df4bae
         method: GET
       response:
         proto: HTTP/2.0
@@ -3177,20 +3177,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1006
+        content_length: 1014
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-16T16:33:33.320098Z","description":"","domain_name":"tfnsgallanthaibtku6hfpsd-test-acc-container-pn-c02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a9e5fed6-13c0-4943-ae02-701b5bf3398b","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c02","namespace_id":"36b36416-4c12-41cd-ba2b-52a002600f06","port":8080,"privacy":"public","private_network_id":"8a415abf-00cd-4db2-bdc4-12408ad70c98","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsgallanthaibtku6hfpsd/test-acc-container-pn-c02:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:33:33.320098Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:13.772341Z","description":"","domain_name":"tfnsstoicvisvesvarayusdiiaiq-test-acc-container-pn-c02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"46867816-e5e1-47a4-993c-852289df4bae","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c02","namespace_id":"627dd919-7422-43e4-bc7b-ce02de6605c9","port":8080,"privacy":"public","private_network_id":"932f31bb-f882-443f-be0e-9cc4f0bd70fa","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsstoicvisvesvarayusdiiaiq/test-acc-container-pn-c02:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:13.772341Z"}'
         headers:
             Content-Length:
-                - "1006"
+                - "1014"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:49 GMT
+                - Wed, 27 Aug 2025 15:06:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3198,10 +3198,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cca3ee34-c6e7-4bd6-8d90-95064d5646eb
+                - 48d1e98f-4a7b-4d21-8dce-ba3a3de5485b
         status: 200 OK
         code: 200
-        duration: 59.975581ms
+        duration: 80.739422ms
     - id: 65
       request:
         proto: HTTP/1.1
@@ -3218,7 +3218,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/1df2d836-32fe-4bf3-8a83-1fb38505f339
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a574568d-5c43-482b-9d82-513f27e7d2ad
         method: GET
       response:
         proto: HTTP/2.0
@@ -3226,20 +3226,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1044
+        content_length: 1018
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-16T16:33:33.616540Z","description":"","domain_name":"tfnsgallanthaibtku6hfpsd-test-acc-container-pn-c01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"1df2d836-32fe-4bf3-8a83-1fb38505f339","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c01","namespace_id":"36b36416-4c12-41cd-ba2b-52a002600f06","port":8080,"privacy":"public","private_network_id":"c806474f-01fa-47a9-b59a-a57f0ddfce80","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsgallanthaibtku6hfpsd/test-acc-container-pn-c01:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:33:43.744515Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:10.000784Z","description":"","domain_name":"tfnsstoicvisvesvarayusdiiaiq-test-acc-container-pn-c00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a574568d-5c43-482b-9d82-513f27e7d2ad","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c00","namespace_id":"627dd919-7422-43e4-bc7b-ce02de6605c9","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsstoicvisvesvarayusdiiaiq/test-acc-container-pn-c00:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:26.288370Z"}'
         headers:
             Content-Length:
-                - "1044"
+                - "1018"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:49 GMT
+                - Wed, 27 Aug 2025 15:06:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3247,10 +3247,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 789b482a-68a8-4ec4-8bf7-09b008768c83
+                - 34ea1b9d-d13a-475a-a2ae-c155429b69f3
         status: 200 OK
         code: 200
-        duration: 60.495015ms
+        duration: 91.035162ms
     - id: 66
       request:
         proto: HTTP/1.1
@@ -3267,7 +3267,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/aa1afb40-4da5-4bf9-a989-3cfb175fb432
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/8a6e08c5-fc29-4bbe-af65-a749a99f7dc1
         method: GET
       response:
         proto: HTTP/2.0
@@ -3275,20 +3275,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1010
+        content_length: 1052
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-16T16:33:29.364423Z","description":"","domain_name":"tfnsgallanthaibtku6hfpsd-test-acc-container-pn-c00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"aa1afb40-4da5-4bf9-a989-3cfb175fb432","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c00","namespace_id":"36b36416-4c12-41cd-ba2b-52a002600f06","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsgallanthaibtku6hfpsd/test-acc-container-pn-c00:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:33:43.777804Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:13.805947Z","description":"","domain_name":"tfnsstoicvisvesvarayusdiiaiq-test-acc-container-pn-c01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"8a6e08c5-fc29-4bbe-af65-a749a99f7dc1","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c01","namespace_id":"627dd919-7422-43e4-bc7b-ce02de6605c9","port":8080,"privacy":"public","private_network_id":"49592394-2619-4001-b8ab-cbb5017db9d9","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsstoicvisvesvarayusdiiaiq/test-acc-container-pn-c01:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:22.766495Z"}'
         headers:
             Content-Length:
-                - "1010"
+                - "1052"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:49 GMT
+                - Wed, 27 Aug 2025 15:06:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3296,10 +3296,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b7f3beac-2e6b-491b-bc28-8c8a2cbeb50a
+                - 72820e1e-1362-4d05-b53c-de913c85ccf8
         status: 200 OK
         code: 200
-        duration: 66.104103ms
+        duration: 146.552193ms
     - id: 67
       request:
         proto: HTTP/1.1
@@ -3316,7 +3316,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a9e5fed6-13c0-4943-ae02-701b5bf3398b
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a574568d-5c43-482b-9d82-513f27e7d2ad
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -3324,20 +3324,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1010
+        content_length: 984
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-16T16:33:33.320098Z","description":"","domain_name":"tfnsgallanthaibtku6hfpsd-test-acc-container-pn-c02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a9e5fed6-13c0-4943-ae02-701b5bf3398b","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c02","namespace_id":"36b36416-4c12-41cd-ba2b-52a002600f06","port":8080,"privacy":"public","private_network_id":"8a415abf-00cd-4db2-bdc4-12408ad70c98","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsgallanthaibtku6hfpsd/test-acc-container-pn-c02:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:33:49.892665569Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:10.000784Z","description":"","domain_name":"tfnsstoicvisvesvarayusdiiaiq-test-acc-container-pn-c00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a574568d-5c43-482b-9d82-513f27e7d2ad","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c00","namespace_id":"627dd919-7422-43e4-bc7b-ce02de6605c9","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsstoicvisvesvarayusdiiaiq/test-acc-container-pn-c00:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:28.476574496Z"}'
         headers:
             Content-Length:
-                - "1010"
+                - "984"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:49 GMT
+                - Wed, 27 Aug 2025 15:06:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3345,10 +3345,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 79299e57-50c8-48d0-9a00-87928abf1d62
+                - 20f0b13f-b502-4c34-9015-232ca8d8c37b
         status: 200 OK
         code: 200
-        duration: 159.526411ms
+        duration: 169.753542ms
     - id: 68
       request:
         proto: HTTP/1.1
@@ -3365,7 +3365,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/aa1afb40-4da5-4bf9-a989-3cfb175fb432
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/46867816-e5e1-47a4-993c-852289df4bae
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -3373,20 +3373,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 976
+        content_length: 1018
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-16T16:33:29.364423Z","description":"","domain_name":"tfnsgallanthaibtku6hfpsd-test-acc-container-pn-c00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"aa1afb40-4da5-4bf9-a989-3cfb175fb432","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c00","namespace_id":"36b36416-4c12-41cd-ba2b-52a002600f06","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsgallanthaibtku6hfpsd/test-acc-container-pn-c00:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:33:49.922103113Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:13.772341Z","description":"","domain_name":"tfnsstoicvisvesvarayusdiiaiq-test-acc-container-pn-c02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"46867816-e5e1-47a4-993c-852289df4bae","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c02","namespace_id":"627dd919-7422-43e4-bc7b-ce02de6605c9","port":8080,"privacy":"public","private_network_id":"932f31bb-f882-443f-be0e-9cc4f0bd70fa","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsstoicvisvesvarayusdiiaiq/test-acc-container-pn-c02:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:28.422530386Z"}'
         headers:
             Content-Length:
-                - "976"
+                - "1018"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:49 GMT
+                - Wed, 27 Aug 2025 15:06:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3394,10 +3394,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d10eba85-1bc9-4292-8cb8-8a8445d11aed
+                - ad91e30d-11fb-4fe7-b51d-19ea27be5b16
         status: 200 OK
         code: 200
-        duration: 156.50215ms
+        duration: 267.352621ms
     - id: 69
       request:
         proto: HTTP/1.1
@@ -3414,7 +3414,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/1df2d836-32fe-4bf3-8a83-1fb38505f339
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/8a6e08c5-fc29-4bbe-af65-a749a99f7dc1
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -3422,20 +3422,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1010
+        content_length: 1018
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-16T16:33:33.616540Z","description":"","domain_name":"tfnsgallanthaibtku6hfpsd-test-acc-container-pn-c01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"1df2d836-32fe-4bf3-8a83-1fb38505f339","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c01","namespace_id":"36b36416-4c12-41cd-ba2b-52a002600f06","port":8080,"privacy":"public","private_network_id":"c806474f-01fa-47a9-b59a-a57f0ddfce80","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsgallanthaibtku6hfpsd/test-acc-container-pn-c01:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:33:49.889456343Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:13.805947Z","description":"","domain_name":"tfnsstoicvisvesvarayusdiiaiq-test-acc-container-pn-c01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"8a6e08c5-fc29-4bbe-af65-a749a99f7dc1","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-acc-container-pn-c01","namespace_id":"627dd919-7422-43e4-bc7b-ce02de6605c9","port":8080,"privacy":"public","private_network_id":"49592394-2619-4001-b8ab-cbb5017db9d9","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsstoicvisvesvarayusdiiaiq/test-acc-container-pn-c01:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:28.487591921Z"}'
         headers:
             Content-Length:
-                - "1010"
+                - "1018"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:49 GMT
+                - Wed, 27 Aug 2025 15:06:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3443,10 +3443,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 97910936-cf28-4884-814a-f7f97ab746cf
+                - e7fa336b-bcb7-4a1f-86b9-1b1cf595f974
         status: 200 OK
         code: 200
-        duration: 161.78152ms
+        duration: 238.495519ms
     - id: 70
       request:
         proto: HTTP/1.1
@@ -3463,7 +3463,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/36b36416-4c12-41cd-ba2b-52a002600f06
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/627dd919-7422-43e4-bc7b-ce02de6605c9
         method: GET
       response:
         proto: HTTP/2.0
@@ -3471,20 +3471,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 583
+        content_length: 592
         uncompressed: false
-        body: '{"created_at":"2025-06-16T16:33:23.753071Z","description":"","environment_variables":{},"error_message":null,"id":"36b36416-4c12-41cd-ba2b-52a002600f06","name":"tf-ns-gallant-haibt","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsgallanthaibtku6hfpsd","registry_namespace_id":"a9a080da-7f15-4f03-adcf-9ab5d353fb37","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-16T16:33:24.797296Z","vpc_integration_activated":true}'
+        body: '{"created_at":"2025-08-27T15:06:03.495907Z","description":"","environment_variables":{},"error_message":null,"id":"627dd919-7422-43e4-bc7b-ce02de6605c9","name":"tf-ns-stoic-visvesvaraya","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsstoicvisvesvarayusdiiaiq","registry_namespace_id":"53f25a1b-bdfc-4c98-b9ea-30968c2ae2f1","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:06.063436Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "583"
+                - "592"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:50 GMT
+                - Wed, 27 Aug 2025 15:06:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3492,10 +3492,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a43ae803-0bbb-474f-9ff9-feb105a5d496
+                - 0ea34b82-e212-4898-bd57-f6e9fb6d2c03
         status: 200 OK
         code: 200
-        duration: 42.179041ms
+        duration: 78.462609ms
     - id: 71
       request:
         proto: HTTP/1.1
@@ -3512,7 +3512,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/36b36416-4c12-41cd-ba2b-52a002600f06
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/627dd919-7422-43e4-bc7b-ce02de6605c9
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -3520,20 +3520,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 589
+        content_length: 598
         uncompressed: false
-        body: '{"created_at":"2025-06-16T16:33:23.753071Z","description":"","environment_variables":{},"error_message":null,"id":"36b36416-4c12-41cd-ba2b-52a002600f06","name":"tf-ns-gallant-haibt","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsgallanthaibtku6hfpsd","registry_namespace_id":"a9a080da-7f15-4f03-adcf-9ab5d353fb37","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-06-16T16:33:50.072352569Z","vpc_integration_activated":true}'
+        body: '{"created_at":"2025-08-27T15:06:03.495907Z","description":"","environment_variables":{},"error_message":null,"id":"627dd919-7422-43e4-bc7b-ce02de6605c9","name":"tf-ns-stoic-visvesvaraya","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsstoicvisvesvarayusdiiaiq","registry_namespace_id":"53f25a1b-bdfc-4c98-b9ea-30968c2ae2f1","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:28.819496593Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "589"
+                - "598"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:50 GMT
+                - Wed, 27 Aug 2025 15:06:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3541,10 +3541,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 18836f55-47da-4bb1-9473-ccb409f75de4
+                - 819900b2-b27f-46fe-b753-7bd37aec008b
         status: 200 OK
         code: 200
-        duration: 209.054743ms
+        duration: 514.344926ms
     - id: 72
       request:
         proto: HTTP/1.1
@@ -3561,7 +3561,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/36b36416-4c12-41cd-ba2b-52a002600f06
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/627dd919-7422-43e4-bc7b-ce02de6605c9
         method: GET
       response:
         proto: HTTP/2.0
@@ -3569,20 +3569,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 586
+        content_length: 595
         uncompressed: false
-        body: '{"created_at":"2025-06-16T16:33:23.753071Z","description":"","environment_variables":{},"error_message":null,"id":"36b36416-4c12-41cd-ba2b-52a002600f06","name":"tf-ns-gallant-haibt","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsgallanthaibtku6hfpsd","registry_namespace_id":"a9a080da-7f15-4f03-adcf-9ab5d353fb37","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-06-16T16:33:50.072353Z","vpc_integration_activated":true}'
+        body: '{"created_at":"2025-08-27T15:06:03.495907Z","description":"","environment_variables":{},"error_message":null,"id":"627dd919-7422-43e4-bc7b-ce02de6605c9","name":"tf-ns-stoic-visvesvaraya","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsstoicvisvesvarayusdiiaiq","registry_namespace_id":"53f25a1b-bdfc-4c98-b9ea-30968c2ae2f1","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:28.819497Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "586"
+                - "595"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:50 GMT
+                - Wed, 27 Aug 2025 15:06:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3590,10 +3590,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cc0475db-d360-4d7d-ae7f-df5941fe743b
+                - c1901ada-5064-4a46-864a-be8f00a0d9d4
         status: 200 OK
         code: 200
-        duration: 41.132719ms
+        duration: 78.719221ms
     - id: 73
       request:
         proto: HTTP/1.1
@@ -3610,7 +3610,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c806474f-01fa-47a9-b59a-a57f0ddfce80
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/932f31bb-f882-443f-be0e-9cc4f0bd70fa
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -3627,9 +3627,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:51 GMT
+                - Wed, 27 Aug 2025 15:06:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3637,10 +3637,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5afdfe80-6c93-43c3-a861-435849a4cf6e
+                - e50e3a43-9c01-475e-8647-57324ab29a02
         status: 204 No Content
         code: 204
-        duration: 1.737376127s
+        duration: 1.32693181s
     - id: 74
       request:
         proto: HTTP/1.1
@@ -3657,7 +3657,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/8a415abf-00cd-4db2-bdc4-12408ad70c98
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/49592394-2619-4001-b8ab-cbb5017db9d9
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -3674,9 +3674,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:51 GMT
+                - Wed, 27 Aug 2025 15:06:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3684,10 +3684,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 721dd323-1744-4936-9498-8eeae4ac1605
+                - 032fb028-1d8b-4b0c-a147-a1797222a77a
         status: 204 No Content
         code: 204
-        duration: 1.746987048s
+        duration: 1.544769605s
     - id: 75
       request:
         proto: HTTP/1.1
@@ -3704,7 +3704,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/36b36416-4c12-41cd-ba2b-52a002600f06
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/627dd919-7422-43e4-bc7b-ce02de6605c9
         method: GET
       response:
         proto: HTTP/2.0
@@ -3712,20 +3712,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 586
+        content_length: 595
         uncompressed: false
-        body: '{"created_at":"2025-06-16T16:33:23.753071Z","description":"","environment_variables":{},"error_message":null,"id":"36b36416-4c12-41cd-ba2b-52a002600f06","name":"tf-ns-gallant-haibt","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsgallanthaibtku6hfpsd","registry_namespace_id":"a9a080da-7f15-4f03-adcf-9ab5d353fb37","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-06-16T16:33:50.072353Z","vpc_integration_activated":true}'
+        body: '{"created_at":"2025-08-27T15:06:03.495907Z","description":"","environment_variables":{},"error_message":null,"id":"627dd919-7422-43e4-bc7b-ce02de6605c9","name":"tf-ns-stoic-visvesvaraya","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsstoicvisvesvarayusdiiaiq","registry_namespace_id":"53f25a1b-bdfc-4c98-b9ea-30968c2ae2f1","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:28.819497Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "586"
+                - "595"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:55 GMT
+                - Wed, 27 Aug 2025 15:06:34 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3733,10 +3733,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 89abfec8-1bff-4820-b91d-a8fc71d387ce
+                - bb9e56d1-c611-451c-9e8e-08fe08f7a751
         status: 200 OK
         code: 200
-        duration: 46.5736ms
+        duration: 93.065213ms
     - id: 76
       request:
         proto: HTTP/1.1
@@ -3753,7 +3753,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/36b36416-4c12-41cd-ba2b-52a002600f06
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/627dd919-7422-43e4-bc7b-ce02de6605c9
         method: GET
       response:
         proto: HTTP/2.0
@@ -3761,20 +3761,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 586
+        content_length: 595
         uncompressed: false
-        body: '{"created_at":"2025-06-16T16:33:23.753071Z","description":"","environment_variables":{},"error_message":null,"id":"36b36416-4c12-41cd-ba2b-52a002600f06","name":"tf-ns-gallant-haibt","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsgallanthaibtku6hfpsd","registry_namespace_id":"a9a080da-7f15-4f03-adcf-9ab5d353fb37","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-06-16T16:33:50.072353Z","vpc_integration_activated":true}'
+        body: '{"created_at":"2025-08-27T15:06:03.495907Z","description":"","environment_variables":{},"error_message":null,"id":"627dd919-7422-43e4-bc7b-ce02de6605c9","name":"tf-ns-stoic-visvesvaraya","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsstoicvisvesvarayusdiiaiq","registry_namespace_id":"53f25a1b-bdfc-4c98-b9ea-30968c2ae2f1","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:28.819497Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "586"
+                - "595"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:34:00 GMT
+                - Wed, 27 Aug 2025 15:06:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3782,10 +3782,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - dc70dece-23d6-47fb-b46f-bcb25fa60a55
+                - 4298c6dd-b2d6-4b22-9807-6c8f5529b836
         status: 200 OK
         code: 200
-        duration: 45.370084ms
+        duration: 95.398292ms
     - id: 77
       request:
         proto: HTTP/1.1
@@ -3802,7 +3802,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/36b36416-4c12-41cd-ba2b-52a002600f06
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/627dd919-7422-43e4-bc7b-ce02de6605c9
         method: GET
       response:
         proto: HTTP/2.0
@@ -3810,20 +3810,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 586
+        content_length: 595
         uncompressed: false
-        body: '{"created_at":"2025-06-16T16:33:23.753071Z","description":"","environment_variables":{},"error_message":null,"id":"36b36416-4c12-41cd-ba2b-52a002600f06","name":"tf-ns-gallant-haibt","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsgallanthaibtku6hfpsd","registry_namespace_id":"a9a080da-7f15-4f03-adcf-9ab5d353fb37","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-06-16T16:33:50.072353Z","vpc_integration_activated":true}'
+        body: '{"created_at":"2025-08-27T15:06:03.495907Z","description":"","environment_variables":{},"error_message":null,"id":"627dd919-7422-43e4-bc7b-ce02de6605c9","name":"tf-ns-stoic-visvesvaraya","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsstoicvisvesvarayusdiiaiq","registry_namespace_id":"53f25a1b-bdfc-4c98-b9ea-30968c2ae2f1","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:28.819497Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "586"
+                - "595"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:34:05 GMT
+                - Wed, 27 Aug 2025 15:06:44 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3831,10 +3831,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cc61386b-3414-434f-b98a-fe6118bdd24b
+                - 1ffc0e68-e586-4ded-9103-a7edddac6e93
         status: 200 OK
         code: 200
-        duration: 44.944194ms
+        duration: 91.945214ms
     - id: 78
       request:
         proto: HTTP/1.1
@@ -3851,7 +3851,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/36b36416-4c12-41cd-ba2b-52a002600f06
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/627dd919-7422-43e4-bc7b-ce02de6605c9
         method: GET
       response:
         proto: HTTP/2.0
@@ -3859,20 +3859,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 586
+        content_length: 595
         uncompressed: false
-        body: '{"created_at":"2025-06-16T16:33:23.753071Z","description":"","environment_variables":{},"error_message":null,"id":"36b36416-4c12-41cd-ba2b-52a002600f06","name":"tf-ns-gallant-haibt","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsgallanthaibtku6hfpsd","registry_namespace_id":"a9a080da-7f15-4f03-adcf-9ab5d353fb37","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-06-16T16:33:50.072353Z","vpc_integration_activated":true}'
+        body: '{"created_at":"2025-08-27T15:06:03.495907Z","description":"","environment_variables":{},"error_message":null,"id":"627dd919-7422-43e4-bc7b-ce02de6605c9","name":"tf-ns-stoic-visvesvaraya","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsstoicvisvesvarayusdiiaiq","registry_namespace_id":"53f25a1b-bdfc-4c98-b9ea-30968c2ae2f1","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:28.819497Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "586"
+                - "595"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:34:10 GMT
+                - Wed, 27 Aug 2025 15:06:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3880,10 +3880,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3f4e9c21-d612-448d-8ac6-0f395f23b57d
+                - b3db5686-647a-4121-9494-2035edc19788
         status: 200 OK
         code: 200
-        duration: 40.779515ms
+        duration: 81.874928ms
     - id: 79
       request:
         proto: HTTP/1.1
@@ -3900,56 +3900,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/36b36416-4c12-41cd-ba2b-52a002600f06
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 586
-        uncompressed: false
-        body: '{"created_at":"2025-06-16T16:33:23.753071Z","description":"","environment_variables":{},"error_message":null,"id":"36b36416-4c12-41cd-ba2b-52a002600f06","name":"tf-ns-gallant-haibt","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsgallanthaibtku6hfpsd","registry_namespace_id":"a9a080da-7f15-4f03-adcf-9ab5d353fb37","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-06-16T16:33:50.072353Z","vpc_integration_activated":true}'
-        headers:
-            Content-Length:
-                - "586"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 16 Jun 2025 16:34:15 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - de33089d-9d27-41a4-b326-05a5f888420f
-        status: 200 OK
-        code: 200
-        duration: 39.781013ms
-    - id: 80
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/36b36416-4c12-41cd-ba2b-52a002600f06
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/627dd919-7422-43e4-bc7b-ce02de6605c9
         method: GET
       response:
         proto: HTTP/2.0
@@ -3968,9 +3919,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:34:20 GMT
+                - Wed, 27 Aug 2025 15:06:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3978,11 +3929,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e648e2e8-1bcd-4308-ac6b-f1f715488099
+                - 48c9751f-d715-4366-9115-8d3362f5268c
         status: 404 Not Found
         code: 404
-        duration: 27.425004ms
-    - id: 81
+        duration: 26.765148ms
+    - id: 80
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3998,7 +3949,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/36b36416-4c12-41cd-ba2b-52a002600f06
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/627dd919-7422-43e4-bc7b-ce02de6605c9
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -4017,9 +3968,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:34:20 GMT
+                - Wed, 27 Aug 2025 15:06:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4027,11 +3978,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f6dcb565-0c55-4568-96d9-084ea82e2d0d
+                - cc3b616b-f8c0-44a0-b4d2-3eed49434c55
         status: 404 Not Found
         code: 404
-        duration: 23.458637ms
-    - id: 82
+        duration: 23.727969ms
+    - id: 81
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -4047,7 +3998,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/36b36416-4c12-41cd-ba2b-52a002600f06
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/627dd919-7422-43e4-bc7b-ce02de6605c9
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -4066,9 +4017,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:34:20 GMT
+                - Wed, 27 Aug 2025 15:06:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4076,10 +4027,59 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 50d92614-f4c4-4aef-8e88-e310c7920b43
+                - c38d64c3-5afe-4fb7-8359-bfa37dd92d98
         status: 404 Not Found
         code: 404
-        duration: 27.346718ms
+        duration: 27.987653ms
+    - id: 82
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/932f31bb-f882-443f-be0e-9cc4f0bd70fa
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 136
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"private_network","resource_id":"932f31bb-f882-443f-be0e-9cc4f0bd70fa","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "136"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:54 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ab2e24bb-52df-45e7-b73d-4dde8c3ec638
+        status: 404 Not Found
+        code: 404
+        duration: 22.943746ms
     - id: 83
       request:
         proto: HTTP/1.1
@@ -4096,7 +4096,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/8a415abf-00cd-4db2-bdc4-12408ad70c98
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/49592394-2619-4001-b8ab-cbb5017db9d9
         method: GET
       response:
         proto: HTTP/2.0
@@ -4106,7 +4106,7 @@ interactions:
         trailer: {}
         content_length: 136
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"private_network","resource_id":"8a415abf-00cd-4db2-bdc4-12408ad70c98","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"private_network","resource_id":"49592394-2619-4001-b8ab-cbb5017db9d9","type":"not_found"}'
         headers:
             Content-Length:
                 - "136"
@@ -4115,9 +4115,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:34:20 GMT
+                - Wed, 27 Aug 2025 15:06:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4125,56 +4125,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e594df7a-29e4-4ae4-9ed0-70701c46bcf3
+                - bb79e4c4-1756-4240-bf85-a5f675ff528c
         status: 404 Not Found
         code: 404
-        duration: 24.31941ms
-    - id: 84
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c806474f-01fa-47a9-b59a-a57f0ddfce80
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 136
-        uncompressed: false
-        body: '{"message":"resource is not found","resource":"private_network","resource_id":"c806474f-01fa-47a9-b59a-a57f0ddfce80","type":"not_found"}'
-        headers:
-            Content-Length:
-                - "136"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 16 Jun 2025 16:34:20 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - c5592b06-c780-43fa-b268-0d2b4ab4c5f2
-        status: 404 Not Found
-        code: 404
-        duration: 23.889425ms
+        duration: 25.713535ms

--- a/internal/services/container/testdata/container-sandbox.cassette.yaml
+++ b/internal/services/container/testdata/container-sandbox.cassette.yaml
@@ -6,19 +6,19 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 156
+        content_length: 191
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-ns-tender-pasteur","environment_variables":{},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","secret_environment_variables":[],"tags":null}'
+        body: '{"name":"tf-ns-cranky-heisenberg","environment_variables":{},"project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","secret_environment_variables":[],"tags":null,"activate_vpc_integration":true}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces
         method: POST
       response:
@@ -27,20 +27,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 472
+        content_length: 508
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:38:03.249776263Z","description":"","environment_variables":{},"error_message":null,"id":"f9ec5c49-a55d-47ed-8464-9545eb0d52bf","name":"tf-ns-tender-pasteur","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:38:03.249776263Z"}'
+        body: '{"created_at":"2025-08-27T15:06:15.199100476Z","description":"","environment_variables":{},"error_message":null,"id":"491350f0-f34b-4717-abd0-586008512a36","name":"tf-ns-cranky-heisenberg","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:06:15.199100476Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "472"
+                - "508"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:03 GMT
+                - Wed, 27 Aug 2025 15:06:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - de9402a6-44ff-496f-8ce8-7593bd8949b6
+                - efce8391-99e2-43a7-a905-3541a5a0f4ba
         status: 200 OK
         code: 200
-        duration: 269.121458ms
+        duration: 1.037110018s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -67,8 +67,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/f9ec5c49-a55d-47ed-8464-9545eb0d52bf
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/491350f0-f34b-4717-abd0-586008512a36
         method: GET
       response:
         proto: HTTP/2.0
@@ -76,20 +76,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 466
+        content_length: 502
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:38:03.249776Z","description":"","environment_variables":{},"error_message":null,"id":"f9ec5c49-a55d-47ed-8464-9545eb0d52bf","name":"tf-ns-tender-pasteur","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:38:03.249776Z"}'
+        body: '{"created_at":"2025-08-27T15:06:15.199100Z","description":"","environment_variables":{},"error_message":null,"id":"491350f0-f34b-4717-abd0-586008512a36","name":"tf-ns-cranky-heisenberg","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:06:15.199100Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "466"
+                - "502"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:03 GMT
+                - Wed, 27 Aug 2025 15:06:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7945b659-1140-4d39-99c7-8d737b153441
+                - c79cd828-77bf-4b8b-b192-19abe4b5b99d
         status: 200 OK
         code: 200
-        duration: 60.778ms
+        duration: 69.108873ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -116,8 +116,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/f9ec5c49-a55d-47ed-8464-9545eb0d52bf
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/491350f0-f34b-4717-abd0-586008512a36
         method: GET
       response:
         proto: HTTP/2.0
@@ -125,20 +125,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 554
+        content_length: 591
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:38:03.249776Z","description":"","environment_variables":{},"error_message":null,"id":"f9ec5c49-a55d-47ed-8464-9545eb0d52bf","name":"tf-ns-tender-pasteur","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnstenderpasteurjsqa1wcn","registry_namespace_id":"ecef20d3-08ac-45ee-b873-4b33575bb86a","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:38:05.802151Z"}'
+        body: '{"created_at":"2025-08-27T15:06:15.199100Z","description":"","environment_variables":{},"error_message":null,"id":"491350f0-f34b-4717-abd0-586008512a36","name":"tf-ns-cranky-heisenberg","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnscrankyheisenbergeukvep5q","registry_namespace_id":"1e102b89-3b35-466c-9461-47100a07fded","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:17.069456Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "554"
+                - "591"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:08 GMT
+                - Wed, 27 Aug 2025 15:06:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -146,10 +146,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5514c83a-d04b-456f-99ac-37ea329d196c
+                - f63e425b-cd5e-4b32-a197-9af2a218501b
         status: 200 OK
         code: 200
-        duration: 117.815084ms
+        duration: 80.64366ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -165,8 +165,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/f9ec5c49-a55d-47ed-8464-9545eb0d52bf
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/491350f0-f34b-4717-abd0-586008512a36
         method: GET
       response:
         proto: HTTP/2.0
@@ -174,20 +174,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 554
+        content_length: 591
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:38:03.249776Z","description":"","environment_variables":{},"error_message":null,"id":"f9ec5c49-a55d-47ed-8464-9545eb0d52bf","name":"tf-ns-tender-pasteur","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnstenderpasteurjsqa1wcn","registry_namespace_id":"ecef20d3-08ac-45ee-b873-4b33575bb86a","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:38:05.802151Z"}'
+        body: '{"created_at":"2025-08-27T15:06:15.199100Z","description":"","environment_variables":{},"error_message":null,"id":"491350f0-f34b-4717-abd0-586008512a36","name":"tf-ns-cranky-heisenberg","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnscrankyheisenbergeukvep5q","registry_namespace_id":"1e102b89-3b35-466c-9461-47100a07fded","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:17.069456Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "554"
+                - "591"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:13 GMT
+                - Wed, 27 Aug 2025 15:06:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -195,10 +195,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e92d86df-3c5b-4e33-949f-41ecd2eaa614
+                - d984874b-0b0a-4b7c-962d-b919df67e59a
         status: 200 OK
         code: 200
-        duration: 73.999ms
+        duration: 79.077822ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -214,8 +214,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/f9ec5c49-a55d-47ed-8464-9545eb0d52bf
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/491350f0-f34b-4717-abd0-586008512a36
         method: GET
       response:
         proto: HTTP/2.0
@@ -223,20 +223,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 554
+        content_length: 591
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:38:03.249776Z","description":"","environment_variables":{},"error_message":null,"id":"f9ec5c49-a55d-47ed-8464-9545eb0d52bf","name":"tf-ns-tender-pasteur","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnstenderpasteurjsqa1wcn","registry_namespace_id":"ecef20d3-08ac-45ee-b873-4b33575bb86a","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:38:05.802151Z"}'
+        body: '{"created_at":"2025-08-27T15:06:15.199100Z","description":"","environment_variables":{},"error_message":null,"id":"491350f0-f34b-4717-abd0-586008512a36","name":"tf-ns-cranky-heisenberg","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnscrankyheisenbergeukvep5q","registry_namespace_id":"1e102b89-3b35-466c-9461-47100a07fded","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:17.069456Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "554"
+                - "591"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:18 GMT
+                - Wed, 27 Aug 2025 15:06:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -244,48 +244,50 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 575dc58f-f412-436b-9f2f-143b7cf4e0e7
+                - 15c02738-f775-4068-ad16-40816a887837
         status: 200 OK
         code: 200
-        duration: 62.871667ms
+        duration: 107.69882ms
     - id: 5
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 250
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"namespace_id":"491350f0-f34b-4717-abd0-586008512a36","name":"tf-co-nervous-leakey","privacy":"public","protocol":"http1","secret_environment_variables":null,"http_option":"enabled","sandbox":"unknown_sandbox","tags":null,"command":null,"args":null}'
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/f9ec5c49-a55d-47ed-8464-9545eb0d52bf
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 552
+        content_length: 971
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:38:03.249776Z","description":"","environment_variables":{},"error_message":null,"id":"f9ec5c49-a55d-47ed-8464-9545eb0d52bf","name":"tf-ns-tender-pasteur","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnstenderpasteurjsqa1wcn","registry_namespace_id":"ecef20d3-08ac-45ee-b873-4b33575bb86a","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:38:18.995187Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:21.522309178Z","description":"","domain_name":"tfnscrankyheisenbergeukvep5q-tf-co-nervous-leakey.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"3011932d-b883-43d5-b101-23c79a0a46da","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-nervous-leakey","namespace_id":"491350f0-f34b-4717-abd0-586008512a36","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnscrankyheisenbergeukvep5q/tf-co-nervous-leakey:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:21.522309178Z"}'
         headers:
             Content-Length:
-                - "552"
+                - "971"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:23 GMT
+                - Wed, 27 Aug 2025 15:06:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -293,10 +295,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - dc0f2ff1-21ce-4af1-b6ea-43f83c38f8a3
+                - 49eb8374-c294-46a1-a7bd-3dd5c24bee49
         status: 200 OK
         code: 200
-        duration: 75.281292ms
+        duration: 1.063594016s
     - id: 6
       request:
         proto: HTTP/1.1
@@ -312,8 +314,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/f9ec5c49-a55d-47ed-8464-9545eb0d52bf
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/3011932d-b883-43d5-b101-23c79a0a46da
         method: GET
       response:
         proto: HTTP/2.0
@@ -321,20 +323,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 552
+        content_length: 965
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:38:03.249776Z","description":"","environment_variables":{},"error_message":null,"id":"f9ec5c49-a55d-47ed-8464-9545eb0d52bf","name":"tf-ns-tender-pasteur","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnstenderpasteurjsqa1wcn","registry_namespace_id":"ecef20d3-08ac-45ee-b873-4b33575bb86a","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:38:18.995187Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:21.522309Z","description":"","domain_name":"tfnscrankyheisenbergeukvep5q-tf-co-nervous-leakey.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"3011932d-b883-43d5-b101-23c79a0a46da","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-nervous-leakey","namespace_id":"491350f0-f34b-4717-abd0-586008512a36","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnscrankyheisenbergeukvep5q/tf-co-nervous-leakey:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:21.522309Z"}'
         headers:
             Content-Length:
-                - "552"
+                - "965"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:23 GMT
+                - Wed, 27 Aug 2025 15:06:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -342,10 +344,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - dbe67043-6492-4b40-856f-78c9082e1e5f
+                - c9afb3bf-283e-421f-b8cf-7e16493e4af5
         status: 200 OK
         code: 200
-        duration: 97.034875ms
+        duration: 88.251256ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -361,8 +363,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/f9ec5c49-a55d-47ed-8464-9545eb0d52bf
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/3011932d-b883-43d5-b101-23c79a0a46da
         method: GET
       response:
         proto: HTTP/2.0
@@ -370,20 +372,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 552
+        content_length: 965
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:38:03.249776Z","description":"","environment_variables":{},"error_message":null,"id":"f9ec5c49-a55d-47ed-8464-9545eb0d52bf","name":"tf-ns-tender-pasteur","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnstenderpasteurjsqa1wcn","registry_namespace_id":"ecef20d3-08ac-45ee-b873-4b33575bb86a","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:38:18.995187Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:21.522309Z","description":"","domain_name":"tfnscrankyheisenbergeukvep5q-tf-co-nervous-leakey.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"3011932d-b883-43d5-b101-23c79a0a46da","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-nervous-leakey","namespace_id":"491350f0-f34b-4717-abd0-586008512a36","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnscrankyheisenbergeukvep5q/tf-co-nervous-leakey:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:21.522309Z"}'
         headers:
             Content-Length:
-                - "552"
+                - "965"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:23 GMT
+                - Wed, 27 Aug 2025 15:06:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -391,50 +393,48 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a40999e9-85ba-4cc5-8635-6eeab9627715
+                - 435fdf15-1096-4914-912c-ffa6d0cf1a97
         status: 200 OK
         code: 200
-        duration: 74.231083ms
+        duration: 85.101686ms
     - id: 8
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 211
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"namespace_id":"f9ec5c49-a55d-47ed-8464-9545eb0d52bf","name":"tf-co-vibrant-wilbur","privacy":"public","protocol":"http1","secret_environment_variables":null,"http_option":"enabled","sandbox":"unknown_sandbox"}'
+        body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers
-        method: POST
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/491350f0-f34b-4717-abd0-586008512a36
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 906
+        content_length: 591
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:24.127100992Z","description":"","domain_name":"tfnstenderpasteurjsqa1wcn-tf-co-vibrant-wilbur.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f1d21e7d-cdb4-4233-bc8b-1ea62911c468","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-vibrant-wilbur","namespace_id":"f9ec5c49-a55d-47ed-8464-9545eb0d52bf","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnstenderpasteurjsqa1wcn/tf-co-vibrant-wilbur:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:38:24.127100992Z"}'
+        body: '{"created_at":"2025-08-27T15:06:15.199100Z","description":"","environment_variables":{},"error_message":null,"id":"491350f0-f34b-4717-abd0-586008512a36","name":"tf-ns-cranky-heisenberg","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnscrankyheisenbergeukvep5q","registry_namespace_id":"1e102b89-3b35-466c-9461-47100a07fded","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:17.069456Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "906"
+                - "591"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:24 GMT
+                - Wed, 27 Aug 2025 15:06:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -442,10 +442,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 83fd59f0-c22d-4c94-b475-2aa8ee9c15c2
+                - 9ca74eb6-adab-4c20-9b53-465478dbb234
         status: 200 OK
         code: 200
-        duration: 313.688ms
+        duration: 71.143572ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -461,8 +461,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f1d21e7d-cdb4-4233-bc8b-1ea62911c468
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/3011932d-b883-43d5-b101-23c79a0a46da
         method: GET
       response:
         proto: HTTP/2.0
@@ -470,20 +470,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 900
+        content_length: 965
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:24.127101Z","description":"","domain_name":"tfnstenderpasteurjsqa1wcn-tf-co-vibrant-wilbur.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f1d21e7d-cdb4-4233-bc8b-1ea62911c468","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-vibrant-wilbur","namespace_id":"f9ec5c49-a55d-47ed-8464-9545eb0d52bf","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnstenderpasteurjsqa1wcn/tf-co-vibrant-wilbur:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:38:24.127101Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:21.522309Z","description":"","domain_name":"tfnscrankyheisenbergeukvep5q-tf-co-nervous-leakey.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"3011932d-b883-43d5-b101-23c79a0a46da","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-nervous-leakey","namespace_id":"491350f0-f34b-4717-abd0-586008512a36","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnscrankyheisenbergeukvep5q/tf-co-nervous-leakey:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:21.522309Z"}'
         headers:
             Content-Length:
-                - "900"
+                - "965"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:24 GMT
+                - Wed, 27 Aug 2025 15:06:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -491,10 +491,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - db41f967-fa5b-4029-911d-570ff162341b
+                - 727239b4-1f18-4205-bc20-736381dac030
         status: 200 OK
         code: 200
-        duration: 83.468167ms
+        duration: 103.858885ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -510,8 +510,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f1d21e7d-cdb4-4233-bc8b-1ea62911c468
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/491350f0-f34b-4717-abd0-586008512a36
         method: GET
       response:
         proto: HTTP/2.0
@@ -519,20 +519,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 900
+        content_length: 591
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:24.127101Z","description":"","domain_name":"tfnstenderpasteurjsqa1wcn-tf-co-vibrant-wilbur.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f1d21e7d-cdb4-4233-bc8b-1ea62911c468","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-vibrant-wilbur","namespace_id":"f9ec5c49-a55d-47ed-8464-9545eb0d52bf","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnstenderpasteurjsqa1wcn/tf-co-vibrant-wilbur:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:38:24.127101Z"}'
+        body: '{"created_at":"2025-08-27T15:06:15.199100Z","description":"","environment_variables":{},"error_message":null,"id":"491350f0-f34b-4717-abd0-586008512a36","name":"tf-ns-cranky-heisenberg","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnscrankyheisenbergeukvep5q","registry_namespace_id":"1e102b89-3b35-466c-9461-47100a07fded","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:17.069456Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "900"
+                - "591"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:24 GMT
+                - Wed, 27 Aug 2025 15:06:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -540,10 +540,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f9bf7a9a-744f-4529-8200-991b7d6ab691
+                - 068659d0-286a-4e08-85e5-d05c4f90c09d
         status: 200 OK
         code: 200
-        duration: 66.681625ms
+        duration: 80.221308ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -559,8 +559,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/f9ec5c49-a55d-47ed-8464-9545eb0d52bf
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/3011932d-b883-43d5-b101-23c79a0a46da
         method: GET
       response:
         proto: HTTP/2.0
@@ -568,20 +568,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 552
+        content_length: 965
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:38:03.249776Z","description":"","environment_variables":{},"error_message":null,"id":"f9ec5c49-a55d-47ed-8464-9545eb0d52bf","name":"tf-ns-tender-pasteur","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnstenderpasteurjsqa1wcn","registry_namespace_id":"ecef20d3-08ac-45ee-b873-4b33575bb86a","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:38:18.995187Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:21.522309Z","description":"","domain_name":"tfnscrankyheisenbergeukvep5q-tf-co-nervous-leakey.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"3011932d-b883-43d5-b101-23c79a0a46da","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-nervous-leakey","namespace_id":"491350f0-f34b-4717-abd0-586008512a36","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnscrankyheisenbergeukvep5q/tf-co-nervous-leakey:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:21.522309Z"}'
         headers:
             Content-Length:
-                - "552"
+                - "965"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:25 GMT
+                - Wed, 27 Aug 2025 15:06:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -589,10 +589,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 629decdc-dcf7-4081-874d-875c94a7e684
+                - 8b5eb234-1bc7-48c5-bb68-a336e112c8d2
         status: 200 OK
         code: 200
-        duration: 104.417667ms
+        duration: 110.852228ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -608,8 +608,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f1d21e7d-cdb4-4233-bc8b-1ea62911c468
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/3011932d-b883-43d5-b101-23c79a0a46da
         method: GET
       response:
         proto: HTTP/2.0
@@ -617,20 +617,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 900
+        content_length: 965
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:24.127101Z","description":"","domain_name":"tfnstenderpasteurjsqa1wcn-tf-co-vibrant-wilbur.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f1d21e7d-cdb4-4233-bc8b-1ea62911c468","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-vibrant-wilbur","namespace_id":"f9ec5c49-a55d-47ed-8464-9545eb0d52bf","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnstenderpasteurjsqa1wcn/tf-co-vibrant-wilbur:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:38:24.127101Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:21.522309Z","description":"","domain_name":"tfnscrankyheisenbergeukvep5q-tf-co-nervous-leakey.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"3011932d-b883-43d5-b101-23c79a0a46da","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-nervous-leakey","namespace_id":"491350f0-f34b-4717-abd0-586008512a36","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnscrankyheisenbergeukvep5q/tf-co-nervous-leakey:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:21.522309Z"}'
         headers:
             Content-Length:
-                - "900"
+                - "965"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:25 GMT
+                - Wed, 27 Aug 2025 15:06:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -638,10 +638,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 53c933b8-9426-46ce-b323-2eaeb19e098d
+                - e0412e2a-07f5-4329-91f3-725a5c21e265
         status: 200 OK
         code: 200
-        duration: 69.749958ms
+        duration: 87.057617ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -657,8 +657,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/f9ec5c49-a55d-47ed-8464-9545eb0d52bf
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/491350f0-f34b-4717-abd0-586008512a36
         method: GET
       response:
         proto: HTTP/2.0
@@ -666,20 +666,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 552
+        content_length: 591
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:38:03.249776Z","description":"","environment_variables":{},"error_message":null,"id":"f9ec5c49-a55d-47ed-8464-9545eb0d52bf","name":"tf-ns-tender-pasteur","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnstenderpasteurjsqa1wcn","registry_namespace_id":"ecef20d3-08ac-45ee-b873-4b33575bb86a","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:38:18.995187Z"}'
+        body: '{"created_at":"2025-08-27T15:06:15.199100Z","description":"","environment_variables":{},"error_message":null,"id":"491350f0-f34b-4717-abd0-586008512a36","name":"tf-ns-cranky-heisenberg","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnscrankyheisenbergeukvep5q","registry_namespace_id":"1e102b89-3b35-466c-9461-47100a07fded","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:17.069456Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "552"
+                - "591"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:26 GMT
+                - Wed, 27 Aug 2025 15:06:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -687,10 +687,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 62daeb3e-70ec-4bd2-b270-5d79fa0c5e53
+                - fc835d87-a364-4713-bc7e-157faa95e15b
         status: 200 OK
         code: 200
-        duration: 70.092459ms
+        duration: 99.840104ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -706,8 +706,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f1d21e7d-cdb4-4233-bc8b-1ea62911c468
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/3011932d-b883-43d5-b101-23c79a0a46da
         method: GET
       response:
         proto: HTTP/2.0
@@ -715,20 +715,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 900
+        content_length: 965
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:24.127101Z","description":"","domain_name":"tfnstenderpasteurjsqa1wcn-tf-co-vibrant-wilbur.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f1d21e7d-cdb4-4233-bc8b-1ea62911c468","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-vibrant-wilbur","namespace_id":"f9ec5c49-a55d-47ed-8464-9545eb0d52bf","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnstenderpasteurjsqa1wcn/tf-co-vibrant-wilbur:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:38:24.127101Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:21.522309Z","description":"","domain_name":"tfnscrankyheisenbergeukvep5q-tf-co-nervous-leakey.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"3011932d-b883-43d5-b101-23c79a0a46da","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-nervous-leakey","namespace_id":"491350f0-f34b-4717-abd0-586008512a36","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnscrankyheisenbergeukvep5q/tf-co-nervous-leakey:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:21.522309Z"}'
         headers:
             Content-Length:
-                - "900"
+                - "965"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:26 GMT
+                - Wed, 27 Aug 2025 15:06:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -736,10 +736,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c7be25a4-dec4-4143-a6aa-877863e35664
+                - 85e2e43f-fe34-4304-8222-6c39fb1f2d4b
         status: 200 OK
         code: 200
-        duration: 82.092042ms
+        duration: 94.143755ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -755,8 +755,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f1d21e7d-cdb4-4233-bc8b-1ea62911c468
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/491350f0-f34b-4717-abd0-586008512a36
         method: GET
       response:
         proto: HTTP/2.0
@@ -764,20 +764,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 900
+        content_length: 591
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:24.127101Z","description":"","domain_name":"tfnstenderpasteurjsqa1wcn-tf-co-vibrant-wilbur.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f1d21e7d-cdb4-4233-bc8b-1ea62911c468","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-vibrant-wilbur","namespace_id":"f9ec5c49-a55d-47ed-8464-9545eb0d52bf","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnstenderpasteurjsqa1wcn/tf-co-vibrant-wilbur:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:38:24.127101Z"}'
+        body: '{"created_at":"2025-08-27T15:06:15.199100Z","description":"","environment_variables":{},"error_message":null,"id":"491350f0-f34b-4717-abd0-586008512a36","name":"tf-ns-cranky-heisenberg","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnscrankyheisenbergeukvep5q","registry_namespace_id":"1e102b89-3b35-466c-9461-47100a07fded","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:17.069456Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "900"
+                - "591"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:27 GMT
+                - Wed, 27 Aug 2025 15:06:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -785,10 +785,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7c509cde-7ad5-486a-bd51-ee26a92e0fe0
+                - 3afe5de7-7b30-4824-bbb1-131255b5cea9
         status: 200 OK
         code: 200
-        duration: 73.656125ms
+        duration: 78.835508ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -804,8 +804,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/f9ec5c49-a55d-47ed-8464-9545eb0d52bf
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/3011932d-b883-43d5-b101-23c79a0a46da
         method: GET
       response:
         proto: HTTP/2.0
@@ -813,20 +813,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 552
+        content_length: 965
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:38:03.249776Z","description":"","environment_variables":{},"error_message":null,"id":"f9ec5c49-a55d-47ed-8464-9545eb0d52bf","name":"tf-ns-tender-pasteur","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnstenderpasteurjsqa1wcn","registry_namespace_id":"ecef20d3-08ac-45ee-b873-4b33575bb86a","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:38:18.995187Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:21.522309Z","description":"","domain_name":"tfnscrankyheisenbergeukvep5q-tf-co-nervous-leakey.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"3011932d-b883-43d5-b101-23c79a0a46da","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-nervous-leakey","namespace_id":"491350f0-f34b-4717-abd0-586008512a36","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnscrankyheisenbergeukvep5q/tf-co-nervous-leakey:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:21.522309Z"}'
         headers:
             Content-Length:
-                - "552"
+                - "965"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:27 GMT
+                - Wed, 27 Aug 2025 15:06:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -834,10 +834,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 787bace5-1eba-4e10-b3e4-5895333d8d5b
+                - d9ff0758-516e-485a-bfd7-98cc93a76728
         status: 200 OK
         code: 200
-        duration: 66.272ms
+        duration: 97.72762ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -853,8 +853,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f1d21e7d-cdb4-4233-bc8b-1ea62911c468
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/491350f0-f34b-4717-abd0-586008512a36
         method: GET
       response:
         proto: HTTP/2.0
@@ -862,20 +862,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 900
+        content_length: 591
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:24.127101Z","description":"","domain_name":"tfnstenderpasteurjsqa1wcn-tf-co-vibrant-wilbur.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f1d21e7d-cdb4-4233-bc8b-1ea62911c468","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-vibrant-wilbur","namespace_id":"f9ec5c49-a55d-47ed-8464-9545eb0d52bf","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnstenderpasteurjsqa1wcn/tf-co-vibrant-wilbur:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:38:24.127101Z"}'
+        body: '{"created_at":"2025-08-27T15:06:15.199100Z","description":"","environment_variables":{},"error_message":null,"id":"491350f0-f34b-4717-abd0-586008512a36","name":"tf-ns-cranky-heisenberg","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnscrankyheisenbergeukvep5q","registry_namespace_id":"1e102b89-3b35-466c-9461-47100a07fded","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:17.069456Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "900"
+                - "591"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:27 GMT
+                - Wed, 27 Aug 2025 15:06:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -883,10 +883,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8a487165-795a-4273-8cbb-eaf4e691de88
+                - d3f4ac26-99ad-4244-b156-fd3f40c33cb5
         status: 200 OK
         code: 200
-        duration: 88.051292ms
+        duration: 93.74695ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -902,8 +902,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/f9ec5c49-a55d-47ed-8464-9545eb0d52bf
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/3011932d-b883-43d5-b101-23c79a0a46da
         method: GET
       response:
         proto: HTTP/2.0
@@ -911,20 +911,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 552
+        content_length: 965
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:38:03.249776Z","description":"","environment_variables":{},"error_message":null,"id":"f9ec5c49-a55d-47ed-8464-9545eb0d52bf","name":"tf-ns-tender-pasteur","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnstenderpasteurjsqa1wcn","registry_namespace_id":"ecef20d3-08ac-45ee-b873-4b33575bb86a","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:38:18.995187Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:21.522309Z","description":"","domain_name":"tfnscrankyheisenbergeukvep5q-tf-co-nervous-leakey.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"3011932d-b883-43d5-b101-23c79a0a46da","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-nervous-leakey","namespace_id":"491350f0-f34b-4717-abd0-586008512a36","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnscrankyheisenbergeukvep5q/tf-co-nervous-leakey:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:21.522309Z"}'
         headers:
             Content-Length:
-                - "552"
+                - "965"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:28 GMT
+                - Wed, 27 Aug 2025 15:06:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -932,158 +932,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1ae3acc9-d321-41f8-8633-3b9b5f62812e
+                - 6f56da6a-2d4b-448d-a4c9-ba472470fadf
         status: 200 OK
         code: 200
-        duration: 74.860958ms
+        duration: 82.751447ms
     - id: 19
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f1d21e7d-cdb4-4233-bc8b-1ea62911c468
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 900
-        uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:24.127101Z","description":"","domain_name":"tfnstenderpasteurjsqa1wcn-tf-co-vibrant-wilbur.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f1d21e7d-cdb4-4233-bc8b-1ea62911c468","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-vibrant-wilbur","namespace_id":"f9ec5c49-a55d-47ed-8464-9545eb0d52bf","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnstenderpasteurjsqa1wcn/tf-co-vibrant-wilbur:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:38:24.127101Z"}'
-        headers:
-            Content-Length:
-                - "900"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:38:28 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 87e99b14-ae85-4e20-ae4b-0a483a37d50e
-        status: 200 OK
-        code: 200
-        duration: 78.929125ms
-    - id: 20
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/f9ec5c49-a55d-47ed-8464-9545eb0d52bf
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 552
-        uncompressed: false
-        body: '{"created_at":"2025-01-24T15:38:03.249776Z","description":"","environment_variables":{},"error_message":null,"id":"f9ec5c49-a55d-47ed-8464-9545eb0d52bf","name":"tf-ns-tender-pasteur","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnstenderpasteurjsqa1wcn","registry_namespace_id":"ecef20d3-08ac-45ee-b873-4b33575bb86a","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:38:18.995187Z"}'
-        headers:
-            Content-Length:
-                - "552"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:38:29 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - dd5fbf1f-cdf5-486d-b8cb-77882cc81e9a
-        status: 200 OK
-        code: 200
-        duration: 82.489042ms
-    - id: 21
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f1d21e7d-cdb4-4233-bc8b-1ea62911c468
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 900
-        uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:24.127101Z","description":"","domain_name":"tfnstenderpasteurjsqa1wcn-tf-co-vibrant-wilbur.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f1d21e7d-cdb4-4233-bc8b-1ea62911c468","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-vibrant-wilbur","namespace_id":"f9ec5c49-a55d-47ed-8464-9545eb0d52bf","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnstenderpasteurjsqa1wcn/tf-co-vibrant-wilbur:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:38:24.127101Z"}'
-        headers:
-            Content-Length:
-                - "900"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:38:29 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 859643ae-b254-437e-88ba-0dc8f2d950b9
-        status: 200 OK
-        code: 200
-        duration: 81.619875ms
-    - id: 22
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1100,8 +953,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f1d21e7d-cdb4-4233-bc8b-1ea62911c468
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/3011932d-b883-43d5-b101-23c79a0a46da
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -1109,20 +962,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 903
+        content_length: 968
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:24.127101Z","description":"","domain_name":"tfnstenderpasteurjsqa1wcn-tf-co-vibrant-wilbur.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f1d21e7d-cdb4-4233-bc8b-1ea62911c468","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-vibrant-wilbur","namespace_id":"f9ec5c49-a55d-47ed-8464-9545eb0d52bf","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnstenderpasteurjsqa1wcn/tf-co-vibrant-wilbur:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","timeout":"300s","updated_at":"2025-01-24T15:38:29.777497071Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:21.522309Z","description":"","domain_name":"tfnscrankyheisenbergeukvep5q-tf-co-nervous-leakey.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"3011932d-b883-43d5-b101-23c79a0a46da","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-nervous-leakey","namespace_id":"491350f0-f34b-4717-abd0-586008512a36","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnscrankyheisenbergeukvep5q/tf-co-nervous-leakey:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:24.758271317Z"}'
         headers:
             Content-Length:
-                - "903"
+                - "968"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:29 GMT
+                - Wed, 27 Aug 2025 15:06:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1130,10 +983,157 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - dad9511b-8415-4ba4-976f-472a0f5f5cf7
+                - f39f094c-2cc7-4d24-b2b9-7feb7e152682
         status: 200 OK
         code: 200
-        duration: 104.721125ms
+        duration: 115.651895ms
+    - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/3011932d-b883-43d5-b101-23c79a0a46da
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 965
+        uncompressed: false
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:21.522309Z","description":"","domain_name":"tfnscrankyheisenbergeukvep5q-tf-co-nervous-leakey.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"3011932d-b883-43d5-b101-23c79a0a46da","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-nervous-leakey","namespace_id":"491350f0-f34b-4717-abd0-586008512a36","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnscrankyheisenbergeukvep5q/tf-co-nervous-leakey:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:24.758271Z"}'
+        headers:
+            Content-Length:
+                - "965"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:24 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - a303448b-1fc5-4069-8296-3a6e93b02cf1
+        status: 200 OK
+        code: 200
+        duration: 86.600008ms
+    - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/3011932d-b883-43d5-b101-23c79a0a46da
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 965
+        uncompressed: false
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:21.522309Z","description":"","domain_name":"tfnscrankyheisenbergeukvep5q-tf-co-nervous-leakey.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"3011932d-b883-43d5-b101-23c79a0a46da","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-nervous-leakey","namespace_id":"491350f0-f34b-4717-abd0-586008512a36","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnscrankyheisenbergeukvep5q/tf-co-nervous-leakey:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:24.758271Z"}'
+        headers:
+            Content-Length:
+                - "965"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:30 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 06f79d17-e2fa-4145-a00a-b840a856613c
+        status: 200 OK
+        code: 200
+        duration: 107.04735ms
+    - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/3011932d-b883-43d5-b101-23c79a0a46da
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1003
+        uncompressed: false
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:21.522309Z","description":"","domain_name":"tfnscrankyheisenbergeukvep5q-tf-co-nervous-leakey.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"3011932d-b883-43d5-b101-23c79a0a46da","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-nervous-leakey","namespace_id":"491350f0-f34b-4717-abd0-586008512a36","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnscrankyheisenbergeukvep5q/tf-co-nervous-leakey:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:32.249619Z"}'
+        headers:
+            Content-Length:
+                - "1003"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b765f635-c06e-4334-a874-4673321d10e4
+        status: 200 OK
+        code: 200
+        duration: 97.955804ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1149,8 +1149,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f1d21e7d-cdb4-4233-bc8b-1ea62911c468
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/3011932d-b883-43d5-b101-23c79a0a46da
         method: GET
       response:
         proto: HTTP/2.0
@@ -1158,20 +1158,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 900
+        content_length: 1003
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:24.127101Z","description":"","domain_name":"tfnstenderpasteurjsqa1wcn-tf-co-vibrant-wilbur.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f1d21e7d-cdb4-4233-bc8b-1ea62911c468","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-vibrant-wilbur","namespace_id":"f9ec5c49-a55d-47ed-8464-9545eb0d52bf","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnstenderpasteurjsqa1wcn/tf-co-vibrant-wilbur:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","timeout":"300s","updated_at":"2025-01-24T15:38:29.777497Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:21.522309Z","description":"","domain_name":"tfnscrankyheisenbergeukvep5q-tf-co-nervous-leakey.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"3011932d-b883-43d5-b101-23c79a0a46da","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-nervous-leakey","namespace_id":"491350f0-f34b-4717-abd0-586008512a36","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnscrankyheisenbergeukvep5q/tf-co-nervous-leakey:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:32.249619Z"}'
         headers:
             Content-Length:
-                - "900"
+                - "1003"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:29 GMT
+                - Wed, 27 Aug 2025 15:06:35 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1179,10 +1179,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bc2d602f-f657-45be-89bf-dd200bdebc1f
+                - dcf492e9-2e09-4edb-9442-13f2b654f90c
         status: 200 OK
         code: 200
-        duration: 73.959833ms
+        duration: 110.588408ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1198,8 +1198,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f1d21e7d-cdb4-4233-bc8b-1ea62911c468
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/3011932d-b883-43d5-b101-23c79a0a46da
         method: GET
       response:
         proto: HTTP/2.0
@@ -1207,20 +1207,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 900
+        content_length: 1003
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:24.127101Z","description":"","domain_name":"tfnstenderpasteurjsqa1wcn-tf-co-vibrant-wilbur.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f1d21e7d-cdb4-4233-bc8b-1ea62911c468","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-vibrant-wilbur","namespace_id":"f9ec5c49-a55d-47ed-8464-9545eb0d52bf","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnstenderpasteurjsqa1wcn/tf-co-vibrant-wilbur:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","timeout":"300s","updated_at":"2025-01-24T15:38:29.777497Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:21.522309Z","description":"","domain_name":"tfnscrankyheisenbergeukvep5q-tf-co-nervous-leakey.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"3011932d-b883-43d5-b101-23c79a0a46da","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-nervous-leakey","namespace_id":"491350f0-f34b-4717-abd0-586008512a36","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnscrankyheisenbergeukvep5q/tf-co-nervous-leakey:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:32.249619Z"}'
         headers:
             Content-Length:
-                - "900"
+                - "1003"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:34 GMT
+                - Wed, 27 Aug 2025 15:06:35 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1228,10 +1228,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 20307f94-3df7-4869-b6ab-a90668c3e3d2
+                - dacdf13e-1dcd-4d8f-ab15-9c6a38af0b57
         status: 200 OK
         code: 200
-        duration: 82.3455ms
+        duration: 86.486839ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1247,8 +1247,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f1d21e7d-cdb4-4233-bc8b-1ea62911c468
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/491350f0-f34b-4717-abd0-586008512a36
         method: GET
       response:
         proto: HTTP/2.0
@@ -1256,20 +1256,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 938
+        content_length: 591
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:24.127101Z","description":"","domain_name":"tfnstenderpasteurjsqa1wcn-tf-co-vibrant-wilbur.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f1d21e7d-cdb4-4233-bc8b-1ea62911c468","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-vibrant-wilbur","namespace_id":"f9ec5c49-a55d-47ed-8464-9545eb0d52bf","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnstenderpasteurjsqa1wcn/tf-co-vibrant-wilbur:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-24T15:38:36.083040Z"}'
+        body: '{"created_at":"2025-08-27T15:06:15.199100Z","description":"","environment_variables":{},"error_message":null,"id":"491350f0-f34b-4717-abd0-586008512a36","name":"tf-ns-cranky-heisenberg","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnscrankyheisenbergeukvep5q","registry_namespace_id":"1e102b89-3b35-466c-9461-47100a07fded","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:17.069456Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "938"
+                - "591"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:40 GMT
+                - Wed, 27 Aug 2025 15:06:35 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1277,10 +1277,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 95cd7b42-17d5-4edf-942a-b57800b1763a
+                - dd612b09-4348-4b06-9912-12debae11052
         status: 200 OK
         code: 200
-        duration: 84.75ms
+        duration: 101.944867ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1296,8 +1296,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f1d21e7d-cdb4-4233-bc8b-1ea62911c468
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/3011932d-b883-43d5-b101-23c79a0a46da
         method: GET
       response:
         proto: HTTP/2.0
@@ -1305,20 +1305,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 938
+        content_length: 1003
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:24.127101Z","description":"","domain_name":"tfnstenderpasteurjsqa1wcn-tf-co-vibrant-wilbur.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f1d21e7d-cdb4-4233-bc8b-1ea62911c468","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-vibrant-wilbur","namespace_id":"f9ec5c49-a55d-47ed-8464-9545eb0d52bf","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnstenderpasteurjsqa1wcn/tf-co-vibrant-wilbur:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-24T15:38:36.083040Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:21.522309Z","description":"","domain_name":"tfnscrankyheisenbergeukvep5q-tf-co-nervous-leakey.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"3011932d-b883-43d5-b101-23c79a0a46da","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-nervous-leakey","namespace_id":"491350f0-f34b-4717-abd0-586008512a36","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnscrankyheisenbergeukvep5q/tf-co-nervous-leakey:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:32.249619Z"}'
         headers:
             Content-Length:
-                - "938"
+                - "1003"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:40 GMT
+                - Wed, 27 Aug 2025 15:06:35 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1326,10 +1326,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f756f613-c6bc-41ef-802e-88e7304df5c7
+                - 0cae32ea-20c7-4013-9821-cf8de1bc3281
         status: 200 OK
         code: 200
-        duration: 65.669709ms
+        duration: 96.898007ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1345,8 +1345,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f1d21e7d-cdb4-4233-bc8b-1ea62911c468
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/491350f0-f34b-4717-abd0-586008512a36
         method: GET
       response:
         proto: HTTP/2.0
@@ -1354,20 +1354,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 938
+        content_length: 591
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:24.127101Z","description":"","domain_name":"tfnstenderpasteurjsqa1wcn-tf-co-vibrant-wilbur.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f1d21e7d-cdb4-4233-bc8b-1ea62911c468","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-vibrant-wilbur","namespace_id":"f9ec5c49-a55d-47ed-8464-9545eb0d52bf","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnstenderpasteurjsqa1wcn/tf-co-vibrant-wilbur:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-24T15:38:36.083040Z"}'
+        body: '{"created_at":"2025-08-27T15:06:15.199100Z","description":"","environment_variables":{},"error_message":null,"id":"491350f0-f34b-4717-abd0-586008512a36","name":"tf-ns-cranky-heisenberg","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnscrankyheisenbergeukvep5q","registry_namespace_id":"1e102b89-3b35-466c-9461-47100a07fded","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:17.069456Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "938"
+                - "591"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:40 GMT
+                - Wed, 27 Aug 2025 15:06:36 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1375,10 +1375,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1a24e724-1961-4e5c-9bb1-dc0b53831af4
+                - 72f33642-6f98-4521-9a7c-294a47d4e10f
         status: 200 OK
         code: 200
-        duration: 80.201875ms
+        duration: 74.445723ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1394,8 +1394,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/f9ec5c49-a55d-47ed-8464-9545eb0d52bf
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/3011932d-b883-43d5-b101-23c79a0a46da
         method: GET
       response:
         proto: HTTP/2.0
@@ -1403,20 +1403,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 552
+        content_length: 1003
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:38:03.249776Z","description":"","environment_variables":{},"error_message":null,"id":"f9ec5c49-a55d-47ed-8464-9545eb0d52bf","name":"tf-ns-tender-pasteur","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnstenderpasteurjsqa1wcn","registry_namespace_id":"ecef20d3-08ac-45ee-b873-4b33575bb86a","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:38:18.995187Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:21.522309Z","description":"","domain_name":"tfnscrankyheisenbergeukvep5q-tf-co-nervous-leakey.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"3011932d-b883-43d5-b101-23c79a0a46da","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-nervous-leakey","namespace_id":"491350f0-f34b-4717-abd0-586008512a36","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnscrankyheisenbergeukvep5q/tf-co-nervous-leakey:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:32.249619Z"}'
         headers:
             Content-Length:
-                - "552"
+                - "1003"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:41 GMT
+                - Wed, 27 Aug 2025 15:06:36 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1424,10 +1424,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a689eee8-949d-4058-8114-9742f78450c4
+                - ab89aba6-9cae-4766-a1d1-4d23bc3f76d3
         status: 200 OK
         code: 200
-        duration: 56.714125ms
+        duration: 109.030043ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1443,8 +1443,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f1d21e7d-cdb4-4233-bc8b-1ea62911c468
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/491350f0-f34b-4717-abd0-586008512a36
         method: GET
       response:
         proto: HTTP/2.0
@@ -1452,20 +1452,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 938
+        content_length: 591
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:24.127101Z","description":"","domain_name":"tfnstenderpasteurjsqa1wcn-tf-co-vibrant-wilbur.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f1d21e7d-cdb4-4233-bc8b-1ea62911c468","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-vibrant-wilbur","namespace_id":"f9ec5c49-a55d-47ed-8464-9545eb0d52bf","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnstenderpasteurjsqa1wcn/tf-co-vibrant-wilbur:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-24T15:38:36.083040Z"}'
+        body: '{"created_at":"2025-08-27T15:06:15.199100Z","description":"","environment_variables":{},"error_message":null,"id":"491350f0-f34b-4717-abd0-586008512a36","name":"tf-ns-cranky-heisenberg","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnscrankyheisenbergeukvep5q","registry_namespace_id":"1e102b89-3b35-466c-9461-47100a07fded","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:17.069456Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "938"
+                - "591"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:41 GMT
+                - Wed, 27 Aug 2025 15:06:36 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1473,10 +1473,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a56125d0-3a42-4ed5-b463-afe04391a084
+                - 4a3c591d-f1d8-4f82-8570-e012bc99706f
         status: 200 OK
         code: 200
-        duration: 83.910833ms
+        duration: 93.031631ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1492,8 +1492,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/f9ec5c49-a55d-47ed-8464-9545eb0d52bf
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/3011932d-b883-43d5-b101-23c79a0a46da
         method: GET
       response:
         proto: HTTP/2.0
@@ -1501,20 +1501,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 552
+        content_length: 1003
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:38:03.249776Z","description":"","environment_variables":{},"error_message":null,"id":"f9ec5c49-a55d-47ed-8464-9545eb0d52bf","name":"tf-ns-tender-pasteur","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnstenderpasteurjsqa1wcn","registry_namespace_id":"ecef20d3-08ac-45ee-b873-4b33575bb86a","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:38:18.995187Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:21.522309Z","description":"","domain_name":"tfnscrankyheisenbergeukvep5q-tf-co-nervous-leakey.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"3011932d-b883-43d5-b101-23c79a0a46da","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-nervous-leakey","namespace_id":"491350f0-f34b-4717-abd0-586008512a36","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnscrankyheisenbergeukvep5q/tf-co-nervous-leakey:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:32.249619Z"}'
         headers:
             Content-Length:
-                - "552"
+                - "1003"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:41 GMT
+                - Wed, 27 Aug 2025 15:06:36 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1522,158 +1522,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e53a0c85-16bb-493c-955c-bb8f4e7a563e
+                - a8d429f2-4115-4aa5-8608-48ea08b0341f
         status: 200 OK
         code: 200
-        duration: 169.98175ms
+        duration: 92.553283ms
     - id: 31
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f1d21e7d-cdb4-4233-bc8b-1ea62911c468
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 938
-        uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:24.127101Z","description":"","domain_name":"tfnstenderpasteurjsqa1wcn-tf-co-vibrant-wilbur.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f1d21e7d-cdb4-4233-bc8b-1ea62911c468","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-vibrant-wilbur","namespace_id":"f9ec5c49-a55d-47ed-8464-9545eb0d52bf","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnstenderpasteurjsqa1wcn/tf-co-vibrant-wilbur:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-24T15:38:36.083040Z"}'
-        headers:
-            Content-Length:
-                - "938"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:38:42 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - f462a87e-fdbe-4711-90be-3b711684d4f1
-        status: 200 OK
-        code: 200
-        duration: 75.994417ms
-    - id: 32
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/f9ec5c49-a55d-47ed-8464-9545eb0d52bf
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 552
-        uncompressed: false
-        body: '{"created_at":"2025-01-24T15:38:03.249776Z","description":"","environment_variables":{},"error_message":null,"id":"f9ec5c49-a55d-47ed-8464-9545eb0d52bf","name":"tf-ns-tender-pasteur","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnstenderpasteurjsqa1wcn","registry_namespace_id":"ecef20d3-08ac-45ee-b873-4b33575bb86a","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:38:18.995187Z"}'
-        headers:
-            Content-Length:
-                - "552"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:38:42 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 8f87e18c-b722-403c-b2a0-9fb5f2b52aa6
-        status: 200 OK
-        code: 200
-        duration: 66.040208ms
-    - id: 33
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f1d21e7d-cdb4-4233-bc8b-1ea62911c468
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 938
-        uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:24.127101Z","description":"","domain_name":"tfnstenderpasteurjsqa1wcn-tf-co-vibrant-wilbur.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f1d21e7d-cdb4-4233-bc8b-1ea62911c468","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-vibrant-wilbur","namespace_id":"f9ec5c49-a55d-47ed-8464-9545eb0d52bf","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnstenderpasteurjsqa1wcn/tf-co-vibrant-wilbur:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-24T15:38:36.083040Z"}'
-        headers:
-            Content-Length:
-                - "938"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:38:42 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - deaea465-f525-4064-a76b-1214a9916200
-        status: 200 OK
-        code: 200
-        duration: 203.217083ms
-    - id: 34
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1690,8 +1543,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f1d21e7d-cdb4-4233-bc8b-1ea62911c468
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/3011932d-b883-43d5-b101-23c79a0a46da
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -1699,20 +1552,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 903
+        content_length: 968
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:24.127101Z","description":"","domain_name":"tfnstenderpasteurjsqa1wcn-tf-co-vibrant-wilbur.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f1d21e7d-cdb4-4233-bc8b-1ea62911c468","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-vibrant-wilbur","namespace_id":"f9ec5c49-a55d-47ed-8464-9545eb0d52bf","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnstenderpasteurjsqa1wcn/tf-co-vibrant-wilbur:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","timeout":"300s","updated_at":"2025-01-24T15:38:43.213280660Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:21.522309Z","description":"","domain_name":"tfnscrankyheisenbergeukvep5q-tf-co-nervous-leakey.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"3011932d-b883-43d5-b101-23c79a0a46da","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-nervous-leakey","namespace_id":"491350f0-f34b-4717-abd0-586008512a36","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnscrankyheisenbergeukvep5q/tf-co-nervous-leakey:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:36.960140781Z"}'
         headers:
             Content-Length:
-                - "903"
+                - "968"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:43 GMT
+                - Wed, 27 Aug 2025 15:06:37 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1720,10 +1573,157 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2ce27dea-aab1-4ee0-8d1d-f33d16954d33
+                - 7be90df5-66a9-45b9-babc-8fd804eaa385
         status: 200 OK
         code: 200
-        duration: 131.735084ms
+        duration: 142.352125ms
+    - id: 32
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/3011932d-b883-43d5-b101-23c79a0a46da
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 965
+        uncompressed: false
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:21.522309Z","description":"","domain_name":"tfnscrankyheisenbergeukvep5q-tf-co-nervous-leakey.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"3011932d-b883-43d5-b101-23c79a0a46da","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-nervous-leakey","namespace_id":"491350f0-f34b-4717-abd0-586008512a36","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnscrankyheisenbergeukvep5q/tf-co-nervous-leakey:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:36.960141Z"}'
+        headers:
+            Content-Length:
+                - "965"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:37 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 8310bb80-1ee5-4b84-b67d-03e90f21bcb7
+        status: 200 OK
+        code: 200
+        duration: 98.57799ms
+    - id: 33
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/3011932d-b883-43d5-b101-23c79a0a46da
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 965
+        uncompressed: false
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:21.522309Z","description":"","domain_name":"tfnscrankyheisenbergeukvep5q-tf-co-nervous-leakey.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"3011932d-b883-43d5-b101-23c79a0a46da","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-nervous-leakey","namespace_id":"491350f0-f34b-4717-abd0-586008512a36","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnscrankyheisenbergeukvep5q/tf-co-nervous-leakey:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:36.960141Z"}'
+        headers:
+            Content-Length:
+                - "965"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:42 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f95c76c3-3891-4f94-a9c6-28b5e86f80cd
+        status: 200 OK
+        code: 200
+        duration: 91.252815ms
+    - id: 34
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/3011932d-b883-43d5-b101-23c79a0a46da
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1003
+        uncompressed: false
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:21.522309Z","description":"","domain_name":"tfnscrankyheisenbergeukvep5q-tf-co-nervous-leakey.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"3011932d-b883-43d5-b101-23c79a0a46da","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-nervous-leakey","namespace_id":"491350f0-f34b-4717-abd0-586008512a36","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnscrankyheisenbergeukvep5q/tf-co-nervous-leakey:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:43.294835Z"}'
+        headers:
+            Content-Length:
+                - "1003"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:47 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 6b802d1c-650e-49a2-8e2b-6c9a0656ac28
+        status: 200 OK
+        code: 200
+        duration: 101.473697ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1739,8 +1739,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f1d21e7d-cdb4-4233-bc8b-1ea62911c468
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/3011932d-b883-43d5-b101-23c79a0a46da
         method: GET
       response:
         proto: HTTP/2.0
@@ -1748,20 +1748,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 900
+        content_length: 1003
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:24.127101Z","description":"","domain_name":"tfnstenderpasteurjsqa1wcn-tf-co-vibrant-wilbur.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f1d21e7d-cdb4-4233-bc8b-1ea62911c468","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-vibrant-wilbur","namespace_id":"f9ec5c49-a55d-47ed-8464-9545eb0d52bf","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnstenderpasteurjsqa1wcn/tf-co-vibrant-wilbur:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","timeout":"300s","updated_at":"2025-01-24T15:38:43.213281Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:21.522309Z","description":"","domain_name":"tfnscrankyheisenbergeukvep5q-tf-co-nervous-leakey.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"3011932d-b883-43d5-b101-23c79a0a46da","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-nervous-leakey","namespace_id":"491350f0-f34b-4717-abd0-586008512a36","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnscrankyheisenbergeukvep5q/tf-co-nervous-leakey:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:43.294835Z"}'
         headers:
             Content-Length:
-                - "900"
+                - "1003"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:43 GMT
+                - Wed, 27 Aug 2025 15:06:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1769,10 +1769,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cc9bb90a-4c3f-4445-8bff-92634fcaca5f
+                - 0f255fcf-1baa-4544-9a06-f765c243d16c
         status: 200 OK
         code: 200
-        duration: 73.520833ms
+        duration: 109.459222ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1788,8 +1788,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f1d21e7d-cdb4-4233-bc8b-1ea62911c468
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/3011932d-b883-43d5-b101-23c79a0a46da
         method: GET
       response:
         proto: HTTP/2.0
@@ -1797,20 +1797,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 900
+        content_length: 1003
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:24.127101Z","description":"","domain_name":"tfnstenderpasteurjsqa1wcn-tf-co-vibrant-wilbur.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f1d21e7d-cdb4-4233-bc8b-1ea62911c468","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-vibrant-wilbur","namespace_id":"f9ec5c49-a55d-47ed-8464-9545eb0d52bf","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnstenderpasteurjsqa1wcn/tf-co-vibrant-wilbur:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","timeout":"300s","updated_at":"2025-01-24T15:38:43.213281Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:21.522309Z","description":"","domain_name":"tfnscrankyheisenbergeukvep5q-tf-co-nervous-leakey.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"3011932d-b883-43d5-b101-23c79a0a46da","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-nervous-leakey","namespace_id":"491350f0-f34b-4717-abd0-586008512a36","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnscrankyheisenbergeukvep5q/tf-co-nervous-leakey:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:43.294835Z"}'
         headers:
             Content-Length:
-                - "900"
+                - "1003"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:48 GMT
+                - Wed, 27 Aug 2025 15:06:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1818,10 +1818,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6b1e73f1-75b6-43e1-a8d4-7d447ed3aaa1
+                - df68a14b-fe7e-4525-bbff-f9cf52df6d08
         status: 200 OK
         code: 200
-        duration: 89.199125ms
+        duration: 110.67295ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1837,8 +1837,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f1d21e7d-cdb4-4233-bc8b-1ea62911c468
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/491350f0-f34b-4717-abd0-586008512a36
         method: GET
       response:
         proto: HTTP/2.0
@@ -1846,20 +1846,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 900
+        content_length: 591
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:24.127101Z","description":"","domain_name":"tfnstenderpasteurjsqa1wcn-tf-co-vibrant-wilbur.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f1d21e7d-cdb4-4233-bc8b-1ea62911c468","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-vibrant-wilbur","namespace_id":"f9ec5c49-a55d-47ed-8464-9545eb0d52bf","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnstenderpasteurjsqa1wcn/tf-co-vibrant-wilbur:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","timeout":"300s","updated_at":"2025-01-24T15:38:43.213281Z"}'
+        body: '{"created_at":"2025-08-27T15:06:15.199100Z","description":"","environment_variables":{},"error_message":null,"id":"491350f0-f34b-4717-abd0-586008512a36","name":"tf-ns-cranky-heisenberg","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnscrankyheisenbergeukvep5q","registry_namespace_id":"1e102b89-3b35-466c-9461-47100a07fded","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:17.069456Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "900"
+                - "591"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:53 GMT
+                - Wed, 27 Aug 2025 15:06:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1867,10 +1867,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 47a5180a-1607-4d3b-b880-5a9fa9796af4
+                - d5c61b09-c2a4-4a8e-8576-dc847842d243
         status: 200 OK
         code: 200
-        duration: 95.131291ms
+        duration: 86.664736ms
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1886,8 +1886,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f1d21e7d-cdb4-4233-bc8b-1ea62911c468
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/3011932d-b883-43d5-b101-23c79a0a46da
         method: GET
       response:
         proto: HTTP/2.0
@@ -1895,20 +1895,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 938
+        content_length: 1003
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:24.127101Z","description":"","domain_name":"tfnstenderpasteurjsqa1wcn-tf-co-vibrant-wilbur.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f1d21e7d-cdb4-4233-bc8b-1ea62911c468","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-vibrant-wilbur","namespace_id":"f9ec5c49-a55d-47ed-8464-9545eb0d52bf","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnstenderpasteurjsqa1wcn/tf-co-vibrant-wilbur:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-24T15:38:53.891594Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:21.522309Z","description":"","domain_name":"tfnscrankyheisenbergeukvep5q-tf-co-nervous-leakey.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"3011932d-b883-43d5-b101-23c79a0a46da","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-nervous-leakey","namespace_id":"491350f0-f34b-4717-abd0-586008512a36","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnscrankyheisenbergeukvep5q/tf-co-nervous-leakey:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:43.294835Z"}'
         headers:
             Content-Length:
-                - "938"
+                - "1003"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:58 GMT
+                - Wed, 27 Aug 2025 15:06:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1916,10 +1916,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - abe715b6-c4d1-4dba-94e8-b40095a7f49c
+                - 64ba9207-7e6a-4ddb-9292-1def43dc03d8
         status: 200 OK
         code: 200
-        duration: 80.722959ms
+        duration: 96.460869ms
     - id: 39
       request:
         proto: HTTP/1.1
@@ -1935,8 +1935,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f1d21e7d-cdb4-4233-bc8b-1ea62911c468
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/3011932d-b883-43d5-b101-23c79a0a46da
         method: GET
       response:
         proto: HTTP/2.0
@@ -1944,20 +1944,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 938
+        content_length: 1003
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:24.127101Z","description":"","domain_name":"tfnstenderpasteurjsqa1wcn-tf-co-vibrant-wilbur.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f1d21e7d-cdb4-4233-bc8b-1ea62911c468","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-vibrant-wilbur","namespace_id":"f9ec5c49-a55d-47ed-8464-9545eb0d52bf","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnstenderpasteurjsqa1wcn/tf-co-vibrant-wilbur:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-24T15:38:53.891594Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:21.522309Z","description":"","domain_name":"tfnscrankyheisenbergeukvep5q-tf-co-nervous-leakey.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"3011932d-b883-43d5-b101-23c79a0a46da","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-nervous-leakey","namespace_id":"491350f0-f34b-4717-abd0-586008512a36","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnscrankyheisenbergeukvep5q/tf-co-nervous-leakey:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:43.294835Z"}'
         headers:
             Content-Length:
-                - "938"
+                - "1003"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:58 GMT
+                - Wed, 27 Aug 2025 15:06:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1965,10 +1965,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a14939a2-8a63-46b7-acbd-a378415d4a82
+                - 12b97680-02ba-4608-912e-9e00843a33fd
         status: 200 OK
         code: 200
-        duration: 80.880333ms
+        duration: 97.775096ms
     - id: 40
       request:
         proto: HTTP/1.1
@@ -1984,29 +1984,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f1d21e7d-cdb4-4233-bc8b-1ea62911c468
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/3011932d-b883-43d5-b101-23c79a0a46da
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 938
+        content_length: 969
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:24.127101Z","description":"","domain_name":"tfnstenderpasteurjsqa1wcn-tf-co-vibrant-wilbur.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f1d21e7d-cdb4-4233-bc8b-1ea62911c468","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-vibrant-wilbur","namespace_id":"f9ec5c49-a55d-47ed-8464-9545eb0d52bf","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnstenderpasteurjsqa1wcn/tf-co-vibrant-wilbur:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-24T15:38:53.891594Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:21.522309Z","description":"","domain_name":"tfnscrankyheisenbergeukvep5q-tf-co-nervous-leakey.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"3011932d-b883-43d5-b101-23c79a0a46da","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-nervous-leakey","namespace_id":"491350f0-f34b-4717-abd0-586008512a36","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnscrankyheisenbergeukvep5q/tf-co-nervous-leakey:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:48.680590197Z"}'
         headers:
             Content-Length:
-                - "938"
+                - "969"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:58 GMT
+                - Wed, 27 Aug 2025 15:06:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2014,10 +2014,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 02cf1b64-6836-4ac1-8c16-e0169aef8d44
+                - 4ae88011-159c-43cf-b3bf-feb957d9727f
         status: 200 OK
         code: 200
-        duration: 73.667417ms
+        duration: 164.416797ms
     - id: 41
       request:
         proto: HTTP/1.1
@@ -2033,8 +2033,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/f9ec5c49-a55d-47ed-8464-9545eb0d52bf
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/491350f0-f34b-4717-abd0-586008512a36
         method: GET
       response:
         proto: HTTP/2.0
@@ -2042,20 +2042,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 552
+        content_length: 591
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:38:03.249776Z","description":"","environment_variables":{},"error_message":null,"id":"f9ec5c49-a55d-47ed-8464-9545eb0d52bf","name":"tf-ns-tender-pasteur","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnstenderpasteurjsqa1wcn","registry_namespace_id":"ecef20d3-08ac-45ee-b873-4b33575bb86a","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:38:18.995187Z"}'
+        body: '{"created_at":"2025-08-27T15:06:15.199100Z","description":"","environment_variables":{},"error_message":null,"id":"491350f0-f34b-4717-abd0-586008512a36","name":"tf-ns-cranky-heisenberg","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnscrankyheisenbergeukvep5q","registry_namespace_id":"1e102b89-3b35-466c-9461-47100a07fded","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:17.069456Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "552"
+                - "591"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:59 GMT
+                - Wed, 27 Aug 2025 15:06:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2063,10 +2063,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6ef2a2a0-5a32-4459-841b-f5aaa495ae51
+                - 0604b2f6-464a-457b-890e-1b30ad1ab966
         status: 200 OK
         code: 200
-        duration: 66.259792ms
+        duration: 99.254491ms
     - id: 42
       request:
         proto: HTTP/1.1
@@ -2082,29 +2082,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f1d21e7d-cdb4-4233-bc8b-1ea62911c468
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/491350f0-f34b-4717-abd0-586008512a36
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 938
+        content_length: 597
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:24.127101Z","description":"","domain_name":"tfnstenderpasteurjsqa1wcn-tf-co-vibrant-wilbur.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f1d21e7d-cdb4-4233-bc8b-1ea62911c468","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-vibrant-wilbur","namespace_id":"f9ec5c49-a55d-47ed-8464-9545eb0d52bf","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnstenderpasteurjsqa1wcn/tf-co-vibrant-wilbur:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-24T15:38:53.891594Z"}'
+        body: '{"created_at":"2025-08-27T15:06:15.199100Z","description":"","environment_variables":{},"error_message":null,"id":"491350f0-f34b-4717-abd0-586008512a36","name":"tf-ns-cranky-heisenberg","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnscrankyheisenbergeukvep5q","registry_namespace_id":"1e102b89-3b35-466c-9461-47100a07fded","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:48.875706240Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "938"
+                - "597"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:59 GMT
+                - Wed, 27 Aug 2025 15:06:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2112,10 +2112,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d2a3b76d-a1ca-402b-a938-a1a9805b54d2
+                - 059ec82b-e4b5-4977-8830-6a3fdb795baf
         status: 200 OK
         code: 200
-        duration: 77.496416ms
+        duration: 282.895687ms
     - id: 43
       request:
         proto: HTTP/1.1
@@ -2131,8 +2131,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f1d21e7d-cdb4-4233-bc8b-1ea62911c468
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/491350f0-f34b-4717-abd0-586008512a36
         method: GET
       response:
         proto: HTTP/2.0
@@ -2140,20 +2140,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 938
+        content_length: 594
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:24.127101Z","description":"","domain_name":"tfnstenderpasteurjsqa1wcn-tf-co-vibrant-wilbur.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f1d21e7d-cdb4-4233-bc8b-1ea62911c468","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-vibrant-wilbur","namespace_id":"f9ec5c49-a55d-47ed-8464-9545eb0d52bf","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnstenderpasteurjsqa1wcn/tf-co-vibrant-wilbur:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-24T15:38:53.891594Z"}'
+        body: '{"created_at":"2025-08-27T15:06:15.199100Z","description":"","environment_variables":{},"error_message":null,"id":"491350f0-f34b-4717-abd0-586008512a36","name":"tf-ns-cranky-heisenberg","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnscrankyheisenbergeukvep5q","registry_namespace_id":"1e102b89-3b35-466c-9461-47100a07fded","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:48.875706Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "938"
+                - "594"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:39:00 GMT
+                - Wed, 27 Aug 2025 15:06:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2161,10 +2161,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c15a4d66-3eac-4f48-922b-d1cccb103993
+                - d533dd6c-33a6-4082-9b33-45880f1c986a
         status: 200 OK
         code: 200
-        duration: 93.291ms
+        duration: 79.729722ms
     - id: 44
       request:
         proto: HTTP/1.1
@@ -2180,29 +2180,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f1d21e7d-cdb4-4233-bc8b-1ea62911c468
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/491350f0-f34b-4717-abd0-586008512a36
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 904
+        content_length: 594
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:24.127101Z","description":"","domain_name":"tfnstenderpasteurjsqa1wcn-tf-co-vibrant-wilbur.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f1d21e7d-cdb4-4233-bc8b-1ea62911c468","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-vibrant-wilbur","namespace_id":"f9ec5c49-a55d-47ed-8464-9545eb0d52bf","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnstenderpasteurjsqa1wcn/tf-co-vibrant-wilbur:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"deleting","timeout":"300s","updated_at":"2025-01-24T15:39:00.768889741Z"}'
+        body: '{"created_at":"2025-08-27T15:06:15.199100Z","description":"","environment_variables":{},"error_message":null,"id":"491350f0-f34b-4717-abd0-586008512a36","name":"tf-ns-cranky-heisenberg","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnscrankyheisenbergeukvep5q","registry_namespace_id":"1e102b89-3b35-466c-9461-47100a07fded","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:48.875706Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "904"
+                - "594"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:39:00 GMT
+                - Wed, 27 Aug 2025 15:06:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2210,10 +2210,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 51bf5bfa-6c48-49e3-953a-6b30bbe6499a
+                - a298930b-b7c0-40c7-a2cf-d183af2e7e1f
         status: 200 OK
         code: 200
-        duration: 137.568667ms
+        duration: 101.379844ms
     - id: 45
       request:
         proto: HTTP/1.1
@@ -2229,8 +2229,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/f9ec5c49-a55d-47ed-8464-9545eb0d52bf
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/491350f0-f34b-4717-abd0-586008512a36
         method: GET
       response:
         proto: HTTP/2.0
@@ -2238,20 +2238,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 552
+        content_length: 594
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:38:03.249776Z","description":"","environment_variables":{},"error_message":null,"id":"f9ec5c49-a55d-47ed-8464-9545eb0d52bf","name":"tf-ns-tender-pasteur","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnstenderpasteurjsqa1wcn","registry_namespace_id":"ecef20d3-08ac-45ee-b873-4b33575bb86a","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:38:18.995187Z"}'
+        body: '{"created_at":"2025-08-27T15:06:15.199100Z","description":"","environment_variables":{},"error_message":null,"id":"491350f0-f34b-4717-abd0-586008512a36","name":"tf-ns-cranky-heisenberg","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnscrankyheisenbergeukvep5q","registry_namespace_id":"1e102b89-3b35-466c-9461-47100a07fded","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:48.875706Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "552"
+                - "594"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:39:00 GMT
+                - Wed, 27 Aug 2025 15:06:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2259,10 +2259,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 56095d4f-0db5-4e0b-8fc8-c90882efc52f
+                - bee0a969-7968-42c0-b6ba-2045e2daeaf3
         status: 200 OK
         code: 200
-        duration: 70.237542ms
+        duration: 90.421268ms
     - id: 46
       request:
         proto: HTTP/1.1
@@ -2278,29 +2278,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/f9ec5c49-a55d-47ed-8464-9545eb0d52bf
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/491350f0-f34b-4717-abd0-586008512a36
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 558
+        content_length: 594
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:38:03.249776Z","description":"","environment_variables":{},"error_message":null,"id":"f9ec5c49-a55d-47ed-8464-9545eb0d52bf","name":"tf-ns-tender-pasteur","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnstenderpasteurjsqa1wcn","registry_namespace_id":"ecef20d3-08ac-45ee-b873-4b33575bb86a","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:39:00.991022293Z"}'
+        body: '{"created_at":"2025-08-27T15:06:15.199100Z","description":"","environment_variables":{},"error_message":null,"id":"491350f0-f34b-4717-abd0-586008512a36","name":"tf-ns-cranky-heisenberg","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnscrankyheisenbergeukvep5q","registry_namespace_id":"1e102b89-3b35-466c-9461-47100a07fded","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:48.875706Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "558"
+                - "594"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:39:01 GMT
+                - Wed, 27 Aug 2025 15:07:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2308,10 +2308,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8444992a-1e11-463d-954b-45f9f8de0ca1
+                - 24755d52-359b-403e-9054-e267895e81a5
         status: 200 OK
         code: 200
-        duration: 247.320209ms
+        duration: 79.219458ms
     - id: 47
       request:
         proto: HTTP/1.1
@@ -2327,8 +2327,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/f9ec5c49-a55d-47ed-8464-9545eb0d52bf
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/491350f0-f34b-4717-abd0-586008512a36
         method: GET
       response:
         proto: HTTP/2.0
@@ -2336,20 +2336,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 555
+        content_length: 594
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:38:03.249776Z","description":"","environment_variables":{},"error_message":null,"id":"f9ec5c49-a55d-47ed-8464-9545eb0d52bf","name":"tf-ns-tender-pasteur","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnstenderpasteurjsqa1wcn","registry_namespace_id":"ecef20d3-08ac-45ee-b873-4b33575bb86a","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:39:00.991022Z"}'
+        body: '{"created_at":"2025-08-27T15:06:15.199100Z","description":"","environment_variables":{},"error_message":null,"id":"491350f0-f34b-4717-abd0-586008512a36","name":"tf-ns-cranky-heisenberg","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnscrankyheisenbergeukvep5q","registry_namespace_id":"1e102b89-3b35-466c-9461-47100a07fded","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:48.875706Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "555"
+                - "594"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:39:01 GMT
+                - Wed, 27 Aug 2025 15:07:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2357,10 +2357,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5d74ba9c-4f1b-45ea-9e28-89d9df29455f
+                - 3b0d3680-955d-4f1b-a3d5-97d1938d7964
         status: 200 OK
         code: 200
-        duration: 70.451875ms
+        duration: 85.035735ms
     - id: 48
       request:
         proto: HTTP/1.1
@@ -2376,8 +2376,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/f9ec5c49-a55d-47ed-8464-9545eb0d52bf
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/491350f0-f34b-4717-abd0-586008512a36
         method: GET
       response:
         proto: HTTP/2.0
@@ -2385,20 +2385,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 555
+        content_length: 594
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:38:03.249776Z","description":"","environment_variables":{},"error_message":null,"id":"f9ec5c49-a55d-47ed-8464-9545eb0d52bf","name":"tf-ns-tender-pasteur","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnstenderpasteurjsqa1wcn","registry_namespace_id":"ecef20d3-08ac-45ee-b873-4b33575bb86a","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:39:00.991022Z"}'
+        body: '{"created_at":"2025-08-27T15:06:15.199100Z","description":"","environment_variables":{},"error_message":null,"id":"491350f0-f34b-4717-abd0-586008512a36","name":"tf-ns-cranky-heisenberg","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnscrankyheisenbergeukvep5q","registry_namespace_id":"1e102b89-3b35-466c-9461-47100a07fded","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:48.875706Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "555"
+                - "594"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:39:06 GMT
+                - Wed, 27 Aug 2025 15:07:14 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2406,10 +2406,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f0650cf6-4496-4a22-816c-1465464447e7
+                - 54f06fb3-0866-4093-9def-107299e2ab3a
         status: 200 OK
         code: 200
-        duration: 81.095625ms
+        duration: 97.035665ms
     - id: 49
       request:
         proto: HTTP/1.1
@@ -2425,204 +2425,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/f9ec5c49-a55d-47ed-8464-9545eb0d52bf
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 555
-        uncompressed: false
-        body: '{"created_at":"2025-01-24T15:38:03.249776Z","description":"","environment_variables":{},"error_message":null,"id":"f9ec5c49-a55d-47ed-8464-9545eb0d52bf","name":"tf-ns-tender-pasteur","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnstenderpasteurjsqa1wcn","registry_namespace_id":"ecef20d3-08ac-45ee-b873-4b33575bb86a","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:39:00.991022Z"}'
-        headers:
-            Content-Length:
-                - "555"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:39:11 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 3570494d-a7ba-4921-8df4-b8c82c581b65
-        status: 200 OK
-        code: 200
-        duration: 80.898375ms
-    - id: 50
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/f9ec5c49-a55d-47ed-8464-9545eb0d52bf
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 555
-        uncompressed: false
-        body: '{"created_at":"2025-01-24T15:38:03.249776Z","description":"","environment_variables":{},"error_message":null,"id":"f9ec5c49-a55d-47ed-8464-9545eb0d52bf","name":"tf-ns-tender-pasteur","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnstenderpasteurjsqa1wcn","registry_namespace_id":"ecef20d3-08ac-45ee-b873-4b33575bb86a","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:39:00.991022Z"}'
-        headers:
-            Content-Length:
-                - "555"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:39:16 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - c60dac1a-791d-4b6d-a232-c882cb31cd12
-        status: 200 OK
-        code: 200
-        duration: 76.414583ms
-    - id: 51
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/f9ec5c49-a55d-47ed-8464-9545eb0d52bf
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 555
-        uncompressed: false
-        body: '{"created_at":"2025-01-24T15:38:03.249776Z","description":"","environment_variables":{},"error_message":null,"id":"f9ec5c49-a55d-47ed-8464-9545eb0d52bf","name":"tf-ns-tender-pasteur","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnstenderpasteurjsqa1wcn","registry_namespace_id":"ecef20d3-08ac-45ee-b873-4b33575bb86a","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:39:00.991022Z"}'
-        headers:
-            Content-Length:
-                - "555"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:39:21 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 9ce9797c-15d3-4bf1-83c1-cbab01cfe298
-        status: 200 OK
-        code: 200
-        duration: 100.624417ms
-    - id: 52
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/f9ec5c49-a55d-47ed-8464-9545eb0d52bf
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 555
-        uncompressed: false
-        body: '{"created_at":"2025-01-24T15:38:03.249776Z","description":"","environment_variables":{},"error_message":null,"id":"f9ec5c49-a55d-47ed-8464-9545eb0d52bf","name":"tf-ns-tender-pasteur","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnstenderpasteurjsqa1wcn","registry_namespace_id":"ecef20d3-08ac-45ee-b873-4b33575bb86a","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:39:00.991022Z"}'
-        headers:
-            Content-Length:
-                - "555"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:39:26 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 04ed0041-ad99-4412-9640-7fed5dfc14f2
-        status: 200 OK
-        code: 200
-        duration: 71.13525ms
-    - id: 53
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/f9ec5c49-a55d-47ed-8464-9545eb0d52bf
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/491350f0-f34b-4717-abd0-586008512a36
         method: GET
       response:
         proto: HTTP/2.0
@@ -2641,9 +2445,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:39:31 GMT
+                - Wed, 27 Aug 2025 15:07:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2651,11 +2455,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 95314a2d-2c91-4bfb-aa6e-2e29d3f27cb9
+                - c94a1f78-f099-4579-86b8-8d25ff3315fd
         status: 404 Not Found
         code: 404
-        duration: 27.412792ms
-    - id: 54
+        duration: 25.354332ms
+    - id: 50
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2670,8 +2474,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f9ec5c49-a55d-47ed-8464-9545eb0d52bf
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/491350f0-f34b-4717-abd0-586008512a36
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -2690,9 +2494,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:39:31 GMT
+                - Wed, 27 Aug 2025 15:07:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2700,7 +2504,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 283ada10-c65d-4e05-8b88-15dc7ad6b9aa
+                - d22d8e57-dd8f-4fd7-b1b8-61442b30d1af
         status: 404 Not Found
         code: 404
-        duration: 24.025292ms
+        duration: 54.70207ms

--- a/internal/services/container/testdata/container-scaling-option.cassette.yaml
+++ b/internal/services/container/testdata/container-scaling-option.cassette.yaml
@@ -6,19 +6,19 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 154
+        content_length: 190
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-ns-hungry-raman","environment_variables":{},"project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","secret_environment_variables":[],"tags":null}'
+        body: '{"name":"tf-ns-upbeat-albattani","environment_variables":{},"project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","secret_environment_variables":[],"tags":null,"activate_vpc_integration":true}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces
         method: POST
       response:
@@ -27,20 +27,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 484
+        content_length: 507
         uncompressed: false
-        body: '{"created_at":"2025-01-15T14:25:06.718105673Z","description":"","environment_variables":{},"error_message":null,"id":"9c64cf6f-986b-43f5-add0-1c27794ab564","name":"tf-ns-hungry-raman","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-15T14:25:06.718105673Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.897114734Z","description":"","environment_variables":{},"error_message":null,"id":"e2d2ff72-d1c8-4df2-bb44-b0187305141a","name":"tf-ns-upbeat-albattani","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:40.897114734Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "484"
+                - "507"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:25:06 GMT
+                - Wed, 27 Aug 2025 15:05:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d5ec7203-a7f5-4f47-bb8f-67670c9ba7ef
+                - de7f7642-40d6-4def-bb06-69c85f24bc36
         status: 200 OK
         code: 200
-        duration: 318.24725ms
+        duration: 4.969894382s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -67,8 +67,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9c64cf6f-986b-43f5-add0-1c27794ab564
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/e2d2ff72-d1c8-4df2-bb44-b0187305141a
         method: GET
       response:
         proto: HTTP/2.0
@@ -76,20 +76,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 478
+        content_length: 501
         uncompressed: false
-        body: '{"created_at":"2025-01-15T14:25:06.718106Z","description":"","environment_variables":{},"error_message":null,"id":"9c64cf6f-986b-43f5-add0-1c27794ab564","name":"tf-ns-hungry-raman","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-15T14:25:06.718106Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.897115Z","description":"","environment_variables":{},"error_message":null,"id":"e2d2ff72-d1c8-4df2-bb44-b0187305141a","name":"tf-ns-upbeat-albattani","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:40.897115Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "478"
+                - "501"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:25:06 GMT
+                - Wed, 27 Aug 2025 15:05:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c9746937-5579-4d3e-a86c-a177fd679fb5
+                - eaff00ab-b320-4115-8916-688b05ee8474
         status: 200 OK
         code: 200
-        duration: 54.630541ms
+        duration: 108.739068ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -116,8 +116,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9c64cf6f-986b-43f5-add0-1c27794ab564
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/e2d2ff72-d1c8-4df2-bb44-b0187305141a
         method: GET
       response:
         proto: HTTP/2.0
@@ -125,20 +125,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 562
+        content_length: 501
         uncompressed: false
-        body: '{"created_at":"2025-01-15T14:25:06.718106Z","description":"","environment_variables":{},"error_message":null,"id":"9c64cf6f-986b-43f5-add0-1c27794ab564","name":"tf-ns-hungry-raman","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f","registry_namespace_id":"b4999fd9-3117-4019-9dae-a7d4efebde8e","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-15T14:25:10.179302Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.897115Z","description":"","environment_variables":{},"error_message":null,"id":"e2d2ff72-d1c8-4df2-bb44-b0187305141a","name":"tf-ns-upbeat-albattani","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:42.141530Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "562"
+                - "501"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:25:11 GMT
+                - Wed, 27 Aug 2025 15:05:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -146,10 +146,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 961ea1ee-8488-495b-a771-623ae7d46b48
+                - 2835688f-696c-41e1-9816-3d8fe9799c4a
         status: 200 OK
         code: 200
-        duration: 45.760209ms
+        duration: 98.653165ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -165,8 +165,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9c64cf6f-986b-43f5-add0-1c27794ab564
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/e2d2ff72-d1c8-4df2-bb44-b0187305141a
         method: GET
       response:
         proto: HTTP/2.0
@@ -174,20 +174,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 562
+        content_length: 501
         uncompressed: false
-        body: '{"created_at":"2025-01-15T14:25:06.718106Z","description":"","environment_variables":{},"error_message":null,"id":"9c64cf6f-986b-43f5-add0-1c27794ab564","name":"tf-ns-hungry-raman","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f","registry_namespace_id":"b4999fd9-3117-4019-9dae-a7d4efebde8e","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-15T14:25:10.179302Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.897115Z","description":"","environment_variables":{},"error_message":null,"id":"e2d2ff72-d1c8-4df2-bb44-b0187305141a","name":"tf-ns-upbeat-albattani","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:42.141530Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "562"
+                - "501"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:25:11 GMT
+                - Wed, 27 Aug 2025 15:05:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -195,10 +195,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 49b4d89b-3cbb-4368-ab46-9cccc0d5a6d7
+                - c9baf6ab-6543-49cb-bc65-1cf398d9d0ab
         status: 200 OK
         code: 200
-        duration: 50.066041ms
+        duration: 89.062691ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -214,8 +214,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9c64cf6f-986b-43f5-add0-1c27794ab564
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/e2d2ff72-d1c8-4df2-bb44-b0187305141a
         method: GET
       response:
         proto: HTTP/2.0
@@ -223,20 +223,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 562
+        content_length: 589
         uncompressed: false
-        body: '{"created_at":"2025-01-15T14:25:06.718106Z","description":"","environment_variables":{},"error_message":null,"id":"9c64cf6f-986b-43f5-add0-1c27794ab564","name":"tf-ns-hungry-raman","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f","registry_namespace_id":"b4999fd9-3117-4019-9dae-a7d4efebde8e","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-15T14:25:10.179302Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.897115Z","description":"","environment_variables":{},"error_message":null,"id":"e2d2ff72-d1c8-4df2-bb44-b0187305141a","name":"tf-ns-upbeat-albattani","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsupbeatalbattani1cgtihmg","registry_namespace_id":"463097b3-f54d-4ab3-affd-f86069a616c9","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:52.053040Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "562"
+                - "589"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:25:11 GMT
+                - Wed, 27 Aug 2025 15:05:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -244,50 +244,48 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 68dc3901-6ec2-4741-b9df-d1d908a34397
+                - 16fa15a1-e725-4852-b5ca-f80bc4d133e1
         status: 200 OK
         code: 200
-        duration: 46.4005ms
+        duration: 73.15893ms
     - id: 5
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 209
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"namespace_id":"9c64cf6f-986b-43f5-add0-1c27794ab564","name":"tf-co-jolly-fermat","privacy":"public","protocol":"http1","secret_environment_variables":null,"http_option":"enabled","sandbox":"unknown_sandbox"}'
+        body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers
-        method: POST
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/e2d2ff72-d1c8-4df2-bb44-b0187305141a
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 925
+        content_length: 589
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:25:12.144068658Z","description":"","domain_name":"tfnshungryramanms1v4s2f-tf-co-jolly-fermat.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f65c58fe-37f2-4510-aff4-007a09dde1d4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-jolly-fermat","namespace_id":"9c64cf6f-986b-43f5-add0-1c27794ab564","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f/tf-co-jolly-fermat:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-15T14:25:12.144068658Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.897115Z","description":"","environment_variables":{},"error_message":null,"id":"e2d2ff72-d1c8-4df2-bb44-b0187305141a","name":"tf-ns-upbeat-albattani","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsupbeatalbattani1cgtihmg","registry_namespace_id":"463097b3-f54d-4ab3-affd-f86069a616c9","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:52.053040Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "925"
+                - "589"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:25:12 GMT
+                - Wed, 27 Aug 2025 15:05:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -295,10 +293,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0cc7c61b-1d59-44e0-818a-0d3db1128d70
+                - a7c7d1b2-fce3-4ec8-912f-1f511a852264
         status: 200 OK
         code: 200
-        duration: 287.932333ms
+        duration: 74.383527ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -314,8 +312,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f65c58fe-37f2-4510-aff4-007a09dde1d4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/e2d2ff72-d1c8-4df2-bb44-b0187305141a
         method: GET
       response:
         proto: HTTP/2.0
@@ -323,20 +321,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 919
+        content_length: 589
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:25:12.144069Z","description":"","domain_name":"tfnshungryramanms1v4s2f-tf-co-jolly-fermat.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f65c58fe-37f2-4510-aff4-007a09dde1d4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-jolly-fermat","namespace_id":"9c64cf6f-986b-43f5-add0-1c27794ab564","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f/tf-co-jolly-fermat:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-15T14:25:12.144069Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.897115Z","description":"","environment_variables":{},"error_message":null,"id":"e2d2ff72-d1c8-4df2-bb44-b0187305141a","name":"tf-ns-upbeat-albattani","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsupbeatalbattani1cgtihmg","registry_namespace_id":"463097b3-f54d-4ab3-affd-f86069a616c9","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:52.053040Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "919"
+                - "589"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:25:12 GMT
+                - Wed, 27 Aug 2025 15:05:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -344,48 +342,50 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3ff29e5b-e1ca-4bf2-a94c-a9de8fd30a7b
+                - fed3ad52-12f0-4e6a-81dc-9c51efc47a9e
         status: 200 OK
         code: 200
-        duration: 56.1205ms
+        duration: 83.78009ms
     - id: 7
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 252
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"namespace_id":"e2d2ff72-d1c8-4df2-bb44-b0187305141a","name":"tf-co-objective-rhodes","privacy":"public","protocol":"http1","secret_environment_variables":null,"http_option":"enabled","sandbox":"unknown_sandbox","tags":null,"command":null,"args":null}'
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f65c58fe-37f2-4510-aff4-007a09dde1d4
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 919
+        content_length: 975
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:25:12.144069Z","description":"","domain_name":"tfnshungryramanms1v4s2f-tf-co-jolly-fermat.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f65c58fe-37f2-4510-aff4-007a09dde1d4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-jolly-fermat","namespace_id":"9c64cf6f-986b-43f5-add0-1c27794ab564","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f/tf-co-jolly-fermat:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-15T14:25:12.144069Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:58.361820263Z","description":"","domain_name":"tfnsupbeatalbattani1cgtihmg-tf-co-objective-rhodes.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"378df471-6405-4f31-8455-697bb9300641","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-objective-rhodes","namespace_id":"e2d2ff72-d1c8-4df2-bb44-b0187305141a","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsupbeatalbattani1cgtihmg/tf-co-objective-rhodes:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:58.361820263Z"}'
         headers:
             Content-Length:
-                - "919"
+                - "975"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:25:12 GMT
+                - Wed, 27 Aug 2025 15:05:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -393,10 +393,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0a497b68-2400-41c6-ad07-334796d5758e
+                - 780a98f6-d87e-4ee7-b36d-c89a80318d78
         status: 200 OK
         code: 200
-        duration: 48.314ms
+        duration: 1.874927771s
     - id: 8
       request:
         proto: HTTP/1.1
@@ -412,8 +412,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9c64cf6f-986b-43f5-add0-1c27794ab564
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/378df471-6405-4f31-8455-697bb9300641
         method: GET
       response:
         proto: HTTP/2.0
@@ -421,20 +421,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 562
+        content_length: 969
         uncompressed: false
-        body: '{"created_at":"2025-01-15T14:25:06.718106Z","description":"","environment_variables":{},"error_message":null,"id":"9c64cf6f-986b-43f5-add0-1c27794ab564","name":"tf-ns-hungry-raman","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f","registry_namespace_id":"b4999fd9-3117-4019-9dae-a7d4efebde8e","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-15T14:25:10.179302Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:58.361820Z","description":"","domain_name":"tfnsupbeatalbattani1cgtihmg-tf-co-objective-rhodes.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"378df471-6405-4f31-8455-697bb9300641","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-objective-rhodes","namespace_id":"e2d2ff72-d1c8-4df2-bb44-b0187305141a","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsupbeatalbattani1cgtihmg/tf-co-objective-rhodes:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:58.361820Z"}'
         headers:
             Content-Length:
-                - "562"
+                - "969"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:25:12 GMT
+                - Wed, 27 Aug 2025 15:05:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -442,10 +442,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 290350ea-fd25-42f0-b8e3-758c030fdabb
+                - 4b1ae006-2262-482c-a96a-50b952a3f408
         status: 200 OK
         code: 200
-        duration: 42.256584ms
+        duration: 101.838165ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -461,8 +461,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f65c58fe-37f2-4510-aff4-007a09dde1d4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/378df471-6405-4f31-8455-697bb9300641
         method: GET
       response:
         proto: HTTP/2.0
@@ -470,20 +470,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 919
+        content_length: 969
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:25:12.144069Z","description":"","domain_name":"tfnshungryramanms1v4s2f-tf-co-jolly-fermat.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f65c58fe-37f2-4510-aff4-007a09dde1d4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-jolly-fermat","namespace_id":"9c64cf6f-986b-43f5-add0-1c27794ab564","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f/tf-co-jolly-fermat:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-15T14:25:12.144069Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:58.361820Z","description":"","domain_name":"tfnsupbeatalbattani1cgtihmg-tf-co-objective-rhodes.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"378df471-6405-4f31-8455-697bb9300641","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-objective-rhodes","namespace_id":"e2d2ff72-d1c8-4df2-bb44-b0187305141a","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsupbeatalbattani1cgtihmg/tf-co-objective-rhodes:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:58.361820Z"}'
         headers:
             Content-Length:
-                - "919"
+                - "969"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:25:12 GMT
+                - Wed, 27 Aug 2025 15:05:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -491,10 +491,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6e5f76fd-74fb-43db-bbfa-f8ef836c52c4
+                - 079da8fe-8a1d-4a2c-b755-fedcc34becbb
         status: 200 OK
         code: 200
-        duration: 51.278167ms
+        duration: 90.660741ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -510,8 +510,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9c64cf6f-986b-43f5-add0-1c27794ab564
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/e2d2ff72-d1c8-4df2-bb44-b0187305141a
         method: GET
       response:
         proto: HTTP/2.0
@@ -519,20 +519,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 562
+        content_length: 589
         uncompressed: false
-        body: '{"created_at":"2025-01-15T14:25:06.718106Z","description":"","environment_variables":{},"error_message":null,"id":"9c64cf6f-986b-43f5-add0-1c27794ab564","name":"tf-ns-hungry-raman","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f","registry_namespace_id":"b4999fd9-3117-4019-9dae-a7d4efebde8e","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-15T14:25:10.179302Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.897115Z","description":"","environment_variables":{},"error_message":null,"id":"e2d2ff72-d1c8-4df2-bb44-b0187305141a","name":"tf-ns-upbeat-albattani","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsupbeatalbattani1cgtihmg","registry_namespace_id":"463097b3-f54d-4ab3-affd-f86069a616c9","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:52.053040Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "562"
+                - "589"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:25:12 GMT
+                - Wed, 27 Aug 2025 15:05:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -540,10 +540,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 979be1ba-9be5-472c-a7a4-1558a6ea067f
+                - 7fc5915f-4955-49df-96d2-0b2d66dbf149
         status: 200 OK
         code: 200
-        duration: 56.015542ms
+        duration: 171.723182ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -559,8 +559,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f65c58fe-37f2-4510-aff4-007a09dde1d4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/378df471-6405-4f31-8455-697bb9300641
         method: GET
       response:
         proto: HTTP/2.0
@@ -568,20 +568,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 919
+        content_length: 969
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:25:12.144069Z","description":"","domain_name":"tfnshungryramanms1v4s2f-tf-co-jolly-fermat.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f65c58fe-37f2-4510-aff4-007a09dde1d4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-jolly-fermat","namespace_id":"9c64cf6f-986b-43f5-add0-1c27794ab564","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f/tf-co-jolly-fermat:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-15T14:25:12.144069Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:58.361820Z","description":"","domain_name":"tfnsupbeatalbattani1cgtihmg-tf-co-objective-rhodes.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"378df471-6405-4f31-8455-697bb9300641","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-objective-rhodes","namespace_id":"e2d2ff72-d1c8-4df2-bb44-b0187305141a","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsupbeatalbattani1cgtihmg/tf-co-objective-rhodes:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:58.361820Z"}'
         headers:
             Content-Length:
-                - "919"
+                - "969"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:25:12 GMT
+                - Wed, 27 Aug 2025 15:05:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -589,10 +589,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6117e83b-21e0-460d-9dd9-3055e1a843dd
+                - c9bc7967-626b-47cc-97c2-1e511cd2da04
         status: 200 OK
         code: 200
-        duration: 59.118708ms
+        duration: 80.138687ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -608,8 +608,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9c64cf6f-986b-43f5-add0-1c27794ab564
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/e2d2ff72-d1c8-4df2-bb44-b0187305141a
         method: GET
       response:
         proto: HTTP/2.0
@@ -617,20 +617,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 562
+        content_length: 589
         uncompressed: false
-        body: '{"created_at":"2025-01-15T14:25:06.718106Z","description":"","environment_variables":{},"error_message":null,"id":"9c64cf6f-986b-43f5-add0-1c27794ab564","name":"tf-ns-hungry-raman","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f","registry_namespace_id":"b4999fd9-3117-4019-9dae-a7d4efebde8e","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-15T14:25:10.179302Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.897115Z","description":"","environment_variables":{},"error_message":null,"id":"e2d2ff72-d1c8-4df2-bb44-b0187305141a","name":"tf-ns-upbeat-albattani","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsupbeatalbattani1cgtihmg","registry_namespace_id":"463097b3-f54d-4ab3-affd-f86069a616c9","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:52.053040Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "562"
+                - "589"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:25:13 GMT
+                - Wed, 27 Aug 2025 15:05:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -638,10 +638,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d53d0cb7-dac7-4050-be52-409693d359df
+                - becb04fb-9c92-4185-9e56-ac5651585949
         status: 200 OK
         code: 200
-        duration: 56.944291ms
+        duration: 89.804706ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -657,8 +657,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f65c58fe-37f2-4510-aff4-007a09dde1d4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/378df471-6405-4f31-8455-697bb9300641
         method: GET
       response:
         proto: HTTP/2.0
@@ -666,20 +666,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 919
+        content_length: 969
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:25:12.144069Z","description":"","domain_name":"tfnshungryramanms1v4s2f-tf-co-jolly-fermat.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f65c58fe-37f2-4510-aff4-007a09dde1d4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-jolly-fermat","namespace_id":"9c64cf6f-986b-43f5-add0-1c27794ab564","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f/tf-co-jolly-fermat:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-15T14:25:12.144069Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:58.361820Z","description":"","domain_name":"tfnsupbeatalbattani1cgtihmg-tf-co-objective-rhodes.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"378df471-6405-4f31-8455-697bb9300641","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-objective-rhodes","namespace_id":"e2d2ff72-d1c8-4df2-bb44-b0187305141a","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsupbeatalbattani1cgtihmg/tf-co-objective-rhodes:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:58.361820Z"}'
         headers:
             Content-Length:
-                - "919"
+                - "969"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:25:13 GMT
+                - Wed, 27 Aug 2025 15:05:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -687,11 +687,109 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bb391d9d-5ef5-4078-8a2f-fd610b6c7bfe
+                - a0ed6bfa-429a-4e62-8330-4785123bf466
         status: 200 OK
         code: 200
-        duration: 61.971291ms
+        duration: 96.173145ms
     - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/e2d2ff72-d1c8-4df2-bb44-b0187305141a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 589
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:40.897115Z","description":"","environment_variables":{},"error_message":null,"id":"e2d2ff72-d1c8-4df2-bb44-b0187305141a","name":"tf-ns-upbeat-albattani","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsupbeatalbattani1cgtihmg","registry_namespace_id":"463097b3-f54d-4ab3-affd-f86069a616c9","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:52.053040Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "589"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:00 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3c483c3a-77d6-48a4-80c6-174634aafd69
+        status: 200 OK
+        code: 200
+        duration: 80.010567ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/378df471-6405-4f31-8455-697bb9300641
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 969
+        uncompressed: false
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:58.361820Z","description":"","domain_name":"tfnsupbeatalbattani1cgtihmg-tf-co-objective-rhodes.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"378df471-6405-4f31-8455-697bb9300641","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-objective-rhodes","namespace_id":"e2d2ff72-d1c8-4df2-bb44-b0187305141a","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsupbeatalbattani1cgtihmg/tf-co-objective-rhodes:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:58.361820Z"}'
+        headers:
+            Content-Length:
+                - "969"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:00 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f21ebf51-fe01-4ec8-b8b1-e56367a854ff
+        status: 200 OK
+        code: 200
+        duration: 90.195439ms
+    - id: 16
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -708,8 +806,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f65c58fe-37f2-4510-aff4-007a09dde1d4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/378df471-6405-4f31-8455-697bb9300641
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -717,20 +815,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 922
+        content_length: 972
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:25:12.144069Z","description":"","domain_name":"tfnshungryramanms1v4s2f-tf-co-jolly-fermat.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f65c58fe-37f2-4510-aff4-007a09dde1d4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-jolly-fermat","namespace_id":"9c64cf6f-986b-43f5-add0-1c27794ab564","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f/tf-co-jolly-fermat:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":15},"secret_environment_variables":[],"status":"pending","timeout":"300s","updated_at":"2025-01-15T14:25:13.191894651Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:58.361820Z","description":"","domain_name":"tfnsupbeatalbattani1cgtihmg-tf-co-objective-rhodes.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"378df471-6405-4f31-8455-697bb9300641","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-objective-rhodes","namespace_id":"e2d2ff72-d1c8-4df2-bb44-b0187305141a","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsupbeatalbattani1cgtihmg/tf-co-objective-rhodes:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":15},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:00.387662448Z"}'
         headers:
             Content-Length:
-                - "922"
+                - "972"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:25:13 GMT
+                - Wed, 27 Aug 2025 15:06:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -738,108 +836,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 55749356-b1c8-4ce7-8a7d-4d73f6289af2
+                - 6a4150eb-dfb9-49ce-89ab-bc04ab08cfc0
         status: 200 OK
         code: 200
-        duration: 101.924708ms
-    - id: 15
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f65c58fe-37f2-4510-aff4-007a09dde1d4
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 919
-        uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:25:12.144069Z","description":"","domain_name":"tfnshungryramanms1v4s2f-tf-co-jolly-fermat.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f65c58fe-37f2-4510-aff4-007a09dde1d4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-jolly-fermat","namespace_id":"9c64cf6f-986b-43f5-add0-1c27794ab564","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f/tf-co-jolly-fermat:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":15},"secret_environment_variables":[],"status":"pending","timeout":"300s","updated_at":"2025-01-15T14:25:13.191895Z"}'
-        headers:
-            Content-Length:
-                - "919"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 15 Jan 2025 14:25:13 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - a5aa6050-4b29-46fe-89fe-f04556fa9f53
-        status: 200 OK
-        code: 200
-        duration: 55.86375ms
-    - id: 16
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f65c58fe-37f2-4510-aff4-007a09dde1d4
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 919
-        uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:25:12.144069Z","description":"","domain_name":"tfnshungryramanms1v4s2f-tf-co-jolly-fermat.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f65c58fe-37f2-4510-aff4-007a09dde1d4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-jolly-fermat","namespace_id":"9c64cf6f-986b-43f5-add0-1c27794ab564","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f/tf-co-jolly-fermat:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":15},"secret_environment_variables":[],"status":"pending","timeout":"300s","updated_at":"2025-01-15T14:25:13.191895Z"}'
-        headers:
-            Content-Length:
-                - "919"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 15 Jan 2025 14:25:18 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 3f72a135-4b5d-4e77-9bf8-95d43d2e1967
-        status: 200 OK
-        code: 200
-        duration: 58.449833ms
+        duration: 132.29113ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -855,8 +855,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f65c58fe-37f2-4510-aff4-007a09dde1d4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/378df471-6405-4f31-8455-697bb9300641
         method: GET
       response:
         proto: HTTP/2.0
@@ -864,20 +864,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 957
+        content_length: 969
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:25:12.144069Z","description":"","domain_name":"tfnshungryramanms1v4s2f-tf-co-jolly-fermat.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f65c58fe-37f2-4510-aff4-007a09dde1d4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-jolly-fermat","namespace_id":"9c64cf6f-986b-43f5-add0-1c27794ab564","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f/tf-co-jolly-fermat:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":15},"secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-15T14:25:20.224405Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:58.361820Z","description":"","domain_name":"tfnsupbeatalbattani1cgtihmg-tf-co-objective-rhodes.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"378df471-6405-4f31-8455-697bb9300641","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-objective-rhodes","namespace_id":"e2d2ff72-d1c8-4df2-bb44-b0187305141a","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsupbeatalbattani1cgtihmg/tf-co-objective-rhodes:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":15},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:00.387662Z"}'
         headers:
             Content-Length:
-                - "957"
+                - "969"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:25:23 GMT
+                - Wed, 27 Aug 2025 15:06:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -885,10 +885,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c0f91f31-8fab-4aca-848d-25661bd267be
+                - 2e90bb3c-8ce2-49fe-9d86-4130b668ecc1
         status: 200 OK
         code: 200
-        duration: 62.0645ms
+        duration: 86.760022ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -904,8 +904,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f65c58fe-37f2-4510-aff4-007a09dde1d4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/378df471-6405-4f31-8455-697bb9300641
         method: GET
       response:
         proto: HTTP/2.0
@@ -913,20 +913,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 957
+        content_length: 969
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:25:12.144069Z","description":"","domain_name":"tfnshungryramanms1v4s2f-tf-co-jolly-fermat.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f65c58fe-37f2-4510-aff4-007a09dde1d4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-jolly-fermat","namespace_id":"9c64cf6f-986b-43f5-add0-1c27794ab564","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f/tf-co-jolly-fermat:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":15},"secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-15T14:25:20.224405Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:58.361820Z","description":"","domain_name":"tfnsupbeatalbattani1cgtihmg-tf-co-objective-rhodes.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"378df471-6405-4f31-8455-697bb9300641","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-objective-rhodes","namespace_id":"e2d2ff72-d1c8-4df2-bb44-b0187305141a","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsupbeatalbattani1cgtihmg/tf-co-objective-rhodes:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":15},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:00.387662Z"}'
         headers:
             Content-Length:
-                - "957"
+                - "969"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:25:23 GMT
+                - Wed, 27 Aug 2025 15:06:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -934,10 +934,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5905ecdb-6acb-429b-90d2-90b9e2d6496d
+                - 99d07eb2-356f-4aa4-bc84-ef9ce125e70e
         status: 200 OK
         code: 200
-        duration: 52.571791ms
+        duration: 101.45605ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -953,8 +953,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f65c58fe-37f2-4510-aff4-007a09dde1d4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/378df471-6405-4f31-8455-697bb9300641
         method: GET
       response:
         proto: HTTP/2.0
@@ -962,20 +962,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 957
+        content_length: 1007
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:25:12.144069Z","description":"","domain_name":"tfnshungryramanms1v4s2f-tf-co-jolly-fermat.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f65c58fe-37f2-4510-aff4-007a09dde1d4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-jolly-fermat","namespace_id":"9c64cf6f-986b-43f5-add0-1c27794ab564","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f/tf-co-jolly-fermat:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":15},"secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-15T14:25:20.224405Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:58.361820Z","description":"","domain_name":"tfnsupbeatalbattani1cgtihmg-tf-co-objective-rhodes.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"378df471-6405-4f31-8455-697bb9300641","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-objective-rhodes","namespace_id":"e2d2ff72-d1c8-4df2-bb44-b0187305141a","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsupbeatalbattani1cgtihmg/tf-co-objective-rhodes:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":15},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:06.752921Z"}'
         headers:
             Content-Length:
-                - "957"
+                - "1007"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:25:23 GMT
+                - Wed, 27 Aug 2025 15:06:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -983,10 +983,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 49c8d070-594c-4362-a286-720c592c3e9d
+                - 2c44cc7c-7663-464f-92d6-dbab4642e869
         status: 200 OK
         code: 200
-        duration: 59.013584ms
+        duration: 116.252468ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1002,8 +1002,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9c64cf6f-986b-43f5-add0-1c27794ab564
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/378df471-6405-4f31-8455-697bb9300641
         method: GET
       response:
         proto: HTTP/2.0
@@ -1011,20 +1011,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 562
+        content_length: 1007
         uncompressed: false
-        body: '{"created_at":"2025-01-15T14:25:06.718106Z","description":"","environment_variables":{},"error_message":null,"id":"9c64cf6f-986b-43f5-add0-1c27794ab564","name":"tf-ns-hungry-raman","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f","registry_namespace_id":"b4999fd9-3117-4019-9dae-a7d4efebde8e","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-15T14:25:10.179302Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:58.361820Z","description":"","domain_name":"tfnsupbeatalbattani1cgtihmg-tf-co-objective-rhodes.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"378df471-6405-4f31-8455-697bb9300641","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-objective-rhodes","namespace_id":"e2d2ff72-d1c8-4df2-bb44-b0187305141a","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsupbeatalbattani1cgtihmg/tf-co-objective-rhodes:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":15},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:06.752921Z"}'
         headers:
             Content-Length:
-                - "562"
+                - "1007"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:25:23 GMT
+                - Wed, 27 Aug 2025 15:06:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1032,10 +1032,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9b148cfe-904e-4dce-b947-ba0fc77dd7e7
+                - 76787ab9-63a8-496f-9aee-de3543a8375a
         status: 200 OK
         code: 200
-        duration: 43.44325ms
+        duration: 88.881566ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1051,8 +1051,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f65c58fe-37f2-4510-aff4-007a09dde1d4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/378df471-6405-4f31-8455-697bb9300641
         method: GET
       response:
         proto: HTTP/2.0
@@ -1060,20 +1060,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 957
+        content_length: 1007
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:25:12.144069Z","description":"","domain_name":"tfnshungryramanms1v4s2f-tf-co-jolly-fermat.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f65c58fe-37f2-4510-aff4-007a09dde1d4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-jolly-fermat","namespace_id":"9c64cf6f-986b-43f5-add0-1c27794ab564","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f/tf-co-jolly-fermat:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":15},"secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-15T14:25:20.224405Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:58.361820Z","description":"","domain_name":"tfnsupbeatalbattani1cgtihmg-tf-co-objective-rhodes.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"378df471-6405-4f31-8455-697bb9300641","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-objective-rhodes","namespace_id":"e2d2ff72-d1c8-4df2-bb44-b0187305141a","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsupbeatalbattani1cgtihmg/tf-co-objective-rhodes:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":15},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:06.752921Z"}'
         headers:
             Content-Length:
-                - "957"
+                - "1007"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:25:23 GMT
+                - Wed, 27 Aug 2025 15:06:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1081,10 +1081,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 95babeb5-ef81-437d-b6c2-dcb947091d4e
+                - 0e0f8cc1-fe25-4fa6-97ce-4be3e8bd7ef9
         status: 200 OK
         code: 200
-        duration: 52.0675ms
+        duration: 114.236645ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1100,8 +1100,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9c64cf6f-986b-43f5-add0-1c27794ab564
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/e2d2ff72-d1c8-4df2-bb44-b0187305141a
         method: GET
       response:
         proto: HTTP/2.0
@@ -1109,20 +1109,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 562
+        content_length: 589
         uncompressed: false
-        body: '{"created_at":"2025-01-15T14:25:06.718106Z","description":"","environment_variables":{},"error_message":null,"id":"9c64cf6f-986b-43f5-add0-1c27794ab564","name":"tf-ns-hungry-raman","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f","registry_namespace_id":"b4999fd9-3117-4019-9dae-a7d4efebde8e","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-15T14:25:10.179302Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.897115Z","description":"","environment_variables":{},"error_message":null,"id":"e2d2ff72-d1c8-4df2-bb44-b0187305141a","name":"tf-ns-upbeat-albattani","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsupbeatalbattani1cgtihmg","registry_namespace_id":"463097b3-f54d-4ab3-affd-f86069a616c9","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:52.053040Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "562"
+                - "589"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:25:23 GMT
+                - Wed, 27 Aug 2025 15:06:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1130,10 +1130,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 76b41cee-6a2c-45fa-9be3-a1ac48b23b24
+                - 1a4bd0b1-36aa-42f2-bdcf-29e4b8a0b401
         status: 200 OK
         code: 200
-        duration: 43.959542ms
+        duration: 84.347479ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1149,8 +1149,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f65c58fe-37f2-4510-aff4-007a09dde1d4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/378df471-6405-4f31-8455-697bb9300641
         method: GET
       response:
         proto: HTTP/2.0
@@ -1158,20 +1158,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 957
+        content_length: 1007
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:25:12.144069Z","description":"","domain_name":"tfnshungryramanms1v4s2f-tf-co-jolly-fermat.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f65c58fe-37f2-4510-aff4-007a09dde1d4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-jolly-fermat","namespace_id":"9c64cf6f-986b-43f5-add0-1c27794ab564","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f/tf-co-jolly-fermat:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":15},"secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-15T14:25:20.224405Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:58.361820Z","description":"","domain_name":"tfnsupbeatalbattani1cgtihmg-tf-co-objective-rhodes.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"378df471-6405-4f31-8455-697bb9300641","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-objective-rhodes","namespace_id":"e2d2ff72-d1c8-4df2-bb44-b0187305141a","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsupbeatalbattani1cgtihmg/tf-co-objective-rhodes:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":15},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:06.752921Z"}'
         headers:
             Content-Length:
-                - "957"
+                - "1007"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:25:24 GMT
+                - Wed, 27 Aug 2025 15:06:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1179,10 +1179,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fb46b8ac-1ba7-4033-aca8-b20f14d2ee5c
+                - 094eaacc-aa82-4d7f-983d-61dccc363184
         status: 200 OK
         code: 200
-        duration: 57.861917ms
+        duration: 108.200248ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1198,8 +1198,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9c64cf6f-986b-43f5-add0-1c27794ab564
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/e2d2ff72-d1c8-4df2-bb44-b0187305141a
         method: GET
       response:
         proto: HTTP/2.0
@@ -1207,20 +1207,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 562
+        content_length: 589
         uncompressed: false
-        body: '{"created_at":"2025-01-15T14:25:06.718106Z","description":"","environment_variables":{},"error_message":null,"id":"9c64cf6f-986b-43f5-add0-1c27794ab564","name":"tf-ns-hungry-raman","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f","registry_namespace_id":"b4999fd9-3117-4019-9dae-a7d4efebde8e","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-15T14:25:10.179302Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.897115Z","description":"","environment_variables":{},"error_message":null,"id":"e2d2ff72-d1c8-4df2-bb44-b0187305141a","name":"tf-ns-upbeat-albattani","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsupbeatalbattani1cgtihmg","registry_namespace_id":"463097b3-f54d-4ab3-affd-f86069a616c9","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:52.053040Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "562"
+                - "589"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:25:24 GMT
+                - Wed, 27 Aug 2025 15:06:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1228,10 +1228,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 74fec3f4-05cd-45e4-bcaf-2db0def94c74
+                - f5e092af-b8b7-4532-be47-a09e37d36b34
         status: 200 OK
         code: 200
-        duration: 43.783709ms
+        duration: 96.895213ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1247,8 +1247,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f65c58fe-37f2-4510-aff4-007a09dde1d4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/378df471-6405-4f31-8455-697bb9300641
         method: GET
       response:
         proto: HTTP/2.0
@@ -1256,20 +1256,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 957
+        content_length: 1007
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:25:12.144069Z","description":"","domain_name":"tfnshungryramanms1v4s2f-tf-co-jolly-fermat.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f65c58fe-37f2-4510-aff4-007a09dde1d4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-jolly-fermat","namespace_id":"9c64cf6f-986b-43f5-add0-1c27794ab564","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f/tf-co-jolly-fermat:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":15},"secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-15T14:25:20.224405Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:58.361820Z","description":"","domain_name":"tfnsupbeatalbattani1cgtihmg-tf-co-objective-rhodes.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"378df471-6405-4f31-8455-697bb9300641","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-objective-rhodes","namespace_id":"e2d2ff72-d1c8-4df2-bb44-b0187305141a","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsupbeatalbattani1cgtihmg/tf-co-objective-rhodes:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":15},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:06.752921Z"}'
         headers:
             Content-Length:
-                - "957"
+                - "1007"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:25:24 GMT
+                - Wed, 27 Aug 2025 15:06:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1277,11 +1277,109 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4f4ed3f9-dbc3-473a-a27f-e49a207073b0
+                - 30ad637a-d940-481c-835e-9948a407d21e
         status: 200 OK
         code: 200
-        duration: 47.437666ms
+        duration: 117.817095ms
     - id: 26
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/e2d2ff72-d1c8-4df2-bb44-b0187305141a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 589
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:40.897115Z","description":"","environment_variables":{},"error_message":null,"id":"e2d2ff72-d1c8-4df2-bb44-b0187305141a","name":"tf-ns-upbeat-albattani","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsupbeatalbattani1cgtihmg","registry_namespace_id":"463097b3-f54d-4ab3-affd-f86069a616c9","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:52.053040Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "589"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:12 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e18ca7a6-a5b6-419f-9bba-450b7988b550
+        status: 200 OK
+        code: 200
+        duration: 95.101678ms
+    - id: 27
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/378df471-6405-4f31-8455-697bb9300641
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1007
+        uncompressed: false
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:58.361820Z","description":"","domain_name":"tfnsupbeatalbattani1cgtihmg-tf-co-objective-rhodes.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"378df471-6405-4f31-8455-697bb9300641","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-objective-rhodes","namespace_id":"e2d2ff72-d1c8-4df2-bb44-b0187305141a","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsupbeatalbattani1cgtihmg/tf-co-objective-rhodes:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":15},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:06.752921Z"}'
+        headers:
+            Content-Length:
+                - "1007"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:12 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 7dfbfbd3-1d88-4c00-8274-1aa604c97c4f
+        status: 200 OK
+        code: 200
+        duration: 87.679812ms
+    - id: 28
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1298,8 +1396,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f65c58fe-37f2-4510-aff4-007a09dde1d4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/378df471-6405-4f31-8455-697bb9300641
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -1307,20 +1405,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 912
+        content_length: 962
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:25:12.144069Z","description":"","domain_name":"tfnshungryramanms1v4s2f-tf-co-jolly-fermat.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f65c58fe-37f2-4510-aff4-007a09dde1d4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":1,"name":"tf-co-jolly-fermat","namespace_id":"9c64cf6f-986b-43f5-add0-1c27794ab564","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f/tf-co-jolly-fermat:latest","sandbox":"v2","scaling_option":{"cpu_usage_threshold":72},"secret_environment_variables":[],"status":"pending","timeout":"300s","updated_at":"2025-01-15T14:25:24.337405525Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:58.361820Z","description":"","domain_name":"tfnsupbeatalbattani1cgtihmg-tf-co-objective-rhodes.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"378df471-6405-4f31-8455-697bb9300641","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":1,"name":"tf-co-objective-rhodes","namespace_id":"e2d2ff72-d1c8-4df2-bb44-b0187305141a","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsupbeatalbattani1cgtihmg/tf-co-objective-rhodes:latest","sandbox":"v2","scaling_option":{"cpu_usage_threshold":72},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:12.677620781Z"}'
         headers:
             Content-Length:
-                - "912"
+                - "962"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:25:24 GMT
+                - Wed, 27 Aug 2025 15:06:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1328,108 +1426,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ed7ad6bb-a55f-494c-9ed5-d657f945f05a
+                - 0b42fca3-4681-44ee-93ef-01b6dac984ae
         status: 200 OK
         code: 200
-        duration: 110.097584ms
-    - id: 27
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f65c58fe-37f2-4510-aff4-007a09dde1d4
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 909
-        uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:25:12.144069Z","description":"","domain_name":"tfnshungryramanms1v4s2f-tf-co-jolly-fermat.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f65c58fe-37f2-4510-aff4-007a09dde1d4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":1,"name":"tf-co-jolly-fermat","namespace_id":"9c64cf6f-986b-43f5-add0-1c27794ab564","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f/tf-co-jolly-fermat:latest","sandbox":"v2","scaling_option":{"cpu_usage_threshold":72},"secret_environment_variables":[],"status":"pending","timeout":"300s","updated_at":"2025-01-15T14:25:24.337406Z"}'
-        headers:
-            Content-Length:
-                - "909"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 15 Jan 2025 14:25:24 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - d382d7b8-5a24-4728-b816-09df2b32c0c9
-        status: 200 OK
-        code: 200
-        duration: 47.433417ms
-    - id: 28
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f65c58fe-37f2-4510-aff4-007a09dde1d4
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 909
-        uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:25:12.144069Z","description":"","domain_name":"tfnshungryramanms1v4s2f-tf-co-jolly-fermat.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f65c58fe-37f2-4510-aff4-007a09dde1d4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":1,"name":"tf-co-jolly-fermat","namespace_id":"9c64cf6f-986b-43f5-add0-1c27794ab564","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f/tf-co-jolly-fermat:latest","sandbox":"v2","scaling_option":{"cpu_usage_threshold":72},"secret_environment_variables":[],"status":"pending","timeout":"300s","updated_at":"2025-01-15T14:25:24.337406Z"}'
-        headers:
-            Content-Length:
-                - "909"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 15 Jan 2025 14:25:29 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 14b654b2-939a-4107-93c8-d2585a76c910
-        status: 200 OK
-        code: 200
-        duration: 61.425333ms
+        duration: 117.443803ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1445,8 +1445,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f65c58fe-37f2-4510-aff4-007a09dde1d4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/378df471-6405-4f31-8455-697bb9300641
         method: GET
       response:
         proto: HTTP/2.0
@@ -1454,20 +1454,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 947
+        content_length: 959
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:25:12.144069Z","description":"","domain_name":"tfnshungryramanms1v4s2f-tf-co-jolly-fermat.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f65c58fe-37f2-4510-aff4-007a09dde1d4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":1,"name":"tf-co-jolly-fermat","namespace_id":"9c64cf6f-986b-43f5-add0-1c27794ab564","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f/tf-co-jolly-fermat:latest","sandbox":"v2","scaling_option":{"cpu_usage_threshold":72},"secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-15T14:25:30.816438Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:58.361820Z","description":"","domain_name":"tfnsupbeatalbattani1cgtihmg-tf-co-objective-rhodes.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"378df471-6405-4f31-8455-697bb9300641","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":1,"name":"tf-co-objective-rhodes","namespace_id":"e2d2ff72-d1c8-4df2-bb44-b0187305141a","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsupbeatalbattani1cgtihmg/tf-co-objective-rhodes:latest","sandbox":"v2","scaling_option":{"cpu_usage_threshold":72},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:12.677621Z"}'
         headers:
             Content-Length:
-                - "947"
+                - "959"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:25:34 GMT
+                - Wed, 27 Aug 2025 15:06:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1475,10 +1475,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 676e7145-6509-4584-bc82-6fcb7dd6926b
+                - e2a0400f-2638-4e97-8bf6-ff27635f917c
         status: 200 OK
         code: 200
-        duration: 54.8425ms
+        duration: 99.074704ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1494,8 +1494,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f65c58fe-37f2-4510-aff4-007a09dde1d4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/378df471-6405-4f31-8455-697bb9300641
         method: GET
       response:
         proto: HTTP/2.0
@@ -1503,20 +1503,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 947
+        content_length: 959
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:25:12.144069Z","description":"","domain_name":"tfnshungryramanms1v4s2f-tf-co-jolly-fermat.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f65c58fe-37f2-4510-aff4-007a09dde1d4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":1,"name":"tf-co-jolly-fermat","namespace_id":"9c64cf6f-986b-43f5-add0-1c27794ab564","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f/tf-co-jolly-fermat:latest","sandbox":"v2","scaling_option":{"cpu_usage_threshold":72},"secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-15T14:25:30.816438Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:58.361820Z","description":"","domain_name":"tfnsupbeatalbattani1cgtihmg-tf-co-objective-rhodes.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"378df471-6405-4f31-8455-697bb9300641","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":1,"name":"tf-co-objective-rhodes","namespace_id":"e2d2ff72-d1c8-4df2-bb44-b0187305141a","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsupbeatalbattani1cgtihmg/tf-co-objective-rhodes:latest","sandbox":"v2","scaling_option":{"cpu_usage_threshold":72},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:12.677621Z"}'
         headers:
             Content-Length:
-                - "947"
+                - "959"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:25:34 GMT
+                - Wed, 27 Aug 2025 15:06:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1524,10 +1524,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 859ba456-639c-47e4-aa84-08ef53979f04
+                - 15f91dee-4080-4e33-8de9-cde1af2fc12f
         status: 200 OK
         code: 200
-        duration: 61.547708ms
+        duration: 82.692684ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1543,8 +1543,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f65c58fe-37f2-4510-aff4-007a09dde1d4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/378df471-6405-4f31-8455-697bb9300641
         method: GET
       response:
         proto: HTTP/2.0
@@ -1552,20 +1552,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 947
+        content_length: 997
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:25:12.144069Z","description":"","domain_name":"tfnshungryramanms1v4s2f-tf-co-jolly-fermat.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f65c58fe-37f2-4510-aff4-007a09dde1d4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":1,"name":"tf-co-jolly-fermat","namespace_id":"9c64cf6f-986b-43f5-add0-1c27794ab564","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f/tf-co-jolly-fermat:latest","sandbox":"v2","scaling_option":{"cpu_usage_threshold":72},"secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-15T14:25:30.816438Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:58.361820Z","description":"","domain_name":"tfnsupbeatalbattani1cgtihmg-tf-co-objective-rhodes.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"378df471-6405-4f31-8455-697bb9300641","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":1,"name":"tf-co-objective-rhodes","namespace_id":"e2d2ff72-d1c8-4df2-bb44-b0187305141a","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsupbeatalbattani1cgtihmg/tf-co-objective-rhodes:latest","sandbox":"v2","scaling_option":{"cpu_usage_threshold":72},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:19.025068Z"}'
         headers:
             Content-Length:
-                - "947"
+                - "997"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:25:34 GMT
+                - Wed, 27 Aug 2025 15:06:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1573,10 +1573,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 36eff13f-2f75-49b2-8d49-079d069f44c7
+                - 2e6197c1-ee14-42fa-8a09-e6fe56b22a30
         status: 200 OK
         code: 200
-        duration: 57.856875ms
+        duration: 117.65837ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1592,8 +1592,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9c64cf6f-986b-43f5-add0-1c27794ab564
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/378df471-6405-4f31-8455-697bb9300641
         method: GET
       response:
         proto: HTTP/2.0
@@ -1601,20 +1601,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 562
+        content_length: 997
         uncompressed: false
-        body: '{"created_at":"2025-01-15T14:25:06.718106Z","description":"","environment_variables":{},"error_message":null,"id":"9c64cf6f-986b-43f5-add0-1c27794ab564","name":"tf-ns-hungry-raman","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f","registry_namespace_id":"b4999fd9-3117-4019-9dae-a7d4efebde8e","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-15T14:25:10.179302Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:58.361820Z","description":"","domain_name":"tfnsupbeatalbattani1cgtihmg-tf-co-objective-rhodes.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"378df471-6405-4f31-8455-697bb9300641","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":1,"name":"tf-co-objective-rhodes","namespace_id":"e2d2ff72-d1c8-4df2-bb44-b0187305141a","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsupbeatalbattani1cgtihmg/tf-co-objective-rhodes:latest","sandbox":"v2","scaling_option":{"cpu_usage_threshold":72},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:19.025068Z"}'
         headers:
             Content-Length:
-                - "562"
+                - "997"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:25:34 GMT
+                - Wed, 27 Aug 2025 15:06:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1622,10 +1622,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4b23f1db-c66a-4a60-adb0-16e884ec19f2
+                - 7d0ae14f-d4f5-4ee2-8336-44b3300a64c6
         status: 200 OK
         code: 200
-        duration: 41.669542ms
+        duration: 103.533114ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1641,8 +1641,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f65c58fe-37f2-4510-aff4-007a09dde1d4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/378df471-6405-4f31-8455-697bb9300641
         method: GET
       response:
         proto: HTTP/2.0
@@ -1650,20 +1650,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 947
+        content_length: 997
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:25:12.144069Z","description":"","domain_name":"tfnshungryramanms1v4s2f-tf-co-jolly-fermat.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f65c58fe-37f2-4510-aff4-007a09dde1d4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":1,"name":"tf-co-jolly-fermat","namespace_id":"9c64cf6f-986b-43f5-add0-1c27794ab564","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f/tf-co-jolly-fermat:latest","sandbox":"v2","scaling_option":{"cpu_usage_threshold":72},"secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-15T14:25:30.816438Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:58.361820Z","description":"","domain_name":"tfnsupbeatalbattani1cgtihmg-tf-co-objective-rhodes.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"378df471-6405-4f31-8455-697bb9300641","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":1,"name":"tf-co-objective-rhodes","namespace_id":"e2d2ff72-d1c8-4df2-bb44-b0187305141a","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsupbeatalbattani1cgtihmg/tf-co-objective-rhodes:latest","sandbox":"v2","scaling_option":{"cpu_usage_threshold":72},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:19.025068Z"}'
         headers:
             Content-Length:
-                - "947"
+                - "997"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:25:34 GMT
+                - Wed, 27 Aug 2025 15:06:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1671,10 +1671,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 53e890dd-0937-4df1-91ee-da2731665011
+                - e39f7660-b3a2-4979-974f-af9b803192a4
         status: 200 OK
         code: 200
-        duration: 53.509875ms
+        duration: 81.045074ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1690,8 +1690,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9c64cf6f-986b-43f5-add0-1c27794ab564
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/e2d2ff72-d1c8-4df2-bb44-b0187305141a
         method: GET
       response:
         proto: HTTP/2.0
@@ -1699,20 +1699,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 562
+        content_length: 589
         uncompressed: false
-        body: '{"created_at":"2025-01-15T14:25:06.718106Z","description":"","environment_variables":{},"error_message":null,"id":"9c64cf6f-986b-43f5-add0-1c27794ab564","name":"tf-ns-hungry-raman","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f","registry_namespace_id":"b4999fd9-3117-4019-9dae-a7d4efebde8e","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-15T14:25:10.179302Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.897115Z","description":"","environment_variables":{},"error_message":null,"id":"e2d2ff72-d1c8-4df2-bb44-b0187305141a","name":"tf-ns-upbeat-albattani","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsupbeatalbattani1cgtihmg","registry_namespace_id":"463097b3-f54d-4ab3-affd-f86069a616c9","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:52.053040Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "562"
+                - "589"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:25:35 GMT
+                - Wed, 27 Aug 2025 15:06:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1720,10 +1720,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - aa31c1b5-65c7-446f-b195-ed8415b4819d
+                - ca9be01c-02c9-46e3-8a21-c2a8748d24f0
         status: 200 OK
         code: 200
-        duration: 41.19ms
+        duration: 77.756654ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1739,8 +1739,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f65c58fe-37f2-4510-aff4-007a09dde1d4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/378df471-6405-4f31-8455-697bb9300641
         method: GET
       response:
         proto: HTTP/2.0
@@ -1748,20 +1748,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 947
+        content_length: 997
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:25:12.144069Z","description":"","domain_name":"tfnshungryramanms1v4s2f-tf-co-jolly-fermat.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f65c58fe-37f2-4510-aff4-007a09dde1d4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":1,"name":"tf-co-jolly-fermat","namespace_id":"9c64cf6f-986b-43f5-add0-1c27794ab564","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f/tf-co-jolly-fermat:latest","sandbox":"v2","scaling_option":{"cpu_usage_threshold":72},"secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-15T14:25:30.816438Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:58.361820Z","description":"","domain_name":"tfnsupbeatalbattani1cgtihmg-tf-co-objective-rhodes.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"378df471-6405-4f31-8455-697bb9300641","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":1,"name":"tf-co-objective-rhodes","namespace_id":"e2d2ff72-d1c8-4df2-bb44-b0187305141a","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsupbeatalbattani1cgtihmg/tf-co-objective-rhodes:latest","sandbox":"v2","scaling_option":{"cpu_usage_threshold":72},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:19.025068Z"}'
         headers:
             Content-Length:
-                - "947"
+                - "997"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:25:35 GMT
+                - Wed, 27 Aug 2025 15:06:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1769,10 +1769,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d5e18c95-5137-4d75-90d2-808b9a47d7ae
+                - b307f479-f84a-49ab-b461-58524708ee73
         status: 200 OK
         code: 200
-        duration: 65.242792ms
+        duration: 105.697655ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1788,8 +1788,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9c64cf6f-986b-43f5-add0-1c27794ab564
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/e2d2ff72-d1c8-4df2-bb44-b0187305141a
         method: GET
       response:
         proto: HTTP/2.0
@@ -1797,20 +1797,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 562
+        content_length: 589
         uncompressed: false
-        body: '{"created_at":"2025-01-15T14:25:06.718106Z","description":"","environment_variables":{},"error_message":null,"id":"9c64cf6f-986b-43f5-add0-1c27794ab564","name":"tf-ns-hungry-raman","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f","registry_namespace_id":"b4999fd9-3117-4019-9dae-a7d4efebde8e","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-15T14:25:10.179302Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.897115Z","description":"","environment_variables":{},"error_message":null,"id":"e2d2ff72-d1c8-4df2-bb44-b0187305141a","name":"tf-ns-upbeat-albattani","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsupbeatalbattani1cgtihmg","registry_namespace_id":"463097b3-f54d-4ab3-affd-f86069a616c9","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:52.053040Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "562"
+                - "589"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:25:35 GMT
+                - Wed, 27 Aug 2025 15:06:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1818,10 +1818,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b598be2d-4ad9-4a07-a8e3-e7c69db14a41
+                - 97ec9f94-5fdc-4b2a-ba4d-86734a28bc82
         status: 200 OK
         code: 200
-        duration: 50.645292ms
+        duration: 107.103225ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1837,8 +1837,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f65c58fe-37f2-4510-aff4-007a09dde1d4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/378df471-6405-4f31-8455-697bb9300641
         method: GET
       response:
         proto: HTTP/2.0
@@ -1846,20 +1846,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 947
+        content_length: 997
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:25:12.144069Z","description":"","domain_name":"tfnshungryramanms1v4s2f-tf-co-jolly-fermat.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f65c58fe-37f2-4510-aff4-007a09dde1d4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":1,"name":"tf-co-jolly-fermat","namespace_id":"9c64cf6f-986b-43f5-add0-1c27794ab564","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f/tf-co-jolly-fermat:latest","sandbox":"v2","scaling_option":{"cpu_usage_threshold":72},"secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-15T14:25:30.816438Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:58.361820Z","description":"","domain_name":"tfnsupbeatalbattani1cgtihmg-tf-co-objective-rhodes.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"378df471-6405-4f31-8455-697bb9300641","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":1,"name":"tf-co-objective-rhodes","namespace_id":"e2d2ff72-d1c8-4df2-bb44-b0187305141a","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsupbeatalbattani1cgtihmg/tf-co-objective-rhodes:latest","sandbox":"v2","scaling_option":{"cpu_usage_threshold":72},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:19.025068Z"}'
         headers:
             Content-Length:
-                - "947"
+                - "997"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:25:35 GMT
+                - Wed, 27 Aug 2025 15:06:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1867,11 +1867,109 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b8b4066d-0b2f-4566-aaad-bc49db030ebe
+                - 3bdd824f-7265-4c10-84a8-dcc015d92e5f
         status: 200 OK
         code: 200
-        duration: 56.052792ms
+        duration: 104.13273ms
     - id: 38
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/e2d2ff72-d1c8-4df2-bb44-b0187305141a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 589
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:40.897115Z","description":"","environment_variables":{},"error_message":null,"id":"e2d2ff72-d1c8-4df2-bb44-b0187305141a","name":"tf-ns-upbeat-albattani","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsupbeatalbattani1cgtihmg","registry_namespace_id":"463097b3-f54d-4ab3-affd-f86069a616c9","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:52.053040Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "589"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:24 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b2cd1350-ce99-40be-8e80-76c631aadc07
+        status: 200 OK
+        code: 200
+        duration: 82.254324ms
+    - id: 39
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/378df471-6405-4f31-8455-697bb9300641
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 997
+        uncompressed: false
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:58.361820Z","description":"","domain_name":"tfnsupbeatalbattani1cgtihmg-tf-co-objective-rhodes.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"378df471-6405-4f31-8455-697bb9300641","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":1,"name":"tf-co-objective-rhodes","namespace_id":"e2d2ff72-d1c8-4df2-bb44-b0187305141a","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsupbeatalbattani1cgtihmg/tf-co-objective-rhodes:latest","sandbox":"v2","scaling_option":{"cpu_usage_threshold":72},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:19.025068Z"}'
+        headers:
+            Content-Length:
+                - "997"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:24 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f49b64ca-b7b7-465d-b1b6-a58a983f451a
+        status: 200 OK
+        code: 200
+        duration: 99.593972ms
+    - id: 40
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1888,8 +1986,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f65c58fe-37f2-4510-aff4-007a09dde1d4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/378df471-6405-4f31-8455-697bb9300641
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -1897,20 +1995,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 915
+        content_length: 965
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:25:12.144069Z","description":"","domain_name":"tfnshungryramanms1v4s2f-tf-co-jolly-fermat.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f65c58fe-37f2-4510-aff4-007a09dde1d4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":1,"name":"tf-co-jolly-fermat","namespace_id":"9c64cf6f-986b-43f5-add0-1c27794ab564","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f/tf-co-jolly-fermat:latest","sandbox":"v2","scaling_option":{"memory_usage_threshold":66},"secret_environment_variables":[],"status":"pending","timeout":"300s","updated_at":"2025-01-15T14:25:35.505085545Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:58.361820Z","description":"","domain_name":"tfnsupbeatalbattani1cgtihmg-tf-co-objective-rhodes.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"378df471-6405-4f31-8455-697bb9300641","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":1,"name":"tf-co-objective-rhodes","namespace_id":"e2d2ff72-d1c8-4df2-bb44-b0187305141a","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsupbeatalbattani1cgtihmg/tf-co-objective-rhodes:latest","sandbox":"v2","scaling_option":{"memory_usage_threshold":66},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:24.939739666Z"}'
         headers:
             Content-Length:
-                - "915"
+                - "965"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:25:35 GMT
+                - Wed, 27 Aug 2025 15:06:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1918,108 +2016,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cc35a6ca-bdda-41b8-bf78-cd13a1e39a1d
+                - 65f26e92-c5dd-4134-9991-c9137c0de48c
         status: 200 OK
         code: 200
-        duration: 101.10525ms
-    - id: 39
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f65c58fe-37f2-4510-aff4-007a09dde1d4
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 912
-        uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:25:12.144069Z","description":"","domain_name":"tfnshungryramanms1v4s2f-tf-co-jolly-fermat.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f65c58fe-37f2-4510-aff4-007a09dde1d4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":1,"name":"tf-co-jolly-fermat","namespace_id":"9c64cf6f-986b-43f5-add0-1c27794ab564","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f/tf-co-jolly-fermat:latest","sandbox":"v2","scaling_option":{"memory_usage_threshold":66},"secret_environment_variables":[],"status":"pending","timeout":"300s","updated_at":"2025-01-15T14:25:35.505086Z"}'
-        headers:
-            Content-Length:
-                - "912"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 15 Jan 2025 14:25:35 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - e4cc464a-5b4f-427e-bd8a-f234008e8929
-        status: 200 OK
-        code: 200
-        duration: 53.779916ms
-    - id: 40
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f65c58fe-37f2-4510-aff4-007a09dde1d4
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 912
-        uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:25:12.144069Z","description":"","domain_name":"tfnshungryramanms1v4s2f-tf-co-jolly-fermat.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f65c58fe-37f2-4510-aff4-007a09dde1d4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":1,"name":"tf-co-jolly-fermat","namespace_id":"9c64cf6f-986b-43f5-add0-1c27794ab564","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f/tf-co-jolly-fermat:latest","sandbox":"v2","scaling_option":{"memory_usage_threshold":66},"secret_environment_variables":[],"status":"pending","timeout":"300s","updated_at":"2025-01-15T14:25:35.505086Z"}'
-        headers:
-            Content-Length:
-                - "912"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 15 Jan 2025 14:25:40 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - a2ba004c-f7b7-4e18-b91b-7946a1b6b5c8
-        status: 200 OK
-        code: 200
-        duration: 59.456583ms
+        duration: 110.379793ms
     - id: 41
       request:
         proto: HTTP/1.1
@@ -2035,8 +2035,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f65c58fe-37f2-4510-aff4-007a09dde1d4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/378df471-6405-4f31-8455-697bb9300641
         method: GET
       response:
         proto: HTTP/2.0
@@ -2044,20 +2044,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 950
+        content_length: 962
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:25:12.144069Z","description":"","domain_name":"tfnshungryramanms1v4s2f-tf-co-jolly-fermat.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f65c58fe-37f2-4510-aff4-007a09dde1d4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":1,"name":"tf-co-jolly-fermat","namespace_id":"9c64cf6f-986b-43f5-add0-1c27794ab564","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f/tf-co-jolly-fermat:latest","sandbox":"v2","scaling_option":{"memory_usage_threshold":66},"secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-15T14:25:42.109483Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:58.361820Z","description":"","domain_name":"tfnsupbeatalbattani1cgtihmg-tf-co-objective-rhodes.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"378df471-6405-4f31-8455-697bb9300641","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":1,"name":"tf-co-objective-rhodes","namespace_id":"e2d2ff72-d1c8-4df2-bb44-b0187305141a","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsupbeatalbattani1cgtihmg/tf-co-objective-rhodes:latest","sandbox":"v2","scaling_option":{"memory_usage_threshold":66},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:24.939740Z"}'
         headers:
             Content-Length:
-                - "950"
+                - "962"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:25:45 GMT
+                - Wed, 27 Aug 2025 15:06:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2065,10 +2065,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f88014a2-c23f-4438-a6b8-7e381495cf22
+                - 9cb2f178-4770-4a36-932b-a13bda8f367e
         status: 200 OK
         code: 200
-        duration: 85.053875ms
+        duration: 87.689773ms
     - id: 42
       request:
         proto: HTTP/1.1
@@ -2084,8 +2084,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f65c58fe-37f2-4510-aff4-007a09dde1d4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/378df471-6405-4f31-8455-697bb9300641
         method: GET
       response:
         proto: HTTP/2.0
@@ -2093,20 +2093,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 950
+        content_length: 962
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:25:12.144069Z","description":"","domain_name":"tfnshungryramanms1v4s2f-tf-co-jolly-fermat.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f65c58fe-37f2-4510-aff4-007a09dde1d4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":1,"name":"tf-co-jolly-fermat","namespace_id":"9c64cf6f-986b-43f5-add0-1c27794ab564","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f/tf-co-jolly-fermat:latest","sandbox":"v2","scaling_option":{"memory_usage_threshold":66},"secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-15T14:25:42.109483Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:58.361820Z","description":"","domain_name":"tfnsupbeatalbattani1cgtihmg-tf-co-objective-rhodes.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"378df471-6405-4f31-8455-697bb9300641","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":1,"name":"tf-co-objective-rhodes","namespace_id":"e2d2ff72-d1c8-4df2-bb44-b0187305141a","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsupbeatalbattani1cgtihmg/tf-co-objective-rhodes:latest","sandbox":"v2","scaling_option":{"memory_usage_threshold":66},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:24.939740Z"}'
         headers:
             Content-Length:
-                - "950"
+                - "962"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:25:45 GMT
+                - Wed, 27 Aug 2025 15:06:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2114,10 +2114,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3c509044-aa3d-4b37-b43a-2b867e404ab8
+                - 5db9842b-e357-40b2-9b70-16671dafbd24
         status: 200 OK
         code: 200
-        duration: 57.478291ms
+        duration: 103.361443ms
     - id: 43
       request:
         proto: HTTP/1.1
@@ -2133,8 +2133,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f65c58fe-37f2-4510-aff4-007a09dde1d4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/378df471-6405-4f31-8455-697bb9300641
         method: GET
       response:
         proto: HTTP/2.0
@@ -2142,20 +2142,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 950
+        content_length: 962
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:25:12.144069Z","description":"","domain_name":"tfnshungryramanms1v4s2f-tf-co-jolly-fermat.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f65c58fe-37f2-4510-aff4-007a09dde1d4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":1,"name":"tf-co-jolly-fermat","namespace_id":"9c64cf6f-986b-43f5-add0-1c27794ab564","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f/tf-co-jolly-fermat:latest","sandbox":"v2","scaling_option":{"memory_usage_threshold":66},"secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-15T14:25:42.109483Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:58.361820Z","description":"","domain_name":"tfnsupbeatalbattani1cgtihmg-tf-co-objective-rhodes.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"378df471-6405-4f31-8455-697bb9300641","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":1,"name":"tf-co-objective-rhodes","namespace_id":"e2d2ff72-d1c8-4df2-bb44-b0187305141a","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsupbeatalbattani1cgtihmg/tf-co-objective-rhodes:latest","sandbox":"v2","scaling_option":{"memory_usage_threshold":66},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:24.939740Z"}'
         headers:
             Content-Length:
-                - "950"
+                - "962"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:25:45 GMT
+                - Wed, 27 Aug 2025 15:06:35 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2163,10 +2163,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1160e60b-afec-4d97-8d4c-c15529a8d204
+                - ba4646c8-080b-49d2-bf50-a468b157e725
         status: 200 OK
         code: 200
-        duration: 53.333334ms
+        duration: 97.380211ms
     - id: 44
       request:
         proto: HTTP/1.1
@@ -2182,8 +2182,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9c64cf6f-986b-43f5-add0-1c27794ab564
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/378df471-6405-4f31-8455-697bb9300641
         method: GET
       response:
         proto: HTTP/2.0
@@ -2191,20 +2191,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 562
+        content_length: 962
         uncompressed: false
-        body: '{"created_at":"2025-01-15T14:25:06.718106Z","description":"","environment_variables":{},"error_message":null,"id":"9c64cf6f-986b-43f5-add0-1c27794ab564","name":"tf-ns-hungry-raman","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f","registry_namespace_id":"b4999fd9-3117-4019-9dae-a7d4efebde8e","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-15T14:25:10.179302Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:58.361820Z","description":"","domain_name":"tfnsupbeatalbattani1cgtihmg-tf-co-objective-rhodes.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"378df471-6405-4f31-8455-697bb9300641","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":1,"name":"tf-co-objective-rhodes","namespace_id":"e2d2ff72-d1c8-4df2-bb44-b0187305141a","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsupbeatalbattani1cgtihmg/tf-co-objective-rhodes:latest","sandbox":"v2","scaling_option":{"memory_usage_threshold":66},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:24.939740Z"}'
         headers:
             Content-Length:
-                - "562"
+                - "962"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:25:46 GMT
+                - Wed, 27 Aug 2025 15:06:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2212,10 +2212,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bb08d95e-b42e-452a-b746-9358f8e526e8
+                - 0f4d9a35-d3a3-4eba-9991-9ec2d9186158
         status: 200 OK
         code: 200
-        duration: 40.447959ms
+        duration: 107.107607ms
     - id: 45
       request:
         proto: HTTP/1.1
@@ -2231,8 +2231,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f65c58fe-37f2-4510-aff4-007a09dde1d4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/378df471-6405-4f31-8455-697bb9300641
         method: GET
       response:
         proto: HTTP/2.0
@@ -2240,20 +2240,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 950
+        content_length: 962
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:25:12.144069Z","description":"","domain_name":"tfnshungryramanms1v4s2f-tf-co-jolly-fermat.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f65c58fe-37f2-4510-aff4-007a09dde1d4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":1,"name":"tf-co-jolly-fermat","namespace_id":"9c64cf6f-986b-43f5-add0-1c27794ab564","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f/tf-co-jolly-fermat:latest","sandbox":"v2","scaling_option":{"memory_usage_threshold":66},"secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-15T14:25:42.109483Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:58.361820Z","description":"","domain_name":"tfnsupbeatalbattani1cgtihmg-tf-co-objective-rhodes.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"378df471-6405-4f31-8455-697bb9300641","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":1,"name":"tf-co-objective-rhodes","namespace_id":"e2d2ff72-d1c8-4df2-bb44-b0187305141a","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsupbeatalbattani1cgtihmg/tf-co-objective-rhodes:latest","sandbox":"v2","scaling_option":{"memory_usage_threshold":66},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:24.939740Z"}'
         headers:
             Content-Length:
-                - "950"
+                - "962"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:25:46 GMT
+                - Wed, 27 Aug 2025 15:06:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2261,10 +2261,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3c66c6b5-7a7c-4131-bfe4-9ed0ac8fb22f
+                - c0131c50-7137-4f3e-8f6d-a7693ab670a8
         status: 200 OK
         code: 200
-        duration: 60.754292ms
+        duration: 86.145333ms
     - id: 46
       request:
         proto: HTTP/1.1
@@ -2280,8 +2280,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f65c58fe-37f2-4510-aff4-007a09dde1d4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/378df471-6405-4f31-8455-697bb9300641
         method: GET
       response:
         proto: HTTP/2.0
@@ -2289,20 +2289,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 950
+        content_length: 1000
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:25:12.144069Z","description":"","domain_name":"tfnshungryramanms1v4s2f-tf-co-jolly-fermat.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f65c58fe-37f2-4510-aff4-007a09dde1d4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":1,"name":"tf-co-jolly-fermat","namespace_id":"9c64cf6f-986b-43f5-add0-1c27794ab564","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f/tf-co-jolly-fermat:latest","sandbox":"v2","scaling_option":{"memory_usage_threshold":66},"secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-15T14:25:42.109483Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:58.361820Z","description":"","domain_name":"tfnsupbeatalbattani1cgtihmg-tf-co-objective-rhodes.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"378df471-6405-4f31-8455-697bb9300641","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":1,"name":"tf-co-objective-rhodes","namespace_id":"e2d2ff72-d1c8-4df2-bb44-b0187305141a","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsupbeatalbattani1cgtihmg/tf-co-objective-rhodes:latest","sandbox":"v2","scaling_option":{"memory_usage_threshold":66},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:48.297350Z"}'
         headers:
             Content-Length:
-                - "950"
+                - "1000"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:25:46 GMT
+                - Wed, 27 Aug 2025 15:06:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2310,10 +2310,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3b07544c-3469-443d-82d9-27463160f453
+                - 88acef35-6b7f-42f5-a9c7-f6a810f4570a
         status: 200 OK
         code: 200
-        duration: 48.908375ms
+        duration: 107.061603ms
     - id: 47
       request:
         proto: HTTP/1.1
@@ -2329,29 +2329,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f65c58fe-37f2-4510-aff4-007a09dde1d4
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/378df471-6405-4f31-8455-697bb9300641
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 916
+        content_length: 1000
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:25:12.144069Z","description":"","domain_name":"tfnshungryramanms1v4s2f-tf-co-jolly-fermat.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f65c58fe-37f2-4510-aff4-007a09dde1d4","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":1,"name":"tf-co-jolly-fermat","namespace_id":"9c64cf6f-986b-43f5-add0-1c27794ab564","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f/tf-co-jolly-fermat:latest","sandbox":"v2","scaling_option":{"memory_usage_threshold":66},"secret_environment_variables":[],"status":"deleting","timeout":"300s","updated_at":"2025-01-15T14:25:46.416251395Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:58.361820Z","description":"","domain_name":"tfnsupbeatalbattani1cgtihmg-tf-co-objective-rhodes.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"378df471-6405-4f31-8455-697bb9300641","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":1,"name":"tf-co-objective-rhodes","namespace_id":"e2d2ff72-d1c8-4df2-bb44-b0187305141a","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsupbeatalbattani1cgtihmg/tf-co-objective-rhodes:latest","sandbox":"v2","scaling_option":{"memory_usage_threshold":66},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:48.297350Z"}'
         headers:
             Content-Length:
-                - "916"
+                - "1000"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:25:46 GMT
+                - Wed, 27 Aug 2025 15:06:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2359,10 +2359,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e2730b9c-039d-4f38-afa0-57006b6c5cf2
+                - 9c14fbe2-48cf-45d3-9f39-2c61e284946d
         status: 200 OK
         code: 200
-        duration: 130.466083ms
+        duration: 97.538763ms
     - id: 48
       request:
         proto: HTTP/1.1
@@ -2378,8 +2378,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9c64cf6f-986b-43f5-add0-1c27794ab564
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/378df471-6405-4f31-8455-697bb9300641
         method: GET
       response:
         proto: HTTP/2.0
@@ -2387,20 +2387,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 562
+        content_length: 1000
         uncompressed: false
-        body: '{"created_at":"2025-01-15T14:25:06.718106Z","description":"","environment_variables":{},"error_message":null,"id":"9c64cf6f-986b-43f5-add0-1c27794ab564","name":"tf-ns-hungry-raman","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f","registry_namespace_id":"b4999fd9-3117-4019-9dae-a7d4efebde8e","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-15T14:25:10.179302Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:58.361820Z","description":"","domain_name":"tfnsupbeatalbattani1cgtihmg-tf-co-objective-rhodes.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"378df471-6405-4f31-8455-697bb9300641","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":1,"name":"tf-co-objective-rhodes","namespace_id":"e2d2ff72-d1c8-4df2-bb44-b0187305141a","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsupbeatalbattani1cgtihmg/tf-co-objective-rhodes:latest","sandbox":"v2","scaling_option":{"memory_usage_threshold":66},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:48.297350Z"}'
         headers:
             Content-Length:
-                - "562"
+                - "1000"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:25:46 GMT
+                - Wed, 27 Aug 2025 15:06:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2408,10 +2408,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0da9fcad-ed15-4a3e-9fa4-5dd03e4319b2
+                - 50705349-a662-412a-b82c-213d34a3b9f4
         status: 200 OK
         code: 200
-        duration: 43.409458ms
+        duration: 87.281224ms
     - id: 49
       request:
         proto: HTTP/1.1
@@ -2427,29 +2427,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9c64cf6f-986b-43f5-add0-1c27794ab564
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/e2d2ff72-d1c8-4df2-bb44-b0187305141a
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 568
+        content_length: 589
         uncompressed: false
-        body: '{"created_at":"2025-01-15T14:25:06.718106Z","description":"","environment_variables":{},"error_message":null,"id":"9c64cf6f-986b-43f5-add0-1c27794ab564","name":"tf-ns-hungry-raman","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f","registry_namespace_id":"b4999fd9-3117-4019-9dae-a7d4efebde8e","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-15T14:25:46.585675920Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.897115Z","description":"","environment_variables":{},"error_message":null,"id":"e2d2ff72-d1c8-4df2-bb44-b0187305141a","name":"tf-ns-upbeat-albattani","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsupbeatalbattani1cgtihmg","registry_namespace_id":"463097b3-f54d-4ab3-affd-f86069a616c9","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:52.053040Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "568"
+                - "589"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:25:46 GMT
+                - Wed, 27 Aug 2025 15:06:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2457,10 +2457,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fa506295-1c6e-4380-927c-f1b3511afb23
+                - 0a5363c8-a83b-457d-86d4-b61e1fdabbb2
         status: 200 OK
         code: 200
-        duration: 199.553375ms
+        duration: 103.866047ms
     - id: 50
       request:
         proto: HTTP/1.1
@@ -2476,8 +2476,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9c64cf6f-986b-43f5-add0-1c27794ab564
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/378df471-6405-4f31-8455-697bb9300641
         method: GET
       response:
         proto: HTTP/2.0
@@ -2485,20 +2485,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 565
+        content_length: 1000
         uncompressed: false
-        body: '{"created_at":"2025-01-15T14:25:06.718106Z","description":"","environment_variables":{},"error_message":null,"id":"9c64cf6f-986b-43f5-add0-1c27794ab564","name":"tf-ns-hungry-raman","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f","registry_namespace_id":"b4999fd9-3117-4019-9dae-a7d4efebde8e","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-15T14:25:46.585676Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:58.361820Z","description":"","domain_name":"tfnsupbeatalbattani1cgtihmg-tf-co-objective-rhodes.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"378df471-6405-4f31-8455-697bb9300641","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":1,"name":"tf-co-objective-rhodes","namespace_id":"e2d2ff72-d1c8-4df2-bb44-b0187305141a","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsupbeatalbattani1cgtihmg/tf-co-objective-rhodes:latest","sandbox":"v2","scaling_option":{"memory_usage_threshold":66},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:48.297350Z"}'
         headers:
             Content-Length:
-                - "565"
+                - "1000"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:25:46 GMT
+                - Wed, 27 Aug 2025 15:06:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2506,10 +2506,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4f2dd73d-330f-4d99-b75f-b11130c38167
+                - 30ee37dc-0245-496c-9c26-3138a8120c91
         status: 200 OK
         code: 200
-        duration: 43.101584ms
+        duration: 94.946879ms
     - id: 51
       request:
         proto: HTTP/1.1
@@ -2525,8 +2525,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9c64cf6f-986b-43f5-add0-1c27794ab564
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/378df471-6405-4f31-8455-697bb9300641
         method: GET
       response:
         proto: HTTP/2.0
@@ -2534,20 +2534,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 565
+        content_length: 1000
         uncompressed: false
-        body: '{"created_at":"2025-01-15T14:25:06.718106Z","description":"","environment_variables":{},"error_message":null,"id":"9c64cf6f-986b-43f5-add0-1c27794ab564","name":"tf-ns-hungry-raman","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f","registry_namespace_id":"b4999fd9-3117-4019-9dae-a7d4efebde8e","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-15T14:25:46.585676Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:58.361820Z","description":"","domain_name":"tfnsupbeatalbattani1cgtihmg-tf-co-objective-rhodes.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"378df471-6405-4f31-8455-697bb9300641","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":1,"name":"tf-co-objective-rhodes","namespace_id":"e2d2ff72-d1c8-4df2-bb44-b0187305141a","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsupbeatalbattani1cgtihmg/tf-co-objective-rhodes:latest","sandbox":"v2","scaling_option":{"memory_usage_threshold":66},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:48.297350Z"}'
         headers:
             Content-Length:
-                - "565"
+                - "1000"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:25:51 GMT
+                - Wed, 27 Aug 2025 15:06:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2555,10 +2555,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5ab53f49-70d8-4929-9616-4281a338f852
+                - 84e1e800-d4b9-443f-84a1-08f3337fcc5b
         status: 200 OK
         code: 200
-        duration: 41.22025ms
+        duration: 71.908535ms
     - id: 52
       request:
         proto: HTTP/1.1
@@ -2574,29 +2574,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9c64cf6f-986b-43f5-add0-1c27794ab564
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/378df471-6405-4f31-8455-697bb9300641
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 565
+        content_length: 966
         uncompressed: false
-        body: '{"created_at":"2025-01-15T14:25:06.718106Z","description":"","environment_variables":{},"error_message":null,"id":"9c64cf6f-986b-43f5-add0-1c27794ab564","name":"tf-ns-hungry-raman","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f","registry_namespace_id":"b4999fd9-3117-4019-9dae-a7d4efebde8e","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-15T14:25:46.585676Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:58.361820Z","description":"","domain_name":"tfnsupbeatalbattani1cgtihmg-tf-co-objective-rhodes.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"378df471-6405-4f31-8455-697bb9300641","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":1,"name":"tf-co-objective-rhodes","namespace_id":"e2d2ff72-d1c8-4df2-bb44-b0187305141a","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsupbeatalbattani1cgtihmg/tf-co-objective-rhodes:latest","sandbox":"v2","scaling_option":{"memory_usage_threshold":66},"secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:51.805208517Z"}'
         headers:
             Content-Length:
-                - "565"
+                - "966"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:25:56 GMT
+                - Wed, 27 Aug 2025 15:06:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2604,10 +2604,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 03417a20-7d26-4633-a30e-1a7b814aa717
+                - 4086d482-49e0-4f75-82b3-a8e2168756ef
         status: 200 OK
         code: 200
-        duration: 41.028792ms
+        duration: 203.582577ms
     - id: 53
       request:
         proto: HTTP/1.1
@@ -2623,8 +2623,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9c64cf6f-986b-43f5-add0-1c27794ab564
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/e2d2ff72-d1c8-4df2-bb44-b0187305141a
         method: GET
       response:
         proto: HTTP/2.0
@@ -2632,20 +2632,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 565
+        content_length: 589
         uncompressed: false
-        body: '{"created_at":"2025-01-15T14:25:06.718106Z","description":"","environment_variables":{},"error_message":null,"id":"9c64cf6f-986b-43f5-add0-1c27794ab564","name":"tf-ns-hungry-raman","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f","registry_namespace_id":"b4999fd9-3117-4019-9dae-a7d4efebde8e","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-15T14:25:46.585676Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.897115Z","description":"","environment_variables":{},"error_message":null,"id":"e2d2ff72-d1c8-4df2-bb44-b0187305141a","name":"tf-ns-upbeat-albattani","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsupbeatalbattani1cgtihmg","registry_namespace_id":"463097b3-f54d-4ab3-affd-f86069a616c9","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:52.053040Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "565"
+                - "589"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:26:01 GMT
+                - Wed, 27 Aug 2025 15:06:52 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2653,10 +2653,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 76357d56-09ad-457a-9366-393a6509ad1f
+                - 5b065873-5038-41e4-b6a9-a88e8efcbbdf
         status: 200 OK
         code: 200
-        duration: 49.138708ms
+        duration: 94.383062ms
     - id: 54
       request:
         proto: HTTP/1.1
@@ -2672,29 +2672,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9c64cf6f-986b-43f5-add0-1c27794ab564
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/e2d2ff72-d1c8-4df2-bb44-b0187305141a
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 565
+        content_length: 595
         uncompressed: false
-        body: '{"created_at":"2025-01-15T14:25:06.718106Z","description":"","environment_variables":{},"error_message":null,"id":"9c64cf6f-986b-43f5-add0-1c27794ab564","name":"tf-ns-hungry-raman","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f","registry_namespace_id":"b4999fd9-3117-4019-9dae-a7d4efebde8e","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-15T14:25:46.585676Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.897115Z","description":"","environment_variables":{},"error_message":null,"id":"e2d2ff72-d1c8-4df2-bb44-b0187305141a","name":"tf-ns-upbeat-albattani","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsupbeatalbattani1cgtihmg","registry_namespace_id":"463097b3-f54d-4ab3-affd-f86069a616c9","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:52.128956767Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "565"
+                - "595"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:26:06 GMT
+                - Wed, 27 Aug 2025 15:06:52 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2702,10 +2702,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 013ea993-8d0e-4035-b0ba-d5051de108ea
+                - dc24d236-32f2-4519-bf38-f12797dc29ed
         status: 200 OK
         code: 200
-        duration: 54.541167ms
+        duration: 200.564945ms
     - id: 55
       request:
         proto: HTTP/1.1
@@ -2721,8 +2721,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9c64cf6f-986b-43f5-add0-1c27794ab564
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/e2d2ff72-d1c8-4df2-bb44-b0187305141a
         method: GET
       response:
         proto: HTTP/2.0
@@ -2730,20 +2730,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 565
+        content_length: 592
         uncompressed: false
-        body: '{"created_at":"2025-01-15T14:25:06.718106Z","description":"","environment_variables":{},"error_message":null,"id":"9c64cf6f-986b-43f5-add0-1c27794ab564","name":"tf-ns-hungry-raman","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshungryramanms1v4s2f","registry_namespace_id":"b4999fd9-3117-4019-9dae-a7d4efebde8e","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-15T14:25:46.585676Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.897115Z","description":"","environment_variables":{},"error_message":null,"id":"e2d2ff72-d1c8-4df2-bb44-b0187305141a","name":"tf-ns-upbeat-albattani","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsupbeatalbattani1cgtihmg","registry_namespace_id":"463097b3-f54d-4ab3-affd-f86069a616c9","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:52.128957Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "565"
+                - "592"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:26:12 GMT
+                - Wed, 27 Aug 2025 15:06:52 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2751,10 +2751,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0bb48bf1-2637-4944-b96f-41ed581b02c5
+                - f1a719eb-4ca9-4038-ab5b-7f6dadf227ce
         status: 200 OK
         code: 200
-        duration: 43.820917ms
+        duration: 89.993233ms
     - id: 56
       request:
         proto: HTTP/1.1
@@ -2770,8 +2770,253 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9c64cf6f-986b-43f5-add0-1c27794ab564
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/e2d2ff72-d1c8-4df2-bb44-b0187305141a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 592
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:40.897115Z","description":"","environment_variables":{},"error_message":null,"id":"e2d2ff72-d1c8-4df2-bb44-b0187305141a","name":"tf-ns-upbeat-albattani","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsupbeatalbattani1cgtihmg","registry_namespace_id":"463097b3-f54d-4ab3-affd-f86069a616c9","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:52.128957Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "592"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:57 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 820f0bdd-7bf1-49d4-aebc-d26e4f81dddd
+        status: 200 OK
+        code: 200
+        duration: 82.980003ms
+    - id: 57
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/e2d2ff72-d1c8-4df2-bb44-b0187305141a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 592
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:40.897115Z","description":"","environment_variables":{},"error_message":null,"id":"e2d2ff72-d1c8-4df2-bb44-b0187305141a","name":"tf-ns-upbeat-albattani","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsupbeatalbattani1cgtihmg","registry_namespace_id":"463097b3-f54d-4ab3-affd-f86069a616c9","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:52.128957Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "592"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:07:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 12bf0a1f-ed13-4ad3-ace2-aba34adf3dff
+        status: 200 OK
+        code: 200
+        duration: 107.701879ms
+    - id: 58
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/e2d2ff72-d1c8-4df2-bb44-b0187305141a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 592
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:40.897115Z","description":"","environment_variables":{},"error_message":null,"id":"e2d2ff72-d1c8-4df2-bb44-b0187305141a","name":"tf-ns-upbeat-albattani","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsupbeatalbattani1cgtihmg","registry_namespace_id":"463097b3-f54d-4ab3-affd-f86069a616c9","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:52.128957Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "592"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:07:07 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b30a181a-5ae6-4ac7-8304-5ba0bf5b6cc9
+        status: 200 OK
+        code: 200
+        duration: 94.095146ms
+    - id: 59
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/e2d2ff72-d1c8-4df2-bb44-b0187305141a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 592
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:40.897115Z","description":"","environment_variables":{},"error_message":null,"id":"e2d2ff72-d1c8-4df2-bb44-b0187305141a","name":"tf-ns-upbeat-albattani","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsupbeatalbattani1cgtihmg","registry_namespace_id":"463097b3-f54d-4ab3-affd-f86069a616c9","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:52.128957Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "592"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:07:12 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 67af519f-43e8-4d2a-8146-ba566fbf889b
+        status: 200 OK
+        code: 200
+        duration: 90.055575ms
+    - id: 60
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/e2d2ff72-d1c8-4df2-bb44-b0187305141a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 592
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:40.897115Z","description":"","environment_variables":{},"error_message":null,"id":"e2d2ff72-d1c8-4df2-bb44-b0187305141a","name":"tf-ns-upbeat-albattani","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsupbeatalbattani1cgtihmg","registry_namespace_id":"463097b3-f54d-4ab3-affd-f86069a616c9","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:52.128957Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "592"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:07:17 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 486182ec-7a2b-461b-8bf4-e43d24f8f737
+        status: 200 OK
+        code: 200
+        duration: 83.027598ms
+    - id: 61
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/e2d2ff72-d1c8-4df2-bb44-b0187305141a
         method: GET
       response:
         proto: HTTP/2.0
@@ -2790,9 +3035,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:26:17 GMT
+                - Wed, 27 Aug 2025 15:07:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2800,11 +3045,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1bddd23c-61d9-4020-8f43-966a96d0d201
+                - f7cff0a1-603e-4777-9ab4-5a2d821e12b6
         status: 404 Not Found
         code: 404
-        duration: 35.173708ms
-    - id: 57
+        duration: 22.377155ms
+    - id: 62
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2819,8 +3064,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/9c64cf6f-986b-43f5-add0-1c27794ab564
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/e2d2ff72-d1c8-4df2-bb44-b0187305141a
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -2839,9 +3084,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:26:17 GMT
+                - Wed, 27 Aug 2025 15:07:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2849,7 +3094,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - aa864c87-8d67-4812-8031-00a125b27abc
+                - 0b4aa2cf-9c5f-4226-8eea-a7486ee94e0d
         status: 404 Not Found
         code: 404
-        duration: 31.993458ms
+        duration: 23.43965ms

--- a/internal/services/container/testdata/container-with-img.cassette.yaml
+++ b/internal/services/container/testdata/container-with-img.cassette.yaml
@@ -6,19 +6,19 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 213
+        content_length: 212
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"test-cr-ns-02","environment_variables":{},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","description":"test container","secret_environment_variables":[],"tags":null,"activate_vpc_integration":false}'
+        body: '{"name":"test-cr-ns-02","environment_variables":{},"project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","description":"test container","secret_environment_variables":[],"tags":null,"activate_vpc_integration":true}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces
         method: POST
       response:
@@ -27,20 +27,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 528
+        content_length: 512
         uncompressed: false
-        body: '{"created_at":"2025-06-11T12:02:17.091430796Z","description":"test container","environment_variables":{},"error_message":null,"id":"c5fba791-1a29-4ed1-843e-bb6dbf9c9780","name":"test-cr-ns-02","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-06-11T12:02:17.091430796Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2025-08-27T15:05:41.257824453Z","description":"test container","environment_variables":{},"error_message":null,"id":"339f34c3-4c1c-4744-8539-c0f01ed0e6c3","name":"test-cr-ns-02","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:41.257824453Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "528"
+                - "512"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:02:17 GMT
+                - Wed, 27 Aug 2025 15:05:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3c526d33-cea5-4655-8a07-707c486cda68
+                - f6da4dab-fc84-46fc-bbb4-0ca2a8458642
         status: 200 OK
         code: 200
-        duration: 1.130561083s
+        duration: 5.230426386s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -67,8 +67,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c5fba791-1a29-4ed1-843e-bb6dbf9c9780
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/339f34c3-4c1c-4744-8539-c0f01ed0e6c3
         method: GET
       response:
         proto: HTTP/2.0
@@ -76,20 +76,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 522
+        content_length: 506
         uncompressed: false
-        body: '{"created_at":"2025-06-11T12:02:17.091431Z","description":"test container","environment_variables":{},"error_message":null,"id":"c5fba791-1a29-4ed1-843e-bb6dbf9c9780","name":"test-cr-ns-02","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-06-11T12:02:17.091431Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2025-08-27T15:05:41.257824Z","description":"test container","environment_variables":{},"error_message":null,"id":"339f34c3-4c1c-4744-8539-c0f01ed0e6c3","name":"test-cr-ns-02","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:41.257824Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "522"
+                - "506"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:02:17 GMT
+                - Wed, 27 Aug 2025 15:05:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f7281651-4292-483f-af69-53205c8057c1
+                - b99df3f0-e942-4b38-b62d-0fcb13f4aef8
         status: 200 OK
         code: 200
-        duration: 96.774959ms
+        duration: 78.382678ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -116,8 +116,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c5fba791-1a29-4ed1-843e-bb6dbf9c9780
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/339f34c3-4c1c-4744-8539-c0f01ed0e6c3
         method: GET
       response:
         proto: HTTP/2.0
@@ -125,20 +125,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 601
+        content_length: 506
         uncompressed: false
-        body: '{"created_at":"2025-06-11T12:02:17.091431Z","description":"test container","environment_variables":{},"error_message":null,"id":"c5fba791-1a29-4ed1-843e-bb6dbf9c9780","name":"test-cr-ns-02","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns02oioiumez","registry_namespace_id":"c54bcbcb-5f8a-4189-b27d-1863e146fc08","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-11T12:02:18.748632Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2025-08-27T15:05:41.257824Z","description":"test container","environment_variables":{},"error_message":null,"id":"339f34c3-4c1c-4744-8539-c0f01ed0e6c3","name":"test-cr-ns-02","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:41.257824Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "601"
+                - "506"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:02:22 GMT
+                - Wed, 27 Aug 2025 15:05:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -146,10 +146,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e5f5ea04-b959-4d0b-a3ee-6b28d877cbe8
+                - 8991ed59-802b-4016-94cb-b54ca326f8a7
         status: 200 OK
         code: 200
-        duration: 83.0445ms
+        duration: 115.497592ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -165,8 +165,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c5fba791-1a29-4ed1-843e-bb6dbf9c9780
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/339f34c3-4c1c-4744-8539-c0f01ed0e6c3
         method: GET
       response:
         proto: HTTP/2.0
@@ -174,20 +174,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 601
+        content_length: 587
         uncompressed: false
-        body: '{"created_at":"2025-06-11T12:02:17.091431Z","description":"test container","environment_variables":{},"error_message":null,"id":"c5fba791-1a29-4ed1-843e-bb6dbf9c9780","name":"test-cr-ns-02","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns02oioiumez","registry_namespace_id":"c54bcbcb-5f8a-4189-b27d-1863e146fc08","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-11T12:02:18.748632Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2025-08-27T15:05:41.257824Z","description":"test container","environment_variables":{},"error_message":null,"id":"339f34c3-4c1c-4744-8539-c0f01ed0e6c3","name":"test-cr-ns-02","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns02pmr43ixn","registry_namespace_id":"36089a50-e4fe-44a7-bf2b-58d86fab10cf","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:47.968743Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "601"
+                - "587"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:02:22 GMT
+                - Wed, 27 Aug 2025 15:05:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -195,10 +195,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5fbc867d-0925-46e5-bfbf-b881fd392007
+                - 1116b01a-5562-48dc-84af-f3470a1b8932
         status: 200 OK
         code: 200
-        duration: 88.645333ms
+        duration: 77.238804ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -214,8 +214,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c5fba791-1a29-4ed1-843e-bb6dbf9c9780
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/339f34c3-4c1c-4744-8539-c0f01ed0e6c3
         method: GET
       response:
         proto: HTTP/2.0
@@ -223,20 +223,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 601
+        content_length: 585
         uncompressed: false
-        body: '{"created_at":"2025-06-11T12:02:17.091431Z","description":"test container","environment_variables":{},"error_message":null,"id":"c5fba791-1a29-4ed1-843e-bb6dbf9c9780","name":"test-cr-ns-02","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns02oioiumez","registry_namespace_id":"c54bcbcb-5f8a-4189-b27d-1863e146fc08","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-11T12:02:18.748632Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2025-08-27T15:05:41.257824Z","description":"test container","environment_variables":{},"error_message":null,"id":"339f34c3-4c1c-4744-8539-c0f01ed0e6c3","name":"test-cr-ns-02","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns02pmr43ixn","registry_namespace_id":"36089a50-e4fe-44a7-bf2b-58d86fab10cf","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:53.056168Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "601"
+                - "585"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:02:22 GMT
+                - Wed, 27 Aug 2025 15:05:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -244,50 +244,48 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 82c651cc-465b-41e7-b76c-fa78af4e89be
+                - ed3a3fcd-8876-4521-88ca-bfe2d25feb5d
         status: 200 OK
         code: 200
-        duration: 83.744875ms
+        duration: 84.04687ms
     - id: 5
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 478
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"namespace_id":"c5fba791-1a29-4ed1-843e-bb6dbf9c9780","name":"my-container-02","environment_variables":{"foo":"var"},"min_scale":3,"max_scale":5,"memory_limit":256,"cpu_limit":140,"timeout":"600.000000000s","privacy":"private","description":"environment variables test","registry_image":"nginx:latest","max_concurrency":80,"protocol":"h2c","port":80,"secret_environment_variables":null,"http_option":"enabled","sandbox":"unknown_sandbox","tags":null,"command":null,"args":null}'
+        body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers
-        method: POST
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/339f34c3-4c1c-4744-8539-c0f01ed0e6c3
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 945
+        content_length: 585
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":140,"created_at":"2025-06-11T12:02:23.107772645Z","description":"environment variables test","domain_name":"testcrns02oioiumez-my-container-02.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"var"},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"b6d3c0f2-5373-4df3-8de7-f374924bb25e","local_storage_limit":1000,"max_concurrency":80,"max_scale":5,"memory_limit":256,"min_scale":3,"name":"my-container-02","namespace_id":"c5fba791-1a29-4ed1-843e-bb6dbf9c9780","port":80,"privacy":"private","private_network_id":null,"protocol":"h2c","ready_at":null,"region":"fr-par","registry_image":"nginx:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":80},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"600s","updated_at":"2025-06-11T12:02:23.107772645Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.257824Z","description":"test container","environment_variables":{},"error_message":null,"id":"339f34c3-4c1c-4744-8539-c0f01ed0e6c3","name":"test-cr-ns-02","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns02pmr43ixn","registry_namespace_id":"36089a50-e4fe-44a7-bf2b-58d86fab10cf","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:53.056168Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "945"
+                - "585"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:02:23 GMT
+                - Wed, 27 Aug 2025 15:05:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -295,10 +293,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 826dea9b-a870-43ed-a1fc-ee5848345bab
+                - 5d8e37ac-ab4d-4ca6-a0a2-c52b42216d65
         status: 200 OK
         code: 200
-        duration: 665.815167ms
+        duration: 142.773258ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -314,8 +312,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/b6d3c0f2-5373-4df3-8de7-f374924bb25e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/339f34c3-4c1c-4744-8539-c0f01ed0e6c3
         method: GET
       response:
         proto: HTTP/2.0
@@ -323,20 +321,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 939
+        content_length: 585
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":140,"created_at":"2025-06-11T12:02:23.107773Z","description":"environment variables test","domain_name":"testcrns02oioiumez-my-container-02.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"var"},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"b6d3c0f2-5373-4df3-8de7-f374924bb25e","local_storage_limit":1000,"max_concurrency":80,"max_scale":5,"memory_limit":256,"min_scale":3,"name":"my-container-02","namespace_id":"c5fba791-1a29-4ed1-843e-bb6dbf9c9780","port":80,"privacy":"private","private_network_id":null,"protocol":"h2c","ready_at":null,"region":"fr-par","registry_image":"nginx:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":80},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"600s","updated_at":"2025-06-11T12:02:23.107773Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.257824Z","description":"test container","environment_variables":{},"error_message":null,"id":"339f34c3-4c1c-4744-8539-c0f01ed0e6c3","name":"test-cr-ns-02","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns02pmr43ixn","registry_namespace_id":"36089a50-e4fe-44a7-bf2b-58d86fab10cf","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:53.056168Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "939"
+                - "585"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:02:23 GMT
+                - Wed, 27 Aug 2025 15:05:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -344,11 +342,111 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 490e3fe0-c67d-4add-b1b5-86e37b72c853
+                - 9370691f-2607-4eb2-8c68-8a24160367d0
         status: 200 OK
         code: 200
-        duration: 105.109833ms
+        duration: 96.399399ms
     - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 478
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"namespace_id":"339f34c3-4c1c-4744-8539-c0f01ed0e6c3","name":"my-container-02","environment_variables":{"foo":"var"},"min_scale":3,"max_scale":5,"memory_limit":256,"cpu_limit":140,"timeout":"600.000000000s","privacy":"private","description":"environment variables test","registry_image":"nginx:latest","max_concurrency":80,"protocol":"h2c","port":80,"secret_environment_variables":null,"http_option":"enabled","sandbox":"unknown_sandbox","tags":null,"command":null,"args":null}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 912
+        uncompressed: false
+        body: '{"args":[],"command":[],"cpu_limit":140,"created_at":"2025-08-27T15:05:59.174365224Z","description":"environment variables test","domain_name":"testcrns02pmr43ixn-my-container-02.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"var"},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"5009f716-393c-4be9-850e-3d93380648fc","local_storage_limit":1000,"max_concurrency":80,"max_scale":5,"memory_limit":256,"min_scale":3,"name":"my-container-02","namespace_id":"339f34c3-4c1c-4744-8539-c0f01ed0e6c3","port":80,"privacy":"private","private_network_id":null,"protocol":"h2c","ready_at":null,"region":"fr-par","registry_image":"nginx:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":80},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"600s","updated_at":"2025-08-27T15:05:59.174365224Z"}'
+        headers:
+            Content-Length:
+                - "912"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:05:59 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 157ddbfa-1d99-4088-a224-d0f72ba7d26f
+        status: 200 OK
+        code: 200
+        duration: 2.322407821s
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/5009f716-393c-4be9-850e-3d93380648fc
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 906
+        uncompressed: false
+        body: '{"args":[],"command":[],"cpu_limit":140,"created_at":"2025-08-27T15:05:59.174365Z","description":"environment variables test","domain_name":"testcrns02pmr43ixn-my-container-02.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"var"},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"5009f716-393c-4be9-850e-3d93380648fc","local_storage_limit":1000,"max_concurrency":80,"max_scale":5,"memory_limit":256,"min_scale":3,"name":"my-container-02","namespace_id":"339f34c3-4c1c-4744-8539-c0f01ed0e6c3","port":80,"privacy":"private","private_network_id":null,"protocol":"h2c","ready_at":null,"region":"fr-par","registry_image":"nginx:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":80},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"600s","updated_at":"2025-08-27T15:05:59.174365Z"}'
+        headers:
+            Content-Length:
+                - "906"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:05:59 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 4b3b99df-64e8-43f3-80f5-47f938c37b45
+        status: 200 OK
+        code: 200
+        duration: 78.541059ms
+    - id: 9
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -365,8 +463,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/b6d3c0f2-5373-4df3-8de7-f374924bb25e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/5009f716-393c-4be9-850e-3d93380648fc
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -374,20 +472,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 942
+        content_length: 909
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":140,"created_at":"2025-06-11T12:02:23.107773Z","description":"environment variables test","domain_name":"testcrns02oioiumez-my-container-02.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"var"},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"b6d3c0f2-5373-4df3-8de7-f374924bb25e","local_storage_limit":1000,"max_concurrency":80,"max_scale":5,"memory_limit":256,"min_scale":3,"name":"my-container-02","namespace_id":"c5fba791-1a29-4ed1-843e-bb6dbf9c9780","port":80,"privacy":"private","private_network_id":null,"protocol":"h2c","ready_at":null,"region":"fr-par","registry_image":"nginx:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":80},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"600s","updated_at":"2025-06-11T12:02:23.337522125Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":140,"created_at":"2025-08-27T15:05:59.174365Z","description":"environment variables test","domain_name":"testcrns02pmr43ixn-my-container-02.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"var"},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"5009f716-393c-4be9-850e-3d93380648fc","local_storage_limit":1000,"max_concurrency":80,"max_scale":5,"memory_limit":256,"min_scale":3,"name":"my-container-02","namespace_id":"339f34c3-4c1c-4744-8539-c0f01ed0e6c3","port":80,"privacy":"private","private_network_id":null,"protocol":"h2c","ready_at":null,"region":"fr-par","registry_image":"nginx:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":80},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"600s","updated_at":"2025-08-27T15:05:59.368572193Z"}'
         headers:
             Content-Length:
-                - "942"
+                - "909"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:02:23 GMT
+                - Wed, 27 Aug 2025 15:05:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -395,108 +493,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 006168ae-9b3d-44a1-ad71-80e354bf018e
+                - 190f5434-491f-4966-8a97-b09f371207f8
         status: 200 OK
         code: 200
-        duration: 106.815083ms
-    - id: 8
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/b6d3c0f2-5373-4df3-8de7-f374924bb25e
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 939
-        uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":140,"created_at":"2025-06-11T12:02:23.107773Z","description":"environment variables test","domain_name":"testcrns02oioiumez-my-container-02.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"var"},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"b6d3c0f2-5373-4df3-8de7-f374924bb25e","local_storage_limit":1000,"max_concurrency":80,"max_scale":5,"memory_limit":256,"min_scale":3,"name":"my-container-02","namespace_id":"c5fba791-1a29-4ed1-843e-bb6dbf9c9780","port":80,"privacy":"private","private_network_id":null,"protocol":"h2c","ready_at":null,"region":"fr-par","registry_image":"nginx:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":80},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"600s","updated_at":"2025-06-11T12:02:23.337522Z"}'
-        headers:
-            Content-Length:
-                - "939"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 11 Jun 2025 12:02:23 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 49a051ab-41d9-411c-8622-ededac0186c9
-        status: 200 OK
-        code: 200
-        duration: 94.508416ms
-    - id: 9
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/b6d3c0f2-5373-4df3-8de7-f374924bb25e
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 939
-        uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":140,"created_at":"2025-06-11T12:02:23.107773Z","description":"environment variables test","domain_name":"testcrns02oioiumez-my-container-02.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"var"},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"b6d3c0f2-5373-4df3-8de7-f374924bb25e","local_storage_limit":1000,"max_concurrency":80,"max_scale":5,"memory_limit":256,"min_scale":3,"name":"my-container-02","namespace_id":"c5fba791-1a29-4ed1-843e-bb6dbf9c9780","port":80,"privacy":"private","private_network_id":null,"protocol":"h2c","ready_at":null,"region":"fr-par","registry_image":"nginx:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":80},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"600s","updated_at":"2025-06-11T12:02:23.337522Z"}'
-        headers:
-            Content-Length:
-                - "939"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 11 Jun 2025 12:02:28 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 31863d6d-541f-4f95-843c-f16275e78e84
-        status: 200 OK
-        code: 200
-        duration: 84.533416ms
+        duration: 169.477078ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -512,8 +512,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/b6d3c0f2-5373-4df3-8de7-f374924bb25e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/5009f716-393c-4be9-850e-3d93380648fc
         method: GET
       response:
         proto: HTTP/2.0
@@ -521,20 +521,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 939
+        content_length: 906
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":140,"created_at":"2025-06-11T12:02:23.107773Z","description":"environment variables test","domain_name":"testcrns02oioiumez-my-container-02.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"var"},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"b6d3c0f2-5373-4df3-8de7-f374924bb25e","local_storage_limit":1000,"max_concurrency":80,"max_scale":5,"memory_limit":256,"min_scale":3,"name":"my-container-02","namespace_id":"c5fba791-1a29-4ed1-843e-bb6dbf9c9780","port":80,"privacy":"private","private_network_id":null,"protocol":"h2c","ready_at":null,"region":"fr-par","registry_image":"nginx:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":80},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"600s","updated_at":"2025-06-11T12:02:23.337522Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":140,"created_at":"2025-08-27T15:05:59.174365Z","description":"environment variables test","domain_name":"testcrns02pmr43ixn-my-container-02.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"var"},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"5009f716-393c-4be9-850e-3d93380648fc","local_storage_limit":1000,"max_concurrency":80,"max_scale":5,"memory_limit":256,"min_scale":3,"name":"my-container-02","namespace_id":"339f34c3-4c1c-4744-8539-c0f01ed0e6c3","port":80,"privacy":"private","private_network_id":null,"protocol":"h2c","ready_at":null,"region":"fr-par","registry_image":"nginx:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":80},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"600s","updated_at":"2025-08-27T15:05:59.368572Z"}'
         headers:
             Content-Length:
-                - "939"
+                - "906"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:02:33 GMT
+                - Wed, 27 Aug 2025 15:05:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -542,10 +542,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f49467ba-9c37-477a-9c5f-08655ccbda3a
+                - 72f58f14-1e87-4cd0-81a7-1dbd4c2e8f06
         status: 200 OK
         code: 200
-        duration: 88.410166ms
+        duration: 104.922303ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -561,8 +561,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/b6d3c0f2-5373-4df3-8de7-f374924bb25e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/5009f716-393c-4be9-850e-3d93380648fc
         method: GET
       response:
         proto: HTTP/2.0
@@ -570,20 +570,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 939
+        content_length: 906
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":140,"created_at":"2025-06-11T12:02:23.107773Z","description":"environment variables test","domain_name":"testcrns02oioiumez-my-container-02.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"var"},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"b6d3c0f2-5373-4df3-8de7-f374924bb25e","local_storage_limit":1000,"max_concurrency":80,"max_scale":5,"memory_limit":256,"min_scale":3,"name":"my-container-02","namespace_id":"c5fba791-1a29-4ed1-843e-bb6dbf9c9780","port":80,"privacy":"private","private_network_id":null,"protocol":"h2c","ready_at":null,"region":"fr-par","registry_image":"nginx:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":80},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"600s","updated_at":"2025-06-11T12:02:23.337522Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":140,"created_at":"2025-08-27T15:05:59.174365Z","description":"environment variables test","domain_name":"testcrns02pmr43ixn-my-container-02.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"var"},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"5009f716-393c-4be9-850e-3d93380648fc","local_storage_limit":1000,"max_concurrency":80,"max_scale":5,"memory_limit":256,"min_scale":3,"name":"my-container-02","namespace_id":"339f34c3-4c1c-4744-8539-c0f01ed0e6c3","port":80,"privacy":"private","private_network_id":null,"protocol":"h2c","ready_at":null,"region":"fr-par","registry_image":"nginx:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":80},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"600s","updated_at":"2025-08-27T15:05:59.368572Z"}'
         headers:
             Content-Length:
-                - "939"
+                - "906"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:02:38 GMT
+                - Wed, 27 Aug 2025 15:06:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -591,10 +591,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bd1c5239-f296-4aa1-bde2-d0a4c16c2f58
+                - 7329cd7a-c6bf-4ba3-8ec0-7fe103d0acc4
         status: 200 OK
         code: 200
-        duration: 100.593375ms
+        duration: 88.410962ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -610,8 +610,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/b6d3c0f2-5373-4df3-8de7-f374924bb25e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/5009f716-393c-4be9-850e-3d93380648fc
         method: GET
       response:
         proto: HTTP/2.0
@@ -619,20 +619,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 939
+        content_length: 906
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":140,"created_at":"2025-06-11T12:02:23.107773Z","description":"environment variables test","domain_name":"testcrns02oioiumez-my-container-02.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"var"},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"b6d3c0f2-5373-4df3-8de7-f374924bb25e","local_storage_limit":1000,"max_concurrency":80,"max_scale":5,"memory_limit":256,"min_scale":3,"name":"my-container-02","namespace_id":"c5fba791-1a29-4ed1-843e-bb6dbf9c9780","port":80,"privacy":"private","private_network_id":null,"protocol":"h2c","ready_at":null,"region":"fr-par","registry_image":"nginx:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":80},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"600s","updated_at":"2025-06-11T12:02:23.337522Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":140,"created_at":"2025-08-27T15:05:59.174365Z","description":"environment variables test","domain_name":"testcrns02pmr43ixn-my-container-02.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"var"},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"5009f716-393c-4be9-850e-3d93380648fc","local_storage_limit":1000,"max_concurrency":80,"max_scale":5,"memory_limit":256,"min_scale":3,"name":"my-container-02","namespace_id":"339f34c3-4c1c-4744-8539-c0f01ed0e6c3","port":80,"privacy":"private","private_network_id":null,"protocol":"h2c","ready_at":null,"region":"fr-par","registry_image":"nginx:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":80},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"600s","updated_at":"2025-08-27T15:05:59.368572Z"}'
         headers:
             Content-Length:
-                - "939"
+                - "906"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:02:43 GMT
+                - Wed, 27 Aug 2025 15:06:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -640,10 +640,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4eb85af6-5a40-4199-9bcb-db0bf5433399
+                - af1b30a7-7117-4ab9-b932-108cfc071bd8
         status: 200 OK
         code: 200
-        duration: 83.72125ms
+        duration: 98.025525ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -659,8 +659,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/b6d3c0f2-5373-4df3-8de7-f374924bb25e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/5009f716-393c-4be9-850e-3d93380648fc
         method: GET
       response:
         proto: HTTP/2.0
@@ -668,20 +668,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 939
+        content_length: 929
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":140,"created_at":"2025-06-11T12:02:23.107773Z","description":"environment variables test","domain_name":"testcrns02oioiumez-my-container-02.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"var"},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"b6d3c0f2-5373-4df3-8de7-f374924bb25e","local_storage_limit":1000,"max_concurrency":80,"max_scale":5,"memory_limit":256,"min_scale":3,"name":"my-container-02","namespace_id":"c5fba791-1a29-4ed1-843e-bb6dbf9c9780","port":80,"privacy":"private","private_network_id":null,"protocol":"h2c","ready_at":null,"region":"fr-par","registry_image":"nginx:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":80},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"600s","updated_at":"2025-06-11T12:02:23.337522Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":140,"created_at":"2025-08-27T15:05:59.174365Z","description":"environment variables test","domain_name":"testcrns02pmr43ixn-my-container-02.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"var"},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"5009f716-393c-4be9-850e-3d93380648fc","local_storage_limit":1000,"max_concurrency":80,"max_scale":5,"memory_limit":256,"min_scale":3,"name":"my-container-02","namespace_id":"339f34c3-4c1c-4744-8539-c0f01ed0e6c3","port":80,"privacy":"private","private_network_id":null,"protocol":"h2c","ready_at":"2025-08-27T15:06:11.160429Z","region":"fr-par","registry_image":"nginx:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":80},"secret_environment_variables":[],"status":"ready","tags":[],"timeout":"600s","updated_at":"2025-08-27T15:06:11.172300Z"}'
         headers:
             Content-Length:
-                - "939"
+                - "929"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:02:48 GMT
+                - Wed, 27 Aug 2025 15:06:14 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -689,10 +689,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8102fe86-3130-4e92-be47-26a21b52b94c
+                - 1f0b5d53-29fb-42b0-975f-14626dc17022
         status: 200 OK
         code: 200
-        duration: 107.394416ms
+        duration: 103.593334ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -708,8 +708,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/b6d3c0f2-5373-4df3-8de7-f374924bb25e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/5009f716-393c-4be9-850e-3d93380648fc
         method: GET
       response:
         proto: HTTP/2.0
@@ -717,20 +717,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 962
+        content_length: 929
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":140,"created_at":"2025-06-11T12:02:23.107773Z","description":"environment variables test","domain_name":"testcrns02oioiumez-my-container-02.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"var"},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"b6d3c0f2-5373-4df3-8de7-f374924bb25e","local_storage_limit":1000,"max_concurrency":80,"max_scale":5,"memory_limit":256,"min_scale":3,"name":"my-container-02","namespace_id":"c5fba791-1a29-4ed1-843e-bb6dbf9c9780","port":80,"privacy":"private","private_network_id":null,"protocol":"h2c","ready_at":"2025-06-11T12:02:50.167095Z","region":"fr-par","registry_image":"nginx:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":80},"secret_environment_variables":[],"status":"ready","tags":[],"timeout":"600s","updated_at":"2025-06-11T12:02:50.174787Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":140,"created_at":"2025-08-27T15:05:59.174365Z","description":"environment variables test","domain_name":"testcrns02pmr43ixn-my-container-02.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"var"},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"5009f716-393c-4be9-850e-3d93380648fc","local_storage_limit":1000,"max_concurrency":80,"max_scale":5,"memory_limit":256,"min_scale":3,"name":"my-container-02","namespace_id":"339f34c3-4c1c-4744-8539-c0f01ed0e6c3","port":80,"privacy":"private","private_network_id":null,"protocol":"h2c","ready_at":"2025-08-27T15:06:11.160429Z","region":"fr-par","registry_image":"nginx:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":80},"secret_environment_variables":[],"status":"ready","tags":[],"timeout":"600s","updated_at":"2025-08-27T15:06:11.172300Z"}'
         headers:
             Content-Length:
-                - "962"
+                - "929"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:02:54 GMT
+                - Wed, 27 Aug 2025 15:06:14 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -738,10 +738,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4fec76d5-31af-4def-8c70-3e98b2439f15
+                - 5001a08c-ef72-4fbf-8a2f-63cb76d24b0b
         status: 200 OK
         code: 200
-        duration: 102.488042ms
+        duration: 83.129894ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -757,8 +757,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/b6d3c0f2-5373-4df3-8de7-f374924bb25e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/5009f716-393c-4be9-850e-3d93380648fc
         method: GET
       response:
         proto: HTTP/2.0
@@ -766,20 +766,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 962
+        content_length: 929
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":140,"created_at":"2025-06-11T12:02:23.107773Z","description":"environment variables test","domain_name":"testcrns02oioiumez-my-container-02.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"var"},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"b6d3c0f2-5373-4df3-8de7-f374924bb25e","local_storage_limit":1000,"max_concurrency":80,"max_scale":5,"memory_limit":256,"min_scale":3,"name":"my-container-02","namespace_id":"c5fba791-1a29-4ed1-843e-bb6dbf9c9780","port":80,"privacy":"private","private_network_id":null,"protocol":"h2c","ready_at":"2025-06-11T12:02:50.167095Z","region":"fr-par","registry_image":"nginx:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":80},"secret_environment_variables":[],"status":"ready","tags":[],"timeout":"600s","updated_at":"2025-06-11T12:02:50.174787Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":140,"created_at":"2025-08-27T15:05:59.174365Z","description":"environment variables test","domain_name":"testcrns02pmr43ixn-my-container-02.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"var"},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"5009f716-393c-4be9-850e-3d93380648fc","local_storage_limit":1000,"max_concurrency":80,"max_scale":5,"memory_limit":256,"min_scale":3,"name":"my-container-02","namespace_id":"339f34c3-4c1c-4744-8539-c0f01ed0e6c3","port":80,"privacy":"private","private_network_id":null,"protocol":"h2c","ready_at":"2025-08-27T15:06:11.160429Z","region":"fr-par","registry_image":"nginx:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":80},"secret_environment_variables":[],"status":"ready","tags":[],"timeout":"600s","updated_at":"2025-08-27T15:06:11.172300Z"}'
         headers:
             Content-Length:
-                - "962"
+                - "929"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:02:54 GMT
+                - Wed, 27 Aug 2025 15:06:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -787,10 +787,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 148b76e8-8cc7-4e7e-8e65-d089e9869105
+                - bb4040d0-4785-4d23-ac99-996e93dd559d
         status: 200 OK
         code: 200
-        duration: 87.449375ms
+        duration: 94.718571ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -806,8 +806,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/b6d3c0f2-5373-4df3-8de7-f374924bb25e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/339f34c3-4c1c-4744-8539-c0f01ed0e6c3
         method: GET
       response:
         proto: HTTP/2.0
@@ -815,20 +815,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 962
+        content_length: 585
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":140,"created_at":"2025-06-11T12:02:23.107773Z","description":"environment variables test","domain_name":"testcrns02oioiumez-my-container-02.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"var"},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"b6d3c0f2-5373-4df3-8de7-f374924bb25e","local_storage_limit":1000,"max_concurrency":80,"max_scale":5,"memory_limit":256,"min_scale":3,"name":"my-container-02","namespace_id":"c5fba791-1a29-4ed1-843e-bb6dbf9c9780","port":80,"privacy":"private","private_network_id":null,"protocol":"h2c","ready_at":"2025-06-11T12:02:50.167095Z","region":"fr-par","registry_image":"nginx:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":80},"secret_environment_variables":[],"status":"ready","tags":[],"timeout":"600s","updated_at":"2025-06-11T12:02:50.174787Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.257824Z","description":"test container","environment_variables":{},"error_message":null,"id":"339f34c3-4c1c-4744-8539-c0f01ed0e6c3","name":"test-cr-ns-02","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns02pmr43ixn","registry_namespace_id":"36089a50-e4fe-44a7-bf2b-58d86fab10cf","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:53.056168Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "962"
+                - "585"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:02:54 GMT
+                - Wed, 27 Aug 2025 15:06:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -836,10 +836,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bad21669-22ac-476b-b301-763c8eebabd0
+                - 5848c10f-5deb-4d39-92ce-365697a0cf43
         status: 200 OK
         code: 200
-        duration: 85.007ms
+        duration: 106.622699ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -855,8 +855,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c5fba791-1a29-4ed1-843e-bb6dbf9c9780
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/5009f716-393c-4be9-850e-3d93380648fc
         method: GET
       response:
         proto: HTTP/2.0
@@ -864,20 +864,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 601
+        content_length: 929
         uncompressed: false
-        body: '{"created_at":"2025-06-11T12:02:17.091431Z","description":"test container","environment_variables":{},"error_message":null,"id":"c5fba791-1a29-4ed1-843e-bb6dbf9c9780","name":"test-cr-ns-02","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns02oioiumez","registry_namespace_id":"c54bcbcb-5f8a-4189-b27d-1863e146fc08","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-11T12:02:18.748632Z","vpc_integration_activated":false}'
+        body: '{"args":[],"command":[],"cpu_limit":140,"created_at":"2025-08-27T15:05:59.174365Z","description":"environment variables test","domain_name":"testcrns02pmr43ixn-my-container-02.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"var"},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"5009f716-393c-4be9-850e-3d93380648fc","local_storage_limit":1000,"max_concurrency":80,"max_scale":5,"memory_limit":256,"min_scale":3,"name":"my-container-02","namespace_id":"339f34c3-4c1c-4744-8539-c0f01ed0e6c3","port":80,"privacy":"private","private_network_id":null,"protocol":"h2c","ready_at":"2025-08-27T15:06:11.160429Z","region":"fr-par","registry_image":"nginx:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":80},"secret_environment_variables":[],"status":"ready","tags":[],"timeout":"600s","updated_at":"2025-08-27T15:06:11.172300Z"}'
         headers:
             Content-Length:
-                - "601"
+                - "929"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:02:54 GMT
+                - Wed, 27 Aug 2025 15:06:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -885,10 +885,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 89a01ca3-98cb-4c4e-b423-f1740ad300c4
+                - 33777b40-eaed-455c-837c-4a4788441690
         status: 200 OK
         code: 200
-        duration: 136.476042ms
+        duration: 84.167651ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -904,8 +904,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/b6d3c0f2-5373-4df3-8de7-f374924bb25e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/5009f716-393c-4be9-850e-3d93380648fc
         method: GET
       response:
         proto: HTTP/2.0
@@ -913,20 +913,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 962
+        content_length: 929
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":140,"created_at":"2025-06-11T12:02:23.107773Z","description":"environment variables test","domain_name":"testcrns02oioiumez-my-container-02.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"var"},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"b6d3c0f2-5373-4df3-8de7-f374924bb25e","local_storage_limit":1000,"max_concurrency":80,"max_scale":5,"memory_limit":256,"min_scale":3,"name":"my-container-02","namespace_id":"c5fba791-1a29-4ed1-843e-bb6dbf9c9780","port":80,"privacy":"private","private_network_id":null,"protocol":"h2c","ready_at":"2025-06-11T12:02:50.167095Z","region":"fr-par","registry_image":"nginx:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":80},"secret_environment_variables":[],"status":"ready","tags":[],"timeout":"600s","updated_at":"2025-06-11T12:02:50.174787Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":140,"created_at":"2025-08-27T15:05:59.174365Z","description":"environment variables test","domain_name":"testcrns02pmr43ixn-my-container-02.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"var"},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"5009f716-393c-4be9-850e-3d93380648fc","local_storage_limit":1000,"max_concurrency":80,"max_scale":5,"memory_limit":256,"min_scale":3,"name":"my-container-02","namespace_id":"339f34c3-4c1c-4744-8539-c0f01ed0e6c3","port":80,"privacy":"private","private_network_id":null,"protocol":"h2c","ready_at":"2025-08-27T15:06:11.160429Z","region":"fr-par","registry_image":"nginx:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":80},"secret_environment_variables":[],"status":"ready","tags":[],"timeout":"600s","updated_at":"2025-08-27T15:06:11.172300Z"}'
         headers:
             Content-Length:
-                - "962"
+                - "929"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:02:54 GMT
+                - Wed, 27 Aug 2025 15:06:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -934,10 +934,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 34239d9a-c4fd-4db1-bdac-0d306aa979c4
+                - e2bba6f1-d049-4818-8096-6a6feaecd2fa
         status: 200 OK
         code: 200
-        duration: 82.599375ms
+        duration: 159.352458ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -953,29 +953,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/b6d3c0f2-5373-4df3-8de7-f374924bb25e
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/5009f716-393c-4be9-850e-3d93380648fc
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 962
+        content_length: 935
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":140,"created_at":"2025-06-11T12:02:23.107773Z","description":"environment variables test","domain_name":"testcrns02oioiumez-my-container-02.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"var"},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"b6d3c0f2-5373-4df3-8de7-f374924bb25e","local_storage_limit":1000,"max_concurrency":80,"max_scale":5,"memory_limit":256,"min_scale":3,"name":"my-container-02","namespace_id":"c5fba791-1a29-4ed1-843e-bb6dbf9c9780","port":80,"privacy":"private","private_network_id":null,"protocol":"h2c","ready_at":"2025-06-11T12:02:50.167095Z","region":"fr-par","registry_image":"nginx:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":80},"secret_environment_variables":[],"status":"ready","tags":[],"timeout":"600s","updated_at":"2025-06-11T12:02:50.174787Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":140,"created_at":"2025-08-27T15:05:59.174365Z","description":"environment variables test","domain_name":"testcrns02pmr43ixn-my-container-02.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"var"},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"5009f716-393c-4be9-850e-3d93380648fc","local_storage_limit":1000,"max_concurrency":80,"max_scale":5,"memory_limit":256,"min_scale":3,"name":"my-container-02","namespace_id":"339f34c3-4c1c-4744-8539-c0f01ed0e6c3","port":80,"privacy":"private","private_network_id":null,"protocol":"h2c","ready_at":"2025-08-27T15:06:11.160429Z","region":"fr-par","registry_image":"nginx:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":80},"secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"600s","updated_at":"2025-08-27T15:06:16.299790309Z"}'
         headers:
             Content-Length:
-                - "962"
+                - "935"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:02:55 GMT
+                - Wed, 27 Aug 2025 15:06:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -983,10 +983,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e7fc4d0e-4df5-4379-afc9-a899766b1b3c
+                - c2342bb4-ba42-4023-a92c-537f78633949
         status: 200 OK
         code: 200
-        duration: 83.605166ms
+        duration: 398.029589ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1002,29 +1002,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/b6d3c0f2-5373-4df3-8de7-f374924bb25e
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/339f34c3-4c1c-4744-8539-c0f01ed0e6c3
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 968
+        content_length: 585
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":140,"created_at":"2025-06-11T12:02:23.107773Z","description":"environment variables test","domain_name":"testcrns02oioiumez-my-container-02.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"var"},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"b6d3c0f2-5373-4df3-8de7-f374924bb25e","local_storage_limit":1000,"max_concurrency":80,"max_scale":5,"memory_limit":256,"min_scale":3,"name":"my-container-02","namespace_id":"c5fba791-1a29-4ed1-843e-bb6dbf9c9780","port":80,"privacy":"private","private_network_id":null,"protocol":"h2c","ready_at":"2025-06-11T12:02:50.167095Z","region":"fr-par","registry_image":"nginx:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":80},"secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"600s","updated_at":"2025-06-11T12:02:55.111195038Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.257824Z","description":"test container","environment_variables":{},"error_message":null,"id":"339f34c3-4c1c-4744-8539-c0f01ed0e6c3","name":"test-cr-ns-02","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns02pmr43ixn","registry_namespace_id":"36089a50-e4fe-44a7-bf2b-58d86fab10cf","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:53.056168Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "968"
+                - "585"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:02:55 GMT
+                - Wed, 27 Aug 2025 15:06:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1032,10 +1032,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d8bb8e84-4365-4818-9ecc-ee02dcd6f0f9
+                - 2ae196f4-f2ab-4620-9fea-4e8d57191e4a
         status: 200 OK
         code: 200
-        duration: 229.292959ms
+        duration: 81.923621ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1051,29 +1051,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c5fba791-1a29-4ed1-843e-bb6dbf9c9780
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/339f34c3-4c1c-4744-8539-c0f01ed0e6c3
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 601
+        content_length: 591
         uncompressed: false
-        body: '{"created_at":"2025-06-11T12:02:17.091431Z","description":"test container","environment_variables":{},"error_message":null,"id":"c5fba791-1a29-4ed1-843e-bb6dbf9c9780","name":"test-cr-ns-02","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns02oioiumez","registry_namespace_id":"c54bcbcb-5f8a-4189-b27d-1863e146fc08","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-11T12:02:18.748632Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2025-08-27T15:05:41.257824Z","description":"test container","environment_variables":{},"error_message":null,"id":"339f34c3-4c1c-4744-8539-c0f01ed0e6c3","name":"test-cr-ns-02","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns02pmr43ixn","registry_namespace_id":"36089a50-e4fe-44a7-bf2b-58d86fab10cf","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:16.781355045Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "601"
+                - "591"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:02:55 GMT
+                - Wed, 27 Aug 2025 15:06:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1081,10 +1081,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2d42d393-cf25-4070-ba46-c7cc67c8c6ad
+                - b0d08c95-d578-429d-a172-a7d83c4b8e42
         status: 200 OK
         code: 200
-        duration: 82.621958ms
+        duration: 436.346271ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1100,29 +1100,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c5fba791-1a29-4ed1-843e-bb6dbf9c9780
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/339f34c3-4c1c-4744-8539-c0f01ed0e6c3
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 607
+        content_length: 588
         uncompressed: false
-        body: '{"created_at":"2025-06-11T12:02:17.091431Z","description":"test container","environment_variables":{},"error_message":null,"id":"c5fba791-1a29-4ed1-843e-bb6dbf9c9780","name":"test-cr-ns-02","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns02oioiumez","registry_namespace_id":"c54bcbcb-5f8a-4189-b27d-1863e146fc08","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-06-11T12:02:55.436539551Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2025-08-27T15:05:41.257824Z","description":"test container","environment_variables":{},"error_message":null,"id":"339f34c3-4c1c-4744-8539-c0f01ed0e6c3","name":"test-cr-ns-02","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns02pmr43ixn","registry_namespace_id":"36089a50-e4fe-44a7-bf2b-58d86fab10cf","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:16.781355Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "607"
+                - "588"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:02:56 GMT
+                - Wed, 27 Aug 2025 15:06:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1130,10 +1130,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a6317904-ac98-4c81-9259-a3b3d327d54b
+                - b8616239-d32d-461c-bcde-e0ab158d2ef6
         status: 200 OK
         code: 200
-        duration: 886.271625ms
+        duration: 82.367784ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1149,8 +1149,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c5fba791-1a29-4ed1-843e-bb6dbf9c9780
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/339f34c3-4c1c-4744-8539-c0f01ed0e6c3
         method: GET
       response:
         proto: HTTP/2.0
@@ -1158,20 +1158,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 604
+        content_length: 588
         uncompressed: false
-        body: '{"created_at":"2025-06-11T12:02:17.091431Z","description":"test container","environment_variables":{},"error_message":null,"id":"c5fba791-1a29-4ed1-843e-bb6dbf9c9780","name":"test-cr-ns-02","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns02oioiumez","registry_namespace_id":"c54bcbcb-5f8a-4189-b27d-1863e146fc08","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-06-11T12:02:55.436540Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2025-08-27T15:05:41.257824Z","description":"test container","environment_variables":{},"error_message":null,"id":"339f34c3-4c1c-4744-8539-c0f01ed0e6c3","name":"test-cr-ns-02","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns02pmr43ixn","registry_namespace_id":"36089a50-e4fe-44a7-bf2b-58d86fab10cf","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:16.781355Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "604"
+                - "588"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:02:56 GMT
+                - Wed, 27 Aug 2025 15:06:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1179,10 +1179,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 25493a50-b6d7-404d-a554-45c731a9a36d
+                - baf7c4de-4043-4365-a862-2cafe35c1f44
         status: 200 OK
         code: 200
-        duration: 73.386917ms
+        duration: 92.608113ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1198,8 +1198,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c5fba791-1a29-4ed1-843e-bb6dbf9c9780
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/339f34c3-4c1c-4744-8539-c0f01ed0e6c3
         method: GET
       response:
         proto: HTTP/2.0
@@ -1218,9 +1218,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:03:01 GMT
+                - Wed, 27 Aug 2025 15:06:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1228,10 +1228,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ff19e6c5-9f68-45b0-aa47-239b6e979db4
+                - fa695f01-7abc-47b0-bc2d-d82f6e81788f
         status: 404 Not Found
         code: 404
-        duration: 26.014917ms
+        duration: 25.136129ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1247,8 +1247,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/c5fba791-1a29-4ed1-843e-bb6dbf9c9780
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/339f34c3-4c1c-4744-8539-c0f01ed0e6c3
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1267,9 +1267,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:03:01 GMT
+                - Wed, 27 Aug 2025 15:06:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1277,7 +1277,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d9e18ae5-2bbd-4930-9532-828db702a2b4
+                - 8b44133f-b3dc-49c6-a888-d6f148e334fb
         status: 404 Not Found
         code: 404
-        duration: 22.436375ms
+        duration: 78.929986ms

--- a/internal/services/container/testdata/cron-basic.cassette.yaml
+++ b/internal/services/container/testdata/cron-basic.cassette.yaml
@@ -6,19 +6,19 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 157
+        content_length: 195
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-ns-quizzical-nobel","environment_variables":{},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","secret_environment_variables":[],"tags":null}'
+        body: '{"name":"tf-ns-condescending-davinci","environment_variables":{},"project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","secret_environment_variables":[],"tags":null,"activate_vpc_integration":true}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces
         method: POST
       response:
@@ -27,20 +27,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 473
+        content_length: 512
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.343394333Z","description":"","environment_variables":{},"error_message":null,"id":"1732421d-58af-4b37-ab1f-a138dda68cf0","name":"tf-ns-quizzical-nobel","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:37:49.343394333Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.173657118Z","description":"","environment_variables":{},"error_message":null,"id":"a9144d96-848f-4f8c-8be0-4d0e28420919","name":"tf-ns-condescending-davinci","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:40.173657118Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "473"
+                - "512"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:37:49 GMT
+                - Wed, 27 Aug 2025 15:05:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cc722976-8fcb-4e9f-bfb2-55058afff24b
+                - 27b80d2a-3f33-4cad-8efb-0eb7a89eb4e7
         status: 200 OK
         code: 200
-        duration: 969.276916ms
+        duration: 4.168754542s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -67,8 +67,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/1732421d-58af-4b37-ab1f-a138dda68cf0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/a9144d96-848f-4f8c-8be0-4d0e28420919
         method: GET
       response:
         proto: HTTP/2.0
@@ -76,20 +76,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 467
+        content_length: 506
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.343394Z","description":"","environment_variables":{},"error_message":null,"id":"1732421d-58af-4b37-ab1f-a138dda68cf0","name":"tf-ns-quizzical-nobel","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:37:49.343394Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.173657Z","description":"","environment_variables":{},"error_message":null,"id":"a9144d96-848f-4f8c-8be0-4d0e28420919","name":"tf-ns-condescending-davinci","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:40.173657Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "467"
+                - "506"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:37:49 GMT
+                - Wed, 27 Aug 2025 15:05:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3e3d175b-79be-4ec7-8c43-8a2e24816b7f
+                - aae79b9b-c5f1-49f6-9881-d2d2c24e35d6
         status: 200 OK
         code: 200
-        duration: 66.768375ms
+        duration: 83.154972ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -116,8 +116,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/1732421d-58af-4b37-ab1f-a138dda68cf0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/a9144d96-848f-4f8c-8be0-4d0e28420919
         method: GET
       response:
         proto: HTTP/2.0
@@ -125,20 +125,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 467
+        content_length: 506
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.343394Z","description":"","environment_variables":{},"error_message":null,"id":"1732421d-58af-4b37-ab1f-a138dda68cf0","name":"tf-ns-quizzical-nobel","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:37:50.847190Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.173657Z","description":"","environment_variables":{},"error_message":null,"id":"a9144d96-848f-4f8c-8be0-4d0e28420919","name":"tf-ns-condescending-davinci","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:40.173657Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "467"
+                - "506"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:37:54 GMT
+                - Wed, 27 Aug 2025 15:05:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -146,10 +146,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e2d17a2a-f61a-4ecf-b44f-60b64d9ced49
+                - 43aabd4f-2898-4a09-8a64-5477eb554892
         status: 200 OK
         code: 200
-        duration: 84.797917ms
+        duration: 82.246529ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -165,8 +165,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/1732421d-58af-4b37-ab1f-a138dda68cf0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/a9144d96-848f-4f8c-8be0-4d0e28420919
         method: GET
       response:
         proto: HTTP/2.0
@@ -174,20 +174,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 467
+        content_length: 595
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.343394Z","description":"","environment_variables":{},"error_message":null,"id":"1732421d-58af-4b37-ab1f-a138dda68cf0","name":"tf-ns-quizzical-nobel","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:37:50.847190Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.173657Z","description":"","environment_variables":{},"error_message":null,"id":"a9144d96-848f-4f8c-8be0-4d0e28420919","name":"tf-ns-condescending-davinci","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnscondescendingdavrry6gqta","registry_namespace_id":"baa92514-ade4-4162-99e8-8844b2c8bc2d","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:46.670806Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "467"
+                - "595"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:37:59 GMT
+                - Wed, 27 Aug 2025 15:05:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -195,10 +195,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 98d1ddd7-6f43-4121-9068-47427cfd1ec1
+                - 6b7fddf5-f5aa-4059-824d-a6036b20d37c
         status: 200 OK
         code: 200
-        duration: 66.742458ms
+        duration: 89.862321ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -214,8 +214,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/1732421d-58af-4b37-ab1f-a138dda68cf0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/a9144d96-848f-4f8c-8be0-4d0e28420919
         method: GET
       response:
         proto: HTTP/2.0
@@ -223,20 +223,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 467
+        content_length: 595
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.343394Z","description":"","environment_variables":{},"error_message":null,"id":"1732421d-58af-4b37-ab1f-a138dda68cf0","name":"tf-ns-quizzical-nobel","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:37:50.847190Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.173657Z","description":"","environment_variables":{},"error_message":null,"id":"a9144d96-848f-4f8c-8be0-4d0e28420919","name":"tf-ns-condescending-davinci","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnscondescendingdavrry6gqta","registry_namespace_id":"baa92514-ade4-4162-99e8-8844b2c8bc2d","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:46.670806Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "467"
+                - "595"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:04 GMT
+                - Wed, 27 Aug 2025 15:05:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -244,10 +244,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7a1d86a2-a46a-41cc-a680-3b5b7fa258ef
+                - ed9e2eea-d848-4534-899f-36efd646bee0
         status: 200 OK
         code: 200
-        duration: 57.634083ms
+        duration: 107.673703ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -263,8 +263,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/1732421d-58af-4b37-ab1f-a138dda68cf0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/a9144d96-848f-4f8c-8be0-4d0e28420919
         method: GET
       response:
         proto: HTTP/2.0
@@ -272,20 +272,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 467
+        content_length: 595
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.343394Z","description":"","environment_variables":{},"error_message":null,"id":"1732421d-58af-4b37-ab1f-a138dda68cf0","name":"tf-ns-quizzical-nobel","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:37:50.847190Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.173657Z","description":"","environment_variables":{},"error_message":null,"id":"a9144d96-848f-4f8c-8be0-4d0e28420919","name":"tf-ns-condescending-davinci","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnscondescendingdavrry6gqta","registry_namespace_id":"baa92514-ade4-4162-99e8-8844b2c8bc2d","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:46.670806Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "467"
+                - "595"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:09 GMT
+                - Wed, 27 Aug 2025 15:05:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -293,48 +293,50 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f1b7a0c2-93cf-4f34-9368-5127e29d4182
+                - 8df427c3-bb24-4f5d-aff6-0dafdae7c5d8
         status: 200 OK
         code: 200
-        duration: 56.029583ms
+        duration: 106.730152ms
     - id: 6
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 255
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"namespace_id":"a9144d96-848f-4f8c-8be0-4d0e28420919","name":"my-container-with-cron-tf","privacy":"public","protocol":"http1","secret_environment_variables":null,"http_option":"enabled","sandbox":"unknown_sandbox","tags":null,"command":null,"args":null}'
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/1732421d-58af-4b37-ab1f-a138dda68cf0
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 467
+        content_length: 986
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.343394Z","description":"","environment_variables":{},"error_message":null,"id":"1732421d-58af-4b37-ab1f-a138dda68cf0","name":"tf-ns-quizzical-nobel","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:37:50.847190Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:51.442678320Z","description":"","domain_name":"tfnscondescendingdavrry6gqta-my-container-with-cron-tf.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"9936cdaf-5081-45be-8dfe-eb4b961a3a0e","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"my-container-with-cron-tf","namespace_id":"a9144d96-848f-4f8c-8be0-4d0e28420919","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnscondescendingdavrry6gqta/my-container-with-cron-tf:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:51.442678320Z"}'
         headers:
             Content-Length:
-                - "467"
+                - "986"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:14 GMT
+                - Wed, 27 Aug 2025 15:05:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -342,10 +344,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0da242a4-cee3-42ed-9e95-7b22dae7843e
+                - 3c8a1714-9684-4135-ba3a-3267920f4bd3
         status: 200 OK
         code: 200
-        duration: 70.381292ms
+        duration: 791.040587ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -361,8 +363,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/1732421d-58af-4b37-ab1f-a138dda68cf0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/9936cdaf-5081-45be-8dfe-eb4b961a3a0e
         method: GET
       response:
         proto: HTTP/2.0
@@ -370,20 +372,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 554
+        content_length: 980
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.343394Z","description":"","environment_variables":{},"error_message":null,"id":"1732421d-58af-4b37-ab1f-a138dda68cf0","name":"tf-ns-quizzical-nobel","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsquizzicalnobelq4aextoz","registry_namespace_id":"62eb2648-f3d3-4279-bd01-9b759058777a","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:38:17.429138Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:51.442678Z","description":"","domain_name":"tfnscondescendingdavrry6gqta-my-container-with-cron-tf.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"9936cdaf-5081-45be-8dfe-eb4b961a3a0e","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"my-container-with-cron-tf","namespace_id":"a9144d96-848f-4f8c-8be0-4d0e28420919","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnscondescendingdavrry6gqta/my-container-with-cron-tf:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:51.442678Z"}'
         headers:
             Content-Length:
-                - "554"
+                - "980"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:19 GMT
+                - Wed, 27 Aug 2025 15:05:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -391,48 +393,50 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 532801ee-83d6-4938-82e5-31718af197b0
+                - 4a7a3714-188e-4cff-b99d-7aec574e197e
         status: 200 OK
         code: 200
-        duration: 56.259917ms
+        duration: 86.608826ms
     - id: 8
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 139
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"container_id":"9936cdaf-5081-45be-8dfe-eb4b961a3a0e","schedule":"5 4 * * *","args":{"test":"scw"},"name":"tf-tests-container-cron-basic"}'
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/1732421d-58af-4b37-ab1f-a138dda68cf0
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/crons
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 554
+        content_length: 202
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.343394Z","description":"","environment_variables":{},"error_message":null,"id":"1732421d-58af-4b37-ab1f-a138dda68cf0","name":"tf-ns-quizzical-nobel","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsquizzicalnobelq4aextoz","registry_namespace_id":"62eb2648-f3d3-4279-bd01-9b759058777a","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:38:17.429138Z"}'
+        body: '{"args":{"test":"scw"},"container_id":"9936cdaf-5081-45be-8dfe-eb4b961a3a0e","id":"c40ad375-434f-4e9e-859d-c6e9cb39bc9f","name":"tf-tests-container-cron-basic","schedule":"5 4 * * *","status":"pending"}'
         headers:
             Content-Length:
-                - "554"
+                - "202"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:19 GMT
+                - Wed, 27 Aug 2025 15:05:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -440,10 +444,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 07164634-073a-441a-a451-6a2a7cc430db
+                - 36a1ab36-2d4b-4566-b372-8c7cadca3803
         status: 200 OK
         code: 200
-        duration: 58.345333ms
+        duration: 212.906496ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -459,8 +463,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/1732421d-58af-4b37-ab1f-a138dda68cf0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/crons/c40ad375-434f-4e9e-859d-c6e9cb39bc9f
         method: GET
       response:
         proto: HTTP/2.0
@@ -468,20 +472,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 554
+        content_length: 202
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.343394Z","description":"","environment_variables":{},"error_message":null,"id":"1732421d-58af-4b37-ab1f-a138dda68cf0","name":"tf-ns-quizzical-nobel","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsquizzicalnobelq4aextoz","registry_namespace_id":"62eb2648-f3d3-4279-bd01-9b759058777a","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:38:17.429138Z"}'
+        body: '{"args":{"test":"scw"},"container_id":"9936cdaf-5081-45be-8dfe-eb4b961a3a0e","id":"c40ad375-434f-4e9e-859d-c6e9cb39bc9f","name":"tf-tests-container-cron-basic","schedule":"5 4 * * *","status":"pending"}'
         headers:
             Content-Length:
-                - "554"
+                - "202"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:19 GMT
+                - Wed, 27 Aug 2025 15:05:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -489,50 +493,48 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2a607499-20f1-4f73-a22a-d8c723f12a54
+                - 90299d23-b740-49c2-abbb-43b86c7d3ffb
         status: 200 OK
         code: 200
-        duration: 62.990333ms
+        duration: 115.193814ms
     - id: 10
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 216
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"namespace_id":"1732421d-58af-4b37-ab1f-a138dda68cf0","name":"my-container-with-cron-tf","privacy":"public","protocol":"http1","secret_environment_variables":null,"http_option":"enabled","sandbox":"unknown_sandbox"}'
+        body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers
-        method: POST
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/crons/c40ad375-434f-4e9e-859d-c6e9cb39bc9f
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 923
+        content_length: 202
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:20.573131718Z","description":"","domain_name":"tfnsquizzicalnobelq4aextoz-my-container-with-cron-tf.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"732824f2-d0e1-43cb-8e3a-dce98dc443b9","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"my-container-with-cron-tf","namespace_id":"1732421d-58af-4b37-ab1f-a138dda68cf0","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsquizzicalnobelq4aextoz/my-container-with-cron-tf:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:38:20.573131718Z"}'
+        body: '{"args":{"test":"scw"},"container_id":"9936cdaf-5081-45be-8dfe-eb4b961a3a0e","id":"c40ad375-434f-4e9e-859d-c6e9cb39bc9f","name":"tf-tests-container-cron-basic","schedule":"5 4 * * *","status":"pending"}'
         headers:
             Content-Length:
-                - "923"
+                - "202"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:20 GMT
+                - Wed, 27 Aug 2025 15:05:57 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -540,10 +542,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 42839c1f-da66-4eb7-9041-8b8aa6c9c984
+                - 4f98473c-f960-4dc1-bbf9-906ff2405096
         status: 200 OK
         code: 200
-        duration: 646.917667ms
+        duration: 369.314392ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -559,60 +561,9 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/732824f2-d0e1-43cb-8e3a-dce98dc443b9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/crons/c40ad375-434f-4e9e-859d-c6e9cb39bc9f
         method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 917
-        uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:20.573132Z","description":"","domain_name":"tfnsquizzicalnobelq4aextoz-my-container-with-cron-tf.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"732824f2-d0e1-43cb-8e3a-dce98dc443b9","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"my-container-with-cron-tf","namespace_id":"1732421d-58af-4b37-ab1f-a138dda68cf0","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsquizzicalnobelq4aextoz/my-container-with-cron-tf:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:38:20.573132Z"}'
-        headers:
-            Content-Length:
-                - "917"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:38:20 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - d50e635f-862d-481a-a92e-59ec53099abd
-        status: 200 OK
-        code: 200
-        duration: 83.496666ms
-    - id: 12
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 139
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"container_id":"732824f2-d0e1-43cb-8e3a-dce98dc443b9","schedule":"5 4 * * *","args":{"test":"scw"},"name":"tf-tests-container-cron-basic"}'
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/crons
-        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
@@ -621,7 +572,7 @@ interactions:
         trailer: {}
         content_length: 202
         uncompressed: false
-        body: '{"args":{"test":"scw"},"container_id":"732824f2-d0e1-43cb-8e3a-dce98dc443b9","id":"8c9d6d52-337d-4334-9c0b-1667d856def8","name":"tf-tests-container-cron-basic","schedule":"5 4 * * *","status":"pending"}'
+        body: '{"args":{"test":"scw"},"container_id":"9936cdaf-5081-45be-8dfe-eb4b961a3a0e","id":"c40ad375-434f-4e9e-859d-c6e9cb39bc9f","name":"tf-tests-container-cron-basic","schedule":"5 4 * * *","status":"pending"}'
         headers:
             Content-Length:
                 - "202"
@@ -630,9 +581,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:20 GMT
+                - Wed, 27 Aug 2025 15:06:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -640,10 +591,59 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 893d31fc-4cc7-4a84-a2af-da87187085a0
+                - 40239b28-9a2d-42a8-8426-d1b78090b940
         status: 200 OK
         code: 200
-        duration: 95.109125ms
+        duration: 105.942428ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/crons/c40ad375-434f-4e9e-859d-c6e9cb39bc9f
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 200
+        uncompressed: false
+        body: '{"args":{"test":"scw"},"container_id":"9936cdaf-5081-45be-8dfe-eb4b961a3a0e","id":"c40ad375-434f-4e9e-859d-c6e9cb39bc9f","name":"tf-tests-container-cron-basic","schedule":"5 4 * * *","status":"ready"}'
+        headers:
+            Content-Length:
+                - "200"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:07 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 340e8eef-3ba5-4287-abe2-e467b92537ca
+        status: 200 OK
+        code: 200
+        duration: 91.760107ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -659,8 +659,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/crons/8c9d6d52-337d-4334-9c0b-1667d856def8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/crons/c40ad375-434f-4e9e-859d-c6e9cb39bc9f
         method: GET
       response:
         proto: HTTP/2.0
@@ -668,20 +668,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 202
+        content_length: 200
         uncompressed: false
-        body: '{"args":{"test":"scw"},"container_id":"732824f2-d0e1-43cb-8e3a-dce98dc443b9","id":"8c9d6d52-337d-4334-9c0b-1667d856def8","name":"tf-tests-container-cron-basic","schedule":"5 4 * * *","status":"pending"}'
+        body: '{"args":{"test":"scw"},"container_id":"9936cdaf-5081-45be-8dfe-eb4b961a3a0e","id":"c40ad375-434f-4e9e-859d-c6e9cb39bc9f","name":"tf-tests-container-cron-basic","schedule":"5 4 * * *","status":"ready"}'
         headers:
             Content-Length:
-                - "202"
+                - "200"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:20 GMT
+                - Wed, 27 Aug 2025 15:06:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -689,10 +689,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 71d0b9a9-4e6c-4a7f-97f1-04555e28fb73
+                - bb40ebe0-9e95-4482-87f5-01a5fd1533da
         status: 200 OK
         code: 200
-        duration: 83.01275ms
+        duration: 105.95333ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -708,8 +708,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/crons/8c9d6d52-337d-4334-9c0b-1667d856def8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/crons/c40ad375-434f-4e9e-859d-c6e9cb39bc9f
         method: GET
       response:
         proto: HTTP/2.0
@@ -719,7 +719,7 @@ interactions:
         trailer: {}
         content_length: 200
         uncompressed: false
-        body: '{"args":{"test":"scw"},"container_id":"732824f2-d0e1-43cb-8e3a-dce98dc443b9","id":"8c9d6d52-337d-4334-9c0b-1667d856def8","name":"tf-tests-container-cron-basic","schedule":"5 4 * * *","status":"ready"}'
+        body: '{"args":{"test":"scw"},"container_id":"9936cdaf-5081-45be-8dfe-eb4b961a3a0e","id":"c40ad375-434f-4e9e-859d-c6e9cb39bc9f","name":"tf-tests-container-cron-basic","schedule":"5 4 * * *","status":"ready"}'
         headers:
             Content-Length:
                 - "200"
@@ -728,9 +728,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:25 GMT
+                - Wed, 27 Aug 2025 15:06:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -738,10 +738,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2f418766-5491-4488-9259-51e6a48c68c1
+                - d143d06e-1897-4d46-995e-032f8f274d42
         status: 200 OK
         code: 200
-        duration: 89.653417ms
+        duration: 106.590296ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -757,8 +757,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/crons/8c9d6d52-337d-4334-9c0b-1667d856def8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/a9144d96-848f-4f8c-8be0-4d0e28420919
         method: GET
       response:
         proto: HTTP/2.0
@@ -766,20 +766,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 200
+        content_length: 595
         uncompressed: false
-        body: '{"args":{"test":"scw"},"container_id":"732824f2-d0e1-43cb-8e3a-dce98dc443b9","id":"8c9d6d52-337d-4334-9c0b-1667d856def8","name":"tf-tests-container-cron-basic","schedule":"5 4 * * *","status":"ready"}'
+        body: '{"created_at":"2025-08-27T15:05:40.173657Z","description":"","environment_variables":{},"error_message":null,"id":"a9144d96-848f-4f8c-8be0-4d0e28420919","name":"tf-ns-condescending-davinci","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnscondescendingdavrry6gqta","registry_namespace_id":"baa92514-ade4-4162-99e8-8844b2c8bc2d","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:46.670806Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "200"
+                - "595"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:26 GMT
+                - Wed, 27 Aug 2025 15:06:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -787,10 +787,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 37bd3a99-b707-4e7d-9dc3-f98e2b351d07
+                - d3b1e46c-0f9a-4564-ad46-04b7302a7c02
         status: 200 OK
         code: 200
-        duration: 81.264458ms
+        duration: 88.264126ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -806,8 +806,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/crons/8c9d6d52-337d-4334-9c0b-1667d856def8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/9936cdaf-5081-45be-8dfe-eb4b961a3a0e
         method: GET
       response:
         proto: HTTP/2.0
@@ -815,20 +815,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 200
+        content_length: 980
         uncompressed: false
-        body: '{"args":{"test":"scw"},"container_id":"732824f2-d0e1-43cb-8e3a-dce98dc443b9","id":"8c9d6d52-337d-4334-9c0b-1667d856def8","name":"tf-tests-container-cron-basic","schedule":"5 4 * * *","status":"ready"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:51.442678Z","description":"","domain_name":"tfnscondescendingdavrry6gqta-my-container-with-cron-tf.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"9936cdaf-5081-45be-8dfe-eb4b961a3a0e","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"my-container-with-cron-tf","namespace_id":"a9144d96-848f-4f8c-8be0-4d0e28420919","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnscondescendingdavrry6gqta/my-container-with-cron-tf:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:51.442678Z"}'
         headers:
             Content-Length:
-                - "200"
+                - "980"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:26 GMT
+                - Wed, 27 Aug 2025 15:06:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -836,10 +836,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a4ee8fd9-47b5-468a-abdd-e5f8e4b1fd3f
+                - 3b798c3a-75a2-4017-83f3-b85cbbb44a9e
         status: 200 OK
         code: 200
-        duration: 89.117792ms
+        duration: 82.354698ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -855,8 +855,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/1732421d-58af-4b37-ab1f-a138dda68cf0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/crons/c40ad375-434f-4e9e-859d-c6e9cb39bc9f
         method: GET
       response:
         proto: HTTP/2.0
@@ -864,20 +864,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 554
+        content_length: 200
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.343394Z","description":"","environment_variables":{},"error_message":null,"id":"1732421d-58af-4b37-ab1f-a138dda68cf0","name":"tf-ns-quizzical-nobel","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsquizzicalnobelq4aextoz","registry_namespace_id":"62eb2648-f3d3-4279-bd01-9b759058777a","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:38:17.429138Z"}'
+        body: '{"args":{"test":"scw"},"container_id":"9936cdaf-5081-45be-8dfe-eb4b961a3a0e","id":"c40ad375-434f-4e9e-859d-c6e9cb39bc9f","name":"tf-tests-container-cron-basic","schedule":"5 4 * * *","status":"ready"}'
         headers:
             Content-Length:
-                - "554"
+                - "200"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:27 GMT
+                - Wed, 27 Aug 2025 15:06:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -885,10 +885,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 58c49664-9b6a-44a4-b90e-77160bacc629
+                - f52f45cf-1968-4f38-9374-7d743edf7a47
         status: 200 OK
         code: 200
-        duration: 72.317125ms
+        duration: 114.021571ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -904,8 +904,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/732824f2-d0e1-43cb-8e3a-dce98dc443b9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/a9144d96-848f-4f8c-8be0-4d0e28420919
         method: GET
       response:
         proto: HTTP/2.0
@@ -913,20 +913,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 917
+        content_length: 595
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:20.573132Z","description":"","domain_name":"tfnsquizzicalnobelq4aextoz-my-container-with-cron-tf.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"732824f2-d0e1-43cb-8e3a-dce98dc443b9","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"my-container-with-cron-tf","namespace_id":"1732421d-58af-4b37-ab1f-a138dda68cf0","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsquizzicalnobelq4aextoz/my-container-with-cron-tf:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:38:20.573132Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.173657Z","description":"","environment_variables":{},"error_message":null,"id":"a9144d96-848f-4f8c-8be0-4d0e28420919","name":"tf-ns-condescending-davinci","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnscondescendingdavrry6gqta","registry_namespace_id":"baa92514-ade4-4162-99e8-8844b2c8bc2d","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:46.670806Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "917"
+                - "595"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:27 GMT
+                - Wed, 27 Aug 2025 15:06:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -934,10 +934,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 53f94f7e-a0a7-4b84-869f-cd0993469bfb
+                - 24fb47fd-2e02-4a34-9da3-e4e21a9c86c2
         status: 200 OK
         code: 200
-        duration: 78.973167ms
+        duration: 174.007664ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -953,8 +953,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/crons/8c9d6d52-337d-4334-9c0b-1667d856def8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/9936cdaf-5081-45be-8dfe-eb4b961a3a0e
         method: GET
       response:
         proto: HTTP/2.0
@@ -962,20 +962,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 200
+        content_length: 980
         uncompressed: false
-        body: '{"args":{"test":"scw"},"container_id":"732824f2-d0e1-43cb-8e3a-dce98dc443b9","id":"8c9d6d52-337d-4334-9c0b-1667d856def8","name":"tf-tests-container-cron-basic","schedule":"5 4 * * *","status":"ready"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:51.442678Z","description":"","domain_name":"tfnscondescendingdavrry6gqta-my-container-with-cron-tf.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"9936cdaf-5081-45be-8dfe-eb4b961a3a0e","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"my-container-with-cron-tf","namespace_id":"a9144d96-848f-4f8c-8be0-4d0e28420919","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnscondescendingdavrry6gqta/my-container-with-cron-tf:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:51.442678Z"}'
         headers:
             Content-Length:
-                - "200"
+                - "980"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:27 GMT
+                - Wed, 27 Aug 2025 15:06:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -983,10 +983,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - edfc2844-8bdb-4239-ad11-7ccd9963f413
+                - 8f469cbf-aa5d-4f21-aa47-c5d16ea7656a
         status: 200 OK
         code: 200
-        duration: 69.891958ms
+        duration: 88.62268ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1002,8 +1002,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/1732421d-58af-4b37-ab1f-a138dda68cf0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/crons/c40ad375-434f-4e9e-859d-c6e9cb39bc9f
         method: GET
       response:
         proto: HTTP/2.0
@@ -1011,20 +1011,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 554
+        content_length: 200
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.343394Z","description":"","environment_variables":{},"error_message":null,"id":"1732421d-58af-4b37-ab1f-a138dda68cf0","name":"tf-ns-quizzical-nobel","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsquizzicalnobelq4aextoz","registry_namespace_id":"62eb2648-f3d3-4279-bd01-9b759058777a","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:38:17.429138Z"}'
+        body: '{"args":{"test":"scw"},"container_id":"9936cdaf-5081-45be-8dfe-eb4b961a3a0e","id":"c40ad375-434f-4e9e-859d-c6e9cb39bc9f","name":"tf-tests-container-cron-basic","schedule":"5 4 * * *","status":"ready"}'
         headers:
             Content-Length:
-                - "554"
+                - "200"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:27 GMT
+                - Wed, 27 Aug 2025 15:06:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1032,48 +1032,50 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8c004589-22a4-4b0a-aed5-1d5923b8ee94
+                - 3672c9ed-c9dc-44e3-b406-87722a312bf4
         status: 200 OK
         code: 200
-        duration: 80.507875ms
+        duration: 102.427355ms
     - id: 21
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 102
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"container_id":"9936cdaf-5081-45be-8dfe-eb4b961a3a0e","name":"tf-tests-container-cron-basic-changed"}'
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/732824f2-d0e1-43cb-8e3a-dce98dc443b9
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/crons/c40ad375-434f-4e9e-859d-c6e9cb39bc9f
+        method: PATCH
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 917
+        content_length: 210
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:20.573132Z","description":"","domain_name":"tfnsquizzicalnobelq4aextoz-my-container-with-cron-tf.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"732824f2-d0e1-43cb-8e3a-dce98dc443b9","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"my-container-with-cron-tf","namespace_id":"1732421d-58af-4b37-ab1f-a138dda68cf0","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsquizzicalnobelq4aextoz/my-container-with-cron-tf:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:38:20.573132Z"}'
+        body: '{"args":{"test":"scw"},"container_id":"9936cdaf-5081-45be-8dfe-eb4b961a3a0e","id":"c40ad375-434f-4e9e-859d-c6e9cb39bc9f","name":"tf-tests-container-cron-basic-changed","schedule":"5 4 * * *","status":"pending"}'
         headers:
             Content-Length:
-                - "917"
+                - "210"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:28 GMT
+                - Wed, 27 Aug 2025 15:06:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1081,10 +1083,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8f9d7267-a617-4242-b3b4-426ebbc2c420
+                - e9502256-e310-4d27-8602-831374f6c749
         status: 200 OK
         code: 200
-        duration: 78.378542ms
+        duration: 210.117715ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1100,60 +1102,9 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/crons/8c9d6d52-337d-4334-9c0b-1667d856def8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/crons/c40ad375-434f-4e9e-859d-c6e9cb39bc9f
         method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 200
-        uncompressed: false
-        body: '{"args":{"test":"scw"},"container_id":"732824f2-d0e1-43cb-8e3a-dce98dc443b9","id":"8c9d6d52-337d-4334-9c0b-1667d856def8","name":"tf-tests-container-cron-basic","schedule":"5 4 * * *","status":"ready"}'
-        headers:
-            Content-Length:
-                - "200"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:38:28 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 6e227561-0857-4808-9576-3800b02365c6
-        status: 200 OK
-        code: 200
-        duration: 89.304667ms
-    - id: 23
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 102
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"container_id":"732824f2-d0e1-43cb-8e3a-dce98dc443b9","name":"tf-tests-container-cron-basic-changed"}'
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/crons/8c9d6d52-337d-4334-9c0b-1667d856def8
-        method: PATCH
       response:
         proto: HTTP/2.0
         proto_major: 2
@@ -1162,7 +1113,7 @@ interactions:
         trailer: {}
         content_length: 210
         uncompressed: false
-        body: '{"args":{"test":"scw"},"container_id":"732824f2-d0e1-43cb-8e3a-dce98dc443b9","id":"8c9d6d52-337d-4334-9c0b-1667d856def8","name":"tf-tests-container-cron-basic-changed","schedule":"5 4 * * *","status":"pending"}'
+        body: '{"args":{"test":"scw"},"container_id":"9936cdaf-5081-45be-8dfe-eb4b961a3a0e","id":"c40ad375-434f-4e9e-859d-c6e9cb39bc9f","name":"tf-tests-container-cron-basic-changed","schedule":"5 4 * * *","status":"pending"}'
         headers:
             Content-Length:
                 - "210"
@@ -1171,9 +1122,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:29 GMT
+                - Wed, 27 Aug 2025 15:06:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1181,10 +1132,59 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9737f5e2-c5ee-4450-860e-871fef6095e6
+                - 1b575601-4318-4500-a152-96601b0bbaaf
         status: 200 OK
         code: 200
-        duration: 112.502042ms
+        duration: 123.92826ms
+    - id: 23
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/crons/c40ad375-434f-4e9e-859d-c6e9cb39bc9f
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 208
+        uncompressed: false
+        body: '{"args":{"test":"scw"},"container_id":"9936cdaf-5081-45be-8dfe-eb4b961a3a0e","id":"c40ad375-434f-4e9e-859d-c6e9cb39bc9f","name":"tf-tests-container-cron-basic-changed","schedule":"5 4 * * *","status":"ready"}'
+        headers:
+            Content-Length:
+                - "208"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:14 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 4cd088ea-4fd6-469f-86ce-fc2e7e987a4f
+        status: 200 OK
+        code: 200
+        duration: 100.560462ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1200,8 +1200,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/crons/8c9d6d52-337d-4334-9c0b-1667d856def8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/crons/c40ad375-434f-4e9e-859d-c6e9cb39bc9f
         method: GET
       response:
         proto: HTTP/2.0
@@ -1209,20 +1209,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 210
+        content_length: 208
         uncompressed: false
-        body: '{"args":{"test":"scw"},"container_id":"732824f2-d0e1-43cb-8e3a-dce98dc443b9","id":"8c9d6d52-337d-4334-9c0b-1667d856def8","name":"tf-tests-container-cron-basic-changed","schedule":"5 4 * * *","status":"pending"}'
+        body: '{"args":{"test":"scw"},"container_id":"9936cdaf-5081-45be-8dfe-eb4b961a3a0e","id":"c40ad375-434f-4e9e-859d-c6e9cb39bc9f","name":"tf-tests-container-cron-basic-changed","schedule":"5 4 * * *","status":"ready"}'
         headers:
             Content-Length:
-                - "210"
+                - "208"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:29 GMT
+                - Wed, 27 Aug 2025 15:06:14 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1230,10 +1230,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 98c14166-1dd2-4733-9cd2-c90443d19872
+                - 6b3d58f4-2665-467f-9384-cffcd3c793e3
         status: 200 OK
         code: 200
-        duration: 86.40275ms
+        duration: 82.563041ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1249,8 +1249,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/crons/8c9d6d52-337d-4334-9c0b-1667d856def8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/crons/c40ad375-434f-4e9e-859d-c6e9cb39bc9f
         method: GET
       response:
         proto: HTTP/2.0
@@ -1260,7 +1260,7 @@ interactions:
         trailer: {}
         content_length: 208
         uncompressed: false
-        body: '{"args":{"test":"scw"},"container_id":"732824f2-d0e1-43cb-8e3a-dce98dc443b9","id":"8c9d6d52-337d-4334-9c0b-1667d856def8","name":"tf-tests-container-cron-basic-changed","schedule":"5 4 * * *","status":"ready"}'
+        body: '{"args":{"test":"scw"},"container_id":"9936cdaf-5081-45be-8dfe-eb4b961a3a0e","id":"c40ad375-434f-4e9e-859d-c6e9cb39bc9f","name":"tf-tests-container-cron-basic-changed","schedule":"5 4 * * *","status":"ready"}'
         headers:
             Content-Length:
                 - "208"
@@ -1269,9 +1269,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:34 GMT
+                - Wed, 27 Aug 2025 15:06:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1279,10 +1279,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3f276f39-2545-4062-95a3-3aa4ba1375ff
+                - 40363282-a3b4-41d2-b615-6b481ba2e11b
         status: 200 OK
         code: 200
-        duration: 67.649166ms
+        duration: 87.00211ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1298,8 +1298,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/crons/8c9d6d52-337d-4334-9c0b-1667d856def8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/a9144d96-848f-4f8c-8be0-4d0e28420919
         method: GET
       response:
         proto: HTTP/2.0
@@ -1307,20 +1307,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 208
+        content_length: 595
         uncompressed: false
-        body: '{"args":{"test":"scw"},"container_id":"732824f2-d0e1-43cb-8e3a-dce98dc443b9","id":"8c9d6d52-337d-4334-9c0b-1667d856def8","name":"tf-tests-container-cron-basic-changed","schedule":"5 4 * * *","status":"ready"}'
+        body: '{"created_at":"2025-08-27T15:05:40.173657Z","description":"","environment_variables":{},"error_message":null,"id":"a9144d96-848f-4f8c-8be0-4d0e28420919","name":"tf-ns-condescending-davinci","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnscondescendingdavrry6gqta","registry_namespace_id":"baa92514-ade4-4162-99e8-8844b2c8bc2d","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:46.670806Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "208"
+                - "595"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:34 GMT
+                - Wed, 27 Aug 2025 15:06:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1328,10 +1328,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b76bcbcb-450a-48d4-9845-ed79e2f16bf0
+                - 68f0b93d-75c9-4fab-b7d1-61597cac575f
         status: 200 OK
         code: 200
-        duration: 92.87ms
+        duration: 80.458ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1347,8 +1347,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/crons/8c9d6d52-337d-4334-9c0b-1667d856def8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/9936cdaf-5081-45be-8dfe-eb4b961a3a0e
         method: GET
       response:
         proto: HTTP/2.0
@@ -1356,20 +1356,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 208
+        content_length: 980
         uncompressed: false
-        body: '{"args":{"test":"scw"},"container_id":"732824f2-d0e1-43cb-8e3a-dce98dc443b9","id":"8c9d6d52-337d-4334-9c0b-1667d856def8","name":"tf-tests-container-cron-basic-changed","schedule":"5 4 * * *","status":"ready"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:51.442678Z","description":"","domain_name":"tfnscondescendingdavrry6gqta-my-container-with-cron-tf.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"9936cdaf-5081-45be-8dfe-eb4b961a3a0e","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"my-container-with-cron-tf","namespace_id":"a9144d96-848f-4f8c-8be0-4d0e28420919","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnscondescendingdavrry6gqta/my-container-with-cron-tf:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:51.442678Z"}'
         headers:
             Content-Length:
-                - "208"
+                - "980"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:34 GMT
+                - Wed, 27 Aug 2025 15:06:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1377,10 +1377,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6c795543-35b3-4f65-8d69-673302834e72
+                - 57edf6dc-6cb0-489a-84ed-a30111cd5735
         status: 200 OK
         code: 200
-        duration: 63.793042ms
+        duration: 125.968692ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1396,8 +1396,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/1732421d-58af-4b37-ab1f-a138dda68cf0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/crons/c40ad375-434f-4e9e-859d-c6e9cb39bc9f
         method: GET
       response:
         proto: HTTP/2.0
@@ -1405,20 +1405,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 554
+        content_length: 208
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.343394Z","description":"","environment_variables":{},"error_message":null,"id":"1732421d-58af-4b37-ab1f-a138dda68cf0","name":"tf-ns-quizzical-nobel","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsquizzicalnobelq4aextoz","registry_namespace_id":"62eb2648-f3d3-4279-bd01-9b759058777a","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:38:17.429138Z"}'
+        body: '{"args":{"test":"scw"},"container_id":"9936cdaf-5081-45be-8dfe-eb4b961a3a0e","id":"c40ad375-434f-4e9e-859d-c6e9cb39bc9f","name":"tf-tests-container-cron-basic-changed","schedule":"5 4 * * *","status":"ready"}'
         headers:
             Content-Length:
-                - "554"
+                - "208"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:35 GMT
+                - Wed, 27 Aug 2025 15:06:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1426,10 +1426,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 31c95434-1138-480b-b9c3-d58b97a5c57a
+                - e54776aa-64e3-4164-8085-78bafc020a0f
         status: 200 OK
         code: 200
-        duration: 67.955041ms
+        duration: 85.670932ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1445,8 +1445,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/732824f2-d0e1-43cb-8e3a-dce98dc443b9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/crons/c40ad375-434f-4e9e-859d-c6e9cb39bc9f
         method: GET
       response:
         proto: HTTP/2.0
@@ -1454,20 +1454,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 917
+        content_length: 208
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:20.573132Z","description":"","domain_name":"tfnsquizzicalnobelq4aextoz-my-container-with-cron-tf.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"732824f2-d0e1-43cb-8e3a-dce98dc443b9","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"my-container-with-cron-tf","namespace_id":"1732421d-58af-4b37-ab1f-a138dda68cf0","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsquizzicalnobelq4aextoz/my-container-with-cron-tf:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:38:20.573132Z"}'
+        body: '{"args":{"test":"scw"},"container_id":"9936cdaf-5081-45be-8dfe-eb4b961a3a0e","id":"c40ad375-434f-4e9e-859d-c6e9cb39bc9f","name":"tf-tests-container-cron-basic-changed","schedule":"5 4 * * *","status":"ready"}'
         headers:
             Content-Length:
-                - "917"
+                - "208"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:35 GMT
+                - Wed, 27 Aug 2025 15:06:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1475,10 +1475,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - af9c793d-6588-4633-9836-1c8108366bd4
+                - 1b77d7cb-abdd-473b-b875-37fb68da4794
         status: 200 OK
         code: 200
-        duration: 68.654083ms
+        duration: 99.758058ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1494,29 +1494,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/crons/8c9d6d52-337d-4334-9c0b-1667d856def8
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/crons/c40ad375-434f-4e9e-859d-c6e9cb39bc9f
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 208
+        content_length: 211
         uncompressed: false
-        body: '{"args":{"test":"scw"},"container_id":"732824f2-d0e1-43cb-8e3a-dce98dc443b9","id":"8c9d6d52-337d-4334-9c0b-1667d856def8","name":"tf-tests-container-cron-basic-changed","schedule":"5 4 * * *","status":"ready"}'
+        body: '{"args":{"test":"scw"},"container_id":"9936cdaf-5081-45be-8dfe-eb4b961a3a0e","id":"c40ad375-434f-4e9e-859d-c6e9cb39bc9f","name":"tf-tests-container-cron-basic-changed","schedule":"5 4 * * *","status":"deleting"}'
         headers:
             Content-Length:
-                - "208"
+                - "211"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:35 GMT
+                - Wed, 27 Aug 2025 15:06:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1524,10 +1524,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c3b25e58-f491-45d6-9094-e9b736c13334
+                - afdfb5f4-4017-4e64-8ce4-9f0db081d504
         status: 200 OK
         code: 200
-        duration: 88.308542ms
+        duration: 128.313813ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1543,8 +1543,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/crons/8c9d6d52-337d-4334-9c0b-1667d856def8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/9936cdaf-5081-45be-8dfe-eb4b961a3a0e
         method: GET
       response:
         proto: HTTP/2.0
@@ -1552,20 +1552,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 208
+        content_length: 980
         uncompressed: false
-        body: '{"args":{"test":"scw"},"container_id":"732824f2-d0e1-43cb-8e3a-dce98dc443b9","id":"8c9d6d52-337d-4334-9c0b-1667d856def8","name":"tf-tests-container-cron-basic-changed","schedule":"5 4 * * *","status":"ready"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:51.442678Z","description":"","domain_name":"tfnscondescendingdavrry6gqta-my-container-with-cron-tf.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"9936cdaf-5081-45be-8dfe-eb4b961a3a0e","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"my-container-with-cron-tf","namespace_id":"a9144d96-848f-4f8c-8be0-4d0e28420919","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnscondescendingdavrry6gqta/my-container-with-cron-tf:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:51.442678Z"}'
         headers:
             Content-Length:
-                - "208"
+                - "980"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:36 GMT
+                - Wed, 27 Aug 2025 15:06:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1573,10 +1573,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 33c6b375-1018-45fb-a850-3f4c8ebc4eeb
+                - dc6a5a19-4b29-4ca6-9b30-c48f8166cb2b
         status: 200 OK
         code: 200
-        duration: 82.201042ms
+        duration: 258.364095ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1592,8 +1592,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/crons/8c9d6d52-337d-4334-9c0b-1667d856def8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/9936cdaf-5081-45be-8dfe-eb4b961a3a0e
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1601,20 +1601,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 211
+        content_length: 984
         uncompressed: false
-        body: '{"args":{"test":"scw"},"container_id":"732824f2-d0e1-43cb-8e3a-dce98dc443b9","id":"8c9d6d52-337d-4334-9c0b-1667d856def8","name":"tf-tests-container-cron-basic-changed","schedule":"5 4 * * *","status":"deleting"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:51.442678Z","description":"","domain_name":"tfnscondescendingdavrry6gqta-my-container-with-cron-tf.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"9936cdaf-5081-45be-8dfe-eb4b961a3a0e","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"my-container-with-cron-tf","namespace_id":"a9144d96-848f-4f8c-8be0-4d0e28420919","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnscondescendingdavrry6gqta/my-container-with-cron-tf:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:16.681655722Z"}'
         headers:
             Content-Length:
-                - "211"
+                - "984"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:36 GMT
+                - Wed, 27 Aug 2025 15:06:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1622,10 +1622,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 984b4810-b577-44a9-abc5-d481011dc205
+                - 43cf9d75-0cff-4a97-b8d7-22795da7679d
         status: 200 OK
         code: 200
-        duration: 116.7725ms
+        duration: 246.085493ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1641,8 +1641,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/732824f2-d0e1-43cb-8e3a-dce98dc443b9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/a9144d96-848f-4f8c-8be0-4d0e28420919
         method: GET
       response:
         proto: HTTP/2.0
@@ -1650,20 +1650,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 917
+        content_length: 595
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:20.573132Z","description":"","domain_name":"tfnsquizzicalnobelq4aextoz-my-container-with-cron-tf.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"732824f2-d0e1-43cb-8e3a-dce98dc443b9","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"my-container-with-cron-tf","namespace_id":"1732421d-58af-4b37-ab1f-a138dda68cf0","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsquizzicalnobelq4aextoz/my-container-with-cron-tf:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:38:20.573132Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.173657Z","description":"","environment_variables":{},"error_message":null,"id":"a9144d96-848f-4f8c-8be0-4d0e28420919","name":"tf-ns-condescending-davinci","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnscondescendingdavrry6gqta","registry_namespace_id":"baa92514-ade4-4162-99e8-8844b2c8bc2d","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:46.670806Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "917"
+                - "595"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:36 GMT
+                - Wed, 27 Aug 2025 15:06:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1671,10 +1671,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 26eb1d78-dd38-44b5-87f6-673ba9fc3b58
+                - 721eb4e2-30c4-477d-bcbe-f18890eec39a
         status: 200 OK
         code: 200
-        duration: 78.18925ms
+        duration: 89.720302ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1690,8 +1690,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/732824f2-d0e1-43cb-8e3a-dce98dc443b9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/a9144d96-848f-4f8c-8be0-4d0e28420919
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1699,20 +1699,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 921
+        content_length: 601
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:20.573132Z","description":"","domain_name":"tfnsquizzicalnobelq4aextoz-my-container-with-cron-tf.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"732824f2-d0e1-43cb-8e3a-dce98dc443b9","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"my-container-with-cron-tf","namespace_id":"1732421d-58af-4b37-ab1f-a138dda68cf0","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsquizzicalnobelq4aextoz/my-container-with-cron-tf:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"deleting","timeout":"300s","updated_at":"2025-01-24T15:38:36.871728733Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.173657Z","description":"","environment_variables":{},"error_message":null,"id":"a9144d96-848f-4f8c-8be0-4d0e28420919","name":"tf-ns-condescending-davinci","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnscondescendingdavrry6gqta","registry_namespace_id":"baa92514-ade4-4162-99e8-8844b2c8bc2d","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:17.027478405Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "921"
+                - "601"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:36 GMT
+                - Wed, 27 Aug 2025 15:06:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1720,10 +1720,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4287307a-bfbd-4134-86ff-5d4fd3edb1b1
+                - 3be87834-acf3-4778-bd93-689733a94a48
         status: 200 OK
         code: 200
-        duration: 207.618916ms
+        duration: 329.929279ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1739,8 +1739,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/1732421d-58af-4b37-ab1f-a138dda68cf0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/a9144d96-848f-4f8c-8be0-4d0e28420919
         method: GET
       response:
         proto: HTTP/2.0
@@ -1748,20 +1748,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 554
+        content_length: 598
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.343394Z","description":"","environment_variables":{},"error_message":null,"id":"1732421d-58af-4b37-ab1f-a138dda68cf0","name":"tf-ns-quizzical-nobel","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsquizzicalnobelq4aextoz","registry_namespace_id":"62eb2648-f3d3-4279-bd01-9b759058777a","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:38:17.429138Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.173657Z","description":"","environment_variables":{},"error_message":null,"id":"a9144d96-848f-4f8c-8be0-4d0e28420919","name":"tf-ns-condescending-davinci","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnscondescendingdavrry6gqta","registry_namespace_id":"baa92514-ade4-4162-99e8-8844b2c8bc2d","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:17.027478Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "554"
+                - "598"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:37 GMT
+                - Wed, 27 Aug 2025 15:06:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1769,10 +1769,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 635e6600-8e77-41cd-bc54-4a63c38b8ec6
+                - 16dc4331-ea29-40f1-9c7b-ef9fa3cba2af
         status: 200 OK
         code: 200
-        duration: 76.274583ms
+        duration: 85.185973ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1788,351 +1788,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/1732421d-58af-4b37-ab1f-a138dda68cf0
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 560
-        uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.343394Z","description":"","environment_variables":{},"error_message":null,"id":"1732421d-58af-4b37-ab1f-a138dda68cf0","name":"tf-ns-quizzical-nobel","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsquizzicalnobelq4aextoz","registry_namespace_id":"62eb2648-f3d3-4279-bd01-9b759058777a","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:38:37.082503679Z"}'
-        headers:
-            Content-Length:
-                - "560"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:38:37 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 05396c11-eca4-4495-bd6e-f607e528c45c
-        status: 200 OK
-        code: 200
-        duration: 245.885792ms
-    - id: 37
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/1732421d-58af-4b37-ab1f-a138dda68cf0
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 557
-        uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.343394Z","description":"","environment_variables":{},"error_message":null,"id":"1732421d-58af-4b37-ab1f-a138dda68cf0","name":"tf-ns-quizzical-nobel","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsquizzicalnobelq4aextoz","registry_namespace_id":"62eb2648-f3d3-4279-bd01-9b759058777a","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:38:37.082504Z"}'
-        headers:
-            Content-Length:
-                - "557"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:38:37 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - b32b259d-4f10-45ec-942d-8f26a08710c8
-        status: 200 OK
-        code: 200
-        duration: 69.183791ms
-    - id: 38
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/1732421d-58af-4b37-ab1f-a138dda68cf0
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 557
-        uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.343394Z","description":"","environment_variables":{},"error_message":null,"id":"1732421d-58af-4b37-ab1f-a138dda68cf0","name":"tf-ns-quizzical-nobel","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsquizzicalnobelq4aextoz","registry_namespace_id":"62eb2648-f3d3-4279-bd01-9b759058777a","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:38:37.082504Z"}'
-        headers:
-            Content-Length:
-                - "557"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:38:42 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 018793ff-075c-4834-b944-1c1371452689
-        status: 200 OK
-        code: 200
-        duration: 64.983458ms
-    - id: 39
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/1732421d-58af-4b37-ab1f-a138dda68cf0
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 557
-        uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.343394Z","description":"","environment_variables":{},"error_message":null,"id":"1732421d-58af-4b37-ab1f-a138dda68cf0","name":"tf-ns-quizzical-nobel","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsquizzicalnobelq4aextoz","registry_namespace_id":"62eb2648-f3d3-4279-bd01-9b759058777a","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:38:37.082504Z"}'
-        headers:
-            Content-Length:
-                - "557"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:38:47 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - d1370091-f4d5-4d40-83a8-91cf3d94625c
-        status: 200 OK
-        code: 200
-        duration: 70.24975ms
-    - id: 40
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/1732421d-58af-4b37-ab1f-a138dda68cf0
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 557
-        uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.343394Z","description":"","environment_variables":{},"error_message":null,"id":"1732421d-58af-4b37-ab1f-a138dda68cf0","name":"tf-ns-quizzical-nobel","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsquizzicalnobelq4aextoz","registry_namespace_id":"62eb2648-f3d3-4279-bd01-9b759058777a","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:38:37.082504Z"}'
-        headers:
-            Content-Length:
-                - "557"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:38:52 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 9bade760-afb7-49de-a46e-87377928cbe4
-        status: 200 OK
-        code: 200
-        duration: 61.093833ms
-    - id: 41
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/1732421d-58af-4b37-ab1f-a138dda68cf0
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 557
-        uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.343394Z","description":"","environment_variables":{},"error_message":null,"id":"1732421d-58af-4b37-ab1f-a138dda68cf0","name":"tf-ns-quizzical-nobel","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsquizzicalnobelq4aextoz","registry_namespace_id":"62eb2648-f3d3-4279-bd01-9b759058777a","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:38:37.082504Z"}'
-        headers:
-            Content-Length:
-                - "557"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:38:57 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 058cf940-e7d5-4db3-aa29-9c0eaaacb44a
-        status: 200 OK
-        code: 200
-        duration: 63.626541ms
-    - id: 42
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/1732421d-58af-4b37-ab1f-a138dda68cf0
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 557
-        uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.343394Z","description":"","environment_variables":{},"error_message":null,"id":"1732421d-58af-4b37-ab1f-a138dda68cf0","name":"tf-ns-quizzical-nobel","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsquizzicalnobelq4aextoz","registry_namespace_id":"62eb2648-f3d3-4279-bd01-9b759058777a","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:38:37.082504Z"}'
-        headers:
-            Content-Length:
-                - "557"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:39:02 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 33048672-74ce-407f-99ca-e30db5983fa7
-        status: 200 OK
-        code: 200
-        duration: 64.626833ms
-    - id: 43
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/1732421d-58af-4b37-ab1f-a138dda68cf0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/a9144d96-848f-4f8c-8be0-4d0e28420919
         method: GET
       response:
         proto: HTTP/2.0
@@ -2151,9 +1808,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:39:07 GMT
+                - Wed, 27 Aug 2025 15:06:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2161,11 +1818,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 968abcbe-a6dc-4147-a38b-6bc1c4cd7412
+                - 69a20684-5845-470f-962f-f6a793ad2dff
         status: 404 Not Found
         code: 404
-        duration: 27.498708ms
-    - id: 44
+        duration: 25.67476ms
+    - id: 37
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2180,8 +1837,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/crons/8c9d6d52-337d-4334-9c0b-1667d856def8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/crons/c40ad375-434f-4e9e-859d-c6e9cb39bc9f
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -2200,9 +1857,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:39:07 GMT
+                - Wed, 27 Aug 2025 15:06:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2210,7 +1867,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 94bb673e-64f2-4b56-bfde-d50fc6d20e26
+                - ad17d0ac-fe83-4a76-9a59-2ef51208f98a
         status: 404 Not Found
         code: 404
-        duration: 25.738333ms
+        duration: 26.339497ms

--- a/internal/services/container/testdata/cron-with-multi-args.cassette.yaml
+++ b/internal/services/container/testdata/cron-with-multi-args.cassette.yaml
@@ -6,19 +6,19 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 155
+        content_length: 192
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-ns-vigorous-benz","environment_variables":{},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","secret_environment_variables":[],"tags":null}'
+        body: '{"name":"tf-ns-interesting-bartik","environment_variables":{},"project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","secret_environment_variables":[],"tags":null,"activate_vpc_integration":true}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces
         method: POST
       response:
@@ -27,20 +27,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 471
+        content_length: 509
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.278499805Z","description":"","environment_variables":{},"error_message":null,"id":"34594269-f6d6-4973-81e7-e8aa89beb825","name":"tf-ns-vigorous-benz","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:37:49.278499805Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.873326819Z","description":"","environment_variables":{},"error_message":null,"id":"d3220d1b-aadd-4201-8bc2-87a62beaf139","name":"tf-ns-interesting-bartik","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:40.873326819Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "471"
+                - "509"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:37:49 GMT
+                - Wed, 27 Aug 2025 15:05:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 16609a64-e816-4b58-94c2-8b8c9a0f68fd
+                - e1ca34b5-e5ce-4a88-83ad-a2b7c0e0e3de
         status: 200 OK
         code: 200
-        duration: 931.459541ms
+        duration: 4.893191757s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -67,8 +67,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/34594269-f6d6-4973-81e7-e8aa89beb825
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d3220d1b-aadd-4201-8bc2-87a62beaf139
         method: GET
       response:
         proto: HTTP/2.0
@@ -76,20 +76,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 465
+        content_length: 503
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.278500Z","description":"","environment_variables":{},"error_message":null,"id":"34594269-f6d6-4973-81e7-e8aa89beb825","name":"tf-ns-vigorous-benz","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:37:49.278500Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.873327Z","description":"","environment_variables":{},"error_message":null,"id":"d3220d1b-aadd-4201-8bc2-87a62beaf139","name":"tf-ns-interesting-bartik","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:40.873327Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "465"
+                - "503"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:37:49 GMT
+                - Wed, 27 Aug 2025 15:05:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8f62defa-01d3-4373-8624-563a0042db19
+                - d71cbf75-b211-4b01-88f6-8103b707a10c
         status: 200 OK
         code: 200
-        duration: 63.6655ms
+        duration: 80.714624ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -116,8 +116,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/34594269-f6d6-4973-81e7-e8aa89beb825
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d3220d1b-aadd-4201-8bc2-87a62beaf139
         method: GET
       response:
         proto: HTTP/2.0
@@ -125,20 +125,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 552
+        content_length: 594
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.278500Z","description":"","environment_variables":{},"error_message":null,"id":"34594269-f6d6-4973-81e7-e8aa89beb825","name":"tf-ns-vigorous-benz","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsvigorousbenzcxr4zoly","registry_namespace_id":"6c75a0d9-117c-4e58-aa7a-9724e11d4d2b","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:37:51.009364Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.873327Z","description":"","environment_variables":{},"error_message":null,"id":"d3220d1b-aadd-4201-8bc2-87a62beaf139","name":"tf-ns-interesting-bartik","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsinterestingbartirzq5ntud","registry_namespace_id":"114451fc-ec14-4b77-b933-c624377bb727","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:44.912918Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "552"
+                - "594"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:37:54 GMT
+                - Wed, 27 Aug 2025 15:05:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -146,10 +146,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0539d951-3bf6-452c-b447-bb6e88542a70
+                - 6093e0a1-77d2-412f-93ce-48df8f932b4e
         status: 200 OK
         code: 200
-        duration: 98.91725ms
+        duration: 107.771906ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -165,8 +165,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/34594269-f6d6-4973-81e7-e8aa89beb825
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d3220d1b-aadd-4201-8bc2-87a62beaf139
         method: GET
       response:
         proto: HTTP/2.0
@@ -174,20 +174,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 552
+        content_length: 594
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.278500Z","description":"","environment_variables":{},"error_message":null,"id":"34594269-f6d6-4973-81e7-e8aa89beb825","name":"tf-ns-vigorous-benz","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsvigorousbenzcxr4zoly","registry_namespace_id":"6c75a0d9-117c-4e58-aa7a-9724e11d4d2b","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:37:51.009364Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.873327Z","description":"","environment_variables":{},"error_message":null,"id":"d3220d1b-aadd-4201-8bc2-87a62beaf139","name":"tf-ns-interesting-bartik","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsinterestingbartirzq5ntud","registry_namespace_id":"114451fc-ec14-4b77-b933-c624377bb727","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:44.912918Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "552"
+                - "594"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:37:59 GMT
+                - Wed, 27 Aug 2025 15:05:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -195,10 +195,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bc34a00e-05dc-46bf-9c88-c20c57d2a22b
+                - db51c2d9-dee7-4713-ac4e-ef557b31f100
         status: 200 OK
         code: 200
-        duration: 62.805833ms
+        duration: 85.14559ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -214,8 +214,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/34594269-f6d6-4973-81e7-e8aa89beb825
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d3220d1b-aadd-4201-8bc2-87a62beaf139
         method: GET
       response:
         proto: HTTP/2.0
@@ -223,20 +223,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 552
+        content_length: 594
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.278500Z","description":"","environment_variables":{},"error_message":null,"id":"34594269-f6d6-4973-81e7-e8aa89beb825","name":"tf-ns-vigorous-benz","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsvigorousbenzcxr4zoly","registry_namespace_id":"6c75a0d9-117c-4e58-aa7a-9724e11d4d2b","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:37:51.009364Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.873327Z","description":"","environment_variables":{},"error_message":null,"id":"d3220d1b-aadd-4201-8bc2-87a62beaf139","name":"tf-ns-interesting-bartik","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsinterestingbartirzq5ntud","registry_namespace_id":"114451fc-ec14-4b77-b933-c624377bb727","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:44.912918Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "552"
+                - "594"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:04 GMT
+                - Wed, 27 Aug 2025 15:05:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -244,10 +244,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d4ad30e3-239d-4d41-958e-4d58dec3980f
+                - caeafccb-2126-41a7-b937-ae08519796ea
         status: 200 OK
         code: 200
-        duration: 70.606292ms
+        duration: 81.225956ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -263,8 +263,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/34594269-f6d6-4973-81e7-e8aa89beb825
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d3220d1b-aadd-4201-8bc2-87a62beaf139
         method: GET
       response:
         proto: HTTP/2.0
@@ -272,20 +272,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 552
+        content_length: 594
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.278500Z","description":"","environment_variables":{},"error_message":null,"id":"34594269-f6d6-4973-81e7-e8aa89beb825","name":"tf-ns-vigorous-benz","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsvigorousbenzcxr4zoly","registry_namespace_id":"6c75a0d9-117c-4e58-aa7a-9724e11d4d2b","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:37:51.009364Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.873327Z","description":"","environment_variables":{},"error_message":null,"id":"d3220d1b-aadd-4201-8bc2-87a62beaf139","name":"tf-ns-interesting-bartik","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsinterestingbartirzq5ntud","registry_namespace_id":"114451fc-ec14-4b77-b933-c624377bb727","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:44.912918Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "552"
+                - "594"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:09 GMT
+                - Wed, 27 Aug 2025 15:06:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -293,10 +293,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 50f07a65-90b1-42e8-b396-139cceca7563
+                - 96eae2f5-5ca4-4e6f-86dc-cf5acffa909b
         status: 200 OK
         code: 200
-        duration: 67.765667ms
+        duration: 85.098134ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -312,8 +312,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/34594269-f6d6-4973-81e7-e8aa89beb825
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d3220d1b-aadd-4201-8bc2-87a62beaf139
         method: GET
       response:
         proto: HTTP/2.0
@@ -321,20 +321,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 552
+        content_length: 592
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.278500Z","description":"","environment_variables":{},"error_message":null,"id":"34594269-f6d6-4973-81e7-e8aa89beb825","name":"tf-ns-vigorous-benz","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsvigorousbenzcxr4zoly","registry_namespace_id":"6c75a0d9-117c-4e58-aa7a-9724e11d4d2b","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:37:51.009364Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.873327Z","description":"","environment_variables":{},"error_message":null,"id":"d3220d1b-aadd-4201-8bc2-87a62beaf139","name":"tf-ns-interesting-bartik","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsinterestingbartirzq5ntud","registry_namespace_id":"114451fc-ec14-4b77-b933-c624377bb727","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:04.122926Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "552"
+                - "592"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:14 GMT
+                - Wed, 27 Aug 2025 15:06:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -342,10 +342,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5b811492-da5b-49bf-8815-c0f66866b454
+                - e364b000-9449-440c-9a74-61680eeca816
         status: 200 OK
         code: 200
-        duration: 75.011875ms
+        duration: 77.308828ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -361,8 +361,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/34594269-f6d6-4973-81e7-e8aa89beb825
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d3220d1b-aadd-4201-8bc2-87a62beaf139
         method: GET
       response:
         proto: HTTP/2.0
@@ -370,20 +370,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 550
+        content_length: 592
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.278500Z","description":"","environment_variables":{},"error_message":null,"id":"34594269-f6d6-4973-81e7-e8aa89beb825","name":"tf-ns-vigorous-benz","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsvigorousbenzcxr4zoly","registry_namespace_id":"6c75a0d9-117c-4e58-aa7a-9724e11d4d2b","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:38:18.849885Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.873327Z","description":"","environment_variables":{},"error_message":null,"id":"d3220d1b-aadd-4201-8bc2-87a62beaf139","name":"tf-ns-interesting-bartik","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsinterestingbartirzq5ntud","registry_namespace_id":"114451fc-ec14-4b77-b933-c624377bb727","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:04.122926Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "550"
+                - "592"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:19 GMT
+                - Wed, 27 Aug 2025 15:06:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -391,10 +391,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 437d4f45-1e52-4686-9e95-0ad9f213d0e6
+                - 09be9312-0863-4ae4-9884-efdc34b27311
         status: 200 OK
         code: 200
-        duration: 63.240667ms
+        duration: 87.182317ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -410,8 +410,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/34594269-f6d6-4973-81e7-e8aa89beb825
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d3220d1b-aadd-4201-8bc2-87a62beaf139
         method: GET
       response:
         proto: HTTP/2.0
@@ -419,20 +419,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 550
+        content_length: 592
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.278500Z","description":"","environment_variables":{},"error_message":null,"id":"34594269-f6d6-4973-81e7-e8aa89beb825","name":"tf-ns-vigorous-benz","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsvigorousbenzcxr4zoly","registry_namespace_id":"6c75a0d9-117c-4e58-aa7a-9724e11d4d2b","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:38:18.849885Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.873327Z","description":"","environment_variables":{},"error_message":null,"id":"d3220d1b-aadd-4201-8bc2-87a62beaf139","name":"tf-ns-interesting-bartik","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsinterestingbartirzq5ntud","registry_namespace_id":"114451fc-ec14-4b77-b933-c624377bb727","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:04.122926Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "550"
+                - "592"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:19 GMT
+                - Wed, 27 Aug 2025 15:06:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -440,77 +440,28 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8e8c681b-cb18-4426-9614-2d327b7b66be
+                - ec6742e8-8dc3-4d52-a174-727537d3b188
         status: 200 OK
         code: 200
-        duration: 62.660459ms
+        duration: 83.536304ms
     - id: 9
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 255
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/34594269-f6d6-4973-81e7-e8aa89beb825
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 550
-        uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.278500Z","description":"","environment_variables":{},"error_message":null,"id":"34594269-f6d6-4973-81e7-e8aa89beb825","name":"tf-ns-vigorous-benz","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsvigorousbenzcxr4zoly","registry_namespace_id":"6c75a0d9-117c-4e58-aa7a-9724e11d4d2b","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:38:18.849885Z"}'
-        headers:
-            Content-Length:
-                - "550"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:38:19 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 665280d6-9c34-4c28-a7ed-255376042816
-        status: 200 OK
-        code: 200
-        duration: 66.244042ms
-    - id: 10
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 216
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"namespace_id":"34594269-f6d6-4973-81e7-e8aa89beb825","name":"my-container-with-cron-tf","privacy":"public","protocol":"http1","secret_environment_variables":null,"http_option":"enabled","sandbox":"unknown_sandbox"}'
+        body: '{"namespace_id":"d3220d1b-aadd-4201-8bc2-87a62beaf139","name":"my-container-with-cron-tf","privacy":"public","protocol":"http1","secret_environment_variables":null,"http_option":"enabled","sandbox":"unknown_sandbox","tags":null,"command":null,"args":null}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers
         method: POST
       response:
@@ -519,20 +470,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 919
+        content_length: 986
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:20.833469920Z","description":"","domain_name":"tfnsvigorousbenzcxr4zoly-my-container-with-cron-tf.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"d2562792-6988-4059-8647-6fd43f9abc6f","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"my-container-with-cron-tf","namespace_id":"34594269-f6d6-4973-81e7-e8aa89beb825","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsvigorousbenzcxr4zoly/my-container-with-cron-tf:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:38:20.833469920Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:07.424453167Z","description":"","domain_name":"tfnsinterestingbartirzq5ntud-my-container-with-cron-tf.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"5c1cc97b-82ca-491b-b321-6403bb9a7015","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"my-container-with-cron-tf","namespace_id":"d3220d1b-aadd-4201-8bc2-87a62beaf139","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsinterestingbartirzq5ntud/my-container-with-cron-tf:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:07.424453167Z"}'
         headers:
             Content-Length:
-                - "919"
+                - "986"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:20 GMT
+                - Wed, 27 Aug 2025 15:06:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -540,11 +491,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 671eab3c-94ad-4234-b4c4-44b8bbaaab89
+                - d41cd5c4-15cf-4c3b-8a35-eb6ec3dfaacc
         status: 200 OK
         code: 200
-        duration: 911.429583ms
-    - id: 11
+        duration: 852.697727ms
+    - id: 10
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -559,8 +510,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/d2562792-6988-4059-8647-6fd43f9abc6f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/5c1cc97b-82ca-491b-b321-6403bb9a7015
         method: GET
       response:
         proto: HTTP/2.0
@@ -568,20 +519,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 913
+        content_length: 980
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:20.833470Z","description":"","domain_name":"tfnsvigorousbenzcxr4zoly-my-container-with-cron-tf.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"d2562792-6988-4059-8647-6fd43f9abc6f","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"my-container-with-cron-tf","namespace_id":"34594269-f6d6-4973-81e7-e8aa89beb825","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsvigorousbenzcxr4zoly/my-container-with-cron-tf:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:38:20.833470Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:07.424453Z","description":"","domain_name":"tfnsinterestingbartirzq5ntud-my-container-with-cron-tf.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"5c1cc97b-82ca-491b-b321-6403bb9a7015","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"my-container-with-cron-tf","namespace_id":"d3220d1b-aadd-4201-8bc2-87a62beaf139","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsinterestingbartirzq5ntud/my-container-with-cron-tf:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:07.424453Z"}'
         headers:
             Content-Length:
-                - "913"
+                - "980"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:20 GMT
+                - Wed, 27 Aug 2025 15:06:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -589,11 +540,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 68434db8-0034-467c-ae6f-e7f17e1cf4e7
+                - 412ac457-8a2c-4961-86f6-f805917fb5d4
         status: 200 OK
         code: 200
-        duration: 75.294291ms
-    - id: 12
+        duration: 98.426627ms
+    - id: 11
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -604,13 +555,13 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"container_id":"d2562792-6988-4059-8647-6fd43f9abc6f","schedule":"5 4 1 * *","args":{"address":{"city":"Paris","country":"FR"},"age":23,"firstName":"John","isAlive":true,"lastName":"Smith"}}'
+        body: '{"container_id":"5c1cc97b-82ca-491b-b321-6403bb9a7015","schedule":"5 4 1 * *","args":{"address":{"city":"Paris","country":"FR"},"age":23,"firstName":"John","isAlive":true,"lastName":"Smith"}}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/crons
         method: POST
       response:
@@ -621,7 +572,7 @@ interactions:
         trailer: {}
         content_length: 305
         uncompressed: false
-        body: '{"args":{"address":{"city":"Paris","country":"FR"},"age":23,"firstName":"John","isAlive":true,"lastName":"Smith"},"container_id":"d2562792-6988-4059-8647-6fd43f9abc6f","id":"e1095853-6479-4944-9116-732dbc5d51ae","name":"cron-e1095853-6479-4944-9116-732dbc5d51ae","schedule":"5 4 1 * *","status":"pending"}'
+        body: '{"args":{"address":{"city":"Paris","country":"FR"},"age":23,"firstName":"John","isAlive":true,"lastName":"Smith"},"container_id":"5c1cc97b-82ca-491b-b321-6403bb9a7015","id":"bb651f5b-6196-43f9-86c7-9981169641ad","name":"cron-bb651f5b-6196-43f9-86c7-9981169641ad","schedule":"5 4 1 * *","status":"pending"}'
         headers:
             Content-Length:
                 - "305"
@@ -630,9 +581,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:21 GMT
+                - Wed, 27 Aug 2025 15:06:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -640,10 +591,59 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0cd127fe-b1a8-4a9c-92f4-bc1d237f6909
+                - 16f71863-88b1-407b-b2e3-53c15d174b10
         status: 200 OK
         code: 200
-        duration: 115.246167ms
+        duration: 123.305141ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/crons/bb651f5b-6196-43f9-86c7-9981169641ad
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 305
+        uncompressed: false
+        body: '{"args":{"address":{"city":"Paris","country":"FR"},"age":23,"firstName":"John","isAlive":true,"lastName":"Smith"},"container_id":"5c1cc97b-82ca-491b-b321-6403bb9a7015","id":"bb651f5b-6196-43f9-86c7-9981169641ad","name":"cron-bb651f5b-6196-43f9-86c7-9981169641ad","schedule":"5 4 1 * *","status":"pending"}'
+        headers:
+            Content-Length:
+                - "305"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:07 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 6e29cdaf-3f8b-4d83-9264-a6272e3bbedc
+        status: 200 OK
+        code: 200
+        duration: 119.227759ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -659,8 +659,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/crons/e1095853-6479-4944-9116-732dbc5d51ae
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/crons/bb651f5b-6196-43f9-86c7-9981169641ad
         method: GET
       response:
         proto: HTTP/2.0
@@ -668,20 +668,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 305
+        content_length: 303
         uncompressed: false
-        body: '{"args":{"address":{"city":"Paris","country":"FR"},"age":23,"firstName":"John","isAlive":true,"lastName":"Smith"},"container_id":"d2562792-6988-4059-8647-6fd43f9abc6f","id":"e1095853-6479-4944-9116-732dbc5d51ae","name":"cron-e1095853-6479-4944-9116-732dbc5d51ae","schedule":"5 4 1 * *","status":"pending"}'
+        body: '{"args":{"address":{"city":"Paris","country":"FR"},"age":23,"firstName":"John","isAlive":true,"lastName":"Smith"},"container_id":"5c1cc97b-82ca-491b-b321-6403bb9a7015","id":"bb651f5b-6196-43f9-86c7-9981169641ad","name":"cron-bb651f5b-6196-43f9-86c7-9981169641ad","schedule":"5 4 1 * *","status":"ready"}'
         headers:
             Content-Length:
-                - "305"
+                - "303"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:21 GMT
+                - Wed, 27 Aug 2025 15:06:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -689,10 +689,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5454096f-273e-4158-a985-f495519f8315
+                - f3f17845-ebfd-4db1-b61f-d5d2e4a3bfb5
         status: 200 OK
         code: 200
-        duration: 72.943625ms
+        duration: 103.059912ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -708,8 +708,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/crons/e1095853-6479-4944-9116-732dbc5d51ae
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/crons/bb651f5b-6196-43f9-86c7-9981169641ad
         method: GET
       response:
         proto: HTTP/2.0
@@ -719,7 +719,7 @@ interactions:
         trailer: {}
         content_length: 303
         uncompressed: false
-        body: '{"args":{"address":{"city":"Paris","country":"FR"},"age":23,"firstName":"John","isAlive":true,"lastName":"Smith"},"container_id":"d2562792-6988-4059-8647-6fd43f9abc6f","id":"e1095853-6479-4944-9116-732dbc5d51ae","name":"cron-e1095853-6479-4944-9116-732dbc5d51ae","schedule":"5 4 1 * *","status":"ready"}'
+        body: '{"args":{"address":{"city":"Paris","country":"FR"},"age":23,"firstName":"John","isAlive":true,"lastName":"Smith"},"container_id":"5c1cc97b-82ca-491b-b321-6403bb9a7015","id":"bb651f5b-6196-43f9-86c7-9981169641ad","name":"cron-bb651f5b-6196-43f9-86c7-9981169641ad","schedule":"5 4 1 * *","status":"ready"}'
         headers:
             Content-Length:
                 - "303"
@@ -728,9 +728,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:26 GMT
+                - Wed, 27 Aug 2025 15:06:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -738,10 +738,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 51ff8fd5-ddee-404f-9b92-da92f09cad5f
+                - 7abaee29-c91f-45cc-8bef-0593e576875e
         status: 200 OK
         code: 200
-        duration: 96.803209ms
+        duration: 102.582527ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -757,8 +757,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/crons/e1095853-6479-4944-9116-732dbc5d51ae
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/crons/bb651f5b-6196-43f9-86c7-9981169641ad
         method: GET
       response:
         proto: HTTP/2.0
@@ -768,7 +768,7 @@ interactions:
         trailer: {}
         content_length: 303
         uncompressed: false
-        body: '{"args":{"address":{"city":"Paris","country":"FR"},"age":23,"firstName":"John","isAlive":true,"lastName":"Smith"},"container_id":"d2562792-6988-4059-8647-6fd43f9abc6f","id":"e1095853-6479-4944-9116-732dbc5d51ae","name":"cron-e1095853-6479-4944-9116-732dbc5d51ae","schedule":"5 4 1 * *","status":"ready"}'
+        body: '{"args":{"address":{"city":"Paris","country":"FR"},"age":23,"firstName":"John","isAlive":true,"lastName":"Smith"},"container_id":"5c1cc97b-82ca-491b-b321-6403bb9a7015","id":"bb651f5b-6196-43f9-86c7-9981169641ad","name":"cron-bb651f5b-6196-43f9-86c7-9981169641ad","schedule":"5 4 1 * *","status":"ready"}'
         headers:
             Content-Length:
                 - "303"
@@ -777,9 +777,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:26 GMT
+                - Wed, 27 Aug 2025 15:06:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -787,10 +787,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - dbb7399d-280f-4ff7-83c0-ce81367b7e4a
+                - 76f46bb5-be11-456a-b7b0-74facd180b7b
         status: 200 OK
         code: 200
-        duration: 85.917042ms
+        duration: 113.604009ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -806,8 +806,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/crons/e1095853-6479-4944-9116-732dbc5d51ae
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d3220d1b-aadd-4201-8bc2-87a62beaf139
         method: GET
       response:
         proto: HTTP/2.0
@@ -815,20 +815,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 303
+        content_length: 592
         uncompressed: false
-        body: '{"args":{"address":{"city":"Paris","country":"FR"},"age":23,"firstName":"John","isAlive":true,"lastName":"Smith"},"container_id":"d2562792-6988-4059-8647-6fd43f9abc6f","id":"e1095853-6479-4944-9116-732dbc5d51ae","name":"cron-e1095853-6479-4944-9116-732dbc5d51ae","schedule":"5 4 1 * *","status":"ready"}'
+        body: '{"created_at":"2025-08-27T15:05:40.873327Z","description":"","environment_variables":{},"error_message":null,"id":"d3220d1b-aadd-4201-8bc2-87a62beaf139","name":"tf-ns-interesting-bartik","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsinterestingbartirzq5ntud","registry_namespace_id":"114451fc-ec14-4b77-b933-c624377bb727","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:04.122926Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "303"
+                - "592"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:26 GMT
+                - Wed, 27 Aug 2025 15:06:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -836,10 +836,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 640a45e6-c607-4d39-9512-0c629f61cd09
+                - 9ddeaf9b-d652-4e85-a9ab-cdf7fe77c637
         status: 200 OK
         code: 200
-        duration: 81.769958ms
+        duration: 69.051836ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -855,8 +855,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/34594269-f6d6-4973-81e7-e8aa89beb825
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/5c1cc97b-82ca-491b-b321-6403bb9a7015
         method: GET
       response:
         proto: HTTP/2.0
@@ -864,20 +864,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 550
+        content_length: 980
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.278500Z","description":"","environment_variables":{},"error_message":null,"id":"34594269-f6d6-4973-81e7-e8aa89beb825","name":"tf-ns-vigorous-benz","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsvigorousbenzcxr4zoly","registry_namespace_id":"6c75a0d9-117c-4e58-aa7a-9724e11d4d2b","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:38:18.849885Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:07.424453Z","description":"","domain_name":"tfnsinterestingbartirzq5ntud-my-container-with-cron-tf.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"5c1cc97b-82ca-491b-b321-6403bb9a7015","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"my-container-with-cron-tf","namespace_id":"d3220d1b-aadd-4201-8bc2-87a62beaf139","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsinterestingbartirzq5ntud/my-container-with-cron-tf:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:07.424453Z"}'
         headers:
             Content-Length:
-                - "550"
+                - "980"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:27 GMT
+                - Wed, 27 Aug 2025 15:06:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -885,10 +885,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1c41d7df-f3eb-4d93-bbab-9e86b55d52fc
+                - 32d8463f-4111-4bda-94d8-867aeec00355
         status: 200 OK
         code: 200
-        duration: 73.747291ms
+        duration: 96.466389ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -904,8 +904,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/d2562792-6988-4059-8647-6fd43f9abc6f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/crons/bb651f5b-6196-43f9-86c7-9981169641ad
         method: GET
       response:
         proto: HTTP/2.0
@@ -913,20 +913,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 913
+        content_length: 303
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:20.833470Z","description":"","domain_name":"tfnsvigorousbenzcxr4zoly-my-container-with-cron-tf.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"d2562792-6988-4059-8647-6fd43f9abc6f","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"my-container-with-cron-tf","namespace_id":"34594269-f6d6-4973-81e7-e8aa89beb825","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsvigorousbenzcxr4zoly/my-container-with-cron-tf:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:38:20.833470Z"}'
+        body: '{"args":{"address":{"city":"Paris","country":"FR"},"age":23,"firstName":"John","isAlive":true,"lastName":"Smith"},"container_id":"5c1cc97b-82ca-491b-b321-6403bb9a7015","id":"bb651f5b-6196-43f9-86c7-9981169641ad","name":"cron-bb651f5b-6196-43f9-86c7-9981169641ad","schedule":"5 4 1 * *","status":"ready"}'
         headers:
             Content-Length:
-                - "913"
+                - "303"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:27 GMT
+                - Wed, 27 Aug 2025 15:06:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -934,10 +934,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e02d056c-87ec-4400-b9be-9f8a39fcf7be
+                - c8587d51-9bef-4a6f-a11d-edaef74a4ab7
         status: 200 OK
         code: 200
-        duration: 77.118041ms
+        duration: 96.192215ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -953,8 +953,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/crons/e1095853-6479-4944-9116-732dbc5d51ae
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d3220d1b-aadd-4201-8bc2-87a62beaf139
         method: GET
       response:
         proto: HTTP/2.0
@@ -962,20 +962,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 303
+        content_length: 592
         uncompressed: false
-        body: '{"args":{"address":{"city":"Paris","country":"FR"},"age":23,"firstName":"John","isAlive":true,"lastName":"Smith"},"container_id":"d2562792-6988-4059-8647-6fd43f9abc6f","id":"e1095853-6479-4944-9116-732dbc5d51ae","name":"cron-e1095853-6479-4944-9116-732dbc5d51ae","schedule":"5 4 1 * *","status":"ready"}'
+        body: '{"created_at":"2025-08-27T15:05:40.873327Z","description":"","environment_variables":{},"error_message":null,"id":"d3220d1b-aadd-4201-8bc2-87a62beaf139","name":"tf-ns-interesting-bartik","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsinterestingbartirzq5ntud","registry_namespace_id":"114451fc-ec14-4b77-b933-c624377bb727","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:04.122926Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "303"
+                - "592"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:27 GMT
+                - Wed, 27 Aug 2025 15:06:14 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -983,10 +983,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c8c0d147-6669-41a6-9ac0-887a09430f70
+                - d46e2c0f-6c2d-4b1c-9c26-7be56dc9f15f
         status: 200 OK
         code: 200
-        duration: 74.3245ms
+        duration: 86.053701ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1002,8 +1002,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/34594269-f6d6-4973-81e7-e8aa89beb825
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/5c1cc97b-82ca-491b-b321-6403bb9a7015
         method: GET
       response:
         proto: HTTP/2.0
@@ -1011,20 +1011,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 550
+        content_length: 980
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.278500Z","description":"","environment_variables":{},"error_message":null,"id":"34594269-f6d6-4973-81e7-e8aa89beb825","name":"tf-ns-vigorous-benz","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsvigorousbenzcxr4zoly","registry_namespace_id":"6c75a0d9-117c-4e58-aa7a-9724e11d4d2b","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:38:18.849885Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:07.424453Z","description":"","domain_name":"tfnsinterestingbartirzq5ntud-my-container-with-cron-tf.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"5c1cc97b-82ca-491b-b321-6403bb9a7015","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"my-container-with-cron-tf","namespace_id":"d3220d1b-aadd-4201-8bc2-87a62beaf139","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsinterestingbartirzq5ntud/my-container-with-cron-tf:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:07.424453Z"}'
         headers:
             Content-Length:
-                - "550"
+                - "980"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:28 GMT
+                - Wed, 27 Aug 2025 15:06:14 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1032,10 +1032,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e5a4fce6-8c7d-4a93-9185-eea65229d955
+                - a066a65d-fc50-4624-bfc3-ef1f692d256f
         status: 200 OK
         code: 200
-        duration: 74.690833ms
+        duration: 94.987145ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1051,8 +1051,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/d2562792-6988-4059-8647-6fd43f9abc6f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/crons/bb651f5b-6196-43f9-86c7-9981169641ad
         method: GET
       response:
         proto: HTTP/2.0
@@ -1060,20 +1060,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 913
+        content_length: 303
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:20.833470Z","description":"","domain_name":"tfnsvigorousbenzcxr4zoly-my-container-with-cron-tf.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"d2562792-6988-4059-8647-6fd43f9abc6f","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"my-container-with-cron-tf","namespace_id":"34594269-f6d6-4973-81e7-e8aa89beb825","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsvigorousbenzcxr4zoly/my-container-with-cron-tf:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:38:20.833470Z"}'
+        body: '{"args":{"address":{"city":"Paris","country":"FR"},"age":23,"firstName":"John","isAlive":true,"lastName":"Smith"},"container_id":"5c1cc97b-82ca-491b-b321-6403bb9a7015","id":"bb651f5b-6196-43f9-86c7-9981169641ad","name":"cron-bb651f5b-6196-43f9-86c7-9981169641ad","schedule":"5 4 1 * *","status":"ready"}'
         headers:
             Content-Length:
-                - "913"
+                - "303"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:28 GMT
+                - Wed, 27 Aug 2025 15:06:14 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1081,11 +1081,62 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1b8193c6-c071-45a3-afbf-cf216fd2cac8
+                - 9419676a-09ad-4d6e-af86-8f28197da693
         status: 200 OK
         code: 200
-        duration: 82.920333ms
+        duration: 94.619264ms
     - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 100
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"container_id":"5c1cc97b-82ca-491b-b321-6403bb9a7015","schedule":"5 4 * * 1","args":{"test":"scw"}}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/crons/bb651f5b-6196-43f9-86c7-9981169641ad
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 214
+        uncompressed: false
+        body: '{"args":{"test":"scw"},"container_id":"5c1cc97b-82ca-491b-b321-6403bb9a7015","id":"bb651f5b-6196-43f9-86c7-9981169641ad","name":"cron-bb651f5b-6196-43f9-86c7-9981169641ad","schedule":"5 4 * * 1","status":"pending"}'
+        headers:
+            Content-Length:
+                - "214"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:15 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 15ace4d8-55f7-4972-ad76-7db163262e6e
+        status: 200 OK
+        code: 200
+        duration: 123.328427ms
+    - id: 23
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1100,60 +1151,9 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/crons/e1095853-6479-4944-9116-732dbc5d51ae
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/crons/bb651f5b-6196-43f9-86c7-9981169641ad
         method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 303
-        uncompressed: false
-        body: '{"args":{"address":{"city":"Paris","country":"FR"},"age":23,"firstName":"John","isAlive":true,"lastName":"Smith"},"container_id":"d2562792-6988-4059-8647-6fd43f9abc6f","id":"e1095853-6479-4944-9116-732dbc5d51ae","name":"cron-e1095853-6479-4944-9116-732dbc5d51ae","schedule":"5 4 1 * *","status":"ready"}'
-        headers:
-            Content-Length:
-                - "303"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:38:28 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 684982dd-cc5a-4157-a346-76c8124973eb
-        status: 200 OK
-        code: 200
-        duration: 82.674625ms
-    - id: 23
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 100
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"container_id":"d2562792-6988-4059-8647-6fd43f9abc6f","schedule":"5 4 * * 1","args":{"test":"scw"}}'
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/crons/e1095853-6479-4944-9116-732dbc5d51ae
-        method: PATCH
       response:
         proto: HTTP/2.0
         proto_major: 2
@@ -1162,7 +1162,7 @@ interactions:
         trailer: {}
         content_length: 214
         uncompressed: false
-        body: '{"args":{"test":"scw"},"container_id":"d2562792-6988-4059-8647-6fd43f9abc6f","id":"e1095853-6479-4944-9116-732dbc5d51ae","name":"cron-e1095853-6479-4944-9116-732dbc5d51ae","schedule":"5 4 * * 1","status":"pending"}'
+        body: '{"args":{"test":"scw"},"container_id":"5c1cc97b-82ca-491b-b321-6403bb9a7015","id":"bb651f5b-6196-43f9-86c7-9981169641ad","name":"cron-bb651f5b-6196-43f9-86c7-9981169641ad","schedule":"5 4 * * 1","status":"pending"}'
         headers:
             Content-Length:
                 - "214"
@@ -1171,9 +1171,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:29 GMT
+                - Wed, 27 Aug 2025 15:06:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1181,10 +1181,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5eb3c41c-7a78-43fc-9af5-9b782c688e71
+                - 07ff4e94-4f98-417b-81ab-0dff57e9ed2c
         status: 200 OK
         code: 200
-        duration: 104.596625ms
+        duration: 99.252288ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1200,8 +1200,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/crons/e1095853-6479-4944-9116-732dbc5d51ae
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/crons/bb651f5b-6196-43f9-86c7-9981169641ad
         method: GET
       response:
         proto: HTTP/2.0
@@ -1209,20 +1209,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 212
+        content_length: 214
         uncompressed: false
-        body: '{"args":{"test":"scw"},"container_id":"d2562792-6988-4059-8647-6fd43f9abc6f","id":"e1095853-6479-4944-9116-732dbc5d51ae","name":"cron-e1095853-6479-4944-9116-732dbc5d51ae","schedule":"5 4 * * 1","status":"ready"}'
+        body: '{"args":{"test":"scw"},"container_id":"5c1cc97b-82ca-491b-b321-6403bb9a7015","id":"bb651f5b-6196-43f9-86c7-9981169641ad","name":"cron-bb651f5b-6196-43f9-86c7-9981169641ad","schedule":"5 4 * * 1","status":"pending"}'
         headers:
             Content-Length:
-                - "212"
+                - "214"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:29 GMT
+                - Wed, 27 Aug 2025 15:06:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1230,10 +1230,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 258251ba-a1cf-4830-89ce-50126ce24796
+                - 82879442-8f1d-4129-8404-cb3a7a41bc0d
         status: 200 OK
         code: 200
-        duration: 101.327084ms
+        duration: 91.967158ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1249,8 +1249,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/crons/e1095853-6479-4944-9116-732dbc5d51ae
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/crons/bb651f5b-6196-43f9-86c7-9981169641ad
         method: GET
       response:
         proto: HTTP/2.0
@@ -1258,20 +1258,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 212
+        content_length: 214
         uncompressed: false
-        body: '{"args":{"test":"scw"},"container_id":"d2562792-6988-4059-8647-6fd43f9abc6f","id":"e1095853-6479-4944-9116-732dbc5d51ae","name":"cron-e1095853-6479-4944-9116-732dbc5d51ae","schedule":"5 4 * * 1","status":"ready"}'
+        body: '{"args":{"test":"scw"},"container_id":"5c1cc97b-82ca-491b-b321-6403bb9a7015","id":"bb651f5b-6196-43f9-86c7-9981169641ad","name":"cron-bb651f5b-6196-43f9-86c7-9981169641ad","schedule":"5 4 * * 1","status":"pending"}'
         headers:
             Content-Length:
-                - "212"
+                - "214"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:29 GMT
+                - Wed, 27 Aug 2025 15:06:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1279,10 +1279,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 208e51c1-6826-4377-85df-d07f9dff6a1f
+                - 15260d30-0089-4365-ba59-79fca52b2d95
         status: 200 OK
         code: 200
-        duration: 80.681ms
+        duration: 99.777337ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1298,8 +1298,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/34594269-f6d6-4973-81e7-e8aa89beb825
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/crons/bb651f5b-6196-43f9-86c7-9981169641ad
         method: GET
       response:
         proto: HTTP/2.0
@@ -1307,20 +1307,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 550
+        content_length: 212
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.278500Z","description":"","environment_variables":{},"error_message":null,"id":"34594269-f6d6-4973-81e7-e8aa89beb825","name":"tf-ns-vigorous-benz","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsvigorousbenzcxr4zoly","registry_namespace_id":"6c75a0d9-117c-4e58-aa7a-9724e11d4d2b","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:38:18.849885Z"}'
+        body: '{"args":{"test":"scw"},"container_id":"5c1cc97b-82ca-491b-b321-6403bb9a7015","id":"bb651f5b-6196-43f9-86c7-9981169641ad","name":"cron-bb651f5b-6196-43f9-86c7-9981169641ad","schedule":"5 4 * * 1","status":"ready"}'
         headers:
             Content-Length:
-                - "550"
+                - "212"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:30 GMT
+                - Wed, 27 Aug 2025 15:06:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1328,10 +1328,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 98540ce4-9957-44be-9c0e-26dbd27e57ec
+                - cabfe60c-1a94-4749-9761-9c05049c8c8a
         status: 200 OK
         code: 200
-        duration: 71.405584ms
+        duration: 107.572116ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1347,8 +1347,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/d2562792-6988-4059-8647-6fd43f9abc6f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/crons/bb651f5b-6196-43f9-86c7-9981169641ad
         method: GET
       response:
         proto: HTTP/2.0
@@ -1356,20 +1356,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 913
+        content_length: 212
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:20.833470Z","description":"","domain_name":"tfnsvigorousbenzcxr4zoly-my-container-with-cron-tf.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"d2562792-6988-4059-8647-6fd43f9abc6f","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"my-container-with-cron-tf","namespace_id":"34594269-f6d6-4973-81e7-e8aa89beb825","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsvigorousbenzcxr4zoly/my-container-with-cron-tf:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:38:20.833470Z"}'
+        body: '{"args":{"test":"scw"},"container_id":"5c1cc97b-82ca-491b-b321-6403bb9a7015","id":"bb651f5b-6196-43f9-86c7-9981169641ad","name":"cron-bb651f5b-6196-43f9-86c7-9981169641ad","schedule":"5 4 * * 1","status":"ready"}'
         headers:
             Content-Length:
-                - "913"
+                - "212"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:30 GMT
+                - Wed, 27 Aug 2025 15:06:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1377,10 +1377,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1d79021b-895e-4a4c-889b-5daaa4d82feb
+                - 91a9029d-2c62-4ece-b2f7-e4f24ea48da2
         status: 200 OK
         code: 200
-        duration: 83.349541ms
+        duration: 81.221006ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1396,8 +1396,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/crons/e1095853-6479-4944-9116-732dbc5d51ae
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d3220d1b-aadd-4201-8bc2-87a62beaf139
         method: GET
       response:
         proto: HTTP/2.0
@@ -1405,20 +1405,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 212
+        content_length: 592
         uncompressed: false
-        body: '{"args":{"test":"scw"},"container_id":"d2562792-6988-4059-8647-6fd43f9abc6f","id":"e1095853-6479-4944-9116-732dbc5d51ae","name":"cron-e1095853-6479-4944-9116-732dbc5d51ae","schedule":"5 4 * * 1","status":"ready"}'
+        body: '{"created_at":"2025-08-27T15:05:40.873327Z","description":"","environment_variables":{},"error_message":null,"id":"d3220d1b-aadd-4201-8bc2-87a62beaf139","name":"tf-ns-interesting-bartik","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsinterestingbartirzq5ntud","registry_namespace_id":"114451fc-ec14-4b77-b933-c624377bb727","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:04.122926Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "212"
+                - "592"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:30 GMT
+                - Wed, 27 Aug 2025 15:06:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1426,10 +1426,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 11057b09-e9ed-4f44-8f9a-06eafb5b2572
+                - ca53c9f5-21bf-440e-8ee0-13de7b0b023b
         status: 200 OK
         code: 200
-        duration: 77.520875ms
+        duration: 78.251143ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1445,8 +1445,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/crons/e1095853-6479-4944-9116-732dbc5d51ae
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/5c1cc97b-82ca-491b-b321-6403bb9a7015
         method: GET
       response:
         proto: HTTP/2.0
@@ -1454,20 +1454,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 212
+        content_length: 980
         uncompressed: false
-        body: '{"args":{"test":"scw"},"container_id":"d2562792-6988-4059-8647-6fd43f9abc6f","id":"e1095853-6479-4944-9116-732dbc5d51ae","name":"cron-e1095853-6479-4944-9116-732dbc5d51ae","schedule":"5 4 * * 1","status":"ready"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:07.424453Z","description":"","domain_name":"tfnsinterestingbartirzq5ntud-my-container-with-cron-tf.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"5c1cc97b-82ca-491b-b321-6403bb9a7015","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"my-container-with-cron-tf","namespace_id":"d3220d1b-aadd-4201-8bc2-87a62beaf139","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsinterestingbartirzq5ntud/my-container-with-cron-tf:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:07.424453Z"}'
         headers:
             Content-Length:
-                - "212"
+                - "980"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:31 GMT
+                - Wed, 27 Aug 2025 15:06:31 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1475,10 +1475,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6d81575a-61fc-463a-b99a-fa6a2e48488f
+                - 1741eac9-d989-4e0d-b581-4534d08073ea
         status: 200 OK
         code: 200
-        duration: 90.562125ms
+        duration: 96.841168ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1494,29 +1494,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/crons/e1095853-6479-4944-9116-732dbc5d51ae
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/crons/bb651f5b-6196-43f9-86c7-9981169641ad
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 215
+        content_length: 212
         uncompressed: false
-        body: '{"args":{"test":"scw"},"container_id":"d2562792-6988-4059-8647-6fd43f9abc6f","id":"e1095853-6479-4944-9116-732dbc5d51ae","name":"cron-e1095853-6479-4944-9116-732dbc5d51ae","schedule":"5 4 * * 1","status":"deleting"}'
+        body: '{"args":{"test":"scw"},"container_id":"5c1cc97b-82ca-491b-b321-6403bb9a7015","id":"bb651f5b-6196-43f9-86c7-9981169641ad","name":"cron-bb651f5b-6196-43f9-86c7-9981169641ad","schedule":"5 4 * * 1","status":"ready"}'
         headers:
             Content-Length:
-                - "215"
+                - "212"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:31 GMT
+                - Wed, 27 Aug 2025 15:06:31 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1524,10 +1524,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5e4c200c-6316-4485-a1fe-14f65cd213f8
+                - 71f67653-46e3-41ef-9b94-b5c2647f077d
         status: 200 OK
         code: 200
-        duration: 131.628834ms
+        duration: 101.214285ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1543,8 +1543,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/d2562792-6988-4059-8647-6fd43f9abc6f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/crons/bb651f5b-6196-43f9-86c7-9981169641ad
         method: GET
       response:
         proto: HTTP/2.0
@@ -1552,20 +1552,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 913
+        content_length: 212
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:20.833470Z","description":"","domain_name":"tfnsvigorousbenzcxr4zoly-my-container-with-cron-tf.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"d2562792-6988-4059-8647-6fd43f9abc6f","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"my-container-with-cron-tf","namespace_id":"34594269-f6d6-4973-81e7-e8aa89beb825","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsvigorousbenzcxr4zoly/my-container-with-cron-tf:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:38:20.833470Z"}'
+        body: '{"args":{"test":"scw"},"container_id":"5c1cc97b-82ca-491b-b321-6403bb9a7015","id":"bb651f5b-6196-43f9-86c7-9981169641ad","name":"cron-bb651f5b-6196-43f9-86c7-9981169641ad","schedule":"5 4 * * 1","status":"ready"}'
         headers:
             Content-Length:
-                - "913"
+                - "212"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:31 GMT
+                - Wed, 27 Aug 2025 15:06:31 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1573,10 +1573,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 065110e5-e098-4050-9273-3dcdb678ee2c
+                - 2c53503e-6e2e-4636-8da6-917cddbe30b6
         status: 200 OK
         code: 200
-        duration: 74.616458ms
+        duration: 95.614688ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1592,8 +1592,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/d2562792-6988-4059-8647-6fd43f9abc6f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/crons/bb651f5b-6196-43f9-86c7-9981169641ad
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1601,20 +1601,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 917
+        content_length: 215
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:20.833470Z","description":"","domain_name":"tfnsvigorousbenzcxr4zoly-my-container-with-cron-tf.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"d2562792-6988-4059-8647-6fd43f9abc6f","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"my-container-with-cron-tf","namespace_id":"34594269-f6d6-4973-81e7-e8aa89beb825","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsvigorousbenzcxr4zoly/my-container-with-cron-tf:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"deleting","timeout":"300s","updated_at":"2025-01-24T15:38:31.671086377Z"}'
+        body: '{"args":{"test":"scw"},"container_id":"5c1cc97b-82ca-491b-b321-6403bb9a7015","id":"bb651f5b-6196-43f9-86c7-9981169641ad","name":"cron-bb651f5b-6196-43f9-86c7-9981169641ad","schedule":"5 4 * * 1","status":"deleting"}'
         headers:
             Content-Length:
-                - "917"
+                - "215"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:31 GMT
+                - Wed, 27 Aug 2025 15:06:31 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1622,10 +1622,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 26cfd6b8-c6dd-45a6-a1bb-b1509160cd57
+                - c9eaab92-bc76-4b61-adb5-79ce20b4390c
         status: 200 OK
         code: 200
-        duration: 144.334292ms
+        duration: 150.44548ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1641,8 +1641,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/34594269-f6d6-4973-81e7-e8aa89beb825
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/5c1cc97b-82ca-491b-b321-6403bb9a7015
         method: GET
       response:
         proto: HTTP/2.0
@@ -1650,20 +1650,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 550
+        content_length: 980
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.278500Z","description":"","environment_variables":{},"error_message":null,"id":"34594269-f6d6-4973-81e7-e8aa89beb825","name":"tf-ns-vigorous-benz","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsvigorousbenzcxr4zoly","registry_namespace_id":"6c75a0d9-117c-4e58-aa7a-9724e11d4d2b","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:38:18.849885Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:07.424453Z","description":"","domain_name":"tfnsinterestingbartirzq5ntud-my-container-with-cron-tf.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"5c1cc97b-82ca-491b-b321-6403bb9a7015","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"my-container-with-cron-tf","namespace_id":"d3220d1b-aadd-4201-8bc2-87a62beaf139","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsinterestingbartirzq5ntud/my-container-with-cron-tf:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:07.424453Z"}'
         headers:
             Content-Length:
-                - "550"
+                - "980"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:31 GMT
+                - Wed, 27 Aug 2025 15:06:31 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1671,10 +1671,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ba395925-2619-47d5-9766-b1d140f85000
+                - 31b5f58e-3da4-4abb-ac7d-e9a851dbd01d
         status: 200 OK
         code: 200
-        duration: 80.19275ms
+        duration: 97.844702ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1690,8 +1690,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/34594269-f6d6-4973-81e7-e8aa89beb825
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/5c1cc97b-82ca-491b-b321-6403bb9a7015
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1699,20 +1699,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 556
+        content_length: 984
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.278500Z","description":"","environment_variables":{},"error_message":null,"id":"34594269-f6d6-4973-81e7-e8aa89beb825","name":"tf-ns-vigorous-benz","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsvigorousbenzcxr4zoly","registry_namespace_id":"6c75a0d9-117c-4e58-aa7a-9724e11d4d2b","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:38:31.893295574Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:07.424453Z","description":"","domain_name":"tfnsinterestingbartirzq5ntud-my-container-with-cron-tf.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"5c1cc97b-82ca-491b-b321-6403bb9a7015","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"my-container-with-cron-tf","namespace_id":"d3220d1b-aadd-4201-8bc2-87a62beaf139","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsinterestingbartirzq5ntud/my-container-with-cron-tf:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:32.059261435Z"}'
         headers:
             Content-Length:
-                - "556"
+                - "984"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:32 GMT
+                - Wed, 27 Aug 2025 15:06:32 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1720,10 +1720,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d02e6be5-3b84-4215-b8c2-46685664d385
+                - 53d1507b-2209-451b-ad88-31ec56a17e65
         status: 200 OK
         code: 200
-        duration: 212.771125ms
+        duration: 157.523874ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1739,8 +1739,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/34594269-f6d6-4973-81e7-e8aa89beb825
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d3220d1b-aadd-4201-8bc2-87a62beaf139
         method: GET
       response:
         proto: HTTP/2.0
@@ -1748,20 +1748,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 553
+        content_length: 592
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.278500Z","description":"","environment_variables":{},"error_message":null,"id":"34594269-f6d6-4973-81e7-e8aa89beb825","name":"tf-ns-vigorous-benz","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsvigorousbenzcxr4zoly","registry_namespace_id":"6c75a0d9-117c-4e58-aa7a-9724e11d4d2b","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:38:31.893296Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.873327Z","description":"","environment_variables":{},"error_message":null,"id":"d3220d1b-aadd-4201-8bc2-87a62beaf139","name":"tf-ns-interesting-bartik","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsinterestingbartirzq5ntud","registry_namespace_id":"114451fc-ec14-4b77-b933-c624377bb727","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:04.122926Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "553"
+                - "592"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:32 GMT
+                - Wed, 27 Aug 2025 15:06:32 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1769,10 +1769,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 43c89027-3508-4ef2-8b9e-33cccfcefe23
+                - 1932638e-b2fd-488e-9383-f24840eb199a
         status: 200 OK
         code: 200
-        duration: 61.488ms
+        duration: 100.514522ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1788,29 +1788,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/34594269-f6d6-4973-81e7-e8aa89beb825
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d3220d1b-aadd-4201-8bc2-87a62beaf139
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 553
+        content_length: 598
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.278500Z","description":"","environment_variables":{},"error_message":null,"id":"34594269-f6d6-4973-81e7-e8aa89beb825","name":"tf-ns-vigorous-benz","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsvigorousbenzcxr4zoly","registry_namespace_id":"6c75a0d9-117c-4e58-aa7a-9724e11d4d2b","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:38:31.893296Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.873327Z","description":"","environment_variables":{},"error_message":null,"id":"d3220d1b-aadd-4201-8bc2-87a62beaf139","name":"tf-ns-interesting-bartik","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsinterestingbartirzq5ntud","registry_namespace_id":"114451fc-ec14-4b77-b933-c624377bb727","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:32.264575153Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "553"
+                - "598"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:37 GMT
+                - Wed, 27 Aug 2025 15:06:32 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1818,10 +1818,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 85fdaa39-6db3-4133-a3a1-e8abbebfbe81
+                - 795fb9c0-4bf0-4572-9b85-ec246f4ef591
         status: 200 OK
         code: 200
-        duration: 67.795334ms
+        duration: 263.42286ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1837,8 +1837,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/34594269-f6d6-4973-81e7-e8aa89beb825
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d3220d1b-aadd-4201-8bc2-87a62beaf139
         method: GET
       response:
         proto: HTTP/2.0
@@ -1846,20 +1846,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 553
+        content_length: 595
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.278500Z","description":"","environment_variables":{},"error_message":null,"id":"34594269-f6d6-4973-81e7-e8aa89beb825","name":"tf-ns-vigorous-benz","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsvigorousbenzcxr4zoly","registry_namespace_id":"6c75a0d9-117c-4e58-aa7a-9724e11d4d2b","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:38:31.893296Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.873327Z","description":"","environment_variables":{},"error_message":null,"id":"d3220d1b-aadd-4201-8bc2-87a62beaf139","name":"tf-ns-interesting-bartik","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsinterestingbartirzq5ntud","registry_namespace_id":"114451fc-ec14-4b77-b933-c624377bb727","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:32.264575Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "553"
+                - "595"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:42 GMT
+                - Wed, 27 Aug 2025 15:06:32 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1867,10 +1867,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3403d6db-5020-4ec1-91a9-2de9318ac1fd
+                - 6d3bcb4f-e474-43b1-b54c-0be3b55aeec4
         status: 200 OK
         code: 200
-        duration: 70.406ms
+        duration: 93.691428ms
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1886,8 +1886,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/34594269-f6d6-4973-81e7-e8aa89beb825
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d3220d1b-aadd-4201-8bc2-87a62beaf139
         method: GET
       response:
         proto: HTTP/2.0
@@ -1895,20 +1895,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 553
+        content_length: 595
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.278500Z","description":"","environment_variables":{},"error_message":null,"id":"34594269-f6d6-4973-81e7-e8aa89beb825","name":"tf-ns-vigorous-benz","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsvigorousbenzcxr4zoly","registry_namespace_id":"6c75a0d9-117c-4e58-aa7a-9724e11d4d2b","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:38:31.893296Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.873327Z","description":"","environment_variables":{},"error_message":null,"id":"d3220d1b-aadd-4201-8bc2-87a62beaf139","name":"tf-ns-interesting-bartik","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsinterestingbartirzq5ntud","registry_namespace_id":"114451fc-ec14-4b77-b933-c624377bb727","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:32.264575Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "553"
+                - "595"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:47 GMT
+                - Wed, 27 Aug 2025 15:06:37 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1916,10 +1916,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3da75efc-47ca-418f-ac83-3fb371f90c87
+                - f8d5f026-b58b-43c4-87cb-797fbfe75c54
         status: 200 OK
         code: 200
-        duration: 64.754208ms
+        duration: 83.390298ms
     - id: 39
       request:
         proto: HTTP/1.1
@@ -1935,8 +1935,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/34594269-f6d6-4973-81e7-e8aa89beb825
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d3220d1b-aadd-4201-8bc2-87a62beaf139
         method: GET
       response:
         proto: HTTP/2.0
@@ -1944,20 +1944,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 553
+        content_length: 595
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.278500Z","description":"","environment_variables":{},"error_message":null,"id":"34594269-f6d6-4973-81e7-e8aa89beb825","name":"tf-ns-vigorous-benz","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsvigorousbenzcxr4zoly","registry_namespace_id":"6c75a0d9-117c-4e58-aa7a-9724e11d4d2b","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:38:31.893296Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.873327Z","description":"","environment_variables":{},"error_message":null,"id":"d3220d1b-aadd-4201-8bc2-87a62beaf139","name":"tf-ns-interesting-bartik","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsinterestingbartirzq5ntud","registry_namespace_id":"114451fc-ec14-4b77-b933-c624377bb727","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:32.264575Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "553"
+                - "595"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:52 GMT
+                - Wed, 27 Aug 2025 15:06:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1965,10 +1965,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 35e1dd81-7f4b-4a4a-b195-9213576bce75
+                - 5dbd1183-d08a-48f3-a685-7e63ba9dc46d
         status: 200 OK
         code: 200
-        duration: 64.413083ms
+        duration: 88.074069ms
     - id: 40
       request:
         proto: HTTP/1.1
@@ -1984,8 +1984,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/34594269-f6d6-4973-81e7-e8aa89beb825
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d3220d1b-aadd-4201-8bc2-87a62beaf139
         method: GET
       response:
         proto: HTTP/2.0
@@ -1993,20 +1993,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 553
+        content_length: 595
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.278500Z","description":"","environment_variables":{},"error_message":null,"id":"34594269-f6d6-4973-81e7-e8aa89beb825","name":"tf-ns-vigorous-benz","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsvigorousbenzcxr4zoly","registry_namespace_id":"6c75a0d9-117c-4e58-aa7a-9724e11d4d2b","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:38:31.893296Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.873327Z","description":"","environment_variables":{},"error_message":null,"id":"d3220d1b-aadd-4201-8bc2-87a62beaf139","name":"tf-ns-interesting-bartik","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsinterestingbartirzq5ntud","registry_namespace_id":"114451fc-ec14-4b77-b933-c624377bb727","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:32.264575Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "553"
+                - "595"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:57 GMT
+                - Wed, 27 Aug 2025 15:06:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2014,10 +2014,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 94259b5a-58c6-4014-9ecc-ab128524a0c1
+                - 75fbf72a-0ee5-482e-afe9-e43055f45f82
         status: 200 OK
         code: 200
-        duration: 77.091875ms
+        duration: 87.49302ms
     - id: 41
       request:
         proto: HTTP/1.1
@@ -2033,8 +2033,302 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/34594269-f6d6-4973-81e7-e8aa89beb825
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d3220d1b-aadd-4201-8bc2-87a62beaf139
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 595
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:40.873327Z","description":"","environment_variables":{},"error_message":null,"id":"d3220d1b-aadd-4201-8bc2-87a62beaf139","name":"tf-ns-interesting-bartik","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsinterestingbartirzq5ntud","registry_namespace_id":"114451fc-ec14-4b77-b933-c624377bb727","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:32.264575Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "595"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 96e0de0d-d271-4e9a-bb91-324aeb389879
+        status: 200 OK
+        code: 200
+        duration: 90.487852ms
+    - id: 42
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d3220d1b-aadd-4201-8bc2-87a62beaf139
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 595
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:40.873327Z","description":"","environment_variables":{},"error_message":null,"id":"d3220d1b-aadd-4201-8bc2-87a62beaf139","name":"tf-ns-interesting-bartik","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsinterestingbartirzq5ntud","registry_namespace_id":"114451fc-ec14-4b77-b933-c624377bb727","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:32.264575Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "595"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:57 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 0fdff2b5-be19-4bbf-bb74-d353e1e53082
+        status: 200 OK
+        code: 200
+        duration: 92.316226ms
+    - id: 43
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d3220d1b-aadd-4201-8bc2-87a62beaf139
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 595
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:40.873327Z","description":"","environment_variables":{},"error_message":null,"id":"d3220d1b-aadd-4201-8bc2-87a62beaf139","name":"tf-ns-interesting-bartik","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsinterestingbartirzq5ntud","registry_namespace_id":"114451fc-ec14-4b77-b933-c624377bb727","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:32.264575Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "595"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:07:03 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 0dcaa269-1715-4a50-8bf1-1e737a8dff51
+        status: 200 OK
+        code: 200
+        duration: 106.49222ms
+    - id: 44
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d3220d1b-aadd-4201-8bc2-87a62beaf139
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 595
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:40.873327Z","description":"","environment_variables":{},"error_message":null,"id":"d3220d1b-aadd-4201-8bc2-87a62beaf139","name":"tf-ns-interesting-bartik","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsinterestingbartirzq5ntud","registry_namespace_id":"114451fc-ec14-4b77-b933-c624377bb727","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:32.264575Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "595"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:07:08 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e1340a97-eecc-4905-8754-ea56927d94dc
+        status: 200 OK
+        code: 200
+        duration: 85.840074ms
+    - id: 45
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d3220d1b-aadd-4201-8bc2-87a62beaf139
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 595
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:40.873327Z","description":"","environment_variables":{},"error_message":null,"id":"d3220d1b-aadd-4201-8bc2-87a62beaf139","name":"tf-ns-interesting-bartik","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsinterestingbartirzq5ntud","registry_namespace_id":"114451fc-ec14-4b77-b933-c624377bb727","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:32.264575Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "595"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:07:13 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f9ea469c-051c-43f8-985e-545bd65001dc
+        status: 200 OK
+        code: 200
+        duration: 84.28216ms
+    - id: 46
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d3220d1b-aadd-4201-8bc2-87a62beaf139
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 595
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:40.873327Z","description":"","environment_variables":{},"error_message":null,"id":"d3220d1b-aadd-4201-8bc2-87a62beaf139","name":"tf-ns-interesting-bartik","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsinterestingbartirzq5ntud","registry_namespace_id":"114451fc-ec14-4b77-b933-c624377bb727","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:32.264575Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "595"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:07:18 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - de976e1f-80ae-4ab5-8415-123393ee44bb
+        status: 200 OK
+        code: 200
+        duration: 660.572504ms
+    - id: 47
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/d3220d1b-aadd-4201-8bc2-87a62beaf139
         method: GET
       response:
         proto: HTTP/2.0
@@ -2053,9 +2347,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:39:02 GMT
+                - Wed, 27 Aug 2025 15:07:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2063,11 +2357,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 82214ff1-53a1-4828-a5d4-e175dfd14d87
+                - 74058881-f8a7-42c2-94dd-12198c0b8bc5
         status: 404 Not Found
         code: 404
-        duration: 26.91525ms
-    - id: 42
+        duration: 20.570786ms
+    - id: 48
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2082,8 +2376,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/crons/e1095853-6479-4944-9116-732dbc5d51ae
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/crons/bb651f5b-6196-43f9-86c7-9981169641ad
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -2102,9 +2396,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:39:02 GMT
+                - Wed, 27 Aug 2025 15:07:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2112,7 +2406,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cdf7354e-7355-4e36-acad-ebe09aaf8f98
+                - 98ce29a9-f1c7-46f6-820f-8035951083da
         status: 404 Not Found
         code: 404
-        duration: 27.4195ms
+        duration: 29.165385ms

--- a/internal/services/container/testdata/data-source-container-basic.cassette.yaml
+++ b/internal/services/container/testdata/data-source-container-basic.cassette.yaml
@@ -6,19 +6,19 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 159
+        content_length: 187
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-ns-flamboyant-fermat","environment_variables":{},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","secret_environment_variables":[],"tags":null}'
+        body: '{"name":"tf-ns-kind-franklin","environment_variables":{},"project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","secret_environment_variables":[],"tags":null,"activate_vpc_integration":true}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces
         method: POST
       response:
@@ -27,20 +27,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 475
+        content_length: 504
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.306737749Z","description":"","environment_variables":{},"error_message":null,"id":"9221ae3f-2829-4d59-8e25-74fe97c3ad8c","name":"tf-ns-flamboyant-fermat","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:37:49.306737749Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.387962738Z","description":"","environment_variables":{},"error_message":null,"id":"b31bc643-26b3-4978-9758-e778ba988d82","name":"tf-ns-kind-franklin","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:41.387962738Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "475"
+                - "504"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:37:49 GMT
+                - Wed, 27 Aug 2025 15:05:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f4911136-7672-4586-973a-6de169c54f78
+                - c41fba1d-44a4-4b25-8189-cbcf940bee71
         status: 200 OK
         code: 200
-        duration: 981.345625ms
+        duration: 5.429312317s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -67,8 +67,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9221ae3f-2829-4d59-8e25-74fe97c3ad8c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/b31bc643-26b3-4978-9758-e778ba988d82
         method: GET
       response:
         proto: HTTP/2.0
@@ -76,20 +76,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 469
+        content_length: 498
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.306738Z","description":"","environment_variables":{},"error_message":null,"id":"9221ae3f-2829-4d59-8e25-74fe97c3ad8c","name":"tf-ns-flamboyant-fermat","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:37:49.306738Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.387963Z","description":"","environment_variables":{},"error_message":null,"id":"b31bc643-26b3-4978-9758-e778ba988d82","name":"tf-ns-kind-franklin","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:41.387963Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "469"
+                - "498"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:37:49 GMT
+                - Wed, 27 Aug 2025 15:05:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b4d8c92a-4ace-4e92-85a0-cdadce6143e6
+                - 9e1e6842-0b6d-4f32-b5cc-7518ff3d5de5
         status: 200 OK
         code: 200
-        duration: 71.048041ms
+        duration: 82.920562ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -116,8 +116,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9221ae3f-2829-4d59-8e25-74fe97c3ad8c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/b31bc643-26b3-4978-9758-e778ba988d82
         method: GET
       response:
         proto: HTTP/2.0
@@ -125,20 +125,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 558
+        content_length: 585
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.306738Z","description":"","environment_variables":{},"error_message":null,"id":"9221ae3f-2829-4d59-8e25-74fe97c3ad8c","name":"tf-ns-flamboyant-fermat","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsflamboyantfermat8qnpjnod","registry_namespace_id":"30f669a4-bd88-4979-8149-e01d34c4ef34","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:37:51.918156Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.387963Z","description":"","environment_variables":{},"error_message":null,"id":"b31bc643-26b3-4978-9758-e778ba988d82","name":"tf-ns-kind-franklin","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnskindfranklinifyskd50","registry_namespace_id":"b4ce7ea6-5c69-4991-84f8-277f455a7ac1","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:46.433499Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "558"
+                - "585"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:37:54 GMT
+                - Wed, 27 Aug 2025 15:05:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -146,10 +146,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c9e01279-9f78-4daf-9cfb-17e890378f23
+                - 5b6ef187-d279-4835-aa19-dd23fcb2b6ee
         status: 200 OK
         code: 200
-        duration: 111.484916ms
+        duration: 97.334441ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -165,8 +165,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9221ae3f-2829-4d59-8e25-74fe97c3ad8c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/b31bc643-26b3-4978-9758-e778ba988d82
         method: GET
       response:
         proto: HTTP/2.0
@@ -174,20 +174,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 558
+        content_length: 583
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.306738Z","description":"","environment_variables":{},"error_message":null,"id":"9221ae3f-2829-4d59-8e25-74fe97c3ad8c","name":"tf-ns-flamboyant-fermat","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsflamboyantfermat8qnpjnod","registry_namespace_id":"30f669a4-bd88-4979-8149-e01d34c4ef34","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:37:51.918156Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.387963Z","description":"","environment_variables":{},"error_message":null,"id":"b31bc643-26b3-4978-9758-e778ba988d82","name":"tf-ns-kind-franklin","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnskindfranklinifyskd50","registry_namespace_id":"b4ce7ea6-5c69-4991-84f8-277f455a7ac1","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:48.001913Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "558"
+                - "583"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:37:54 GMT
+                - Wed, 27 Aug 2025 15:05:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -195,10 +195,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3bd4a985-628c-4934-a77d-c6a653ab8bcc
+                - ed0a73ef-6873-48e2-b868-cb8d2157c2e8
         status: 200 OK
         code: 200
-        duration: 66.919ms
+        duration: 123.270399ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -214,8 +214,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9221ae3f-2829-4d59-8e25-74fe97c3ad8c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/b31bc643-26b3-4978-9758-e778ba988d82
         method: GET
       response:
         proto: HTTP/2.0
@@ -223,20 +223,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 558
+        content_length: 583
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.306738Z","description":"","environment_variables":{},"error_message":null,"id":"9221ae3f-2829-4d59-8e25-74fe97c3ad8c","name":"tf-ns-flamboyant-fermat","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsflamboyantfermat8qnpjnod","registry_namespace_id":"30f669a4-bd88-4979-8149-e01d34c4ef34","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:37:51.918156Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.387963Z","description":"","environment_variables":{},"error_message":null,"id":"b31bc643-26b3-4978-9758-e778ba988d82","name":"tf-ns-kind-franklin","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnskindfranklinifyskd50","registry_namespace_id":"b4ce7ea6-5c69-4991-84f8-277f455a7ac1","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:48.001913Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "558"
+                - "583"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:37:54 GMT
+                - Wed, 27 Aug 2025 15:05:52 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -244,62 +244,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4bc0efd6-9ab4-4871-9558-54a4057ec56f
+                - 699d300a-8e10-4147-839b-b9ee050fc835
         status: 200 OK
         code: 200
-        duration: 60.31125ms
+        duration: 273.478124ms
     - id: 5
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 210
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"namespace_id":"9221ae3f-2829-4d59-8e25-74fe97c3ad8c","name":"test-container-data","privacy":"public","protocol":"http1","secret_environment_variables":null,"http_option":"enabled","sandbox":"unknown_sandbox"}'
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 909
-        uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:37:54.861590476Z","description":"","domain_name":"tfnsflamboyantfermat8qnpjnod-test-container-data.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a34c8df8-42cb-4819-a0c2-13ba96c0a82c","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-container-data","namespace_id":"9221ae3f-2829-4d59-8e25-74fe97c3ad8c","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsflamboyantfermat8qnpjnod/test-container-data:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:37:54.861590476Z"}'
-        headers:
-            Content-Length:
-                - "909"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:37:54 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 558c29b6-6e2d-434d-8ee7-16a05407e811
-        status: 200 OK
-        code: 200
-        duration: 241.258458ms
-    - id: 6
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -314,8 +263,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a34c8df8-42cb-4819-a0c2-13ba96c0a82c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/b31bc643-26b3-4978-9758-e778ba988d82
         method: GET
       response:
         proto: HTTP/2.0
@@ -323,20 +272,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 903
+        content_length: 583
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:37:54.861590Z","description":"","domain_name":"tfnsflamboyantfermat8qnpjnod-test-container-data.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a34c8df8-42cb-4819-a0c2-13ba96c0a82c","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-container-data","namespace_id":"9221ae3f-2829-4d59-8e25-74fe97c3ad8c","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsflamboyantfermat8qnpjnod/test-container-data:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:37:54.861590Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.387963Z","description":"","environment_variables":{},"error_message":null,"id":"b31bc643-26b3-4978-9758-e778ba988d82","name":"tf-ns-kind-franklin","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnskindfranklinifyskd50","registry_namespace_id":"b4ce7ea6-5c69-4991-84f8-277f455a7ac1","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:48.001913Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "903"
+                - "583"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:37:54 GMT
+                - Wed, 27 Aug 2025 15:05:52 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -344,10 +293,61 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d6fed58e-5366-414d-8e5c-8001a71b7f9f
+                - 754b1df3-c7ca-4e89-bc62-b5b6c7dd5f85
         status: 200 OK
         code: 200
-        duration: 82.396ms
+        duration: 73.321393ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 249
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"namespace_id":"b31bc643-26b3-4978-9758-e778ba988d82","name":"test-container-data","privacy":"public","protocol":"http1","secret_environment_variables":null,"http_option":"enabled","sandbox":"unknown_sandbox","tags":null,"command":null,"args":null}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 960
+        uncompressed: false
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:53.935630501Z","description":"","domain_name":"tfnskindfranklinifyskd50-test-container-data.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a74ab4b9-8ce6-48e6-bb31-c55a7ef563a6","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-container-data","namespace_id":"b31bc643-26b3-4978-9758-e778ba988d82","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnskindfranklinifyskd50/test-container-data:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:53.935630501Z"}'
+        headers:
+            Content-Length:
+                - "960"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:05:53 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f3815385-399d-41ca-b808-431b6d6559d7
+        status: 200 OK
+        code: 200
+        duration: 1.837479714s
     - id: 7
       request:
         proto: HTTP/1.1
@@ -363,8 +363,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a34c8df8-42cb-4819-a0c2-13ba96c0a82c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a74ab4b9-8ce6-48e6-bb31-c55a7ef563a6
         method: GET
       response:
         proto: HTTP/2.0
@@ -372,20 +372,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 903
+        content_length: 954
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:37:54.861590Z","description":"","domain_name":"tfnsflamboyantfermat8qnpjnod-test-container-data.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a34c8df8-42cb-4819-a0c2-13ba96c0a82c","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-container-data","namespace_id":"9221ae3f-2829-4d59-8e25-74fe97c3ad8c","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsflamboyantfermat8qnpjnod/test-container-data:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:37:54.861590Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:53.935631Z","description":"","domain_name":"tfnskindfranklinifyskd50-test-container-data.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a74ab4b9-8ce6-48e6-bb31-c55a7ef563a6","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-container-data","namespace_id":"b31bc643-26b3-4978-9758-e778ba988d82","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnskindfranklinifyskd50/test-container-data:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:53.935631Z"}'
         headers:
             Content-Length:
-                - "903"
+                - "954"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:37:55 GMT
+                - Wed, 27 Aug 2025 15:05:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -393,10 +393,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d123050a-43da-43f1-9005-dc6c52bb3136
+                - 9957eef0-4978-42e3-ab31-b876128b605b
         status: 200 OK
         code: 200
-        duration: 92.593583ms
+        duration: 155.956063ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -412,8 +412,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers?name=test-container-data&namespace_id=9221ae3f-2829-4d59-8e25-74fe97c3ad8c&order_by=created_at_asc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a74ab4b9-8ce6-48e6-bb31-c55a7ef563a6
         method: GET
       response:
         proto: HTTP/2.0
@@ -421,20 +421,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 936
+        content_length: 954
         uncompressed: false
-        body: '{"containers":[{"cpu_limit":1000,"created_at":"2025-01-24T15:37:54.861590Z","description":"","domain_name":"tfnsflamboyantfermat8qnpjnod-test-container-data.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a34c8df8-42cb-4819-a0c2-13ba96c0a82c","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-container-data","namespace_id":"9221ae3f-2829-4d59-8e25-74fe97c3ad8c","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsflamboyantfermat8qnpjnod/test-container-data:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:37:54.861590Z"}],"total_count":1}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:53.935631Z","description":"","domain_name":"tfnskindfranklinifyskd50-test-container-data.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a74ab4b9-8ce6-48e6-bb31-c55a7ef563a6","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-container-data","namespace_id":"b31bc643-26b3-4978-9758-e778ba988d82","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnskindfranklinifyskd50/test-container-data:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:53.935631Z"}'
         headers:
             Content-Length:
-                - "936"
+                - "954"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:37:55 GMT
+                - Wed, 27 Aug 2025 15:05:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -442,10 +442,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e14532bc-e0aa-41b4-8a67-8f6974257769
+                - 3426de0d-1406-4e20-ba1e-1fd936e4d862
         status: 200 OK
         code: 200
-        duration: 137.672667ms
+        duration: 89.725395ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -461,8 +461,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a34c8df8-42cb-4819-a0c2-13ba96c0a82c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers?name=test-container-data&namespace_id=b31bc643-26b3-4978-9758-e778ba988d82&order_by=created_at_asc
         method: GET
       response:
         proto: HTTP/2.0
@@ -470,20 +470,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 903
+        content_length: 987
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:37:54.861590Z","description":"","domain_name":"tfnsflamboyantfermat8qnpjnod-test-container-data.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a34c8df8-42cb-4819-a0c2-13ba96c0a82c","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-container-data","namespace_id":"9221ae3f-2829-4d59-8e25-74fe97c3ad8c","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsflamboyantfermat8qnpjnod/test-container-data:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:37:54.861590Z"}'
+        body: '{"containers":[{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:53.935631Z","description":"","domain_name":"tfnskindfranklinifyskd50-test-container-data.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a74ab4b9-8ce6-48e6-bb31-c55a7ef563a6","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-container-data","namespace_id":"b31bc643-26b3-4978-9758-e778ba988d82","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnskindfranklinifyskd50/test-container-data:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:53.935631Z"}],"total_count":1}'
         headers:
             Content-Length:
-                - "903"
+                - "987"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:37:55 GMT
+                - Wed, 27 Aug 2025 15:05:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -491,10 +491,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 063922ac-0a9e-4e5a-8160-2e1335d2e902
+                - 283cc8d7-c82d-410d-a7e7-949792c3329e
         status: 200 OK
         code: 200
-        duration: 86.205541ms
+        duration: 90.036428ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -510,8 +510,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a34c8df8-42cb-4819-a0c2-13ba96c0a82c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a74ab4b9-8ce6-48e6-bb31-c55a7ef563a6
         method: GET
       response:
         proto: HTTP/2.0
@@ -519,20 +519,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 903
+        content_length: 954
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:37:54.861590Z","description":"","domain_name":"tfnsflamboyantfermat8qnpjnod-test-container-data.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a34c8df8-42cb-4819-a0c2-13ba96c0a82c","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-container-data","namespace_id":"9221ae3f-2829-4d59-8e25-74fe97c3ad8c","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsflamboyantfermat8qnpjnod/test-container-data:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:37:54.861590Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:53.935631Z","description":"","domain_name":"tfnskindfranklinifyskd50-test-container-data.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a74ab4b9-8ce6-48e6-bb31-c55a7ef563a6","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-container-data","namespace_id":"b31bc643-26b3-4978-9758-e778ba988d82","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnskindfranklinifyskd50/test-container-data:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:53.935631Z"}'
         headers:
             Content-Length:
-                - "903"
+                - "954"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:37:55 GMT
+                - Wed, 27 Aug 2025 15:05:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -540,10 +540,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d8f4f964-7191-4046-9d6c-355fe7311404
+                - 21bf295b-f90f-4bb1-840e-f14c098dc017
         status: 200 OK
         code: 200
-        duration: 83.641666ms
+        duration: 94.315839ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -559,8 +559,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a34c8df8-42cb-4819-a0c2-13ba96c0a82c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a74ab4b9-8ce6-48e6-bb31-c55a7ef563a6
         method: GET
       response:
         proto: HTTP/2.0
@@ -568,20 +568,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 903
+        content_length: 954
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:37:54.861590Z","description":"","domain_name":"tfnsflamboyantfermat8qnpjnod-test-container-data.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a34c8df8-42cb-4819-a0c2-13ba96c0a82c","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-container-data","namespace_id":"9221ae3f-2829-4d59-8e25-74fe97c3ad8c","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsflamboyantfermat8qnpjnod/test-container-data:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:37:54.861590Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:53.935631Z","description":"","domain_name":"tfnskindfranklinifyskd50-test-container-data.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a74ab4b9-8ce6-48e6-bb31-c55a7ef563a6","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-container-data","namespace_id":"b31bc643-26b3-4978-9758-e778ba988d82","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnskindfranklinifyskd50/test-container-data:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:53.935631Z"}'
         headers:
             Content-Length:
-                - "903"
+                - "954"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:37:55 GMT
+                - Wed, 27 Aug 2025 15:05:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -589,10 +589,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - db127688-00fa-4d2b-a9f5-d4d1a05a9d2b
+                - d8ceedfe-f797-4206-b8b3-18bd44d966a2
         status: 200 OK
         code: 200
-        duration: 82.379167ms
+        duration: 181.851615ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -608,8 +608,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers?name=test-container-data&namespace_id=9221ae3f-2829-4d59-8e25-74fe97c3ad8c&order_by=created_at_asc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers?name=test-container-data&namespace_id=b31bc643-26b3-4978-9758-e778ba988d82&order_by=created_at_asc
         method: GET
       response:
         proto: HTTP/2.0
@@ -617,20 +617,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 936
+        content_length: 987
         uncompressed: false
-        body: '{"containers":[{"cpu_limit":1000,"created_at":"2025-01-24T15:37:54.861590Z","description":"","domain_name":"tfnsflamboyantfermat8qnpjnod-test-container-data.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a34c8df8-42cb-4819-a0c2-13ba96c0a82c","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-container-data","namespace_id":"9221ae3f-2829-4d59-8e25-74fe97c3ad8c","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsflamboyantfermat8qnpjnod/test-container-data:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:37:54.861590Z"}],"total_count":1}'
+        body: '{"containers":[{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:53.935631Z","description":"","domain_name":"tfnskindfranklinifyskd50-test-container-data.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a74ab4b9-8ce6-48e6-bb31-c55a7ef563a6","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-container-data","namespace_id":"b31bc643-26b3-4978-9758-e778ba988d82","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnskindfranklinifyskd50/test-container-data:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:53.935631Z"}],"total_count":1}'
         headers:
             Content-Length:
-                - "936"
+                - "987"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:37:55 GMT
+                - Wed, 27 Aug 2025 15:05:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -638,10 +638,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d34cb664-5c48-4b4f-9e05-d4544a6a8d7c
+                - a6ad80f9-9ff5-472f-84d2-00b5764da690
         status: 200 OK
         code: 200
-        duration: 82.387ms
+        duration: 117.058685ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -657,8 +657,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a34c8df8-42cb-4819-a0c2-13ba96c0a82c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a74ab4b9-8ce6-48e6-bb31-c55a7ef563a6
         method: GET
       response:
         proto: HTTP/2.0
@@ -666,20 +666,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 903
+        content_length: 954
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:37:54.861590Z","description":"","domain_name":"tfnsflamboyantfermat8qnpjnod-test-container-data.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a34c8df8-42cb-4819-a0c2-13ba96c0a82c","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-container-data","namespace_id":"9221ae3f-2829-4d59-8e25-74fe97c3ad8c","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsflamboyantfermat8qnpjnod/test-container-data:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:37:54.861590Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:53.935631Z","description":"","domain_name":"tfnskindfranklinifyskd50-test-container-data.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a74ab4b9-8ce6-48e6-bb31-c55a7ef563a6","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-container-data","namespace_id":"b31bc643-26b3-4978-9758-e778ba988d82","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnskindfranklinifyskd50/test-container-data:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:53.935631Z"}'
         headers:
             Content-Length:
-                - "903"
+                - "954"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:37:55 GMT
+                - Wed, 27 Aug 2025 15:05:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -687,10 +687,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3b46ad50-351a-4de8-9565-59dd79ca9aad
+                - 0aa62a92-78e5-44df-8ba1-3deb3dda1d97
         status: 200 OK
         code: 200
-        duration: 82.307917ms
+        duration: 119.787776ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -706,8 +706,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9221ae3f-2829-4d59-8e25-74fe97c3ad8c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a74ab4b9-8ce6-48e6-bb31-c55a7ef563a6
         method: GET
       response:
         proto: HTTP/2.0
@@ -715,20 +715,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 558
+        content_length: 954
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.306738Z","description":"","environment_variables":{},"error_message":null,"id":"9221ae3f-2829-4d59-8e25-74fe97c3ad8c","name":"tf-ns-flamboyant-fermat","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsflamboyantfermat8qnpjnod","registry_namespace_id":"30f669a4-bd88-4979-8149-e01d34c4ef34","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:37:51.918156Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:53.935631Z","description":"","domain_name":"tfnskindfranklinifyskd50-test-container-data.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a74ab4b9-8ce6-48e6-bb31-c55a7ef563a6","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-container-data","namespace_id":"b31bc643-26b3-4978-9758-e778ba988d82","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnskindfranklinifyskd50/test-container-data:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:53.935631Z"}'
         headers:
             Content-Length:
-                - "558"
+                - "954"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:37:56 GMT
+                - Wed, 27 Aug 2025 15:05:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -736,10 +736,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0750f60a-6e11-4943-8416-ccbd6b5e7941
+                - 9e271fe8-2878-421f-80d3-5b597fe92229
         status: 200 OK
         code: 200
-        duration: 62.316125ms
+        duration: 100.969754ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -755,8 +755,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a34c8df8-42cb-4819-a0c2-13ba96c0a82c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/b31bc643-26b3-4978-9758-e778ba988d82
         method: GET
       response:
         proto: HTTP/2.0
@@ -764,20 +764,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 903
+        content_length: 583
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:37:54.861590Z","description":"","domain_name":"tfnsflamboyantfermat8qnpjnod-test-container-data.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a34c8df8-42cb-4819-a0c2-13ba96c0a82c","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-container-data","namespace_id":"9221ae3f-2829-4d59-8e25-74fe97c3ad8c","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsflamboyantfermat8qnpjnod/test-container-data:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:37:54.861590Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.387963Z","description":"","environment_variables":{},"error_message":null,"id":"b31bc643-26b3-4978-9758-e778ba988d82","name":"tf-ns-kind-franklin","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnskindfranklinifyskd50","registry_namespace_id":"b4ce7ea6-5c69-4991-84f8-277f455a7ac1","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:48.001913Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "903"
+                - "583"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:37:56 GMT
+                - Wed, 27 Aug 2025 15:05:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -785,10 +785,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6cfd0972-a103-4789-9eea-02a6fe40b31a
+                - 3abffc8f-9048-4fcd-833b-2a2ed5baee8c
         status: 200 OK
         code: 200
-        duration: 91.532459ms
+        duration: 78.23263ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -804,8 +804,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers?name=test-container-data&namespace_id=9221ae3f-2829-4d59-8e25-74fe97c3ad8c&order_by=created_at_asc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a74ab4b9-8ce6-48e6-bb31-c55a7ef563a6
         method: GET
       response:
         proto: HTTP/2.0
@@ -813,20 +813,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 936
+        content_length: 954
         uncompressed: false
-        body: '{"containers":[{"cpu_limit":1000,"created_at":"2025-01-24T15:37:54.861590Z","description":"","domain_name":"tfnsflamboyantfermat8qnpjnod-test-container-data.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a34c8df8-42cb-4819-a0c2-13ba96c0a82c","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-container-data","namespace_id":"9221ae3f-2829-4d59-8e25-74fe97c3ad8c","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsflamboyantfermat8qnpjnod/test-container-data:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:37:54.861590Z"}],"total_count":1}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:53.935631Z","description":"","domain_name":"tfnskindfranklinifyskd50-test-container-data.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a74ab4b9-8ce6-48e6-bb31-c55a7ef563a6","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-container-data","namespace_id":"b31bc643-26b3-4978-9758-e778ba988d82","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnskindfranklinifyskd50/test-container-data:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:53.935631Z"}'
         headers:
             Content-Length:
-                - "936"
+                - "954"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:37:56 GMT
+                - Wed, 27 Aug 2025 15:05:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -834,10 +834,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 12cfc3cb-2b97-48ed-a058-3e91dbbcf8f9
+                - c832c225-a46b-4e39-9446-f646fccac0b4
         status: 200 OK
         code: 200
-        duration: 83.591083ms
+        duration: 83.058235ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -853,8 +853,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a34c8df8-42cb-4819-a0c2-13ba96c0a82c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers?name=test-container-data&namespace_id=b31bc643-26b3-4978-9758-e778ba988d82&order_by=created_at_asc
         method: GET
       response:
         proto: HTTP/2.0
@@ -862,20 +862,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 903
+        content_length: 987
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:37:54.861590Z","description":"","domain_name":"tfnsflamboyantfermat8qnpjnod-test-container-data.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a34c8df8-42cb-4819-a0c2-13ba96c0a82c","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-container-data","namespace_id":"9221ae3f-2829-4d59-8e25-74fe97c3ad8c","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsflamboyantfermat8qnpjnod/test-container-data:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:37:54.861590Z"}'
+        body: '{"containers":[{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:53.935631Z","description":"","domain_name":"tfnskindfranklinifyskd50-test-container-data.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a74ab4b9-8ce6-48e6-bb31-c55a7ef563a6","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-container-data","namespace_id":"b31bc643-26b3-4978-9758-e778ba988d82","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnskindfranklinifyskd50/test-container-data:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:53.935631Z"}],"total_count":1}'
         headers:
             Content-Length:
-                - "903"
+                - "987"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:37:56 GMT
+                - Wed, 27 Aug 2025 15:05:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -883,10 +883,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2696ebc7-ead8-47dc-a9e8-f314abafc6b0
+                - 49695d8d-b584-4851-8802-082b2f009f35
         status: 200 OK
         code: 200
-        duration: 90.663084ms
+        duration: 101.531849ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -902,8 +902,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a34c8df8-42cb-4819-a0c2-13ba96c0a82c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a74ab4b9-8ce6-48e6-bb31-c55a7ef563a6
         method: GET
       response:
         proto: HTTP/2.0
@@ -911,20 +911,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 903
+        content_length: 954
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:37:54.861590Z","description":"","domain_name":"tfnsflamboyantfermat8qnpjnod-test-container-data.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a34c8df8-42cb-4819-a0c2-13ba96c0a82c","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-container-data","namespace_id":"9221ae3f-2829-4d59-8e25-74fe97c3ad8c","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsflamboyantfermat8qnpjnod/test-container-data:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:37:54.861590Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:53.935631Z","description":"","domain_name":"tfnskindfranklinifyskd50-test-container-data.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a74ab4b9-8ce6-48e6-bb31-c55a7ef563a6","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-container-data","namespace_id":"b31bc643-26b3-4978-9758-e778ba988d82","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnskindfranklinifyskd50/test-container-data:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:53.935631Z"}'
         headers:
             Content-Length:
-                - "903"
+                - "954"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:37:56 GMT
+                - Wed, 27 Aug 2025 15:05:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -932,10 +932,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 41dbe1a0-0a22-432b-818c-fe10e38e4767
+                - c9432a6a-1156-46e9-9714-45acb92236c0
         status: 200 OK
         code: 200
-        duration: 70.487791ms
+        duration: 126.603025ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -951,8 +951,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a34c8df8-42cb-4819-a0c2-13ba96c0a82c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a74ab4b9-8ce6-48e6-bb31-c55a7ef563a6
         method: GET
       response:
         proto: HTTP/2.0
@@ -960,20 +960,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 903
+        content_length: 954
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:37:54.861590Z","description":"","domain_name":"tfnsflamboyantfermat8qnpjnod-test-container-data.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a34c8df8-42cb-4819-a0c2-13ba96c0a82c","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-container-data","namespace_id":"9221ae3f-2829-4d59-8e25-74fe97c3ad8c","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsflamboyantfermat8qnpjnod/test-container-data:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:37:54.861590Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:53.935631Z","description":"","domain_name":"tfnskindfranklinifyskd50-test-container-data.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a74ab4b9-8ce6-48e6-bb31-c55a7ef563a6","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-container-data","namespace_id":"b31bc643-26b3-4978-9758-e778ba988d82","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnskindfranklinifyskd50/test-container-data:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:53.935631Z"}'
         headers:
             Content-Length:
-                - "903"
+                - "954"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:37:56 GMT
+                - Wed, 27 Aug 2025 15:05:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -981,10 +981,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0614648b-233f-457e-9960-c79a130ed8f8
+                - af1e5912-8236-4feb-8acd-399fc25109a1
         status: 200 OK
         code: 200
-        duration: 84.220959ms
+        duration: 72.907377ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1000,8 +1000,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers?name=test-container-data&namespace_id=9221ae3f-2829-4d59-8e25-74fe97c3ad8c&order_by=created_at_asc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a74ab4b9-8ce6-48e6-bb31-c55a7ef563a6
         method: GET
       response:
         proto: HTTP/2.0
@@ -1009,20 +1009,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 936
+        content_length: 954
         uncompressed: false
-        body: '{"containers":[{"cpu_limit":1000,"created_at":"2025-01-24T15:37:54.861590Z","description":"","domain_name":"tfnsflamboyantfermat8qnpjnod-test-container-data.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a34c8df8-42cb-4819-a0c2-13ba96c0a82c","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-container-data","namespace_id":"9221ae3f-2829-4d59-8e25-74fe97c3ad8c","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsflamboyantfermat8qnpjnod/test-container-data:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:37:54.861590Z"}],"total_count":1}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:53.935631Z","description":"","domain_name":"tfnskindfranklinifyskd50-test-container-data.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a74ab4b9-8ce6-48e6-bb31-c55a7ef563a6","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-container-data","namespace_id":"b31bc643-26b3-4978-9758-e778ba988d82","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnskindfranklinifyskd50/test-container-data:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:53.935631Z"}'
         headers:
             Content-Length:
-                - "936"
+                - "954"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:37:56 GMT
+                - Wed, 27 Aug 2025 15:05:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1030,10 +1030,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d9eb3b06-f45b-4e3c-9cf1-ae2952b91163
+                - 9b4a7080-41a4-4026-8480-296e706bf9d6
         status: 200 OK
         code: 200
-        duration: 86.624792ms
+        duration: 147.348853ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1049,8 +1049,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a34c8df8-42cb-4819-a0c2-13ba96c0a82c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers?name=test-container-data&namespace_id=b31bc643-26b3-4978-9758-e778ba988d82&order_by=created_at_asc
         method: GET
       response:
         proto: HTTP/2.0
@@ -1058,20 +1058,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 903
+        content_length: 987
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:37:54.861590Z","description":"","domain_name":"tfnsflamboyantfermat8qnpjnod-test-container-data.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a34c8df8-42cb-4819-a0c2-13ba96c0a82c","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-container-data","namespace_id":"9221ae3f-2829-4d59-8e25-74fe97c3ad8c","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsflamboyantfermat8qnpjnod/test-container-data:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:37:54.861590Z"}'
+        body: '{"containers":[{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:53.935631Z","description":"","domain_name":"tfnskindfranklinifyskd50-test-container-data.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a74ab4b9-8ce6-48e6-bb31-c55a7ef563a6","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-container-data","namespace_id":"b31bc643-26b3-4978-9758-e778ba988d82","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnskindfranklinifyskd50/test-container-data:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:53.935631Z"}],"total_count":1}'
         headers:
             Content-Length:
-                - "903"
+                - "987"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:37:57 GMT
+                - Wed, 27 Aug 2025 15:05:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1079,10 +1079,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 086a0b4c-63ed-45ba-8f71-665da03c049d
+                - ddbdc3fb-c6c9-4996-b584-dc363547a780
         status: 200 OK
         code: 200
-        duration: 80.371917ms
+        duration: 164.45382ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1098,8 +1098,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a34c8df8-42cb-4819-a0c2-13ba96c0a82c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a74ab4b9-8ce6-48e6-bb31-c55a7ef563a6
         method: GET
       response:
         proto: HTTP/2.0
@@ -1107,20 +1107,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 903
+        content_length: 954
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:37:54.861590Z","description":"","domain_name":"tfnsflamboyantfermat8qnpjnod-test-container-data.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a34c8df8-42cb-4819-a0c2-13ba96c0a82c","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-container-data","namespace_id":"9221ae3f-2829-4d59-8e25-74fe97c3ad8c","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsflamboyantfermat8qnpjnod/test-container-data:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:37:54.861590Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:53.935631Z","description":"","domain_name":"tfnskindfranklinifyskd50-test-container-data.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a74ab4b9-8ce6-48e6-bb31-c55a7ef563a6","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-container-data","namespace_id":"b31bc643-26b3-4978-9758-e778ba988d82","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnskindfranklinifyskd50/test-container-data:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:53.935631Z"}'
         headers:
             Content-Length:
-                - "903"
+                - "954"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:37:57 GMT
+                - Wed, 27 Aug 2025 15:05:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1128,10 +1128,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cb49f86f-832c-491f-98e9-112131362a88
+                - 70512bf5-75db-4679-9d39-5bbcf34cc706
         status: 200 OK
         code: 200
-        duration: 79.055ms
+        duration: 88.180937ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1147,29 +1147,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a34c8df8-42cb-4819-a0c2-13ba96c0a82c
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a74ab4b9-8ce6-48e6-bb31-c55a7ef563a6
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 907
+        content_length: 954
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:37:54.861590Z","description":"","domain_name":"tfnsflamboyantfermat8qnpjnod-test-container-data.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a34c8df8-42cb-4819-a0c2-13ba96c0a82c","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-container-data","namespace_id":"9221ae3f-2829-4d59-8e25-74fe97c3ad8c","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsflamboyantfermat8qnpjnod/test-container-data:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"deleting","timeout":"300s","updated_at":"2025-01-24T15:37:57.855918580Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:53.935631Z","description":"","domain_name":"tfnskindfranklinifyskd50-test-container-data.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a74ab4b9-8ce6-48e6-bb31-c55a7ef563a6","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-container-data","namespace_id":"b31bc643-26b3-4978-9758-e778ba988d82","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnskindfranklinifyskd50/test-container-data:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:53.935631Z"}'
         headers:
             Content-Length:
-                - "907"
+                - "954"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:37:57 GMT
+                - Wed, 27 Aug 2025 15:05:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1177,10 +1177,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cfc0364a-dac3-4095-a2e9-90866576025e
+                - ad6ff7d9-1c44-40a1-a1e7-59fe7a057477
         status: 200 OK
         code: 200
-        duration: 159.427125ms
+        duration: 104.024047ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1196,29 +1196,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9221ae3f-2829-4d59-8e25-74fe97c3ad8c
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/a74ab4b9-8ce6-48e6-bb31-c55a7ef563a6
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 558
+        content_length: 958
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.306738Z","description":"","environment_variables":{},"error_message":null,"id":"9221ae3f-2829-4d59-8e25-74fe97c3ad8c","name":"tf-ns-flamboyant-fermat","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsflamboyantfermat8qnpjnod","registry_namespace_id":"30f669a4-bd88-4979-8149-e01d34c4ef34","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:37:51.918156Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:53.935631Z","description":"","domain_name":"tfnskindfranklinifyskd50-test-container-data.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"a74ab4b9-8ce6-48e6-bb31-c55a7ef563a6","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"test-container-data","namespace_id":"b31bc643-26b3-4978-9758-e778ba988d82","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnskindfranklinifyskd50/test-container-data:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:56.364319491Z"}'
         headers:
             Content-Length:
-                - "558"
+                - "958"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:37:58 GMT
+                - Wed, 27 Aug 2025 15:05:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1226,10 +1226,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 54df9228-f070-487d-9e0e-1305110830da
+                - dba5c01d-9616-4600-81e4-3a634779db42
         status: 200 OK
         code: 200
-        duration: 65.924209ms
+        duration: 262.105078ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1245,29 +1245,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9221ae3f-2829-4d59-8e25-74fe97c3ad8c
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/b31bc643-26b3-4978-9758-e778ba988d82
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 564
+        content_length: 583
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.306738Z","description":"","environment_variables":{},"error_message":null,"id":"9221ae3f-2829-4d59-8e25-74fe97c3ad8c","name":"tf-ns-flamboyant-fermat","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsflamboyantfermat8qnpjnod","registry_namespace_id":"30f669a4-bd88-4979-8149-e01d34c4ef34","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:37:58.071226128Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.387963Z","description":"","environment_variables":{},"error_message":null,"id":"b31bc643-26b3-4978-9758-e778ba988d82","name":"tf-ns-kind-franklin","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnskindfranklinifyskd50","registry_namespace_id":"b4ce7ea6-5c69-4991-84f8-277f455a7ac1","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:48.001913Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "564"
+                - "583"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:37:58 GMT
+                - Wed, 27 Aug 2025 15:05:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1275,10 +1275,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 37a66a43-1041-45dc-82ff-ef6c6053dcba
+                - 00ef8be1-87ae-4124-879a-fc6941c00e1c
         status: 200 OK
         code: 200
-        duration: 241.253875ms
+        duration: 128.510875ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1294,29 +1294,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9221ae3f-2829-4d59-8e25-74fe97c3ad8c
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/b31bc643-26b3-4978-9758-e778ba988d82
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 561
+        content_length: 589
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.306738Z","description":"","environment_variables":{},"error_message":null,"id":"9221ae3f-2829-4d59-8e25-74fe97c3ad8c","name":"tf-ns-flamboyant-fermat","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsflamboyantfermat8qnpjnod","registry_namespace_id":"30f669a4-bd88-4979-8149-e01d34c4ef34","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:37:58.071226Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.387963Z","description":"","environment_variables":{},"error_message":null,"id":"b31bc643-26b3-4978-9758-e778ba988d82","name":"tf-ns-kind-franklin","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnskindfranklinifyskd50","registry_namespace_id":"b4ce7ea6-5c69-4991-84f8-277f455a7ac1","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:56.687163093Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "561"
+                - "589"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:37:58 GMT
+                - Wed, 27 Aug 2025 15:05:57 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1324,10 +1324,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 652157f4-1372-4d88-865c-febdd452ed2c
+                - 3e8df835-0838-4078-8b98-fc87fbc58b50
         status: 200 OK
         code: 200
-        duration: 67.731125ms
+        duration: 990.403028ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1343,8 +1343,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9221ae3f-2829-4d59-8e25-74fe97c3ad8c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/b31bc643-26b3-4978-9758-e778ba988d82
         method: GET
       response:
         proto: HTTP/2.0
@@ -1352,20 +1352,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 561
+        content_length: 586
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.306738Z","description":"","environment_variables":{},"error_message":null,"id":"9221ae3f-2829-4d59-8e25-74fe97c3ad8c","name":"tf-ns-flamboyant-fermat","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsflamboyantfermat8qnpjnod","registry_namespace_id":"30f669a4-bd88-4979-8149-e01d34c4ef34","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:37:58.071226Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.387963Z","description":"","environment_variables":{},"error_message":null,"id":"b31bc643-26b3-4978-9758-e778ba988d82","name":"tf-ns-kind-franklin","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnskindfranklinifyskd50","registry_namespace_id":"b4ce7ea6-5c69-4991-84f8-277f455a7ac1","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:56.687163Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "561"
+                - "586"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:03 GMT
+                - Wed, 27 Aug 2025 15:05:57 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1373,10 +1373,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6e9eaf58-8f47-4161-9d36-44e148e2849b
+                - 952515b3-887d-4332-8455-93d3247526cf
         status: 200 OK
         code: 200
-        duration: 77.619041ms
+        duration: 89.642971ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1392,8 +1392,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9221ae3f-2829-4d59-8e25-74fe97c3ad8c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/b31bc643-26b3-4978-9758-e778ba988d82
         method: GET
       response:
         proto: HTTP/2.0
@@ -1401,20 +1401,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 561
+        content_length: 586
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.306738Z","description":"","environment_variables":{},"error_message":null,"id":"9221ae3f-2829-4d59-8e25-74fe97c3ad8c","name":"tf-ns-flamboyant-fermat","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsflamboyantfermat8qnpjnod","registry_namespace_id":"30f669a4-bd88-4979-8149-e01d34c4ef34","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:37:58.071226Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.387963Z","description":"","environment_variables":{},"error_message":null,"id":"b31bc643-26b3-4978-9758-e778ba988d82","name":"tf-ns-kind-franklin","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnskindfranklinifyskd50","registry_namespace_id":"b4ce7ea6-5c69-4991-84f8-277f455a7ac1","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:56.687163Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "561"
+                - "586"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:08 GMT
+                - Wed, 27 Aug 2025 15:06:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1422,10 +1422,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 352b11db-247b-44b2-9aa3-f6e5a0843912
+                - f8d3d12d-7348-45b2-98a9-c9273fc7ce6b
         status: 200 OK
         code: 200
-        duration: 108.500125ms
+        duration: 78.814573ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1441,8 +1441,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9221ae3f-2829-4d59-8e25-74fe97c3ad8c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/b31bc643-26b3-4978-9758-e778ba988d82
         method: GET
       response:
         proto: HTTP/2.0
@@ -1450,20 +1450,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 561
+        content_length: 586
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.306738Z","description":"","environment_variables":{},"error_message":null,"id":"9221ae3f-2829-4d59-8e25-74fe97c3ad8c","name":"tf-ns-flamboyant-fermat","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsflamboyantfermat8qnpjnod","registry_namespace_id":"30f669a4-bd88-4979-8149-e01d34c4ef34","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:37:58.071226Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.387963Z","description":"","environment_variables":{},"error_message":null,"id":"b31bc643-26b3-4978-9758-e778ba988d82","name":"tf-ns-kind-franklin","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnskindfranklinifyskd50","registry_namespace_id":"b4ce7ea6-5c69-4991-84f8-277f455a7ac1","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:56.687163Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "561"
+                - "586"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:13 GMT
+                - Wed, 27 Aug 2025 15:06:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1471,10 +1471,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bcc53809-2859-454b-aabf-237f67fb3f37
+                - 439758eb-019b-4713-ae20-9b0c8204ed44
         status: 200 OK
         code: 200
-        duration: 62.849083ms
+        duration: 86.237383ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1490,8 +1490,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9221ae3f-2829-4d59-8e25-74fe97c3ad8c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/b31bc643-26b3-4978-9758-e778ba988d82
         method: GET
       response:
         proto: HTTP/2.0
@@ -1499,20 +1499,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 561
+        content_length: 586
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.306738Z","description":"","environment_variables":{},"error_message":null,"id":"9221ae3f-2829-4d59-8e25-74fe97c3ad8c","name":"tf-ns-flamboyant-fermat","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsflamboyantfermat8qnpjnod","registry_namespace_id":"30f669a4-bd88-4979-8149-e01d34c4ef34","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:37:58.071226Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.387963Z","description":"","environment_variables":{},"error_message":null,"id":"b31bc643-26b3-4978-9758-e778ba988d82","name":"tf-ns-kind-franklin","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnskindfranklinifyskd50","registry_namespace_id":"b4ce7ea6-5c69-4991-84f8-277f455a7ac1","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:56.687163Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "561"
+                - "586"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:18 GMT
+                - Wed, 27 Aug 2025 15:06:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1520,10 +1520,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5a4bfa28-5da4-4a12-9745-6e78ec35a8a6
+                - c473959a-0f89-4f59-9336-c1c852392ed3
         status: 200 OK
         code: 200
-        duration: 77.862209ms
+        duration: 93.627723ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1539,8 +1539,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9221ae3f-2829-4d59-8e25-74fe97c3ad8c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/b31bc643-26b3-4978-9758-e778ba988d82
         method: GET
       response:
         proto: HTTP/2.0
@@ -1548,20 +1548,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 561
+        content_length: 586
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.306738Z","description":"","environment_variables":{},"error_message":null,"id":"9221ae3f-2829-4d59-8e25-74fe97c3ad8c","name":"tf-ns-flamboyant-fermat","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsflamboyantfermat8qnpjnod","registry_namespace_id":"30f669a4-bd88-4979-8149-e01d34c4ef34","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:37:58.071226Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.387963Z","description":"","environment_variables":{},"error_message":null,"id":"b31bc643-26b3-4978-9758-e778ba988d82","name":"tf-ns-kind-franklin","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnskindfranklinifyskd50","registry_namespace_id":"b4ce7ea6-5c69-4991-84f8-277f455a7ac1","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:56.687163Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "561"
+                - "586"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:23 GMT
+                - Wed, 27 Aug 2025 15:06:18 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1569,10 +1569,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c8b8cac7-1f71-49ca-9001-557b04c75f31
+                - 631793ff-b808-4bb0-a63f-85c734bad759
         status: 200 OK
         code: 200
-        duration: 74.445625ms
+        duration: 93.485487ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1588,8 +1588,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9221ae3f-2829-4d59-8e25-74fe97c3ad8c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/b31bc643-26b3-4978-9758-e778ba988d82
         method: GET
       response:
         proto: HTTP/2.0
@@ -1597,20 +1597,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 561
+        content_length: 586
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.306738Z","description":"","environment_variables":{},"error_message":null,"id":"9221ae3f-2829-4d59-8e25-74fe97c3ad8c","name":"tf-ns-flamboyant-fermat","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsflamboyantfermat8qnpjnod","registry_namespace_id":"30f669a4-bd88-4979-8149-e01d34c4ef34","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:37:58.071226Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.387963Z","description":"","environment_variables":{},"error_message":null,"id":"b31bc643-26b3-4978-9758-e778ba988d82","name":"tf-ns-kind-franklin","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnskindfranklinifyskd50","registry_namespace_id":"b4ce7ea6-5c69-4991-84f8-277f455a7ac1","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:56.687163Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "561"
+                - "586"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:28 GMT
+                - Wed, 27 Aug 2025 15:06:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1618,10 +1618,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4e15702d-0a11-452c-ab9b-298872bcf1e1
+                - ada48659-5f3c-4d65-b850-460af03659ba
         status: 200 OK
         code: 200
-        duration: 77.139917ms
+        duration: 83.865376ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1637,155 +1637,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9221ae3f-2829-4d59-8e25-74fe97c3ad8c
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 561
-        uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.306738Z","description":"","environment_variables":{},"error_message":null,"id":"9221ae3f-2829-4d59-8e25-74fe97c3ad8c","name":"tf-ns-flamboyant-fermat","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsflamboyantfermat8qnpjnod","registry_namespace_id":"30f669a4-bd88-4979-8149-e01d34c4ef34","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:37:58.071226Z"}'
-        headers:
-            Content-Length:
-                - "561"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:38:33 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 490e7627-9533-4ff1-a3c5-6fc4d83d7f9c
-        status: 200 OK
-        code: 200
-        duration: 92.0255ms
-    - id: 34
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9221ae3f-2829-4d59-8e25-74fe97c3ad8c
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 561
-        uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.306738Z","description":"","environment_variables":{},"error_message":null,"id":"9221ae3f-2829-4d59-8e25-74fe97c3ad8c","name":"tf-ns-flamboyant-fermat","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsflamboyantfermat8qnpjnod","registry_namespace_id":"30f669a4-bd88-4979-8149-e01d34c4ef34","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:37:58.071226Z"}'
-        headers:
-            Content-Length:
-                - "561"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:38:38 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 1547d86a-d05c-4b6e-99cb-8fa134cbd086
-        status: 200 OK
-        code: 200
-        duration: 73.319292ms
-    - id: 35
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9221ae3f-2829-4d59-8e25-74fe97c3ad8c
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 561
-        uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.306738Z","description":"","environment_variables":{},"error_message":null,"id":"9221ae3f-2829-4d59-8e25-74fe97c3ad8c","name":"tf-ns-flamboyant-fermat","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsflamboyantfermat8qnpjnod","registry_namespace_id":"30f669a4-bd88-4979-8149-e01d34c4ef34","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:37:58.071226Z"}'
-        headers:
-            Content-Length:
-                - "561"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:38:44 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - a4ba4c27-cb58-4a8b-b1cb-423dd3d43390
-        status: 200 OK
-        code: 200
-        duration: 73.425125ms
-    - id: 36
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9221ae3f-2829-4d59-8e25-74fe97c3ad8c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/b31bc643-26b3-4978-9758-e778ba988d82
         method: GET
       response:
         proto: HTTP/2.0
@@ -1804,9 +1657,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:49 GMT
+                - Wed, 27 Aug 2025 15:06:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1814,11 +1667,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 613c070f-4c7e-42b6-9652-e08d3710ba20
+                - 45694218-3a43-44e2-9055-5291e5443e01
         status: 404 Not Found
         code: 404
-        duration: 34.282333ms
-    - id: 37
+        duration: 23.903236ms
+    - id: 34
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1833,8 +1686,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9221ae3f-2829-4d59-8e25-74fe97c3ad8c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/b31bc643-26b3-4978-9758-e778ba988d82
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1853,9 +1706,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:49 GMT
+                - Wed, 27 Aug 2025 15:06:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1863,7 +1716,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3a933552-922b-4dde-a7f6-0e75c6309d5b
+                - c48eba7c-6399-4281-8dd3-b18543d5441b
         status: 404 Not Found
         code: 404
-        duration: 37.394833ms
+        duration: 26.770456ms

--- a/internal/services/container/testdata/data-source-container-health-check.cassette.yaml
+++ b/internal/services/container/testdata/data-source-container-health-check.cassette.yaml
@@ -6,19 +6,19 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 160
+        content_length: 195
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-ns-recursing-meninsky","environment_variables":{},"project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","secret_environment_variables":[],"tags":null}'
+        body: '{"name":"tf-ns-hopeful-proskuriakova","environment_variables":{},"project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","secret_environment_variables":[],"tags":null,"activate_vpc_integration":true}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces
         method: POST
       response:
@@ -27,20 +27,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 490
+        content_length: 512
         uncompressed: false
-        body: '{"created_at":"2025-01-16T10:19:12.487939807Z","description":"","environment_variables":{},"error_message":null,"id":"ee1cc53d-416f-42c5-80db-9876f49941b6","name":"tf-ns-recursing-meninsky","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-16T10:19:12.487939807Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.963414637Z","description":"","environment_variables":{},"error_message":null,"id":"0214ab75-bab5-44ab-97b1-4aa30ad45a5f","name":"tf-ns-hopeful-proskuriakova","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:40.963414637Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "490"
+                - "512"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 16 Jan 2025 10:19:12 GMT
+                - Wed, 27 Aug 2025 15:05:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 40327b77-6e71-480a-bc17-33beb727b774
+                - 69ba5f36-1d98-4eb9-82a9-6843cd660285
         status: 200 OK
         code: 200
-        duration: 435.492583ms
+        duration: 5.066244744s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -67,8 +67,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/ee1cc53d-416f-42c5-80db-9876f49941b6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/0214ab75-bab5-44ab-97b1-4aa30ad45a5f
         method: GET
       response:
         proto: HTTP/2.0
@@ -76,20 +76,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 484
+        content_length: 506
         uncompressed: false
-        body: '{"created_at":"2025-01-16T10:19:12.487940Z","description":"","environment_variables":{},"error_message":null,"id":"ee1cc53d-416f-42c5-80db-9876f49941b6","name":"tf-ns-recursing-meninsky","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-16T10:19:12.487940Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.963415Z","description":"","environment_variables":{},"error_message":null,"id":"0214ab75-bab5-44ab-97b1-4aa30ad45a5f","name":"tf-ns-hopeful-proskuriakova","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:40.963415Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "484"
+                - "506"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 16 Jan 2025 10:19:12 GMT
+                - Wed, 27 Aug 2025 15:05:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ffc3fe15-0a55-4245-bbb9-22bf96b10d91
+                - fc1a56c6-2d55-4b26-84a5-6392e68d2c74
         status: 200 OK
         code: 200
-        duration: 42.161042ms
+        duration: 93.260765ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -116,8 +116,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/ee1cc53d-416f-42c5-80db-9876f49941b6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/0214ab75-bab5-44ab-97b1-4aa30ad45a5f
         method: GET
       response:
         proto: HTTP/2.0
@@ -125,20 +125,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 573
+        content_length: 597
         uncompressed: false
-        body: '{"created_at":"2025-01-16T10:19:12.487940Z","description":"","environment_variables":{},"error_message":null,"id":"ee1cc53d-416f-42c5-80db-9876f49941b6","name":"tf-ns-recursing-meninsky","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsrecursingmeninskriz6ksue","registry_namespace_id":"76e06637-7bac-46a5-95df-726d23332b32","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-16T10:19:14.345675Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.963415Z","description":"","environment_variables":{},"error_message":null,"id":"0214ab75-bab5-44ab-97b1-4aa30ad45a5f","name":"tf-ns-hopeful-proskuriakova","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshopefulproskuriaqrubkshh","registry_namespace_id":"2d4ee1ff-6a68-4256-8af9-1410d1c72d4f","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:45.940706Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "573"
+                - "597"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 16 Jan 2025 10:19:17 GMT
+                - Wed, 27 Aug 2025 15:05:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -146,10 +146,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4e11dd01-2c1f-463a-944c-f58d1529631c
+                - 9e03103b-7ae1-469d-84b3-08f70217174e
         status: 200 OK
         code: 200
-        duration: 44.333625ms
+        duration: 93.632544ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -165,8 +165,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/ee1cc53d-416f-42c5-80db-9876f49941b6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/0214ab75-bab5-44ab-97b1-4aa30ad45a5f
         method: GET
       response:
         proto: HTTP/2.0
@@ -174,20 +174,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 573
+        content_length: 595
         uncompressed: false
-        body: '{"created_at":"2025-01-16T10:19:12.487940Z","description":"","environment_variables":{},"error_message":null,"id":"ee1cc53d-416f-42c5-80db-9876f49941b6","name":"tf-ns-recursing-meninsky","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsrecursingmeninskriz6ksue","registry_namespace_id":"76e06637-7bac-46a5-95df-726d23332b32","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-16T10:19:14.345675Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.963415Z","description":"","environment_variables":{},"error_message":null,"id":"0214ab75-bab5-44ab-97b1-4aa30ad45a5f","name":"tf-ns-hopeful-proskuriakova","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshopefulproskuriaqrubkshh","registry_namespace_id":"2d4ee1ff-6a68-4256-8af9-1410d1c72d4f","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:46.109073Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "573"
+                - "595"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 16 Jan 2025 10:19:17 GMT
+                - Wed, 27 Aug 2025 15:05:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -195,10 +195,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - aab6443e-a0e6-4e8d-a013-bfb0568a6bff
+                - af929aef-9483-4ddc-b992-0bb68a331f10
         status: 200 OK
         code: 200
-        duration: 51.525792ms
+        duration: 81.618563ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -214,8 +214,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/ee1cc53d-416f-42c5-80db-9876f49941b6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/0214ab75-bab5-44ab-97b1-4aa30ad45a5f
         method: GET
       response:
         proto: HTTP/2.0
@@ -223,20 +223,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 573
+        content_length: 595
         uncompressed: false
-        body: '{"created_at":"2025-01-16T10:19:12.487940Z","description":"","environment_variables":{},"error_message":null,"id":"ee1cc53d-416f-42c5-80db-9876f49941b6","name":"tf-ns-recursing-meninsky","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsrecursingmeninskriz6ksue","registry_namespace_id":"76e06637-7bac-46a5-95df-726d23332b32","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-16T10:19:14.345675Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.963415Z","description":"","environment_variables":{},"error_message":null,"id":"0214ab75-bab5-44ab-97b1-4aa30ad45a5f","name":"tf-ns-hopeful-proskuriakova","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshopefulproskuriaqrubkshh","registry_namespace_id":"2d4ee1ff-6a68-4256-8af9-1410d1c72d4f","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:46.109073Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "573"
+                - "595"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 16 Jan 2025 10:19:17 GMT
+                - Wed, 27 Aug 2025 15:05:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -244,62 +244,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5d04a52a-03bd-4231-b68f-0cb03ab332d5
+                - c4831c26-2703-4434-96bc-d3fdc16055c4
         status: 200 OK
         code: 200
-        duration: 42.792625ms
+        duration: 107.322194ms
     - id: 5
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 213
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"namespace_id":"ee1cc53d-416f-42c5-80db-9876f49941b6","name":"tf-co-pedantic-feynman","privacy":"public","protocol":"http1","secret_environment_variables":null,"http_option":"enabled","sandbox":"unknown_sandbox"}'
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 947
-        uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-16T10:19:18.026133228Z","description":"","domain_name":"tfnsrecursingmeninskriz6ksue-tf-co-pedantic-feynman.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"ee289584-2c21-49b4-8d7f-dc1191d0f23e","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-pedantic-feynman","namespace_id":"ee1cc53d-416f-42c5-80db-9876f49941b6","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsrecursingmeninskriz6ksue/tf-co-pedantic-feynman:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-16T10:19:18.026133228Z"}'
-        headers:
-            Content-Length:
-                - "947"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Thu, 16 Jan 2025 10:19:18 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - f3e1178e-ebcb-43b1-a13d-418cc7e3ea91
-        status: 200 OK
-        code: 200
-        duration: 327.538167ms
-    - id: 6
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -314,8 +263,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/ee289584-2c21-49b4-8d7f-dc1191d0f23e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/0214ab75-bab5-44ab-97b1-4aa30ad45a5f
         method: GET
       response:
         proto: HTTP/2.0
@@ -323,20 +272,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 941
+        content_length: 595
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-16T10:19:18.026133Z","description":"","domain_name":"tfnsrecursingmeninskriz6ksue-tf-co-pedantic-feynman.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"ee289584-2c21-49b4-8d7f-dc1191d0f23e","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-pedantic-feynman","namespace_id":"ee1cc53d-416f-42c5-80db-9876f49941b6","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsrecursingmeninskriz6ksue/tf-co-pedantic-feynman:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-16T10:19:18.026133Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.963415Z","description":"","environment_variables":{},"error_message":null,"id":"0214ab75-bab5-44ab-97b1-4aa30ad45a5f","name":"tf-ns-hopeful-proskuriakova","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshopefulproskuriaqrubkshh","registry_namespace_id":"2d4ee1ff-6a68-4256-8af9-1410d1c72d4f","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:46.109073Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "941"
+                - "595"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 16 Jan 2025 10:19:18 GMT
+                - Wed, 27 Aug 2025 15:05:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -344,10 +293,61 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 53182b74-eb24-49bd-aa69-f2d2000fceb1
+                - 4c8ba1ef-84a1-493c-b6d6-3bf2d90b5f17
         status: 200 OK
         code: 200
-        duration: 50.85875ms
+        duration: 92.661623ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 253
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"namespace_id":"0214ab75-bab5-44ab-97b1-4aa30ad45a5f","name":"tf-co-sleepy-williamson","privacy":"public","protocol":"http1","secret_environment_variables":null,"http_option":"enabled","sandbox":"unknown_sandbox","tags":null,"command":null,"args":null}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 980
+        uncompressed: false
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:53.425873036Z","description":"","domain_name":"tfnshopefulproskuriaqrubkshh-tf-co-sleepy-williamson.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"1211f095-c8e1-462d-92ec-76536bb4f599","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-sleepy-williamson","namespace_id":"0214ab75-bab5-44ab-97b1-4aa30ad45a5f","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshopefulproskuriaqrubkshh/tf-co-sleepy-williamson:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:53.425873036Z"}'
+        headers:
+            Content-Length:
+                - "980"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:05:53 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 9c72908d-e3ee-4ac2-b01b-8bec02b10b7e
+        status: 200 OK
+        code: 200
+        duration: 2.022196241s
     - id: 7
       request:
         proto: HTTP/1.1
@@ -363,8 +363,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/ee289584-2c21-49b4-8d7f-dc1191d0f23e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/1211f095-c8e1-462d-92ec-76536bb4f599
         method: GET
       response:
         proto: HTTP/2.0
@@ -372,20 +372,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 941
+        content_length: 974
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-16T10:19:18.026133Z","description":"","domain_name":"tfnsrecursingmeninskriz6ksue-tf-co-pedantic-feynman.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"ee289584-2c21-49b4-8d7f-dc1191d0f23e","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-pedantic-feynman","namespace_id":"ee1cc53d-416f-42c5-80db-9876f49941b6","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsrecursingmeninskriz6ksue/tf-co-pedantic-feynman:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-16T10:19:18.026133Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:53.425873Z","description":"","domain_name":"tfnshopefulproskuriaqrubkshh-tf-co-sleepy-williamson.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"1211f095-c8e1-462d-92ec-76536bb4f599","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-sleepy-williamson","namespace_id":"0214ab75-bab5-44ab-97b1-4aa30ad45a5f","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshopefulproskuriaqrubkshh/tf-co-sleepy-williamson:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:53.425873Z"}'
         headers:
             Content-Length:
-                - "941"
+                - "974"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 16 Jan 2025 10:19:18 GMT
+                - Wed, 27 Aug 2025 15:05:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -393,10 +393,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 18fd4dcc-ece2-4552-b004-3880116527aa
+                - 743f650d-cc87-46c9-bec3-3f194dd91b34
         status: 200 OK
         code: 200
-        duration: 60.991333ms
+        duration: 93.274574ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -412,8 +412,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/ee289584-2c21-49b4-8d7f-dc1191d0f23e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/1211f095-c8e1-462d-92ec-76536bb4f599
         method: GET
       response:
         proto: HTTP/2.0
@@ -421,20 +421,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 941
+        content_length: 974
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-16T10:19:18.026133Z","description":"","domain_name":"tfnsrecursingmeninskriz6ksue-tf-co-pedantic-feynman.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"ee289584-2c21-49b4-8d7f-dc1191d0f23e","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-pedantic-feynman","namespace_id":"ee1cc53d-416f-42c5-80db-9876f49941b6","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsrecursingmeninskriz6ksue/tf-co-pedantic-feynman:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-16T10:19:18.026133Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:53.425873Z","description":"","domain_name":"tfnshopefulproskuriaqrubkshh-tf-co-sleepy-williamson.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"1211f095-c8e1-462d-92ec-76536bb4f599","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-sleepy-williamson","namespace_id":"0214ab75-bab5-44ab-97b1-4aa30ad45a5f","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshopefulproskuriaqrubkshh/tf-co-sleepy-williamson:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:53.425873Z"}'
         headers:
             Content-Length:
-                - "941"
+                - "974"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 16 Jan 2025 10:19:18 GMT
+                - Wed, 27 Aug 2025 15:05:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -442,10 +442,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 08effde3-eb13-48df-b204-892cd016fe88
+                - 7816ae6b-4503-4880-8d4b-486539a51bac
         status: 200 OK
         code: 200
-        duration: 59.646125ms
+        duration: 102.580947ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -461,8 +461,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/ee289584-2c21-49b4-8d7f-dc1191d0f23e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/1211f095-c8e1-462d-92ec-76536bb4f599
         method: GET
       response:
         proto: HTTP/2.0
@@ -470,20 +470,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 941
+        content_length: 974
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-16T10:19:18.026133Z","description":"","domain_name":"tfnsrecursingmeninskriz6ksue-tf-co-pedantic-feynman.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"ee289584-2c21-49b4-8d7f-dc1191d0f23e","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-pedantic-feynman","namespace_id":"ee1cc53d-416f-42c5-80db-9876f49941b6","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsrecursingmeninskriz6ksue/tf-co-pedantic-feynman:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-16T10:19:18.026133Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:53.425873Z","description":"","domain_name":"tfnshopefulproskuriaqrubkshh-tf-co-sleepy-williamson.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"1211f095-c8e1-462d-92ec-76536bb4f599","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-sleepy-williamson","namespace_id":"0214ab75-bab5-44ab-97b1-4aa30ad45a5f","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshopefulproskuriaqrubkshh/tf-co-sleepy-williamson:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:53.425873Z"}'
         headers:
             Content-Length:
-                - "941"
+                - "974"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 16 Jan 2025 10:19:18 GMT
+                - Wed, 27 Aug 2025 15:05:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -491,10 +491,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a0fe6ade-6831-43f7-a9d7-9e2172c08f73
+                - 79757b51-69a2-41d7-991c-617be4a64034
         status: 200 OK
         code: 200
-        duration: 61.4325ms
+        duration: 97.793965ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -510,8 +510,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/ee1cc53d-416f-42c5-80db-9876f49941b6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/1211f095-c8e1-462d-92ec-76536bb4f599
         method: GET
       response:
         proto: HTTP/2.0
@@ -519,20 +519,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 573
+        content_length: 974
         uncompressed: false
-        body: '{"created_at":"2025-01-16T10:19:12.487940Z","description":"","environment_variables":{},"error_message":null,"id":"ee1cc53d-416f-42c5-80db-9876f49941b6","name":"tf-ns-recursing-meninsky","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsrecursingmeninskriz6ksue","registry_namespace_id":"76e06637-7bac-46a5-95df-726d23332b32","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-16T10:19:14.345675Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:53.425873Z","description":"","domain_name":"tfnshopefulproskuriaqrubkshh-tf-co-sleepy-williamson.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"1211f095-c8e1-462d-92ec-76536bb4f599","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-sleepy-williamson","namespace_id":"0214ab75-bab5-44ab-97b1-4aa30ad45a5f","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshopefulproskuriaqrubkshh/tf-co-sleepy-williamson:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:53.425873Z"}'
         headers:
             Content-Length:
-                - "573"
+                - "974"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 16 Jan 2025 10:19:18 GMT
+                - Wed, 27 Aug 2025 15:05:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -540,10 +540,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 48c114a7-8c02-40ab-8144-7afaaf32fd1d
+                - dac03c83-4655-461f-87c0-f30e7bc237c4
         status: 200 OK
         code: 200
-        duration: 48.3ms
+        duration: 108.980195ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -559,8 +559,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/ee289584-2c21-49b4-8d7f-dc1191d0f23e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/0214ab75-bab5-44ab-97b1-4aa30ad45a5f
         method: GET
       response:
         proto: HTTP/2.0
@@ -568,20 +568,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 941
+        content_length: 595
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-16T10:19:18.026133Z","description":"","domain_name":"tfnsrecursingmeninskriz6ksue-tf-co-pedantic-feynman.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"ee289584-2c21-49b4-8d7f-dc1191d0f23e","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-pedantic-feynman","namespace_id":"ee1cc53d-416f-42c5-80db-9876f49941b6","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsrecursingmeninskriz6ksue/tf-co-pedantic-feynman:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-16T10:19:18.026133Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.963415Z","description":"","environment_variables":{},"error_message":null,"id":"0214ab75-bab5-44ab-97b1-4aa30ad45a5f","name":"tf-ns-hopeful-proskuriakova","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshopefulproskuriaqrubkshh","registry_namespace_id":"2d4ee1ff-6a68-4256-8af9-1410d1c72d4f","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:46.109073Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "941"
+                - "595"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 16 Jan 2025 10:19:18 GMT
+                - Wed, 27 Aug 2025 15:05:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -589,10 +589,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1b360420-5fc4-4096-9add-70adf802c769
+                - bc3f5901-2667-4dfc-9736-631ecc20a27f
         status: 200 OK
         code: 200
-        duration: 50.523625ms
+        duration: 91.249616ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -608,8 +608,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/ee289584-2c21-49b4-8d7f-dc1191d0f23e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/1211f095-c8e1-462d-92ec-76536bb4f599
         method: GET
       response:
         proto: HTTP/2.0
@@ -617,20 +617,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 941
+        content_length: 974
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-16T10:19:18.026133Z","description":"","domain_name":"tfnsrecursingmeninskriz6ksue-tf-co-pedantic-feynman.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"ee289584-2c21-49b4-8d7f-dc1191d0f23e","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-pedantic-feynman","namespace_id":"ee1cc53d-416f-42c5-80db-9876f49941b6","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsrecursingmeninskriz6ksue/tf-co-pedantic-feynman:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-16T10:19:18.026133Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:53.425873Z","description":"","domain_name":"tfnshopefulproskuriaqrubkshh-tf-co-sleepy-williamson.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"1211f095-c8e1-462d-92ec-76536bb4f599","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-sleepy-williamson","namespace_id":"0214ab75-bab5-44ab-97b1-4aa30ad45a5f","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshopefulproskuriaqrubkshh/tf-co-sleepy-williamson:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:53.425873Z"}'
         headers:
             Content-Length:
-                - "941"
+                - "974"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 16 Jan 2025 10:19:18 GMT
+                - Wed, 27 Aug 2025 15:05:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -638,10 +638,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 62555ed7-d350-4d6d-961e-1ceb19b8ab5c
+                - e67c2119-01a1-49f0-8d9f-c959e6344e12
         status: 200 OK
         code: 200
-        duration: 62.109083ms
+        duration: 80.884405ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -657,8 +657,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/ee289584-2c21-49b4-8d7f-dc1191d0f23e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/1211f095-c8e1-462d-92ec-76536bb4f599
         method: GET
       response:
         proto: HTTP/2.0
@@ -666,20 +666,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 941
+        content_length: 974
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-16T10:19:18.026133Z","description":"","domain_name":"tfnsrecursingmeninskriz6ksue-tf-co-pedantic-feynman.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"ee289584-2c21-49b4-8d7f-dc1191d0f23e","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-pedantic-feynman","namespace_id":"ee1cc53d-416f-42c5-80db-9876f49941b6","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsrecursingmeninskriz6ksue/tf-co-pedantic-feynman:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-16T10:19:18.026133Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:53.425873Z","description":"","domain_name":"tfnshopefulproskuriaqrubkshh-tf-co-sleepy-williamson.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"1211f095-c8e1-462d-92ec-76536bb4f599","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-sleepy-williamson","namespace_id":"0214ab75-bab5-44ab-97b1-4aa30ad45a5f","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshopefulproskuriaqrubkshh/tf-co-sleepy-williamson:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:53.425873Z"}'
         headers:
             Content-Length:
-                - "941"
+                - "974"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 16 Jan 2025 10:19:18 GMT
+                - Wed, 27 Aug 2025 15:05:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -687,10 +687,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6a0575f1-2aaa-4c20-88b8-d00397946da1
+                - 1a351b4e-ba2c-43ee-8584-fa44f8f68f8b
         status: 200 OK
         code: 200
-        duration: 66.108208ms
+        duration: 175.526747ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -706,8 +706,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/ee289584-2c21-49b4-8d7f-dc1191d0f23e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/1211f095-c8e1-462d-92ec-76536bb4f599
         method: GET
       response:
         proto: HTTP/2.0
@@ -715,20 +715,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 941
+        content_length: 974
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-16T10:19:18.026133Z","description":"","domain_name":"tfnsrecursingmeninskriz6ksue-tf-co-pedantic-feynman.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"ee289584-2c21-49b4-8d7f-dc1191d0f23e","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-pedantic-feynman","namespace_id":"ee1cc53d-416f-42c5-80db-9876f49941b6","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsrecursingmeninskriz6ksue/tf-co-pedantic-feynman:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-16T10:19:18.026133Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:53.425873Z","description":"","domain_name":"tfnshopefulproskuriaqrubkshh-tf-co-sleepy-williamson.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"1211f095-c8e1-462d-92ec-76536bb4f599","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-sleepy-williamson","namespace_id":"0214ab75-bab5-44ab-97b1-4aa30ad45a5f","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshopefulproskuriaqrubkshh/tf-co-sleepy-williamson:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:53.425873Z"}'
         headers:
             Content-Length:
-                - "941"
+                - "974"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 16 Jan 2025 10:19:19 GMT
+                - Wed, 27 Aug 2025 15:05:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -736,10 +736,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 341f806b-d9c5-4754-9a73-f70f41dff76e
+                - 31288a40-6a67-4020-acde-1d62d6549644
         status: 200 OK
         code: 200
-        duration: 61.361917ms
+        duration: 89.058954ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -755,29 +755,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/ee289584-2c21-49b4-8d7f-dc1191d0f23e
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/1211f095-c8e1-462d-92ec-76536bb4f599
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 945
+        content_length: 974
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-16T10:19:18.026133Z","description":"","domain_name":"tfnsrecursingmeninskriz6ksue-tf-co-pedantic-feynman.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"ee289584-2c21-49b4-8d7f-dc1191d0f23e","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-pedantic-feynman","namespace_id":"ee1cc53d-416f-42c5-80db-9876f49941b6","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsrecursingmeninskriz6ksue/tf-co-pedantic-feynman:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"deleting","timeout":"300s","updated_at":"2025-01-16T10:19:19.154425779Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:53.425873Z","description":"","domain_name":"tfnshopefulproskuriaqrubkshh-tf-co-sleepy-williamson.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"1211f095-c8e1-462d-92ec-76536bb4f599","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-sleepy-williamson","namespace_id":"0214ab75-bab5-44ab-97b1-4aa30ad45a5f","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshopefulproskuriaqrubkshh/tf-co-sleepy-williamson:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:53.425873Z"}'
         headers:
             Content-Length:
-                - "945"
+                - "974"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 16 Jan 2025 10:19:19 GMT
+                - Wed, 27 Aug 2025 15:05:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -785,10 +785,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 47650f73-5e52-4e51-a0d9-60aa3c4c869a
+                - 7660a110-a847-4b11-a9b0-6143f17c60ea
         status: 200 OK
         code: 200
-        duration: 120.530958ms
+        duration: 89.490404ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -804,29 +804,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/ee1cc53d-416f-42c5-80db-9876f49941b6
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/1211f095-c8e1-462d-92ec-76536bb4f599
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 573
+        content_length: 978
         uncompressed: false
-        body: '{"created_at":"2025-01-16T10:19:12.487940Z","description":"","environment_variables":{},"error_message":null,"id":"ee1cc53d-416f-42c5-80db-9876f49941b6","name":"tf-ns-recursing-meninsky","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsrecursingmeninskriz6ksue","registry_namespace_id":"76e06637-7bac-46a5-95df-726d23332b32","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-16T10:19:14.345675Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:53.425873Z","description":"","domain_name":"tfnshopefulproskuriaqrubkshh-tf-co-sleepy-williamson.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"1211f095-c8e1-462d-92ec-76536bb4f599","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-sleepy-williamson","namespace_id":"0214ab75-bab5-44ab-97b1-4aa30ad45a5f","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshopefulproskuriaqrubkshh/tf-co-sleepy-williamson:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:55.485283746Z"}'
         headers:
             Content-Length:
-                - "573"
+                - "978"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 16 Jan 2025 10:19:19 GMT
+                - Wed, 27 Aug 2025 15:05:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -834,10 +834,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a447f959-9e8c-469e-b809-723979fa4f15
+                - 22562bfd-b125-47d5-8425-67ecd8131e91
         status: 200 OK
         code: 200
-        duration: 44.802209ms
+        duration: 285.808375ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -853,29 +853,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/ee1cc53d-416f-42c5-80db-9876f49941b6
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/0214ab75-bab5-44ab-97b1-4aa30ad45a5f
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 579
+        content_length: 595
         uncompressed: false
-        body: '{"created_at":"2025-01-16T10:19:12.487940Z","description":"","environment_variables":{},"error_message":null,"id":"ee1cc53d-416f-42c5-80db-9876f49941b6","name":"tf-ns-recursing-meninsky","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsrecursingmeninskriz6ksue","registry_namespace_id":"76e06637-7bac-46a5-95df-726d23332b32","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-16T10:19:19.308954029Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.963415Z","description":"","environment_variables":{},"error_message":null,"id":"0214ab75-bab5-44ab-97b1-4aa30ad45a5f","name":"tf-ns-hopeful-proskuriakova","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshopefulproskuriaqrubkshh","registry_namespace_id":"2d4ee1ff-6a68-4256-8af9-1410d1c72d4f","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:46.109073Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "579"
+                - "595"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 16 Jan 2025 10:19:19 GMT
+                - Wed, 27 Aug 2025 15:05:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -883,10 +883,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 96e0b813-a0fc-4733-89a2-d3d21f405202
+                - ece123d1-8ee4-48ca-838c-b75a1162ac74
         status: 200 OK
         code: 200
-        duration: 142.514542ms
+        duration: 74.89658ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -902,29 +902,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/ee1cc53d-416f-42c5-80db-9876f49941b6
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/0214ab75-bab5-44ab-97b1-4aa30ad45a5f
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 576
+        content_length: 601
         uncompressed: false
-        body: '{"created_at":"2025-01-16T10:19:12.487940Z","description":"","environment_variables":{},"error_message":null,"id":"ee1cc53d-416f-42c5-80db-9876f49941b6","name":"tf-ns-recursing-meninsky","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsrecursingmeninskriz6ksue","registry_namespace_id":"76e06637-7bac-46a5-95df-726d23332b32","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-16T10:19:19.308954Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.963415Z","description":"","environment_variables":{},"error_message":null,"id":"0214ab75-bab5-44ab-97b1-4aa30ad45a5f","name":"tf-ns-hopeful-proskuriakova","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshopefulproskuriaqrubkshh","registry_namespace_id":"2d4ee1ff-6a68-4256-8af9-1410d1c72d4f","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:55.770475103Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "576"
+                - "601"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 16 Jan 2025 10:19:19 GMT
+                - Wed, 27 Aug 2025 15:05:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -932,10 +932,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 31916396-53d1-4c4c-b342-0a1e5082b9bf
+                - fa96f1f0-55c4-44aa-b7ac-3d556e255192
         status: 200 OK
         code: 200
-        duration: 44.282542ms
+        duration: 510.139232ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -951,8 +951,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/ee1cc53d-416f-42c5-80db-9876f49941b6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/0214ab75-bab5-44ab-97b1-4aa30ad45a5f
         method: GET
       response:
         proto: HTTP/2.0
@@ -960,20 +960,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 576
+        content_length: 598
         uncompressed: false
-        body: '{"created_at":"2025-01-16T10:19:12.487940Z","description":"","environment_variables":{},"error_message":null,"id":"ee1cc53d-416f-42c5-80db-9876f49941b6","name":"tf-ns-recursing-meninsky","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsrecursingmeninskriz6ksue","registry_namespace_id":"76e06637-7bac-46a5-95df-726d23332b32","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-16T10:19:19.308954Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.963415Z","description":"","environment_variables":{},"error_message":null,"id":"0214ab75-bab5-44ab-97b1-4aa30ad45a5f","name":"tf-ns-hopeful-proskuriakova","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshopefulproskuriaqrubkshh","registry_namespace_id":"2d4ee1ff-6a68-4256-8af9-1410d1c72d4f","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:55.770475Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "576"
+                - "598"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 16 Jan 2025 10:19:24 GMT
+                - Wed, 27 Aug 2025 15:05:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -981,10 +981,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - dd869cb5-9d3b-4f93-9475-3193fa4f99e7
+                - a2b7ed3c-7c2c-43cb-875d-cdb9aa2f7ca1
         status: 200 OK
         code: 200
-        duration: 50.851042ms
+        duration: 115.506162ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1000,204 +1000,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/ee1cc53d-416f-42c5-80db-9876f49941b6
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 576
-        uncompressed: false
-        body: '{"created_at":"2025-01-16T10:19:12.487940Z","description":"","environment_variables":{},"error_message":null,"id":"ee1cc53d-416f-42c5-80db-9876f49941b6","name":"tf-ns-recursing-meninsky","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsrecursingmeninskriz6ksue","registry_namespace_id":"76e06637-7bac-46a5-95df-726d23332b32","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-16T10:19:19.308954Z"}'
-        headers:
-            Content-Length:
-                - "576"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Thu, 16 Jan 2025 10:19:29 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 7cfb09e6-4e56-4ca9-a16b-ca2f4a349db5
-        status: 200 OK
-        code: 200
-        duration: 48.515208ms
-    - id: 21
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/ee1cc53d-416f-42c5-80db-9876f49941b6
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 576
-        uncompressed: false
-        body: '{"created_at":"2025-01-16T10:19:12.487940Z","description":"","environment_variables":{},"error_message":null,"id":"ee1cc53d-416f-42c5-80db-9876f49941b6","name":"tf-ns-recursing-meninsky","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsrecursingmeninskriz6ksue","registry_namespace_id":"76e06637-7bac-46a5-95df-726d23332b32","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-16T10:19:19.308954Z"}'
-        headers:
-            Content-Length:
-                - "576"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Thu, 16 Jan 2025 10:19:34 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 4bec6348-eef1-4fa4-a6e0-6093e565705b
-        status: 200 OK
-        code: 200
-        duration: 57.864042ms
-    - id: 22
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/ee1cc53d-416f-42c5-80db-9876f49941b6
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 576
-        uncompressed: false
-        body: '{"created_at":"2025-01-16T10:19:12.487940Z","description":"","environment_variables":{},"error_message":null,"id":"ee1cc53d-416f-42c5-80db-9876f49941b6","name":"tf-ns-recursing-meninsky","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsrecursingmeninskriz6ksue","registry_namespace_id":"76e06637-7bac-46a5-95df-726d23332b32","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-16T10:19:19.308954Z"}'
-        headers:
-            Content-Length:
-                - "576"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Thu, 16 Jan 2025 10:19:39 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 53958621-eff3-4f0e-a161-e76457ef6e8f
-        status: 200 OK
-        code: 200
-        duration: 45.83475ms
-    - id: 23
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/ee1cc53d-416f-42c5-80db-9876f49941b6
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 576
-        uncompressed: false
-        body: '{"created_at":"2025-01-16T10:19:12.487940Z","description":"","environment_variables":{},"error_message":null,"id":"ee1cc53d-416f-42c5-80db-9876f49941b6","name":"tf-ns-recursing-meninsky","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsrecursingmeninskriz6ksue","registry_namespace_id":"76e06637-7bac-46a5-95df-726d23332b32","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-16T10:19:19.308954Z"}'
-        headers:
-            Content-Length:
-                - "576"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Thu, 16 Jan 2025 10:19:44 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - c3a8378a-a96d-4ede-a377-37163766f728
-        status: 200 OK
-        code: 200
-        duration: 47.573291ms
-    - id: 24
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/ee1cc53d-416f-42c5-80db-9876f49941b6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/0214ab75-bab5-44ab-97b1-4aa30ad45a5f
         method: GET
       response:
         proto: HTTP/2.0
@@ -1216,9 +1020,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 16 Jan 2025 10:19:49 GMT
+                - Wed, 27 Aug 2025 15:06:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1226,11 +1030,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c4742add-b818-4941-95b3-281eefe29cb7
+                - 6d0748e2-2cfb-4703-8a84-84376966a009
         status: 404 Not Found
         code: 404
-        duration: 27.735833ms
-    - id: 25
+        duration: 27.149536ms
+    - id: 21
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1245,8 +1049,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/ee1cc53d-416f-42c5-80db-9876f49941b6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/0214ab75-bab5-44ab-97b1-4aa30ad45a5f
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1265,9 +1069,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 16 Jan 2025 10:19:49 GMT
+                - Wed, 27 Aug 2025 15:06:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1275,7 +1079,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cd1f85c5-ebdd-4109-ab98-1d1d67d01ba3
+                - a8e26387-dbf0-492c-b972-3c26f28c5a4c
         status: 404 Not Found
         code: 404
-        duration: 31.102ms
+        duration: 19.532993ms

--- a/internal/services/container/testdata/data-source-container-scaling-option.cassette.yaml
+++ b/internal/services/container/testdata/data-source-container-scaling-option.cassette.yaml
@@ -6,19 +6,19 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 153
+        content_length: 190
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-ns-happy-gould","environment_variables":{},"project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","secret_environment_variables":[],"tags":null}'
+        body: '{"name":"tf-ns-agitated-swanson","environment_variables":{},"project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","secret_environment_variables":[],"tags":null,"activate_vpc_integration":true}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces
         method: POST
       response:
@@ -27,20 +27,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 483
+        content_length: 507
         uncompressed: false
-        body: '{"created_at":"2025-01-15T14:43:21.307205802Z","description":"","environment_variables":{},"error_message":null,"id":"c3c7af1b-4e47-45af-99da-e8a3bb5a5c86","name":"tf-ns-happy-gould","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-15T14:43:21.307205802Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.094774466Z","description":"","environment_variables":{},"error_message":null,"id":"cf4fa0e7-bc6a-41de-aeea-bb8885340637","name":"tf-ns-agitated-swanson","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:41.094774466Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "483"
+                - "507"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:43:21 GMT
+                - Wed, 27 Aug 2025 15:05:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 87a0dc82-97f3-4540-8054-cb4961b155b4
+                - 16797636-6c0f-44d7-8446-1e243cfbb1d4
         status: 200 OK
         code: 200
-        duration: 438.462875ms
+        duration: 5.134904299s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -67,8 +67,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c3c7af1b-4e47-45af-99da-e8a3bb5a5c86
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/cf4fa0e7-bc6a-41de-aeea-bb8885340637
         method: GET
       response:
         proto: HTTP/2.0
@@ -76,20 +76,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 477
+        content_length: 501
         uncompressed: false
-        body: '{"created_at":"2025-01-15T14:43:21.307206Z","description":"","environment_variables":{},"error_message":null,"id":"c3c7af1b-4e47-45af-99da-e8a3bb5a5c86","name":"tf-ns-happy-gould","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-15T14:43:21.307206Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.094774Z","description":"","environment_variables":{},"error_message":null,"id":"cf4fa0e7-bc6a-41de-aeea-bb8885340637","name":"tf-ns-agitated-swanson","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:41.094774Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "477"
+                - "501"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:43:21 GMT
+                - Wed, 27 Aug 2025 15:05:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fb9bacaa-0b81-4b52-bd9d-24a59fcb585c
+                - 0e191af4-7ab9-4093-89fe-a35e82f65442
         status: 200 OK
         code: 200
-        duration: 41.378291ms
+        duration: 80.901935ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -116,8 +116,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c3c7af1b-4e47-45af-99da-e8a3bb5a5c86
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/cf4fa0e7-bc6a-41de-aeea-bb8885340637
         method: GET
       response:
         proto: HTTP/2.0
@@ -125,20 +125,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 562
+        content_length: 501
         uncompressed: false
-        body: '{"created_at":"2025-01-15T14:43:21.307206Z","description":"","environment_variables":{},"error_message":null,"id":"c3c7af1b-4e47-45af-99da-e8a3bb5a5c86","name":"tf-ns-happy-gould","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshappygouldsn1vqbrl","registry_namespace_id":"a1825a3d-2245-4554-abee-b011122a7fbe","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-15T14:43:23.371902Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.094774Z","description":"","environment_variables":{},"error_message":null,"id":"cf4fa0e7-bc6a-41de-aeea-bb8885340637","name":"tf-ns-agitated-swanson","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:43.993931Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "562"
+                - "501"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:43:26 GMT
+                - Wed, 27 Aug 2025 15:05:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -146,10 +146,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3f8d921c-f38e-4094-b498-9aa4bdb7853e
+                - ddc024f5-ff0c-492d-8f21-4774eebe340a
         status: 200 OK
         code: 200
-        duration: 49.187292ms
+        duration: 104.570839ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -165,8 +165,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c3c7af1b-4e47-45af-99da-e8a3bb5a5c86
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/cf4fa0e7-bc6a-41de-aeea-bb8885340637
         method: GET
       response:
         proto: HTTP/2.0
@@ -174,20 +174,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 562
+        content_length: 589
         uncompressed: false
-        body: '{"created_at":"2025-01-15T14:43:21.307206Z","description":"","environment_variables":{},"error_message":null,"id":"c3c7af1b-4e47-45af-99da-e8a3bb5a5c86","name":"tf-ns-happy-gould","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshappygouldsn1vqbrl","registry_namespace_id":"a1825a3d-2245-4554-abee-b011122a7fbe","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-15T14:43:23.371902Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.094774Z","description":"","environment_variables":{},"error_message":null,"id":"cf4fa0e7-bc6a-41de-aeea-bb8885340637","name":"tf-ns-agitated-swanson","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsagitatedswansonf1reaayq","registry_namespace_id":"7f1e648e-d0c4-447f-a3e7-446834aca10d","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:46.601056Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "562"
+                - "589"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:43:31 GMT
+                - Wed, 27 Aug 2025 15:05:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -195,10 +195,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7bdac94b-9f32-4f17-8d79-dcc11f73cb79
+                - 23034a4b-01a7-4dc5-9ba7-06f5aefce4d5
         status: 200 OK
         code: 200
-        duration: 44.478584ms
+        duration: 78.749909ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -214,8 +214,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c3c7af1b-4e47-45af-99da-e8a3bb5a5c86
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/cf4fa0e7-bc6a-41de-aeea-bb8885340637
         method: GET
       response:
         proto: HTTP/2.0
@@ -223,20 +223,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 562
+        content_length: 589
         uncompressed: false
-        body: '{"created_at":"2025-01-15T14:43:21.307206Z","description":"","environment_variables":{},"error_message":null,"id":"c3c7af1b-4e47-45af-99da-e8a3bb5a5c86","name":"tf-ns-happy-gould","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshappygouldsn1vqbrl","registry_namespace_id":"a1825a3d-2245-4554-abee-b011122a7fbe","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-15T14:43:23.371902Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.094774Z","description":"","environment_variables":{},"error_message":null,"id":"cf4fa0e7-bc6a-41de-aeea-bb8885340637","name":"tf-ns-agitated-swanson","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsagitatedswansonf1reaayq","registry_namespace_id":"7f1e648e-d0c4-447f-a3e7-446834aca10d","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:46.601056Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "562"
+                - "589"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:43:36 GMT
+                - Wed, 27 Aug 2025 15:05:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -244,10 +244,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 429025f7-4f85-4b71-ac95-92038e5b5609
+                - d61e253c-eec1-40a4-9520-4fc788f8e88a
         status: 200 OK
         code: 200
-        duration: 48.278291ms
+        duration: 84.718188ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -263,8 +263,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c3c7af1b-4e47-45af-99da-e8a3bb5a5c86
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/cf4fa0e7-bc6a-41de-aeea-bb8885340637
         method: GET
       response:
         proto: HTTP/2.0
@@ -272,20 +272,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 562
+        content_length: 589
         uncompressed: false
-        body: '{"created_at":"2025-01-15T14:43:21.307206Z","description":"","environment_variables":{},"error_message":null,"id":"c3c7af1b-4e47-45af-99da-e8a3bb5a5c86","name":"tf-ns-happy-gould","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshappygouldsn1vqbrl","registry_namespace_id":"a1825a3d-2245-4554-abee-b011122a7fbe","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-15T14:43:23.371902Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.094774Z","description":"","environment_variables":{},"error_message":null,"id":"cf4fa0e7-bc6a-41de-aeea-bb8885340637","name":"tf-ns-agitated-swanson","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsagitatedswansonf1reaayq","registry_namespace_id":"7f1e648e-d0c4-447f-a3e7-446834aca10d","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:46.601056Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "562"
+                - "589"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:43:41 GMT
+                - Wed, 27 Aug 2025 15:05:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -293,48 +293,50 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b7a9b81d-cbbe-42f1-92c6-7a7a4d3d5b7c
+                - c21b8fd2-7734-432f-9911-cce7a0047da7
         status: 200 OK
         code: 200
-        duration: 63.925125ms
+        duration: 80.615861ms
     - id: 6
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 252
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"namespace_id":"cf4fa0e7-bc6a-41de-aeea-bb8885340637","name":"tf-co-interesting-nash","privacy":"public","protocol":"http1","secret_environment_variables":null,"http_option":"enabled","sandbox":"unknown_sandbox","tags":null,"command":null,"args":null}'
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c3c7af1b-4e47-45af-99da-e8a3bb5a5c86
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 562
+        content_length: 975
         uncompressed: false
-        body: '{"created_at":"2025-01-15T14:43:21.307206Z","description":"","environment_variables":{},"error_message":null,"id":"c3c7af1b-4e47-45af-99da-e8a3bb5a5c86","name":"tf-ns-happy-gould","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshappygouldsn1vqbrl","registry_namespace_id":"a1825a3d-2245-4554-abee-b011122a7fbe","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-15T14:43:23.371902Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:53.715575803Z","description":"","domain_name":"tfnsagitatedswansonf1reaayq-tf-co-interesting-nash.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"4ce712c9-b808-4259-829b-17240e722795","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-interesting-nash","namespace_id":"cf4fa0e7-bc6a-41de-aeea-bb8885340637","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsagitatedswansonf1reaayq/tf-co-interesting-nash:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:53.715575803Z"}'
         headers:
             Content-Length:
-                - "562"
+                - "975"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:43:46 GMT
+                - Wed, 27 Aug 2025 15:05:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -342,10 +344,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 13ea3858-ac13-4e89-8790-bd3c089ae5d0
+                - 03e7fe45-3eab-42e0-b784-c79a0a8943cd
         status: 200 OK
         code: 200
-        duration: 53.102667ms
+        duration: 2.144219551s
     - id: 7
       request:
         proto: HTTP/1.1
@@ -361,8 +363,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c3c7af1b-4e47-45af-99da-e8a3bb5a5c86
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/4ce712c9-b808-4259-829b-17240e722795
         method: GET
       response:
         proto: HTTP/2.0
@@ -370,20 +372,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 562
+        content_length: 969
         uncompressed: false
-        body: '{"created_at":"2025-01-15T14:43:21.307206Z","description":"","environment_variables":{},"error_message":null,"id":"c3c7af1b-4e47-45af-99da-e8a3bb5a5c86","name":"tf-ns-happy-gould","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshappygouldsn1vqbrl","registry_namespace_id":"a1825a3d-2245-4554-abee-b011122a7fbe","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-15T14:43:23.371902Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:53.715576Z","description":"","domain_name":"tfnsagitatedswansonf1reaayq-tf-co-interesting-nash.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"4ce712c9-b808-4259-829b-17240e722795","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-interesting-nash","namespace_id":"cf4fa0e7-bc6a-41de-aeea-bb8885340637","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsagitatedswansonf1reaayq/tf-co-interesting-nash:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:53.715576Z"}'
         headers:
             Content-Length:
-                - "562"
+                - "969"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:43:51 GMT
+                - Wed, 27 Aug 2025 15:05:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -391,10 +393,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 23239b86-6b05-4935-93d5-9a643a5ea6fb
+                - 757d2859-aa2f-437c-b493-215f1760c614
         status: 200 OK
         code: 200
-        duration: 54.749584ms
+        duration: 89.087217ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -410,8 +412,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c3c7af1b-4e47-45af-99da-e8a3bb5a5c86
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/4ce712c9-b808-4259-829b-17240e722795
         method: GET
       response:
         proto: HTTP/2.0
@@ -419,20 +421,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 560
+        content_length: 969
         uncompressed: false
-        body: '{"created_at":"2025-01-15T14:43:21.307206Z","description":"","environment_variables":{},"error_message":null,"id":"c3c7af1b-4e47-45af-99da-e8a3bb5a5c86","name":"tf-ns-happy-gould","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshappygouldsn1vqbrl","registry_namespace_id":"a1825a3d-2245-4554-abee-b011122a7fbe","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-15T14:43:53.723511Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:53.715576Z","description":"","domain_name":"tfnsagitatedswansonf1reaayq-tf-co-interesting-nash.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"4ce712c9-b808-4259-829b-17240e722795","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-interesting-nash","namespace_id":"cf4fa0e7-bc6a-41de-aeea-bb8885340637","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsagitatedswansonf1reaayq/tf-co-interesting-nash:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:53.715576Z"}'
         headers:
             Content-Length:
-                - "560"
+                - "969"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:43:57 GMT
+                - Wed, 27 Aug 2025 15:05:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -440,10 +442,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5d2bb2c3-4baf-4799-9404-9661e55a1889
+                - 319a8b6b-24ab-4528-b230-95f29e116588
         status: 200 OK
         code: 200
-        duration: 272.634667ms
+        duration: 83.416616ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -459,8 +461,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c3c7af1b-4e47-45af-99da-e8a3bb5a5c86
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/4ce712c9-b808-4259-829b-17240e722795
         method: GET
       response:
         proto: HTTP/2.0
@@ -468,20 +470,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 560
+        content_length: 969
         uncompressed: false
-        body: '{"created_at":"2025-01-15T14:43:21.307206Z","description":"","environment_variables":{},"error_message":null,"id":"c3c7af1b-4e47-45af-99da-e8a3bb5a5c86","name":"tf-ns-happy-gould","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshappygouldsn1vqbrl","registry_namespace_id":"a1825a3d-2245-4554-abee-b011122a7fbe","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-15T14:43:53.723511Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:53.715576Z","description":"","domain_name":"tfnsagitatedswansonf1reaayq-tf-co-interesting-nash.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"4ce712c9-b808-4259-829b-17240e722795","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-interesting-nash","namespace_id":"cf4fa0e7-bc6a-41de-aeea-bb8885340637","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsagitatedswansonf1reaayq/tf-co-interesting-nash:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:53.715576Z"}'
         headers:
             Content-Length:
-                - "560"
+                - "969"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:43:57 GMT
+                - Wed, 27 Aug 2025 15:05:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -489,10 +491,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6e03246a-d920-4c1c-a27d-5a328dad3e64
+                - 6bc15b29-b6b5-4beb-a8b2-fcba470a5582
         status: 200 OK
         code: 200
-        duration: 606.923166ms
+        duration: 124.499066ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -508,8 +510,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c3c7af1b-4e47-45af-99da-e8a3bb5a5c86
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/4ce712c9-b808-4259-829b-17240e722795
         method: GET
       response:
         proto: HTTP/2.0
@@ -517,20 +519,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 560
+        content_length: 969
         uncompressed: false
-        body: '{"created_at":"2025-01-15T14:43:21.307206Z","description":"","environment_variables":{},"error_message":null,"id":"c3c7af1b-4e47-45af-99da-e8a3bb5a5c86","name":"tf-ns-happy-gould","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshappygouldsn1vqbrl","registry_namespace_id":"a1825a3d-2245-4554-abee-b011122a7fbe","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-15T14:43:53.723511Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:53.715576Z","description":"","domain_name":"tfnsagitatedswansonf1reaayq-tf-co-interesting-nash.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"4ce712c9-b808-4259-829b-17240e722795","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-interesting-nash","namespace_id":"cf4fa0e7-bc6a-41de-aeea-bb8885340637","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsagitatedswansonf1reaayq/tf-co-interesting-nash:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:53.715576Z"}'
         headers:
             Content-Length:
-                - "560"
+                - "969"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:43:57 GMT
+                - Wed, 27 Aug 2025 15:05:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -538,50 +540,48 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 18684d58-38a0-4258-a6c6-f7a88cc01e3e
+                - ac3afea7-09da-4634-8a3f-08314753afc0
         status: 200 OK
         code: 200
-        duration: 119.093208ms
+        duration: 89.700759ms
     - id: 11
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 212
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"namespace_id":"c3c7af1b-4e47-45af-99da-e8a3bb5a5c86","name":"tf-co-hardcore-agnesi","privacy":"public","protocol":"http1","secret_environment_variables":null,"http_option":"enabled","sandbox":"unknown_sandbox"}'
+        body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers
-        method: POST
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/cf4fa0e7-bc6a-41de-aeea-bb8885340637
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 932
+        content_length: 589
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:43:58.056116619Z","description":"","domain_name":"tfnshappygouldsn1vqbrl-tf-co-hardcore-agnesi.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"93e0702b-9a39-4ee2-be0c-d43edb3eff3c","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-hardcore-agnesi","namespace_id":"c3c7af1b-4e47-45af-99da-e8a3bb5a5c86","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshappygouldsn1vqbrl/tf-co-hardcore-agnesi:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-15T14:43:58.056116619Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.094774Z","description":"","environment_variables":{},"error_message":null,"id":"cf4fa0e7-bc6a-41de-aeea-bb8885340637","name":"tf-ns-agitated-swanson","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsagitatedswansonf1reaayq","registry_namespace_id":"7f1e648e-d0c4-447f-a3e7-446834aca10d","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:46.601056Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "932"
+                - "589"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:43:58 GMT
+                - Wed, 27 Aug 2025 15:05:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -589,10 +589,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4ba25ae0-cd16-40c2-bd74-6e2bc29b31e1
+                - b1e64e1e-11f6-4952-a335-19bbde2710cf
         status: 200 OK
         code: 200
-        duration: 371.138833ms
+        duration: 82.957796ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -608,8 +608,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/93e0702b-9a39-4ee2-be0c-d43edb3eff3c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/4ce712c9-b808-4259-829b-17240e722795
         method: GET
       response:
         proto: HTTP/2.0
@@ -617,20 +617,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 926
+        content_length: 969
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:43:58.056117Z","description":"","domain_name":"tfnshappygouldsn1vqbrl-tf-co-hardcore-agnesi.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"93e0702b-9a39-4ee2-be0c-d43edb3eff3c","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-hardcore-agnesi","namespace_id":"c3c7af1b-4e47-45af-99da-e8a3bb5a5c86","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshappygouldsn1vqbrl/tf-co-hardcore-agnesi:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-15T14:43:58.056117Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:53.715576Z","description":"","domain_name":"tfnsagitatedswansonf1reaayq-tf-co-interesting-nash.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"4ce712c9-b808-4259-829b-17240e722795","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-interesting-nash","namespace_id":"cf4fa0e7-bc6a-41de-aeea-bb8885340637","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsagitatedswansonf1reaayq/tf-co-interesting-nash:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:53.715576Z"}'
         headers:
             Content-Length:
-                - "926"
+                - "969"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:43:58 GMT
+                - Wed, 27 Aug 2025 15:05:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -638,10 +638,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2d8c5e4c-a8ba-4634-ae88-39507d8b88e5
+                - 61026042-7841-4649-bc37-3af42ee57285
         status: 200 OK
         code: 200
-        duration: 61.921417ms
+        duration: 101.385394ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -657,8 +657,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/93e0702b-9a39-4ee2-be0c-d43edb3eff3c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/4ce712c9-b808-4259-829b-17240e722795
         method: GET
       response:
         proto: HTTP/2.0
@@ -666,20 +666,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 926
+        content_length: 969
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:43:58.056117Z","description":"","domain_name":"tfnshappygouldsn1vqbrl-tf-co-hardcore-agnesi.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"93e0702b-9a39-4ee2-be0c-d43edb3eff3c","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-hardcore-agnesi","namespace_id":"c3c7af1b-4e47-45af-99da-e8a3bb5a5c86","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshappygouldsn1vqbrl/tf-co-hardcore-agnesi:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-15T14:43:58.056117Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:53.715576Z","description":"","domain_name":"tfnsagitatedswansonf1reaayq-tf-co-interesting-nash.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"4ce712c9-b808-4259-829b-17240e722795","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-interesting-nash","namespace_id":"cf4fa0e7-bc6a-41de-aeea-bb8885340637","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsagitatedswansonf1reaayq/tf-co-interesting-nash:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:53.715576Z"}'
         headers:
             Content-Length:
-                - "926"
+                - "969"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:43:58 GMT
+                - Wed, 27 Aug 2025 15:05:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -687,10 +687,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 921130d3-4259-4803-bd66-6f4f35d96d84
+                - ebc4a615-0be1-468d-b319-9b5d744792b3
         status: 200 OK
         code: 200
-        duration: 62.9315ms
+        duration: 93.898987ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -706,8 +706,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/93e0702b-9a39-4ee2-be0c-d43edb3eff3c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/4ce712c9-b808-4259-829b-17240e722795
         method: GET
       response:
         proto: HTTP/2.0
@@ -715,20 +715,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 926
+        content_length: 969
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:43:58.056117Z","description":"","domain_name":"tfnshappygouldsn1vqbrl-tf-co-hardcore-agnesi.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"93e0702b-9a39-4ee2-be0c-d43edb3eff3c","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-hardcore-agnesi","namespace_id":"c3c7af1b-4e47-45af-99da-e8a3bb5a5c86","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshappygouldsn1vqbrl/tf-co-hardcore-agnesi:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-15T14:43:58.056117Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:53.715576Z","description":"","domain_name":"tfnsagitatedswansonf1reaayq-tf-co-interesting-nash.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"4ce712c9-b808-4259-829b-17240e722795","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-interesting-nash","namespace_id":"cf4fa0e7-bc6a-41de-aeea-bb8885340637","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsagitatedswansonf1reaayq/tf-co-interesting-nash:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:53.715576Z"}'
         headers:
             Content-Length:
-                - "926"
+                - "969"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:43:58 GMT
+                - Wed, 27 Aug 2025 15:05:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -736,10 +736,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ca6c94ee-e1fd-412c-84e0-565f326845e9
+                - 34a5e99f-f7f0-43c7-a8f4-ee8647f4364c
         status: 200 OK
         code: 200
-        duration: 101.7385ms
+        duration: 81.718761ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -755,8 +755,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/93e0702b-9a39-4ee2-be0c-d43edb3eff3c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/4ce712c9-b808-4259-829b-17240e722795
         method: GET
       response:
         proto: HTTP/2.0
@@ -764,20 +764,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 926
+        content_length: 969
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:43:58.056117Z","description":"","domain_name":"tfnshappygouldsn1vqbrl-tf-co-hardcore-agnesi.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"93e0702b-9a39-4ee2-be0c-d43edb3eff3c","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-hardcore-agnesi","namespace_id":"c3c7af1b-4e47-45af-99da-e8a3bb5a5c86","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshappygouldsn1vqbrl/tf-co-hardcore-agnesi:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-15T14:43:58.056117Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:53.715576Z","description":"","domain_name":"tfnsagitatedswansonf1reaayq-tf-co-interesting-nash.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"4ce712c9-b808-4259-829b-17240e722795","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-interesting-nash","namespace_id":"cf4fa0e7-bc6a-41de-aeea-bb8885340637","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsagitatedswansonf1reaayq/tf-co-interesting-nash:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:53.715576Z"}'
         headers:
             Content-Length:
-                - "926"
+                - "969"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:43:58 GMT
+                - Wed, 27 Aug 2025 15:05:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -785,10 +785,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9d70617c-3f5a-447b-bcad-e6de2dc0a499
+                - 3f664cec-8771-4963-866a-8b9a4a9c1cf2
         status: 200 OK
         code: 200
-        duration: 86.351375ms
+        duration: 88.50202ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -804,29 +804,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c3c7af1b-4e47-45af-99da-e8a3bb5a5c86
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/4ce712c9-b808-4259-829b-17240e722795
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 560
+        content_length: 973
         uncompressed: false
-        body: '{"created_at":"2025-01-15T14:43:21.307206Z","description":"","environment_variables":{},"error_message":null,"id":"c3c7af1b-4e47-45af-99da-e8a3bb5a5c86","name":"tf-ns-happy-gould","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshappygouldsn1vqbrl","registry_namespace_id":"a1825a3d-2245-4554-abee-b011122a7fbe","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-15T14:43:53.723511Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:53.715576Z","description":"","domain_name":"tfnsagitatedswansonf1reaayq-tf-co-interesting-nash.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"4ce712c9-b808-4259-829b-17240e722795","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-interesting-nash","namespace_id":"cf4fa0e7-bc6a-41de-aeea-bb8885340637","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsagitatedswansonf1reaayq/tf-co-interesting-nash:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:55.578027939Z"}'
         headers:
             Content-Length:
-                - "560"
+                - "973"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:43:58 GMT
+                - Wed, 27 Aug 2025 15:05:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -834,10 +834,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0bc426ba-c2e6-4d95-9b3f-268fbd0ddbcb
+                - 5c7b6bd7-b4b9-4967-8b8f-38ae313f8f99
         status: 200 OK
         code: 200
-        duration: 51.516292ms
+        duration: 237.034774ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -853,8 +853,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/93e0702b-9a39-4ee2-be0c-d43edb3eff3c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/cf4fa0e7-bc6a-41de-aeea-bb8885340637
         method: GET
       response:
         proto: HTTP/2.0
@@ -862,20 +862,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 926
+        content_length: 589
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:43:58.056117Z","description":"","domain_name":"tfnshappygouldsn1vqbrl-tf-co-hardcore-agnesi.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"93e0702b-9a39-4ee2-be0c-d43edb3eff3c","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-hardcore-agnesi","namespace_id":"c3c7af1b-4e47-45af-99da-e8a3bb5a5c86","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshappygouldsn1vqbrl/tf-co-hardcore-agnesi:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-15T14:43:58.056117Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.094774Z","description":"","environment_variables":{},"error_message":null,"id":"cf4fa0e7-bc6a-41de-aeea-bb8885340637","name":"tf-ns-agitated-swanson","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsagitatedswansonf1reaayq","registry_namespace_id":"7f1e648e-d0c4-447f-a3e7-446834aca10d","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:46.601056Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "926"
+                - "589"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:43:58 GMT
+                - Wed, 27 Aug 2025 15:05:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -883,10 +883,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 95c1ff5a-e876-470b-9e25-4aa705435d4b
+                - 9229f498-0425-4489-bb3c-113af9d744ce
         status: 200 OK
         code: 200
-        duration: 70.799125ms
+        duration: 102.045734ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -902,29 +902,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/93e0702b-9a39-4ee2-be0c-d43edb3eff3c
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/cf4fa0e7-bc6a-41de-aeea-bb8885340637
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 926
+        content_length: 595
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:43:58.056117Z","description":"","domain_name":"tfnshappygouldsn1vqbrl-tf-co-hardcore-agnesi.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"93e0702b-9a39-4ee2-be0c-d43edb3eff3c","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-hardcore-agnesi","namespace_id":"c3c7af1b-4e47-45af-99da-e8a3bb5a5c86","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshappygouldsn1vqbrl/tf-co-hardcore-agnesi:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-15T14:43:58.056117Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.094774Z","description":"","environment_variables":{},"error_message":null,"id":"cf4fa0e7-bc6a-41de-aeea-bb8885340637","name":"tf-ns-agitated-swanson","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsagitatedswansonf1reaayq","registry_namespace_id":"7f1e648e-d0c4-447f-a3e7-446834aca10d","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:55.902940306Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "926"
+                - "595"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:43:58 GMT
+                - Wed, 27 Aug 2025 15:05:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -932,10 +932,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - df04e135-fc94-40a0-80d9-dc2f9cd58007
+                - 9457d544-cae9-4420-bd8a-ee55cfdd6b13
         status: 200 OK
         code: 200
-        duration: 53.4135ms
+        duration: 520.358057ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -951,8 +951,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/93e0702b-9a39-4ee2-be0c-d43edb3eff3c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/cf4fa0e7-bc6a-41de-aeea-bb8885340637
         method: GET
       response:
         proto: HTTP/2.0
@@ -960,20 +960,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 926
+        content_length: 592
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:43:58.056117Z","description":"","domain_name":"tfnshappygouldsn1vqbrl-tf-co-hardcore-agnesi.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"93e0702b-9a39-4ee2-be0c-d43edb3eff3c","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-hardcore-agnesi","namespace_id":"c3c7af1b-4e47-45af-99da-e8a3bb5a5c86","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshappygouldsn1vqbrl/tf-co-hardcore-agnesi:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-15T14:43:58.056117Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.094774Z","description":"","environment_variables":{},"error_message":null,"id":"cf4fa0e7-bc6a-41de-aeea-bb8885340637","name":"tf-ns-agitated-swanson","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsagitatedswansonf1reaayq","registry_namespace_id":"7f1e648e-d0c4-447f-a3e7-446834aca10d","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:55.902940Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "926"
+                - "592"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:43:58 GMT
+                - Wed, 27 Aug 2025 15:05:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -981,10 +981,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3026702d-d147-435d-a8fd-f49c0bb9a63c
+                - ff3ab04e-c7bd-4b79-a6b6-75fb22b80a2f
         status: 200 OK
         code: 200
-        duration: 49.423625ms
+        duration: 81.720295ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1000,8 +1000,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/93e0702b-9a39-4ee2-be0c-d43edb3eff3c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/cf4fa0e7-bc6a-41de-aeea-bb8885340637
         method: GET
       response:
         proto: HTTP/2.0
@@ -1009,20 +1009,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 926
+        content_length: 592
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:43:58.056117Z","description":"","domain_name":"tfnshappygouldsn1vqbrl-tf-co-hardcore-agnesi.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"93e0702b-9a39-4ee2-be0c-d43edb3eff3c","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-hardcore-agnesi","namespace_id":"c3c7af1b-4e47-45af-99da-e8a3bb5a5c86","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshappygouldsn1vqbrl/tf-co-hardcore-agnesi:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-15T14:43:58.056117Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.094774Z","description":"","environment_variables":{},"error_message":null,"id":"cf4fa0e7-bc6a-41de-aeea-bb8885340637","name":"tf-ns-agitated-swanson","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsagitatedswansonf1reaayq","registry_namespace_id":"7f1e648e-d0c4-447f-a3e7-446834aca10d","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:55.902940Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "926"
+                - "592"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:43:59 GMT
+                - Wed, 27 Aug 2025 15:06:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1030,10 +1030,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6846d94e-cf5e-4831-9b6b-04f4037aa0aa
+                - ca046305-2c08-47de-9aa7-8f64bf188bc3
         status: 200 OK
         code: 200
-        duration: 64.481167ms
+        duration: 87.252496ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1049,29 +1049,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/93e0702b-9a39-4ee2-be0c-d43edb3eff3c
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/cf4fa0e7-bc6a-41de-aeea-bb8885340637
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 930
+        content_length: 592
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-15T14:43:58.056117Z","description":"","domain_name":"tfnshappygouldsn1vqbrl-tf-co-hardcore-agnesi.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"93e0702b-9a39-4ee2-be0c-d43edb3eff3c","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-hardcore-agnesi","namespace_id":"c3c7af1b-4e47-45af-99da-e8a3bb5a5c86","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnshappygouldsn1vqbrl/tf-co-hardcore-agnesi:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"deleting","timeout":"300s","updated_at":"2025-01-15T14:43:59.194545102Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.094774Z","description":"","environment_variables":{},"error_message":null,"id":"cf4fa0e7-bc6a-41de-aeea-bb8885340637","name":"tf-ns-agitated-swanson","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsagitatedswansonf1reaayq","registry_namespace_id":"7f1e648e-d0c4-447f-a3e7-446834aca10d","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:55.902940Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "930"
+                - "592"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:43:59 GMT
+                - Wed, 27 Aug 2025 15:06:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1079,10 +1079,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 34f7dc91-7b02-4387-8ed7-2d64fec1f7c4
+                - c4c50fd4-8d17-48bb-b772-019609eb4884
         status: 200 OK
         code: 200
-        duration: 146.539958ms
+        duration: 95.312593ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1098,8 +1098,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c3c7af1b-4e47-45af-99da-e8a3bb5a5c86
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/cf4fa0e7-bc6a-41de-aeea-bb8885340637
         method: GET
       response:
         proto: HTTP/2.0
@@ -1107,20 +1107,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 560
+        content_length: 592
         uncompressed: false
-        body: '{"created_at":"2025-01-15T14:43:21.307206Z","description":"","environment_variables":{},"error_message":null,"id":"c3c7af1b-4e47-45af-99da-e8a3bb5a5c86","name":"tf-ns-happy-gould","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshappygouldsn1vqbrl","registry_namespace_id":"a1825a3d-2245-4554-abee-b011122a7fbe","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-15T14:43:53.723511Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.094774Z","description":"","environment_variables":{},"error_message":null,"id":"cf4fa0e7-bc6a-41de-aeea-bb8885340637","name":"tf-ns-agitated-swanson","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsagitatedswansonf1reaayq","registry_namespace_id":"7f1e648e-d0c4-447f-a3e7-446834aca10d","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:55.902940Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "560"
+                - "592"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:43:59 GMT
+                - Wed, 27 Aug 2025 15:06:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1128,10 +1128,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b8fbaaf3-0092-4e20-a066-f85e9ca71a7a
+                - 75f21098-336d-4af5-be6f-59906b882f80
         status: 200 OK
         code: 200
-        duration: 61.746834ms
+        duration: 81.389868ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1147,29 +1147,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c3c7af1b-4e47-45af-99da-e8a3bb5a5c86
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/cf4fa0e7-bc6a-41de-aeea-bb8885340637
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 566
+        content_length: 592
         uncompressed: false
-        body: '{"created_at":"2025-01-15T14:43:21.307206Z","description":"","environment_variables":{},"error_message":null,"id":"c3c7af1b-4e47-45af-99da-e8a3bb5a5c86","name":"tf-ns-happy-gould","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshappygouldsn1vqbrl","registry_namespace_id":"a1825a3d-2245-4554-abee-b011122a7fbe","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-15T14:43:59.400292789Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.094774Z","description":"","environment_variables":{},"error_message":null,"id":"cf4fa0e7-bc6a-41de-aeea-bb8885340637","name":"tf-ns-agitated-swanson","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsagitatedswansonf1reaayq","registry_namespace_id":"7f1e648e-d0c4-447f-a3e7-446834aca10d","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:55.902940Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "566"
+                - "592"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:44:00 GMT
+                - Wed, 27 Aug 2025 15:06:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1177,10 +1177,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1976ebc7-d007-4bf6-bec2-09f9c33cf326
+                - aa7e99ad-349c-4c93-8444-ddf8224d631c
         status: 200 OK
         code: 200
-        duration: 690.18225ms
+        duration: 85.558212ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1196,8 +1196,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c3c7af1b-4e47-45af-99da-e8a3bb5a5c86
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/cf4fa0e7-bc6a-41de-aeea-bb8885340637
         method: GET
       response:
         proto: HTTP/2.0
@@ -1205,20 +1205,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 563
+        content_length: 592
         uncompressed: false
-        body: '{"created_at":"2025-01-15T14:43:21.307206Z","description":"","environment_variables":{},"error_message":null,"id":"c3c7af1b-4e47-45af-99da-e8a3bb5a5c86","name":"tf-ns-happy-gould","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshappygouldsn1vqbrl","registry_namespace_id":"a1825a3d-2245-4554-abee-b011122a7fbe","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-15T14:43:59.400293Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.094774Z","description":"","environment_variables":{},"error_message":null,"id":"cf4fa0e7-bc6a-41de-aeea-bb8885340637","name":"tf-ns-agitated-swanson","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsagitatedswansonf1reaayq","registry_namespace_id":"7f1e648e-d0c4-447f-a3e7-446834aca10d","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:55.902940Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "563"
+                - "592"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:44:00 GMT
+                - Wed, 27 Aug 2025 15:06:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1226,10 +1226,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8a57d96b-8a0c-4687-ad57-3f2d11fa33b2
+                - fab4e5aa-6e9b-4f68-891c-c087dfb18f76
         status: 200 OK
         code: 200
-        duration: 74.716166ms
+        duration: 94.461981ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1245,8 +1245,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c3c7af1b-4e47-45af-99da-e8a3bb5a5c86
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/cf4fa0e7-bc6a-41de-aeea-bb8885340637
         method: GET
       response:
         proto: HTTP/2.0
@@ -1254,20 +1254,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 563
+        content_length: 592
         uncompressed: false
-        body: '{"created_at":"2025-01-15T14:43:21.307206Z","description":"","environment_variables":{},"error_message":null,"id":"c3c7af1b-4e47-45af-99da-e8a3bb5a5c86","name":"tf-ns-happy-gould","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshappygouldsn1vqbrl","registry_namespace_id":"a1825a3d-2245-4554-abee-b011122a7fbe","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-15T14:43:59.400293Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.094774Z","description":"","environment_variables":{},"error_message":null,"id":"cf4fa0e7-bc6a-41de-aeea-bb8885340637","name":"tf-ns-agitated-swanson","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsagitatedswansonf1reaayq","registry_namespace_id":"7f1e648e-d0c4-447f-a3e7-446834aca10d","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:55.902940Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "563"
+                - "592"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:44:05 GMT
+                - Wed, 27 Aug 2025 15:06:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1275,10 +1275,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 04f6faa3-3d32-4d10-a540-03bb6f2b452b
+                - dc324d0b-11b3-42c2-99cd-ca81082895fa
         status: 200 OK
         code: 200
-        duration: 45.075333ms
+        duration: 94.029711ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1294,253 +1294,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c3c7af1b-4e47-45af-99da-e8a3bb5a5c86
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 563
-        uncompressed: false
-        body: '{"created_at":"2025-01-15T14:43:21.307206Z","description":"","environment_variables":{},"error_message":null,"id":"c3c7af1b-4e47-45af-99da-e8a3bb5a5c86","name":"tf-ns-happy-gould","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshappygouldsn1vqbrl","registry_namespace_id":"a1825a3d-2245-4554-abee-b011122a7fbe","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-15T14:43:59.400293Z"}'
-        headers:
-            Content-Length:
-                - "563"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 15 Jan 2025 14:44:10 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - a59e69ab-bc68-497b-8e69-aca5718f8b35
-        status: 200 OK
-        code: 200
-        duration: 44.604ms
-    - id: 27
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c3c7af1b-4e47-45af-99da-e8a3bb5a5c86
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 563
-        uncompressed: false
-        body: '{"created_at":"2025-01-15T14:43:21.307206Z","description":"","environment_variables":{},"error_message":null,"id":"c3c7af1b-4e47-45af-99da-e8a3bb5a5c86","name":"tf-ns-happy-gould","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshappygouldsn1vqbrl","registry_namespace_id":"a1825a3d-2245-4554-abee-b011122a7fbe","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-15T14:43:59.400293Z"}'
-        headers:
-            Content-Length:
-                - "563"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 15 Jan 2025 14:44:15 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - bd3661fb-50d8-4d4b-a1f8-820c83a2eec6
-        status: 200 OK
-        code: 200
-        duration: 46.504833ms
-    - id: 28
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c3c7af1b-4e47-45af-99da-e8a3bb5a5c86
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 563
-        uncompressed: false
-        body: '{"created_at":"2025-01-15T14:43:21.307206Z","description":"","environment_variables":{},"error_message":null,"id":"c3c7af1b-4e47-45af-99da-e8a3bb5a5c86","name":"tf-ns-happy-gould","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshappygouldsn1vqbrl","registry_namespace_id":"a1825a3d-2245-4554-abee-b011122a7fbe","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-15T14:43:59.400293Z"}'
-        headers:
-            Content-Length:
-                - "563"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 15 Jan 2025 14:44:20 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 8c0cf167-d89f-4713-a162-e85f9e251360
-        status: 200 OK
-        code: 200
-        duration: 51.156292ms
-    - id: 29
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c3c7af1b-4e47-45af-99da-e8a3bb5a5c86
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 563
-        uncompressed: false
-        body: '{"created_at":"2025-01-15T14:43:21.307206Z","description":"","environment_variables":{},"error_message":null,"id":"c3c7af1b-4e47-45af-99da-e8a3bb5a5c86","name":"tf-ns-happy-gould","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshappygouldsn1vqbrl","registry_namespace_id":"a1825a3d-2245-4554-abee-b011122a7fbe","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-15T14:43:59.400293Z"}'
-        headers:
-            Content-Length:
-                - "563"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 15 Jan 2025 14:44:25 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 7d3e05ed-14ce-47ad-888b-7c5219ed97fc
-        status: 200 OK
-        code: 200
-        duration: 59.212291ms
-    - id: 30
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c3c7af1b-4e47-45af-99da-e8a3bb5a5c86
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 563
-        uncompressed: false
-        body: '{"created_at":"2025-01-15T14:43:21.307206Z","description":"","environment_variables":{},"error_message":null,"id":"c3c7af1b-4e47-45af-99da-e8a3bb5a5c86","name":"tf-ns-happy-gould","organization_id":"c252b25c-29e2-4ee0-a1ea-ea9840df7bba","project_id":"d7c3e412-ea77-486f-8b36-2b40967ca636","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnshappygouldsn1vqbrl","registry_namespace_id":"a1825a3d-2245-4554-abee-b011122a7fbe","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-15T14:43:59.400293Z"}'
-        headers:
-            Content-Length:
-                - "563"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 15 Jan 2025 14:44:30 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 795ab630-92d8-4e32-bb84-32aa6feb568e
-        status: 200 OK
-        code: 200
-        duration: 61.089208ms
-    - id: 31
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c3c7af1b-4e47-45af-99da-e8a3bb5a5c86
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/cf4fa0e7-bc6a-41de-aeea-bb8885340637
         method: GET
       response:
         proto: HTTP/2.0
@@ -1559,9 +1314,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:44:35 GMT
+                - Wed, 27 Aug 2025 15:06:32 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1569,11 +1324,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e38d7376-7f97-4e28-86a7-f30a491e829b
+                - 7b725d1a-571a-426c-9ea2-a25ec0d072ad
         status: 404 Not Found
         code: 404
-        duration: 36.563125ms
-    - id: 32
+        duration: 23.854264ms
+    - id: 27
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1588,8 +1343,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c3c7af1b-4e47-45af-99da-e8a3bb5a5c86
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/cf4fa0e7-bc6a-41de-aeea-bb8885340637
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1608,9 +1363,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Jan 2025 14:44:35 GMT
+                - Wed, 27 Aug 2025 15:06:31 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1618,7 +1373,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3397b93a-f696-48c3-895c-dc28ee914cb8
+                - 775bc069-bd50-4c02-a4d7-1df292544520
         status: 404 Not Found
         code: 404
-        duration: 31.835125ms
+        duration: 22.970646ms

--- a/internal/services/container/testdata/data-source-namespace-basic.cassette.yaml
+++ b/internal/services/container/testdata/data-source-namespace-basic.cassette.yaml
@@ -6,19 +6,19 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 148
+        content_length: 180
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"test-cr-data","environment_variables":{},"project_id":"6867048b-fe12-4e96-835e-41c79a39604b","secret_environment_variables":[],"tags":null}'
+        body: '{"name":"test-cr-data","environment_variables":{},"project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","secret_environment_variables":[],"tags":null,"activate_vpc_integration":true}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces
         method: POST
       response:
@@ -27,20 +27,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 478
+        content_length: 497
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:13.596819287Z","description":"","environment_variables":{},"error_message":null,"id":"2eb13c8a-1cde-4813-843a-e9293fee7406","name":"test-cr-data","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-04-28T09:37:13.596819287Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.301093081Z","description":"","environment_variables":{},"error_message":null,"id":"7589b1bb-d3d5-4f5f-8fcd-5c03c7961b2c","name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:41.301093081Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "478"
+                - "497"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:13 GMT
+                - Wed, 27 Aug 2025 15:05:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 72ab1259-f47c-4813-8de5-29ebd06debb5
+                - c8d68dfa-5017-4555-b5ed-a89accb89bce
         status: 200 OK
         code: 200
-        duration: 784.061042ms
+        duration: 5.387508715s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -67,8 +67,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2eb13c8a-1cde-4813-843a-e9293fee7406
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/7589b1bb-d3d5-4f5f-8fcd-5c03c7961b2c
         method: GET
       response:
         proto: HTTP/2.0
@@ -76,20 +76,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 472
+        content_length: 491
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:13.596819Z","description":"","environment_variables":{},"error_message":null,"id":"2eb13c8a-1cde-4813-843a-e9293fee7406","name":"test-cr-data","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-04-28T09:37:13.596819Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.301093Z","description":"","environment_variables":{},"error_message":null,"id":"7589b1bb-d3d5-4f5f-8fcd-5c03c7961b2c","name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:41.301093Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "472"
+                - "491"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:13 GMT
+                - Wed, 27 Aug 2025 15:05:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d225f80e-30b2-4157-9459-d454a3d826cb
+                - 5fafd4fb-1baf-483c-a315-a6a0164b2c94
         status: 200 OK
         code: 200
-        duration: 86.905167ms
+        duration: 74.846793ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -116,8 +116,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2eb13c8a-1cde-4813-843a-e9293fee7406
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/7589b1bb-d3d5-4f5f-8fcd-5c03c7961b2c
         method: GET
       response:
         proto: HTTP/2.0
@@ -125,20 +125,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 472
+        content_length: 572
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:13.596819Z","description":"","environment_variables":{},"error_message":null,"id":"2eb13c8a-1cde-4813-843a-e9293fee7406","name":"test-cr-data","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-04-28T09:37:18.659397Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.301093Z","description":"","environment_variables":{},"error_message":null,"id":"7589b1bb-d3d5-4f5f-8fcd-5c03c7961b2c","name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdataokg1lxkl","registry_namespace_id":"29c254bc-c0bd-45ae-8b19-d319f63c48d7","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:45.942188Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "472"
+                - "572"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:18 GMT
+                - Wed, 27 Aug 2025 15:05:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -146,10 +146,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c8daefb6-efd8-4473-8018-32d774ddc2ac
+                - 111f1832-2e63-4007-852a-949df4441522
         status: 200 OK
         code: 200
-        duration: 42.799375ms
+        duration: 80.639004ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -165,8 +165,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2eb13c8a-1cde-4813-843a-e9293fee7406
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/7589b1bb-d3d5-4f5f-8fcd-5c03c7961b2c
         method: GET
       response:
         proto: HTTP/2.0
@@ -174,20 +174,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 551
+        content_length: 570
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:13.596819Z","description":"","environment_variables":{},"error_message":null,"id":"2eb13c8a-1cde-4813-843a-e9293fee7406","name":"test-cr-data","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdatatmswvrye","registry_namespace_id":"3e3d7531-a0f9-450a-ad58-369f3cdf094f","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-28T09:37:19.657443Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.301093Z","description":"","environment_variables":{},"error_message":null,"id":"7589b1bb-d3d5-4f5f-8fcd-5c03c7961b2c","name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdataokg1lxkl","registry_namespace_id":"29c254bc-c0bd-45ae-8b19-d319f63c48d7","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:46.560573Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "551"
+                - "570"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:23 GMT
+                - Wed, 27 Aug 2025 15:05:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -195,10 +195,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 436d1ff6-3941-42d4-a855-ba770d2a97e4
+                - 6ac115f2-beb2-4947-89cf-f2d8da6a1cde
         status: 200 OK
         code: 200
-        duration: 49.932917ms
+        duration: 80.499161ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -214,8 +214,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2eb13c8a-1cde-4813-843a-e9293fee7406
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/7589b1bb-d3d5-4f5f-8fcd-5c03c7961b2c
         method: GET
       response:
         proto: HTTP/2.0
@@ -223,20 +223,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 551
+        content_length: 570
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:13.596819Z","description":"","environment_variables":{},"error_message":null,"id":"2eb13c8a-1cde-4813-843a-e9293fee7406","name":"test-cr-data","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdatatmswvrye","registry_namespace_id":"3e3d7531-a0f9-450a-ad58-369f3cdf094f","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-28T09:37:19.657443Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.301093Z","description":"","environment_variables":{},"error_message":null,"id":"7589b1bb-d3d5-4f5f-8fcd-5c03c7961b2c","name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdataokg1lxkl","registry_namespace_id":"29c254bc-c0bd-45ae-8b19-d319f63c48d7","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:46.560573Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "551"
+                - "570"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:23 GMT
+                - Wed, 27 Aug 2025 15:05:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -244,10 +244,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - df68ebab-c822-4461-a51c-be82ac1aec75
+                - c7f036f0-d047-4bbb-8d63-10beb3ba42dc
         status: 200 OK
         code: 200
-        duration: 46.812166ms
+        duration: 155.473055ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -263,8 +263,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2eb13c8a-1cde-4813-843a-e9293fee7406
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/7589b1bb-d3d5-4f5f-8fcd-5c03c7961b2c
         method: GET
       response:
         proto: HTTP/2.0
@@ -272,20 +272,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 551
+        content_length: 570
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:13.596819Z","description":"","environment_variables":{},"error_message":null,"id":"2eb13c8a-1cde-4813-843a-e9293fee7406","name":"test-cr-data","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdatatmswvrye","registry_namespace_id":"3e3d7531-a0f9-450a-ad58-369f3cdf094f","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-28T09:37:19.657443Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.301093Z","description":"","environment_variables":{},"error_message":null,"id":"7589b1bb-d3d5-4f5f-8fcd-5c03c7961b2c","name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdataokg1lxkl","registry_namespace_id":"29c254bc-c0bd-45ae-8b19-d319f63c48d7","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:46.560573Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "551"
+                - "570"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:23 GMT
+                - Wed, 27 Aug 2025 15:05:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -293,10 +293,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2fb29026-308a-4676-9553-075ce06beccc
+                - c54671d5-15e9-49df-b325-08e70db26cef
         status: 200 OK
         code: 200
-        duration: 43.762875ms
+        duration: 68.311372ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -312,7 +312,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces?name=test-cr-data&order_by=created_at_asc
         method: GET
       response:
@@ -321,20 +321,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 585
+        content_length: 603
         uncompressed: false
-        body: '{"namespaces":[{"created_at":"2025-04-28T09:37:13.596819Z","description":"","environment_variables":{},"error_message":null,"id":"2eb13c8a-1cde-4813-843a-e9293fee7406","name":"test-cr-data","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdatatmswvrye","registry_namespace_id":"3e3d7531-a0f9-450a-ad58-369f3cdf094f","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-28T09:37:19.657443Z"}],"total_count":1}'
+        body: '{"namespaces":[{"created_at":"2025-08-27T15:05:41.301093Z","description":"","environment_variables":{},"error_message":null,"id":"7589b1bb-d3d5-4f5f-8fcd-5c03c7961b2c","name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdataokg1lxkl","registry_namespace_id":"29c254bc-c0bd-45ae-8b19-d319f63c48d7","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:46.560573Z","vpc_integration_activated":true}],"total_count":1}'
         headers:
             Content-Length:
-                - "585"
+                - "603"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:23 GMT
+                - Wed, 27 Aug 2025 15:05:52 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -342,10 +342,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a345e927-9907-48ac-ad48-392b6971996a
+                - 81028fc8-f33d-4666-8e26-488d48771f2b
         status: 200 OK
         code: 200
-        duration: 49.74225ms
+        duration: 1.261253175s
     - id: 7
       request:
         proto: HTTP/1.1
@@ -361,8 +361,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2eb13c8a-1cde-4813-843a-e9293fee7406
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/7589b1bb-d3d5-4f5f-8fcd-5c03c7961b2c
         method: GET
       response:
         proto: HTTP/2.0
@@ -370,20 +370,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 551
+        content_length: 570
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:13.596819Z","description":"","environment_variables":{},"error_message":null,"id":"2eb13c8a-1cde-4813-843a-e9293fee7406","name":"test-cr-data","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdatatmswvrye","registry_namespace_id":"3e3d7531-a0f9-450a-ad58-369f3cdf094f","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-28T09:37:19.657443Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.301093Z","description":"","environment_variables":{},"error_message":null,"id":"7589b1bb-d3d5-4f5f-8fcd-5c03c7961b2c","name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdataokg1lxkl","registry_namespace_id":"29c254bc-c0bd-45ae-8b19-d319f63c48d7","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:46.560573Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "551"
+                - "570"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:23 GMT
+                - Wed, 27 Aug 2025 15:05:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -391,10 +391,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2754adf6-0626-428b-98ed-9ce925fd802f
+                - d39d294a-20c1-4bcc-b363-306d2d99500f
         status: 200 OK
         code: 200
-        duration: 41.405667ms
+        duration: 87.068709ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -410,8 +410,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2eb13c8a-1cde-4813-843a-e9293fee7406
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/7589b1bb-d3d5-4f5f-8fcd-5c03c7961b2c
         method: GET
       response:
         proto: HTTP/2.0
@@ -419,20 +419,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 551
+        content_length: 570
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:13.596819Z","description":"","environment_variables":{},"error_message":null,"id":"2eb13c8a-1cde-4813-843a-e9293fee7406","name":"test-cr-data","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdatatmswvrye","registry_namespace_id":"3e3d7531-a0f9-450a-ad58-369f3cdf094f","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-28T09:37:19.657443Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.301093Z","description":"","environment_variables":{},"error_message":null,"id":"7589b1bb-d3d5-4f5f-8fcd-5c03c7961b2c","name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdataokg1lxkl","registry_namespace_id":"29c254bc-c0bd-45ae-8b19-d319f63c48d7","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:46.560573Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "551"
+                - "570"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:24 GMT
+                - Wed, 27 Aug 2025 15:05:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -440,10 +440,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6c46b0cd-ce40-4181-bfa9-9ff153924ea8
+                - b4011929-ea36-404d-b1c5-11b96619cbd5
         status: 200 OK
         code: 200
-        duration: 46.232875ms
+        duration: 83.697002ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -459,8 +459,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2eb13c8a-1cde-4813-843a-e9293fee7406
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/7589b1bb-d3d5-4f5f-8fcd-5c03c7961b2c
         method: GET
       response:
         proto: HTTP/2.0
@@ -468,20 +468,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 551
+        content_length: 570
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:13.596819Z","description":"","environment_variables":{},"error_message":null,"id":"2eb13c8a-1cde-4813-843a-e9293fee7406","name":"test-cr-data","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdatatmswvrye","registry_namespace_id":"3e3d7531-a0f9-450a-ad58-369f3cdf094f","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-28T09:37:19.657443Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.301093Z","description":"","environment_variables":{},"error_message":null,"id":"7589b1bb-d3d5-4f5f-8fcd-5c03c7961b2c","name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdataokg1lxkl","registry_namespace_id":"29c254bc-c0bd-45ae-8b19-d319f63c48d7","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:46.560573Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "551"
+                - "570"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:24 GMT
+                - Wed, 27 Aug 2025 15:05:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -489,10 +489,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bd1938b4-71cc-4d8e-a909-eca714215a06
+                - e619abde-a6fd-485f-be4b-e2ea9e2eef29
         status: 200 OK
         code: 200
-        duration: 44.104542ms
+        duration: 87.016101ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -508,7 +508,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces?name=test-cr-data&order_by=created_at_asc
         method: GET
       response:
@@ -517,20 +517,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 585
+        content_length: 603
         uncompressed: false
-        body: '{"namespaces":[{"created_at":"2025-04-28T09:37:13.596819Z","description":"","environment_variables":{},"error_message":null,"id":"2eb13c8a-1cde-4813-843a-e9293fee7406","name":"test-cr-data","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdatatmswvrye","registry_namespace_id":"3e3d7531-a0f9-450a-ad58-369f3cdf094f","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-28T09:37:19.657443Z"}],"total_count":1}'
+        body: '{"namespaces":[{"created_at":"2025-08-27T15:05:41.301093Z","description":"","environment_variables":{},"error_message":null,"id":"7589b1bb-d3d5-4f5f-8fcd-5c03c7961b2c","name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdataokg1lxkl","registry_namespace_id":"29c254bc-c0bd-45ae-8b19-d319f63c48d7","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:46.560573Z","vpc_integration_activated":true}],"total_count":1}'
         headers:
             Content-Length:
-                - "585"
+                - "603"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:24 GMT
+                - Wed, 27 Aug 2025 15:05:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -538,10 +538,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 276aa844-5a2c-4618-9e70-4830a1eb7ddc
+                - abad2901-cd62-480d-aa41-1568cd4a728e
         status: 200 OK
         code: 200
-        duration: 52.745584ms
+        duration: 531.081123ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -557,8 +557,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2eb13c8a-1cde-4813-843a-e9293fee7406
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/7589b1bb-d3d5-4f5f-8fcd-5c03c7961b2c
         method: GET
       response:
         proto: HTTP/2.0
@@ -566,20 +566,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 551
+        content_length: 570
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:13.596819Z","description":"","environment_variables":{},"error_message":null,"id":"2eb13c8a-1cde-4813-843a-e9293fee7406","name":"test-cr-data","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdatatmswvrye","registry_namespace_id":"3e3d7531-a0f9-450a-ad58-369f3cdf094f","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-28T09:37:19.657443Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.301093Z","description":"","environment_variables":{},"error_message":null,"id":"7589b1bb-d3d5-4f5f-8fcd-5c03c7961b2c","name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdataokg1lxkl","registry_namespace_id":"29c254bc-c0bd-45ae-8b19-d319f63c48d7","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:46.560573Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "551"
+                - "570"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:24 GMT
+                - Wed, 27 Aug 2025 15:05:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -587,10 +587,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3ffca4b7-ee41-476c-871c-95a9299dc02e
+                - 7b4a40a6-508d-442a-b782-7d065cd6109d
         status: 200 OK
         code: 200
-        duration: 41.650459ms
+        duration: 147.063857ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -606,8 +606,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2eb13c8a-1cde-4813-843a-e9293fee7406
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/7589b1bb-d3d5-4f5f-8fcd-5c03c7961b2c
         method: GET
       response:
         proto: HTTP/2.0
@@ -615,20 +615,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 551
+        content_length: 570
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:13.596819Z","description":"","environment_variables":{},"error_message":null,"id":"2eb13c8a-1cde-4813-843a-e9293fee7406","name":"test-cr-data","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdatatmswvrye","registry_namespace_id":"3e3d7531-a0f9-450a-ad58-369f3cdf094f","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-28T09:37:19.657443Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.301093Z","description":"","environment_variables":{},"error_message":null,"id":"7589b1bb-d3d5-4f5f-8fcd-5c03c7961b2c","name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdataokg1lxkl","registry_namespace_id":"29c254bc-c0bd-45ae-8b19-d319f63c48d7","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:46.560573Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "551"
+                - "570"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:24 GMT
+                - Wed, 27 Aug 2025 15:05:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -636,10 +636,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7b7c3d37-88ab-4172-8255-e177798eea94
+                - 4f68b055-d96a-4a92-ab6b-26d49f739867
         status: 200 OK
         code: 200
-        duration: 46.352167ms
+        duration: 71.056213ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -655,8 +655,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2eb13c8a-1cde-4813-843a-e9293fee7406
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/7589b1bb-d3d5-4f5f-8fcd-5c03c7961b2c
         method: GET
       response:
         proto: HTTP/2.0
@@ -664,20 +664,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 551
+        content_length: 570
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:13.596819Z","description":"","environment_variables":{},"error_message":null,"id":"2eb13c8a-1cde-4813-843a-e9293fee7406","name":"test-cr-data","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdatatmswvrye","registry_namespace_id":"3e3d7531-a0f9-450a-ad58-369f3cdf094f","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-28T09:37:19.657443Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.301093Z","description":"","environment_variables":{},"error_message":null,"id":"7589b1bb-d3d5-4f5f-8fcd-5c03c7961b2c","name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdataokg1lxkl","registry_namespace_id":"29c254bc-c0bd-45ae-8b19-d319f63c48d7","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:46.560573Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "551"
+                - "570"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:24 GMT
+                - Wed, 27 Aug 2025 15:05:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -685,10 +685,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 63ba603b-2427-4178-ae2e-962d8a1e5b13
+                - e8c8f4d2-511f-4125-947d-870cf07fcd74
         status: 200 OK
         code: 200
-        duration: 48.075875ms
+        duration: 93.613701ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -704,7 +704,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces?name=test-cr-data&order_by=created_at_asc
         method: GET
       response:
@@ -713,20 +713,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 585
+        content_length: 603
         uncompressed: false
-        body: '{"namespaces":[{"created_at":"2025-04-28T09:37:13.596819Z","description":"","environment_variables":{},"error_message":null,"id":"2eb13c8a-1cde-4813-843a-e9293fee7406","name":"test-cr-data","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdatatmswvrye","registry_namespace_id":"3e3d7531-a0f9-450a-ad58-369f3cdf094f","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-28T09:37:19.657443Z"}],"total_count":1}'
+        body: '{"namespaces":[{"created_at":"2025-08-27T15:05:41.301093Z","description":"","environment_variables":{},"error_message":null,"id":"7589b1bb-d3d5-4f5f-8fcd-5c03c7961b2c","name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdataokg1lxkl","registry_namespace_id":"29c254bc-c0bd-45ae-8b19-d319f63c48d7","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:46.560573Z","vpc_integration_activated":true}],"total_count":1}'
         headers:
             Content-Length:
-                - "585"
+                - "603"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:24 GMT
+                - Wed, 27 Aug 2025 15:05:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -734,10 +734,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 254cea2b-2c05-4ef6-be11-07c28985fdaf
+                - 5e98fbc7-fb71-4ede-8bbc-e15a97eff17c
         status: 200 OK
         code: 200
-        duration: 48.04875ms
+        duration: 436.191731ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -753,8 +753,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2eb13c8a-1cde-4813-843a-e9293fee7406
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/7589b1bb-d3d5-4f5f-8fcd-5c03c7961b2c
         method: GET
       response:
         proto: HTTP/2.0
@@ -762,20 +762,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 551
+        content_length: 570
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:13.596819Z","description":"","environment_variables":{},"error_message":null,"id":"2eb13c8a-1cde-4813-843a-e9293fee7406","name":"test-cr-data","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdatatmswvrye","registry_namespace_id":"3e3d7531-a0f9-450a-ad58-369f3cdf094f","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-28T09:37:19.657443Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.301093Z","description":"","environment_variables":{},"error_message":null,"id":"7589b1bb-d3d5-4f5f-8fcd-5c03c7961b2c","name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdataokg1lxkl","registry_namespace_id":"29c254bc-c0bd-45ae-8b19-d319f63c48d7","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:46.560573Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "551"
+                - "570"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:24 GMT
+                - Wed, 27 Aug 2025 15:05:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -783,10 +783,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 74b56a51-92f7-4f0d-9bad-539ad1c42465
+                - 2aba888a-435c-4064-9409-3f5c18391a52
         status: 200 OK
         code: 200
-        duration: 41.637ms
+        duration: 146.375566ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -802,8 +802,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2eb13c8a-1cde-4813-843a-e9293fee7406
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/7589b1bb-d3d5-4f5f-8fcd-5c03c7961b2c
         method: GET
       response:
         proto: HTTP/2.0
@@ -811,20 +811,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 551
+        content_length: 570
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:13.596819Z","description":"","environment_variables":{},"error_message":null,"id":"2eb13c8a-1cde-4813-843a-e9293fee7406","name":"test-cr-data","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdatatmswvrye","registry_namespace_id":"3e3d7531-a0f9-450a-ad58-369f3cdf094f","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-28T09:37:19.657443Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.301093Z","description":"","environment_variables":{},"error_message":null,"id":"7589b1bb-d3d5-4f5f-8fcd-5c03c7961b2c","name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdataokg1lxkl","registry_namespace_id":"29c254bc-c0bd-45ae-8b19-d319f63c48d7","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:46.560573Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "551"
+                - "570"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:24 GMT
+                - Wed, 27 Aug 2025 15:05:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -832,10 +832,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ed19f307-4586-45aa-a9fd-54d69a6a02e7
+                - 1ec65c61-d2d4-45f2-8197-21fbfb4011dd
         status: 200 OK
         code: 200
-        duration: 40.696667ms
+        duration: 115.154452ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -851,7 +851,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces?name=test-cr-data&order_by=created_at_asc
         method: GET
       response:
@@ -860,20 +860,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 585
+        content_length: 603
         uncompressed: false
-        body: '{"namespaces":[{"created_at":"2025-04-28T09:37:13.596819Z","description":"","environment_variables":{},"error_message":null,"id":"2eb13c8a-1cde-4813-843a-e9293fee7406","name":"test-cr-data","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdatatmswvrye","registry_namespace_id":"3e3d7531-a0f9-450a-ad58-369f3cdf094f","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-28T09:37:19.657443Z"}],"total_count":1}'
+        body: '{"namespaces":[{"created_at":"2025-08-27T15:05:41.301093Z","description":"","environment_variables":{},"error_message":null,"id":"7589b1bb-d3d5-4f5f-8fcd-5c03c7961b2c","name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdataokg1lxkl","registry_namespace_id":"29c254bc-c0bd-45ae-8b19-d319f63c48d7","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:46.560573Z","vpc_integration_activated":true}],"total_count":1}'
         headers:
             Content-Length:
-                - "585"
+                - "603"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:24 GMT
+                - Wed, 27 Aug 2025 15:05:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -881,10 +881,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1a5fc430-ee24-4ee6-a07d-9aefc7f9db2e
+                - 0e166c82-3824-4e96-affc-0832c335ccd4
         status: 200 OK
         code: 200
-        duration: 47.553375ms
+        duration: 149.077166ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -900,8 +900,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2eb13c8a-1cde-4813-843a-e9293fee7406
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/7589b1bb-d3d5-4f5f-8fcd-5c03c7961b2c
         method: GET
       response:
         proto: HTTP/2.0
@@ -909,20 +909,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 551
+        content_length: 570
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:13.596819Z","description":"","environment_variables":{},"error_message":null,"id":"2eb13c8a-1cde-4813-843a-e9293fee7406","name":"test-cr-data","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdatatmswvrye","registry_namespace_id":"3e3d7531-a0f9-450a-ad58-369f3cdf094f","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-28T09:37:19.657443Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.301093Z","description":"","environment_variables":{},"error_message":null,"id":"7589b1bb-d3d5-4f5f-8fcd-5c03c7961b2c","name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdataokg1lxkl","registry_namespace_id":"29c254bc-c0bd-45ae-8b19-d319f63c48d7","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:46.560573Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "551"
+                - "570"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:24 GMT
+                - Wed, 27 Aug 2025 15:05:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -930,10 +930,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f5dd1cb3-bc24-498a-9d8c-1dab57d07e49
+                - 2c2650db-65a7-4016-a443-f0fa6697e1fb
         status: 200 OK
         code: 200
-        duration: 37.872667ms
+        duration: 74.844492ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -949,8 +949,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2eb13c8a-1cde-4813-843a-e9293fee7406
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/7589b1bb-d3d5-4f5f-8fcd-5c03c7961b2c
         method: GET
       response:
         proto: HTTP/2.0
@@ -958,20 +958,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 551
+        content_length: 570
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:13.596819Z","description":"","environment_variables":{},"error_message":null,"id":"2eb13c8a-1cde-4813-843a-e9293fee7406","name":"test-cr-data","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdatatmswvrye","registry_namespace_id":"3e3d7531-a0f9-450a-ad58-369f3cdf094f","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-28T09:37:19.657443Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.301093Z","description":"","environment_variables":{},"error_message":null,"id":"7589b1bb-d3d5-4f5f-8fcd-5c03c7961b2c","name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdataokg1lxkl","registry_namespace_id":"29c254bc-c0bd-45ae-8b19-d319f63c48d7","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:46.560573Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "551"
+                - "570"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:24 GMT
+                - Wed, 27 Aug 2025 15:05:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -979,10 +979,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 791232c7-ce00-42d0-be1b-cea28b580a92
+                - 22aa0e0c-b46e-472c-bd81-dea9b67e9094
         status: 200 OK
         code: 200
-        duration: 40.4345ms
+        duration: 72.890576ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -998,8 +998,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2eb13c8a-1cde-4813-843a-e9293fee7406
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/7589b1bb-d3d5-4f5f-8fcd-5c03c7961b2c
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1007,20 +1007,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 557
+        content_length: 576
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:13.596819Z","description":"","environment_variables":{},"error_message":null,"id":"2eb13c8a-1cde-4813-843a-e9293fee7406","name":"test-cr-data","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdatatmswvrye","registry_namespace_id":"3e3d7531-a0f9-450a-ad58-369f3cdf094f","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-04-28T09:37:24.868418932Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.301093Z","description":"","environment_variables":{},"error_message":null,"id":"7589b1bb-d3d5-4f5f-8fcd-5c03c7961b2c","name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdataokg1lxkl","registry_namespace_id":"29c254bc-c0bd-45ae-8b19-d319f63c48d7","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:55.694969683Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "557"
+                - "576"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:24 GMT
+                - Wed, 27 Aug 2025 15:05:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1028,10 +1028,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5b52f83f-52c4-4e36-a6c3-9e7a598475c9
+                - c89982c5-d3d6-442a-8e27-f29097c60cf3
         status: 200 OK
         code: 200
-        duration: 149.005667ms
+        duration: 303.73799ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1047,8 +1047,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2eb13c8a-1cde-4813-843a-e9293fee7406
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/7589b1bb-d3d5-4f5f-8fcd-5c03c7961b2c
         method: GET
       response:
         proto: HTTP/2.0
@@ -1056,20 +1056,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 554
+        content_length: 573
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:13.596819Z","description":"","environment_variables":{},"error_message":null,"id":"2eb13c8a-1cde-4813-843a-e9293fee7406","name":"test-cr-data","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdatatmswvrye","registry_namespace_id":"3e3d7531-a0f9-450a-ad58-369f3cdf094f","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-04-28T09:37:24.868419Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.301093Z","description":"","environment_variables":{},"error_message":null,"id":"7589b1bb-d3d5-4f5f-8fcd-5c03c7961b2c","name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdataokg1lxkl","registry_namespace_id":"29c254bc-c0bd-45ae-8b19-d319f63c48d7","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:55.694970Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "554"
+                - "573"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:25 GMT
+                - Wed, 27 Aug 2025 15:05:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1077,10 +1077,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3f4fda6b-3742-4f58-ade2-d41126644dab
+                - 24c0bd9e-ceaa-492e-bdd7-42a888f6875c
         status: 200 OK
         code: 200
-        duration: 37.28ms
+        duration: 75.472841ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1096,8 +1096,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2eb13c8a-1cde-4813-843a-e9293fee7406
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/7589b1bb-d3d5-4f5f-8fcd-5c03c7961b2c
         method: GET
       response:
         proto: HTTP/2.0
@@ -1116,9 +1116,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:30 GMT
+                - Wed, 27 Aug 2025 15:06:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1126,10 +1126,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8f031c5b-7298-4041-933d-4a5ea143a11a
+                - 7d6ebaba-b4d3-412f-8791-3dda845296e6
         status: 404 Not Found
         code: 404
-        duration: 28.999541ms
+        duration: 24.160637ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1145,8 +1145,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2eb13c8a-1cde-4813-843a-e9293fee7406
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/7589b1bb-d3d5-4f5f-8fcd-5c03c7961b2c
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1165,9 +1165,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:30 GMT
+                - Wed, 27 Aug 2025 15:06:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1175,10 +1175,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0e767116-27d9-4068-b2fc-9c19ebcd78a4
+                - a57849ec-8b41-4e11-bedc-d3049659eade
         status: 404 Not Found
         code: 404
-        duration: 23.206959ms
+        duration: 24.02944ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1194,8 +1194,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2eb13c8a-1cde-4813-843a-e9293fee7406
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/7589b1bb-d3d5-4f5f-8fcd-5c03c7961b2c
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1214,9 +1214,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:30 GMT
+                - Wed, 27 Aug 2025 15:06:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1224,10 +1224,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - be051b79-315e-46e0-91a3-0b643db1b4d0
+                - 5ef7f524-5776-43a7-abc3-9c1b83eb39a1
         status: 404 Not Found
         code: 404
-        duration: 22.8415ms
+        duration: 26.058859ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1243,8 +1243,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2eb13c8a-1cde-4813-843a-e9293fee7406
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/7589b1bb-d3d5-4f5f-8fcd-5c03c7961b2c
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1263,9 +1263,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:30 GMT
+                - Wed, 27 Aug 2025 15:06:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1273,7 +1273,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3cf80fb0-8216-45a2-ae63-7fbe23392cc9
+                - 343e1cb2-0a36-4dfa-a432-44a3f91da5d5
         status: 404 Not Found
         code: 404
-        duration: 24.186416ms
+        duration: 23.691437ms

--- a/internal/services/container/testdata/domain-basic.cassette.yaml
+++ b/internal/services/container/testdata/domain-basic.cassette.yaml
@@ -6,19 +6,19 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 191
+        content_length: 188
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-ns-musing-ramanujan","environment_variables":{},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","secret_environment_variables":[],"tags":null,"activate_vpc_integration":false}'
+        body: '{"name":"tf-ns-strange-wilson","environment_variables":{},"project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","secret_environment_variables":[],"tags":null,"activate_vpc_integration":true}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces
         method: POST
       response:
@@ -27,18 +27,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 523
+        content_length: 505
         uncompressed: false
-        body: '{"created_at":"2025-06-11T12:33:38.809870601Z","description":"","environment_variables":{},"error_message":null,"id":"bda727d4-9d0b-4b1f-9802-6db82804e02c","name":"tf-ns-musing-ramanujan","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-06-11T12:33:38.809870601Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2025-08-27T15:05:41.286324360Z","description":"","environment_variables":{},"error_message":null,"id":"97800be4-3f61-4f2e-b568-790018772ed1","name":"tf-ns-strange-wilson","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:41.286324360Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "523"
+                - "505"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:33:38 GMT
+                - Wed, 27 Aug 2025 15:05:41 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5b030212-d866-4c46-9773-49d0fd06c479
+                - cc7aec0e-569f-4215-a122-070f38b35d67
         status: 200 OK
         code: 200
-        duration: 1.337976958s
+        duration: 5.338710983s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -67,8 +67,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/bda727d4-9d0b-4b1f-9802-6db82804e02c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/97800be4-3f61-4f2e-b568-790018772ed1
         method: GET
       response:
         proto: HTTP/2.0
@@ -76,18 +76,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 517
+        content_length: 499
         uncompressed: false
-        body: '{"created_at":"2025-06-11T12:33:38.809871Z","description":"","environment_variables":{},"error_message":null,"id":"bda727d4-9d0b-4b1f-9802-6db82804e02c","name":"tf-ns-musing-ramanujan","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-06-11T12:33:38.809871Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2025-08-27T15:05:41.286324Z","description":"","environment_variables":{},"error_message":null,"id":"97800be4-3f61-4f2e-b568-790018772ed1","name":"tf-ns-strange-wilson","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:41.286324Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "517"
+                - "499"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:33:38 GMT
+                - Wed, 27 Aug 2025 15:05:41 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4f0095a5-d175-4aa5-a474-8a13aef4f0b5
+                - fc1b5cda-46e2-4ae3-9e6d-0b0332a2a41c
         status: 200 OK
         code: 200
-        duration: 86.384666ms
+        duration: 69.948071ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -116,8 +116,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/bda727d4-9d0b-4b1f-9802-6db82804e02c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/97800be4-3f61-4f2e-b568-790018772ed1
         method: GET
       response:
         proto: HTTP/2.0
@@ -125,18 +125,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 605
+        content_length: 587
         uncompressed: false
-        body: '{"created_at":"2025-06-11T12:33:38.809871Z","description":"","environment_variables":{},"error_message":null,"id":"bda727d4-9d0b-4b1f-9802-6db82804e02c","name":"tf-ns-musing-ramanujan","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsmusingramanujanpkpx1suc","registry_namespace_id":"3fabe0f3-47bf-4c53-a0f5-9c352bb9653c","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-11T12:33:43.385729Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2025-08-27T15:05:41.286324Z","description":"","environment_variables":{},"error_message":null,"id":"97800be4-3f61-4f2e-b568-790018772ed1","name":"tf-ns-strange-wilson","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsstrangewilsonhbofpena","registry_namespace_id":"196bf838-61df-41bf-98c6-ad78b741053a","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:46.143543Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "605"
+                - "587"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:33:44 GMT
+                - Wed, 27 Aug 2025 15:05:46 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -146,10 +146,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7251fc7a-ece4-484f-8ce3-8f147fbf8da6
+                - 43ad556a-e834-4f22-bdf9-6e1134b90e8f
         status: 200 OK
         code: 200
-        duration: 100.8885ms
+        duration: 87.419226ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -165,8 +165,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/bda727d4-9d0b-4b1f-9802-6db82804e02c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/97800be4-3f61-4f2e-b568-790018772ed1
         method: GET
       response:
         proto: HTTP/2.0
@@ -174,18 +174,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 605
+        content_length: 587
         uncompressed: false
-        body: '{"created_at":"2025-06-11T12:33:38.809871Z","description":"","environment_variables":{},"error_message":null,"id":"bda727d4-9d0b-4b1f-9802-6db82804e02c","name":"tf-ns-musing-ramanujan","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsmusingramanujanpkpx1suc","registry_namespace_id":"3fabe0f3-47bf-4c53-a0f5-9c352bb9653c","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-11T12:33:43.385729Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2025-08-27T15:05:41.286324Z","description":"","environment_variables":{},"error_message":null,"id":"97800be4-3f61-4f2e-b568-790018772ed1","name":"tf-ns-strange-wilson","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsstrangewilsonhbofpena","registry_namespace_id":"196bf838-61df-41bf-98c6-ad78b741053a","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:46.143543Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "605"
+                - "587"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:33:44 GMT
+                - Wed, 27 Aug 2025 15:05:51 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -195,10 +195,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5898e330-232d-4268-8d71-7f5b8659df71
+                - 2294bdb4-5378-489f-ba01-f776eef1e3df
         status: 200 OK
         code: 200
-        duration: 75.657417ms
+        duration: 100.917505ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -214,8 +214,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/bda727d4-9d0b-4b1f-9802-6db82804e02c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/97800be4-3f61-4f2e-b568-790018772ed1
         method: GET
       response:
         proto: HTTP/2.0
@@ -223,18 +223,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 605
+        content_length: 585
         uncompressed: false
-        body: '{"created_at":"2025-06-11T12:33:38.809871Z","description":"","environment_variables":{},"error_message":null,"id":"bda727d4-9d0b-4b1f-9802-6db82804e02c","name":"tf-ns-musing-ramanujan","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsmusingramanujanpkpx1suc","registry_namespace_id":"3fabe0f3-47bf-4c53-a0f5-9c352bb9653c","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-11T12:33:43.385729Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2025-08-27T15:05:41.286324Z","description":"","environment_variables":{},"error_message":null,"id":"97800be4-3f61-4f2e-b568-790018772ed1","name":"tf-ns-strange-wilson","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsstrangewilsonhbofpena","registry_namespace_id":"196bf838-61df-41bf-98c6-ad78b741053a","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:52.556806Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "605"
+                - "585"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:33:44 GMT
+                - Wed, 27 Aug 2025 15:05:56 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -244,48 +244,46 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c893fef7-6809-4b7c-8705-1454a533645a
+                - 50da7bdf-59db-469b-92b0-337249e14519
         status: 200 OK
         code: 200
-        duration: 85.836625ms
+        duration: 78.468472ms
     - id: 5
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 293
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"namespace_id":"bda727d4-9d0b-4b1f-9802-6db82804e02c","name":"tf-co-trusting-wilbur","privacy":"public","registry_image":"nginx:latest","protocol":"http1","port":80,"secret_environment_variables":null,"http_option":"enabled","sandbox":"unknown_sandbox","tags":null,"command":null,"args":null}'
+        body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers
-        method: POST
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/97800be4-3f61-4f2e-b568-790018772ed1
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 932
+        content_length: 585
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-11T12:33:44.733303480Z","description":"","domain_name":"tfnsmusingramanujanpkpx1suc-tf-co-trusting-wilbur.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"15f70a78-78fb-4ed1-a2cc-7cc9c7cfc366","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-trusting-wilbur","namespace_id":"bda727d4-9d0b-4b1f-9802-6db82804e02c","port":80,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"nginx:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-11T12:33:44.733303480Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.286324Z","description":"","environment_variables":{},"error_message":null,"id":"97800be4-3f61-4f2e-b568-790018772ed1","name":"tf-ns-strange-wilson","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsstrangewilsonhbofpena","registry_namespace_id":"196bf838-61df-41bf-98c6-ad78b741053a","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:52.556806Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "932"
+                - "585"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:33:44 GMT
+                - Wed, 27 Aug 2025 15:05:56 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -295,10 +293,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b0f1fabc-0661-4154-93b3-77a925ecae46
+                - e202ee5f-c0a1-4dc4-980d-ae16d2ff563b
         status: 200 OK
         code: 200
-        duration: 580.98ms
+        duration: 91.456534ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -314,8 +312,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/15f70a78-78fb-4ed1-a2cc-7cc9c7cfc366
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/97800be4-3f61-4f2e-b568-790018772ed1
         method: GET
       response:
         proto: HTTP/2.0
@@ -323,18 +321,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 926
+        content_length: 585
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-11T12:33:44.733303Z","description":"","domain_name":"tfnsmusingramanujanpkpx1suc-tf-co-trusting-wilbur.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"15f70a78-78fb-4ed1-a2cc-7cc9c7cfc366","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-trusting-wilbur","namespace_id":"bda727d4-9d0b-4b1f-9802-6db82804e02c","port":80,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"nginx:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-11T12:33:44.733303Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.286324Z","description":"","environment_variables":{},"error_message":null,"id":"97800be4-3f61-4f2e-b568-790018772ed1","name":"tf-ns-strange-wilson","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsstrangewilsonhbofpena","registry_namespace_id":"196bf838-61df-41bf-98c6-ad78b741053a","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:52.556806Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "926"
+                - "585"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:33:44 GMT
+                - Wed, 27 Aug 2025 15:05:56 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -344,11 +342,111 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - db33c3b9-4a29-40d5-af45-fc6dc9ddc535
+                - aa4df3d7-e992-43b4-8721-93e0cdc41821
         status: 200 OK
         code: 200
-        duration: 86.772625ms
+        duration: 86.854499ms
     - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 297
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"namespace_id":"97800be4-3f61-4f2e-b568-790018772ed1","name":"tf-co-dazzling-cartwright","privacy":"public","registry_image":"nginx:latest","protocol":"http1","port":80,"secret_environment_variables":null,"http_option":"enabled","sandbox":"unknown_sandbox","tags":null,"command":null,"args":null}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 905
+        uncompressed: false
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:58.583265342Z","description":"","domain_name":"tfnsstrangewilsonhbofpena-tf-co-dazzling-cartwright.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"9822575a-a230-47ab-96e5-ac82fcb42849","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-dazzling-cartwright","namespace_id":"97800be4-3f61-4f2e-b568-790018772ed1","port":80,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"nginx:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:58.583265342Z"}'
+        headers:
+            Content-Length:
+                - "905"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:05:58 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 0e7a10eb-b149-4543-9ee7-ee8d2b6ab392
+        status: 200 OK
+        code: 200
+        duration: 1.776090448s
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/9822575a-a230-47ab-96e5-ac82fcb42849
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 899
+        uncompressed: false
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:58.583265Z","description":"","domain_name":"tfnsstrangewilsonhbofpena-tf-co-dazzling-cartwright.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"9822575a-a230-47ab-96e5-ac82fcb42849","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-dazzling-cartwright","namespace_id":"97800be4-3f61-4f2e-b568-790018772ed1","port":80,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"nginx:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:58.583265Z"}'
+        headers:
+            Content-Length:
+                - "899"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:05:58 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f29358b5-7d15-4663-a2d3-bdbd367299dc
+        status: 200 OK
+        code: 200
+        duration: 74.367558ms
+    - id: 9
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -365,8 +463,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/15f70a78-78fb-4ed1-a2cc-7cc9c7cfc366
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/9822575a-a230-47ab-96e5-ac82fcb42849
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -374,18 +472,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 929
+        content_length: 902
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-11T12:33:44.733303Z","description":"","domain_name":"tfnsmusingramanujanpkpx1suc-tf-co-trusting-wilbur.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"15f70a78-78fb-4ed1-a2cc-7cc9c7cfc366","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-trusting-wilbur","namespace_id":"bda727d4-9d0b-4b1f-9802-6db82804e02c","port":80,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"nginx:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-06-11T12:33:44.973553721Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:58.583265Z","description":"","domain_name":"tfnsstrangewilsonhbofpena-tf-co-dazzling-cartwright.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"9822575a-a230-47ab-96e5-ac82fcb42849","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-dazzling-cartwright","namespace_id":"97800be4-3f61-4f2e-b568-790018772ed1","port":80,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"nginx:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:58.818229202Z"}'
         headers:
             Content-Length:
-                - "929"
+                - "902"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:33:44 GMT
+                - Wed, 27 Aug 2025 15:05:58 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -395,108 +493,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f0b15135-373f-468c-a0ef-d8d7dd413894
+                - 0fb838c3-a751-4f75-ba40-448c386370c5
         status: 200 OK
         code: 200
-        duration: 136.463041ms
-    - id: 8
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/15f70a78-78fb-4ed1-a2cc-7cc9c7cfc366
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 926
-        uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-11T12:33:44.733303Z","description":"","domain_name":"tfnsmusingramanujanpkpx1suc-tf-co-trusting-wilbur.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"15f70a78-78fb-4ed1-a2cc-7cc9c7cfc366","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-trusting-wilbur","namespace_id":"bda727d4-9d0b-4b1f-9802-6db82804e02c","port":80,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"nginx:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-06-11T12:33:44.973554Z"}'
-        headers:
-            Content-Length:
-                - "926"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 11 Jun 2025 12:33:45 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 17f9f91c-151e-4e45-95fe-d2a1dfd1eef7
-        status: 200 OK
-        code: 200
-        duration: 164.447209ms
-    - id: 9
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/15f70a78-78fb-4ed1-a2cc-7cc9c7cfc366
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 926
-        uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-11T12:33:44.733303Z","description":"","domain_name":"tfnsmusingramanujanpkpx1suc-tf-co-trusting-wilbur.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"15f70a78-78fb-4ed1-a2cc-7cc9c7cfc366","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-trusting-wilbur","namespace_id":"bda727d4-9d0b-4b1f-9802-6db82804e02c","port":80,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"nginx:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-06-11T12:33:44.973554Z"}'
-        headers:
-            Content-Length:
-                - "926"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 11 Jun 2025 12:33:50 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - ab63e19d-365d-48f7-90f4-8d79583b7272
-        status: 200 OK
-        code: 200
-        duration: 83.458125ms
+        duration: 157.40306ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -512,8 +512,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/15f70a78-78fb-4ed1-a2cc-7cc9c7cfc366
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/9822575a-a230-47ab-96e5-ac82fcb42849
         method: GET
       response:
         proto: HTTP/2.0
@@ -521,18 +521,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 926
+        content_length: 899
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-11T12:33:44.733303Z","description":"","domain_name":"tfnsmusingramanujanpkpx1suc-tf-co-trusting-wilbur.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"15f70a78-78fb-4ed1-a2cc-7cc9c7cfc366","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-trusting-wilbur","namespace_id":"bda727d4-9d0b-4b1f-9802-6db82804e02c","port":80,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"nginx:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-06-11T12:33:44.973554Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:58.583265Z","description":"","domain_name":"tfnsstrangewilsonhbofpena-tf-co-dazzling-cartwright.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"9822575a-a230-47ab-96e5-ac82fcb42849","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-dazzling-cartwright","namespace_id":"97800be4-3f61-4f2e-b568-790018772ed1","port":80,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"nginx:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:58.818229Z"}'
         headers:
             Content-Length:
-                - "926"
+                - "899"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:33:55 GMT
+                - Wed, 27 Aug 2025 15:05:58 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -542,10 +542,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 40fb55e5-ba11-4bde-8fb2-803a31726fd9
+                - 02f1414e-86bb-46c4-851a-a72bc5f42069
         status: 200 OK
         code: 200
-        duration: 94.653042ms
+        duration: 80.914392ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -561,8 +561,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/15f70a78-78fb-4ed1-a2cc-7cc9c7cfc366
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/9822575a-a230-47ab-96e5-ac82fcb42849
         method: GET
       response:
         proto: HTTP/2.0
@@ -570,18 +570,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 949
+        content_length: 899
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-11T12:33:44.733303Z","description":"","domain_name":"tfnsmusingramanujanpkpx1suc-tf-co-trusting-wilbur.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"15f70a78-78fb-4ed1-a2cc-7cc9c7cfc366","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-trusting-wilbur","namespace_id":"bda727d4-9d0b-4b1f-9802-6db82804e02c","port":80,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":"2025-06-11T12:33:58.858933Z","region":"fr-par","registry_image":"nginx:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"ready","tags":[],"timeout":"300s","updated_at":"2025-06-11T12:33:58.872318Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:58.583265Z","description":"","domain_name":"tfnsstrangewilsonhbofpena-tf-co-dazzling-cartwright.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"9822575a-a230-47ab-96e5-ac82fcb42849","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-dazzling-cartwright","namespace_id":"97800be4-3f61-4f2e-b568-790018772ed1","port":80,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"nginx:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:58.818229Z"}'
         headers:
             Content-Length:
-                - "949"
+                - "899"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:34:00 GMT
+                - Wed, 27 Aug 2025 15:06:04 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -591,10 +591,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 15f78c8c-4e5e-4d47-be75-0aa7d29d36e3
+                - 47fd4cea-14c1-47d1-b994-b378108593fa
         status: 200 OK
         code: 200
-        duration: 80.51175ms
+        duration: 108.667874ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -610,8 +610,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/15f70a78-78fb-4ed1-a2cc-7cc9c7cfc366
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/9822575a-a230-47ab-96e5-ac82fcb42849
         method: GET
       response:
         proto: HTTP/2.0
@@ -619,18 +619,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 949
+        content_length: 899
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-11T12:33:44.733303Z","description":"","domain_name":"tfnsmusingramanujanpkpx1suc-tf-co-trusting-wilbur.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"15f70a78-78fb-4ed1-a2cc-7cc9c7cfc366","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-trusting-wilbur","namespace_id":"bda727d4-9d0b-4b1f-9802-6db82804e02c","port":80,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":"2025-06-11T12:33:58.858933Z","region":"fr-par","registry_image":"nginx:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"ready","tags":[],"timeout":"300s","updated_at":"2025-06-11T12:33:58.872318Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:58.583265Z","description":"","domain_name":"tfnsstrangewilsonhbofpena-tf-co-dazzling-cartwright.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"9822575a-a230-47ab-96e5-ac82fcb42849","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-dazzling-cartwright","namespace_id":"97800be4-3f61-4f2e-b568-790018772ed1","port":80,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"nginx:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:58.818229Z"}'
         headers:
             Content-Length:
-                - "949"
+                - "899"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:34:00 GMT
+                - Wed, 27 Aug 2025 15:06:09 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -640,48 +640,46 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1eed441d-bbf2-4d17-8871-1c81a87be352
+                - ebcb55de-a3cd-4518-87d8-a8540463a0a2
         status: 200 OK
         code: 200
-        duration: 106.04075ms
+        duration: 109.823774ms
     - id: 13
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 269
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"changes":[{"add":{"records":[{"data":"tfnsmusingramanujanpkpx1suc-tf-co-trusting-wilbur.functions.fnc.fr-par.scw.cloud.","name":"container","priority":0,"ttl":60,"type":"CNAME","comment":null,"id":""}]}}],"return_all_records":false,"disallow_new_zone_creation":false}'
+        body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/domain/v2beta1/dns-zones/container-basic.scaleway-terraform.com/records
-        method: PATCH
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/9822575a-a230-47ab-96e5-ac82fcb42849
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 227
+        content_length: 922
         uncompressed: false
-        body: '{"records":[{"comment":null,"data":"tfnsmusingramanujanpkpx1suc-tf-co-trusting-wilbur.functions.fnc.fr-par.scw.cloud.","id":"c12aeb73-838a-46ab-a445-a5b8e3d35ea6","name":"container","priority":0,"ttl":60,"type":"CNAME"}]}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:58.583265Z","description":"","domain_name":"tfnsstrangewilsonhbofpena-tf-co-dazzling-cartwright.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"9822575a-a230-47ab-96e5-ac82fcb42849","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-dazzling-cartwright","namespace_id":"97800be4-3f61-4f2e-b568-790018772ed1","port":80,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":"2025-08-27T15:06:10.272896Z","region":"fr-par","registry_image":"nginx:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"ready","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:10.282216Z"}'
         headers:
             Content-Length:
-                - "227"
+                - "922"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:34:01 GMT
+                - Wed, 27 Aug 2025 15:06:14 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -691,10 +689,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 019af94d-4776-4a0a-ad54-bdd350abd3f0
+                - f25da2a7-3b89-49f1-bebb-610521ae1828
         status: 200 OK
         code: 200
-        duration: 629.774709ms
+        duration: 96.306189ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -710,8 +708,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/domain/v2beta1/dns-zones/container-basic.scaleway-terraform.com/records?name=container&order_by=name_asc&type=CNAME
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/9822575a-a230-47ab-96e5-ac82fcb42849
         method: GET
       response:
         proto: HTTP/2.0
@@ -719,18 +717,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 244
+        content_length: 922
         uncompressed: false
-        body: '{"records":[{"comment":null,"data":"tfnsmusingramanujanpkpx1suc-tf-co-trusting-wilbur.functions.fnc.fr-par.scw.cloud.","id":"c12aeb73-838a-46ab-a445-a5b8e3d35ea6","name":"container","priority":0,"ttl":60,"type":"CNAME"}],"total_count":1}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:58.583265Z","description":"","domain_name":"tfnsstrangewilsonhbofpena-tf-co-dazzling-cartwright.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"9822575a-a230-47ab-96e5-ac82fcb42849","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-dazzling-cartwright","namespace_id":"97800be4-3f61-4f2e-b568-790018772ed1","port":80,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":"2025-08-27T15:06:10.272896Z","region":"fr-par","registry_image":"nginx:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"ready","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:10.282216Z"}'
         headers:
             Content-Length:
-                - "244"
+                - "922"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:34:01 GMT
+                - Wed, 27 Aug 2025 15:06:14 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -740,46 +738,48 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6bb4da40-8cc8-40a9-8d6a-8c991f9c7d01
+                - fd1271e3-ff00-4e0f-bda2-3613397083ea
         status: 200 OK
         code: 200
-        duration: 84.50775ms
+        duration: 95.912511ms
     - id: 15
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 271
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"changes":[{"add":{"records":[{"data":"tfnsstrangewilsonhbofpena-tf-co-dazzling-cartwright.functions.fnc.fr-par.scw.cloud.","name":"container","priority":0,"ttl":60,"type":"CNAME","comment":null,"id":""}]}}],"return_all_records":false,"disallow_new_zone_creation":false}'
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/domain/v2beta1/dns-zones/container-basic.scaleway-terraform.com/records?name=container&order_by=name_asc&page=1&type=CNAME
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/domain/v2beta1/dns-zones/container-basic.scaleway-terraform.com/records
+        method: PATCH
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 244
+        content_length: 223
         uncompressed: false
-        body: '{"records":[{"comment":null,"data":"tfnsmusingramanujanpkpx1suc-tf-co-trusting-wilbur.functions.fnc.fr-par.scw.cloud.","id":"c12aeb73-838a-46ab-a445-a5b8e3d35ea6","name":"container","priority":0,"ttl":60,"type":"CNAME"}],"total_count":1}'
+        body: '{"records":[{"comment":null,"data":"tfnsstrangewilsonhbofpena-tf-co-dazzling-cartwright.functions.fnc.fr-par.scw.cloud.","id":"74837750-e0d6-40d2-a1c1-946d35c2c81d","name":"container","priority":0,"ttl":60,"type":"CNAME"}]}'
         headers:
             Content-Length:
-                - "244"
+                - "223"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:34:01 GMT
+                - Wed, 27 Aug 2025 15:06:14 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -789,10 +789,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 891003dc-59a3-4baa-ba9e-49e8cafd8903
+                - 7903a202-62b0-43df-8964-461f99e31501
         status: 200 OK
         code: 200
-        duration: 81.113541ms
+        duration: 147.876772ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -808,8 +808,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/domain/v2beta1/dns-zones/container-basic.scaleway-terraform.com/records?id=c12aeb73-838a-46ab-a445-a5b8e3d35ea6&name=&order_by=name_asc&page=1&type=unknown
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/domain/v2beta1/dns-zones/container-basic.scaleway-terraform.com/records?name=container&order_by=name_asc&type=CNAME
         method: GET
       response:
         proto: HTTP/2.0
@@ -817,18 +817,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 244
+        content_length: 239
         uncompressed: false
-        body: '{"records":[{"comment":null,"data":"tfnsmusingramanujanpkpx1suc-tf-co-trusting-wilbur.functions.fnc.fr-par.scw.cloud.","id":"c12aeb73-838a-46ab-a445-a5b8e3d35ea6","name":"container","priority":0,"ttl":60,"type":"CNAME"}],"total_count":1}'
+        body: '{"records":[{"comment":null,"data":"tfnsstrangewilsonhbofpena-tf-co-dazzling-cartwright.functions.fnc.fr-par.scw.cloud.","id":"74837750-e0d6-40d2-a1c1-946d35c2c81d","name":"container","priority":0,"ttl":60,"type":"CNAME"}],"total_count":1}'
         headers:
             Content-Length:
-                - "244"
+                - "239"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:34:01 GMT
+                - Wed, 27 Aug 2025 15:06:14 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -838,10 +838,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a25a40d5-2708-4bf3-8207-0e1a04ec41ba
+                - f2d9e435-1cb1-46f7-8069-7521bdc27c46
         status: 200 OK
         code: 200
-        duration: 84.116583ms
+        duration: 91.079923ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -857,8 +857,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zones=container-basic.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/domain/v2beta1/dns-zones/container-basic.scaleway-terraform.com/records?name=container&order_by=name_asc&page=1&type=CNAME
         method: GET
       response:
         proto: HTTP/2.0
@@ -866,18 +866,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 369
+        content_length: 239
         uncompressed: false
-        body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"container-basic","updated_at":"2025-06-11T12:34:01Z"}],"total_count":1}'
+        body: '{"records":[{"comment":null,"data":"tfnsstrangewilsonhbofpena-tf-co-dazzling-cartwright.functions.fnc.fr-par.scw.cloud.","id":"74837750-e0d6-40d2-a1c1-946d35c2c81d","name":"container","priority":0,"ttl":60,"type":"CNAME"}],"total_count":1}'
         headers:
             Content-Length:
-                - "369"
+                - "239"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:34:01 GMT
+                - Wed, 27 Aug 2025 15:06:14 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -887,10 +887,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2820cbe1-4a2e-4942-a195-616fe588dd2c
+                - 6da43540-50fc-4fb1-96d2-b5c64de1b619
         status: 200 OK
         code: 200
-        duration: 93.381ms
+        duration: 92.277249ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -906,8 +906,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/15f70a78-78fb-4ed1-a2cc-7cc9c7cfc366
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/domain/v2beta1/dns-zones/container-basic.scaleway-terraform.com/records?id=74837750-e0d6-40d2-a1c1-946d35c2c81d&name=&order_by=name_asc&page=1&type=unknown
         method: GET
       response:
         proto: HTTP/2.0
@@ -915,18 +915,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 949
+        content_length: 239
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-11T12:33:44.733303Z","description":"","domain_name":"tfnsmusingramanujanpkpx1suc-tf-co-trusting-wilbur.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"15f70a78-78fb-4ed1-a2cc-7cc9c7cfc366","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-trusting-wilbur","namespace_id":"bda727d4-9d0b-4b1f-9802-6db82804e02c","port":80,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":"2025-06-11T12:33:58.858933Z","region":"fr-par","registry_image":"nginx:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"ready","tags":[],"timeout":"300s","updated_at":"2025-06-11T12:33:58.872318Z"}'
+        body: '{"records":[{"comment":null,"data":"tfnsstrangewilsonhbofpena-tf-co-dazzling-cartwright.functions.fnc.fr-par.scw.cloud.","id":"74837750-e0d6-40d2-a1c1-946d35c2c81d","name":"container","priority":0,"ttl":60,"type":"CNAME"}],"total_count":1}'
         headers:
             Content-Length:
-                - "949"
+                - "239"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:34:01 GMT
+                - Wed, 27 Aug 2025 15:06:14 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -936,48 +936,46 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fb97231f-0094-4050-a28a-441c08012852
+                - 15fb0293-fc0b-4cae-8b57-c13908c0cfd4
         status: 200 OK
         code: 200
-        duration: 86.893083ms
+        duration: 86.340368ms
     - id: 19
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 117
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"hostname":"container.container-basic.scaleway-terraform.com","container_id":"15f70a78-78fb-4ed1-a2cc-7cc9c7cfc366"}'
+        body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/domains
-        method: POST
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zones=container-basic.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 215
+        content_length: 357
         uncompressed: false
-        body: '{"container_id":"15f70a78-78fb-4ed1-a2cc-7cc9c7cfc366","error_message":null,"hostname":"container.container-basic.scaleway-terraform.com","id":"36d19db5-73d8-46e3-bf3e-5ed8ad4c9b9f","status":"pending","url":""}'
+        body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"container-basic","updated_at":"2025-08-27T15:06:14Z"}],"total_count":1}'
         headers:
             Content-Length:
-                - "215"
+                - "357"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:34:06 GMT
+                - Wed, 27 Aug 2025 15:06:14 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -987,10 +985,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 490a4043-ebdb-4b2f-be74-b04086b8212a
+                - b553f921-0b7d-4352-a7e1-ef7572b66a14
         status: 200 OK
         code: 200
-        duration: 114.728417ms
+        duration: 88.231307ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1006,8 +1004,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/domains/36d19db5-73d8-46e3-bf3e-5ed8ad4c9b9f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/9822575a-a230-47ab-96e5-ac82fcb42849
         method: GET
       response:
         proto: HTTP/2.0
@@ -1015,18 +1013,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 215
+        content_length: 922
         uncompressed: false
-        body: '{"container_id":"15f70a78-78fb-4ed1-a2cc-7cc9c7cfc366","error_message":null,"hostname":"container.container-basic.scaleway-terraform.com","id":"36d19db5-73d8-46e3-bf3e-5ed8ad4c9b9f","status":"pending","url":""}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:58.583265Z","description":"","domain_name":"tfnsstrangewilsonhbofpena-tf-co-dazzling-cartwright.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"9822575a-a230-47ab-96e5-ac82fcb42849","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-dazzling-cartwright","namespace_id":"97800be4-3f61-4f2e-b568-790018772ed1","port":80,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":"2025-08-27T15:06:10.272896Z","region":"fr-par","registry_image":"nginx:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"ready","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:10.282216Z"}'
         headers:
             Content-Length:
-                - "215"
+                - "922"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:34:06 GMT
+                - Wed, 27 Aug 2025 15:06:14 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -1036,46 +1034,48 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a3ecb5f6-1fa4-4b84-8fa2-a68421c61998
+                - 239acad0-0521-47fe-9103-2c5e05f65392
         status: 200 OK
         code: 200
-        duration: 92.690958ms
+        duration: 93.941622ms
     - id: 21
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 117
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"hostname":"container.container-basic.scaleway-terraform.com","container_id":"9822575a-a230-47ab-96e5-ac82fcb42849"}'
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/domains/36d19db5-73d8-46e3-bf3e-5ed8ad4c9b9f
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/domains
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 215
+        content_length: 210
         uncompressed: false
-        body: '{"container_id":"15f70a78-78fb-4ed1-a2cc-7cc9c7cfc366","error_message":null,"hostname":"container.container-basic.scaleway-terraform.com","id":"36d19db5-73d8-46e3-bf3e-5ed8ad4c9b9f","status":"pending","url":""}'
+        body: '{"container_id":"9822575a-a230-47ab-96e5-ac82fcb42849","error_message":null,"hostname":"container.container-basic.scaleway-terraform.com","id":"cd5bc7a5-c035-4897-886e-5f6cc5838d59","status":"pending","url":""}'
         headers:
             Content-Length:
-                - "215"
+                - "210"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:34:11 GMT
+                - Wed, 27 Aug 2025 15:06:20 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -1085,10 +1085,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cb554778-7e55-4156-b9fb-851645c51a0d
+                - 5dde0196-f827-40a1-800a-934720fb5ba3
         status: 200 OK
         code: 200
-        duration: 147.073416ms
+        duration: 118.619984ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1104,8 +1104,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/domains/36d19db5-73d8-46e3-bf3e-5ed8ad4c9b9f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/domains/cd5bc7a5-c035-4897-886e-5f6cc5838d59
         method: GET
       response:
         proto: HTTP/2.0
@@ -1113,18 +1113,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 269
+        content_length: 210
         uncompressed: false
-        body: '{"container_id":"15f70a78-78fb-4ed1-a2cc-7cc9c7cfc366","error_message":null,"hostname":"container.container-basic.scaleway-terraform.com","id":"36d19db5-73d8-46e3-bf3e-5ed8ad4c9b9f","status":"ready","url":"https://container.container-basic.scaleway-terraform.com"}'
+        body: '{"container_id":"9822575a-a230-47ab-96e5-ac82fcb42849","error_message":null,"hostname":"container.container-basic.scaleway-terraform.com","id":"cd5bc7a5-c035-4897-886e-5f6cc5838d59","status":"pending","url":""}'
         headers:
             Content-Length:
-                - "269"
+                - "210"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:34:17 GMT
+                - Wed, 27 Aug 2025 15:06:20 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -1134,10 +1134,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cef916fa-40f1-4fcb-868a-ead1cb8441a2
+                - a3e843df-f0fd-4a51-81d9-c72a01548c26
         status: 200 OK
         code: 200
-        duration: 98.391208ms
+        duration: 98.732393ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1153,8 +1153,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/domains/36d19db5-73d8-46e3-bf3e-5ed8ad4c9b9f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/domains/cd5bc7a5-c035-4897-886e-5f6cc5838d59
         method: GET
       response:
         proto: HTTP/2.0
@@ -1162,18 +1162,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 269
+        content_length: 210
         uncompressed: false
-        body: '{"container_id":"15f70a78-78fb-4ed1-a2cc-7cc9c7cfc366","error_message":null,"hostname":"container.container-basic.scaleway-terraform.com","id":"36d19db5-73d8-46e3-bf3e-5ed8ad4c9b9f","status":"ready","url":"https://container.container-basic.scaleway-terraform.com"}'
+        body: '{"container_id":"9822575a-a230-47ab-96e5-ac82fcb42849","error_message":null,"hostname":"container.container-basic.scaleway-terraform.com","id":"cd5bc7a5-c035-4897-886e-5f6cc5838d59","status":"pending","url":""}'
         headers:
             Content-Length:
-                - "269"
+                - "210"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:34:17 GMT
+                - Wed, 27 Aug 2025 15:06:25 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -1183,10 +1183,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 480e60ce-4d7b-41af-91fb-2029354da6f6
+                - 563bc9c1-a13f-43bc-8a72-621a7c80ccbd
         status: 200 OK
         code: 200
-        duration: 97.249708ms
+        duration: 110.940305ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1202,8 +1202,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/domains/36d19db5-73d8-46e3-bf3e-5ed8ad4c9b9f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/domains/cd5bc7a5-c035-4897-886e-5f6cc5838d59
         method: GET
       response:
         proto: HTTP/2.0
@@ -1211,18 +1211,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 269
+        content_length: 210
         uncompressed: false
-        body: '{"container_id":"15f70a78-78fb-4ed1-a2cc-7cc9c7cfc366","error_message":null,"hostname":"container.container-basic.scaleway-terraform.com","id":"36d19db5-73d8-46e3-bf3e-5ed8ad4c9b9f","status":"ready","url":"https://container.container-basic.scaleway-terraform.com"}'
+        body: '{"container_id":"9822575a-a230-47ab-96e5-ac82fcb42849","error_message":null,"hostname":"container.container-basic.scaleway-terraform.com","id":"cd5bc7a5-c035-4897-886e-5f6cc5838d59","status":"pending","url":""}'
         headers:
             Content-Length:
-                - "269"
+                - "210"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:34:17 GMT
+                - Wed, 27 Aug 2025 15:06:30 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -1232,10 +1232,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8a3b9f9c-0dac-4821-ad88-863895e33b7b
+                - 1dea500e-cd19-49a5-993e-fa6143446c3c
         status: 200 OK
         code: 200
-        duration: 153.504584ms
+        duration: 98.826594ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1251,8 +1251,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/bda727d4-9d0b-4b1f-9802-6db82804e02c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/domains/cd5bc7a5-c035-4897-886e-5f6cc5838d59
         method: GET
       response:
         proto: HTTP/2.0
@@ -1260,18 +1260,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 605
+        content_length: 210
         uncompressed: false
-        body: '{"created_at":"2025-06-11T12:33:38.809871Z","description":"","environment_variables":{},"error_message":null,"id":"bda727d4-9d0b-4b1f-9802-6db82804e02c","name":"tf-ns-musing-ramanujan","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsmusingramanujanpkpx1suc","registry_namespace_id":"3fabe0f3-47bf-4c53-a0f5-9c352bb9653c","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-11T12:33:43.385729Z","vpc_integration_activated":false}'
+        body: '{"container_id":"9822575a-a230-47ab-96e5-ac82fcb42849","error_message":null,"hostname":"container.container-basic.scaleway-terraform.com","id":"cd5bc7a5-c035-4897-886e-5f6cc5838d59","status":"pending","url":""}'
         headers:
             Content-Length:
-                - "605"
+                - "210"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:34:17 GMT
+                - Wed, 27 Aug 2025 15:06:35 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -1281,10 +1281,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c4541dd9-e178-4270-981f-4322d4ed7f9c
+                - b9aa24e5-9b48-4c1d-a65f-794dcb91d896
         status: 200 OK
         code: 200
-        duration: 70.168625ms
+        duration: 92.391409ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1300,8 +1300,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/15f70a78-78fb-4ed1-a2cc-7cc9c7cfc366
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/domains/cd5bc7a5-c035-4897-886e-5f6cc5838d59
         method: GET
       response:
         proto: HTTP/2.0
@@ -1309,18 +1309,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 949
+        content_length: 210
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-11T12:33:44.733303Z","description":"","domain_name":"tfnsmusingramanujanpkpx1suc-tf-co-trusting-wilbur.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"15f70a78-78fb-4ed1-a2cc-7cc9c7cfc366","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-trusting-wilbur","namespace_id":"bda727d4-9d0b-4b1f-9802-6db82804e02c","port":80,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":"2025-06-11T12:33:58.858933Z","region":"fr-par","registry_image":"nginx:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"ready","tags":[],"timeout":"300s","updated_at":"2025-06-11T12:33:58.872318Z"}'
+        body: '{"container_id":"9822575a-a230-47ab-96e5-ac82fcb42849","error_message":null,"hostname":"container.container-basic.scaleway-terraform.com","id":"cd5bc7a5-c035-4897-886e-5f6cc5838d59","status":"pending","url":""}'
         headers:
             Content-Length:
-                - "949"
+                - "210"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:34:17 GMT
+                - Wed, 27 Aug 2025 15:06:40 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -1330,10 +1330,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b06d3717-c22e-4386-b52f-53d5988594e7
+                - 7d22e29d-4211-4a50-805a-91386dd9c5b6
         status: 200 OK
         code: 200
-        duration: 91.756459ms
+        duration: 106.584264ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1349,8 +1349,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/domain/v2beta1/dns-zones/container-basic.scaleway-terraform.com/records?id=c12aeb73-838a-46ab-a445-a5b8e3d35ea6&name=container&order_by=name_asc&page=1&type=CNAME
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/domains/cd5bc7a5-c035-4897-886e-5f6cc5838d59
         method: GET
       response:
         proto: HTTP/2.0
@@ -1358,18 +1358,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 244
+        content_length: 210
         uncompressed: false
-        body: '{"records":[{"comment":null,"data":"tfnsmusingramanujanpkpx1suc-tf-co-trusting-wilbur.functions.fnc.fr-par.scw.cloud.","id":"c12aeb73-838a-46ab-a445-a5b8e3d35ea6","name":"container","priority":0,"ttl":60,"type":"CNAME"}],"total_count":1}'
+        body: '{"container_id":"9822575a-a230-47ab-96e5-ac82fcb42849","error_message":null,"hostname":"container.container-basic.scaleway-terraform.com","id":"cd5bc7a5-c035-4897-886e-5f6cc5838d59","status":"pending","url":""}'
         headers:
             Content-Length:
-                - "244"
+                - "210"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:34:17 GMT
+                - Wed, 27 Aug 2025 15:06:45 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -1379,10 +1379,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 71840852-f091-4989-9fc1-7b1e774d6dfe
+                - 96bcb7ea-6641-44f5-9c6b-6138703fdea6
         status: 200 OK
         code: 200
-        duration: 90.236209ms
+        duration: 89.575899ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1398,8 +1398,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zones=container-basic.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/domains/cd5bc7a5-c035-4897-886e-5f6cc5838d59
         method: GET
       response:
         proto: HTTP/2.0
@@ -1407,18 +1407,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 368
+        content_length: 210
         uncompressed: false
-        body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"container-basic","updated_at":"2025-06-11T12:34:05Z"}],"total_count":1}'
+        body: '{"container_id":"9822575a-a230-47ab-96e5-ac82fcb42849","error_message":null,"hostname":"container.container-basic.scaleway-terraform.com","id":"cd5bc7a5-c035-4897-886e-5f6cc5838d59","status":"pending","url":""}'
         headers:
             Content-Length:
-                - "368"
+                - "210"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:34:17 GMT
+                - Wed, 27 Aug 2025 15:06:50 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -1428,10 +1428,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c0419187-cffa-4777-afca-b272f56e1791
+                - e9db92f8-e28c-4e6f-881f-4dc1272f223a
         status: 200 OK
         code: 200
-        duration: 85.176917ms
+        duration: 93.345824ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1447,8 +1447,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/domains/36d19db5-73d8-46e3-bf3e-5ed8ad4c9b9f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/domains/cd5bc7a5-c035-4897-886e-5f6cc5838d59
         method: GET
       response:
         proto: HTTP/2.0
@@ -1456,18 +1456,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 269
+        content_length: 210
         uncompressed: false
-        body: '{"container_id":"15f70a78-78fb-4ed1-a2cc-7cc9c7cfc366","error_message":null,"hostname":"container.container-basic.scaleway-terraform.com","id":"36d19db5-73d8-46e3-bf3e-5ed8ad4c9b9f","status":"ready","url":"https://container.container-basic.scaleway-terraform.com"}'
+        body: '{"container_id":"9822575a-a230-47ab-96e5-ac82fcb42849","error_message":null,"hostname":"container.container-basic.scaleway-terraform.com","id":"cd5bc7a5-c035-4897-886e-5f6cc5838d59","status":"pending","url":""}'
         headers:
             Content-Length:
-                - "269"
+                - "210"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:34:18 GMT
+                - Wed, 27 Aug 2025 15:06:55 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -1477,10 +1477,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - edb45651-0928-496d-a9f2-a5409f90d5ac
+                - c5e11742-4bf5-47e5-bcec-226c4da541a6
         status: 200 OK
         code: 200
-        duration: 93.501167ms
+        duration: 116.821051ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1496,8 +1496,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/domains/36d19db5-73d8-46e3-bf3e-5ed8ad4c9b9f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/domains/cd5bc7a5-c035-4897-886e-5f6cc5838d59
         method: GET
       response:
         proto: HTTP/2.0
@@ -1505,18 +1505,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 269
+        content_length: 210
         uncompressed: false
-        body: '{"container_id":"15f70a78-78fb-4ed1-a2cc-7cc9c7cfc366","error_message":null,"hostname":"container.container-basic.scaleway-terraform.com","id":"36d19db5-73d8-46e3-bf3e-5ed8ad4c9b9f","status":"ready","url":"https://container.container-basic.scaleway-terraform.com"}'
+        body: '{"container_id":"9822575a-a230-47ab-96e5-ac82fcb42849","error_message":null,"hostname":"container.container-basic.scaleway-terraform.com","id":"cd5bc7a5-c035-4897-886e-5f6cc5838d59","status":"pending","url":""}'
         headers:
             Content-Length:
-                - "269"
+                - "210"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:34:18 GMT
+                - Wed, 27 Aug 2025 15:07:01 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -1526,10 +1526,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 418babad-aaae-49a3-affd-c685e4377b3c
+                - 2b7ade85-ff43-4f72-82cd-6d03ed9c6612
         status: 200 OK
         code: 200
-        duration: 99.008417ms
+        duration: 79.329777ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1545,27 +1545,27 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/domains/36d19db5-73d8-46e3-bf3e-5ed8ad4c9b9f
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/domains/cd5bc7a5-c035-4897-886e-5f6cc5838d59
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 272
+        content_length: 210
         uncompressed: false
-        body: '{"container_id":"15f70a78-78fb-4ed1-a2cc-7cc9c7cfc366","error_message":null,"hostname":"container.container-basic.scaleway-terraform.com","id":"36d19db5-73d8-46e3-bf3e-5ed8ad4c9b9f","status":"deleting","url":"https://container.container-basic.scaleway-terraform.com"}'
+        body: '{"container_id":"9822575a-a230-47ab-96e5-ac82fcb42849","error_message":null,"hostname":"container.container-basic.scaleway-terraform.com","id":"cd5bc7a5-c035-4897-886e-5f6cc5838d59","status":"pending","url":""}'
         headers:
             Content-Length:
-                - "272"
+                - "210"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:34:18 GMT
+                - Wed, 27 Aug 2025 15:07:06 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -1575,11 +1575,1775 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 557d1a86-8d99-48ff-be0e-c68e39af145e
+                - 4465feb6-7425-48d2-bfe1-eb8df193b9d3
         status: 200 OK
         code: 200
-        duration: 106.186583ms
+        duration: 112.55047ms
     - id: 32
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/domains/cd5bc7a5-c035-4897-886e-5f6cc5838d59
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 210
+        uncompressed: false
+        body: '{"container_id":"9822575a-a230-47ab-96e5-ac82fcb42849","error_message":null,"hostname":"container.container-basic.scaleway-terraform.com","id":"cd5bc7a5-c035-4897-886e-5f6cc5838d59","status":"pending","url":""}'
+        headers:
+            Content-Length:
+                - "210"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:07:11 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f2037471-fa91-4c85-b9c4-55f4dddecfd1
+        status: 200 OK
+        code: 200
+        duration: 97.786353ms
+    - id: 33
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/domains/cd5bc7a5-c035-4897-886e-5f6cc5838d59
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 210
+        uncompressed: false
+        body: '{"container_id":"9822575a-a230-47ab-96e5-ac82fcb42849","error_message":null,"hostname":"container.container-basic.scaleway-terraform.com","id":"cd5bc7a5-c035-4897-886e-5f6cc5838d59","status":"pending","url":""}'
+        headers:
+            Content-Length:
+                - "210"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:07:16 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 289f79a2-f925-4839-818a-67914d871661
+        status: 200 OK
+        code: 200
+        duration: 102.855619ms
+    - id: 34
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/domains/cd5bc7a5-c035-4897-886e-5f6cc5838d59
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 210
+        uncompressed: false
+        body: '{"container_id":"9822575a-a230-47ab-96e5-ac82fcb42849","error_message":null,"hostname":"container.container-basic.scaleway-terraform.com","id":"cd5bc7a5-c035-4897-886e-5f6cc5838d59","status":"pending","url":""}'
+        headers:
+            Content-Length:
+                - "210"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:07:21 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 0c7d6b6f-3032-413f-9e4c-8c27ab933c1c
+        status: 200 OK
+        code: 200
+        duration: 115.877107ms
+    - id: 35
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/domains/cd5bc7a5-c035-4897-886e-5f6cc5838d59
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 210
+        uncompressed: false
+        body: '{"container_id":"9822575a-a230-47ab-96e5-ac82fcb42849","error_message":null,"hostname":"container.container-basic.scaleway-terraform.com","id":"cd5bc7a5-c035-4897-886e-5f6cc5838d59","status":"pending","url":""}'
+        headers:
+            Content-Length:
+                - "210"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:07:26 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 4d913d4f-ef95-4a80-9f08-6cedadcfcaf1
+        status: 200 OK
+        code: 200
+        duration: 109.991654ms
+    - id: 36
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/domains/cd5bc7a5-c035-4897-886e-5f6cc5838d59
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 210
+        uncompressed: false
+        body: '{"container_id":"9822575a-a230-47ab-96e5-ac82fcb42849","error_message":null,"hostname":"container.container-basic.scaleway-terraform.com","id":"cd5bc7a5-c035-4897-886e-5f6cc5838d59","status":"pending","url":""}'
+        headers:
+            Content-Length:
+                - "210"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:07:31 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 716f7b96-39cf-4288-92ff-d31e53ea43be
+        status: 200 OK
+        code: 200
+        duration: 93.327541ms
+    - id: 37
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/domains/cd5bc7a5-c035-4897-886e-5f6cc5838d59
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 210
+        uncompressed: false
+        body: '{"container_id":"9822575a-a230-47ab-96e5-ac82fcb42849","error_message":null,"hostname":"container.container-basic.scaleway-terraform.com","id":"cd5bc7a5-c035-4897-886e-5f6cc5838d59","status":"pending","url":""}'
+        headers:
+            Content-Length:
+                - "210"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:07:36 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - fef8f3f8-3a4a-4814-8ec5-74fc40114794
+        status: 200 OK
+        code: 200
+        duration: 101.53761ms
+    - id: 38
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/domains/cd5bc7a5-c035-4897-886e-5f6cc5838d59
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 210
+        uncompressed: false
+        body: '{"container_id":"9822575a-a230-47ab-96e5-ac82fcb42849","error_message":null,"hostname":"container.container-basic.scaleway-terraform.com","id":"cd5bc7a5-c035-4897-886e-5f6cc5838d59","status":"pending","url":""}'
+        headers:
+            Content-Length:
+                - "210"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:07:41 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 8c2d95e2-e577-4251-a84d-e8b6d6cc3e97
+        status: 200 OK
+        code: 200
+        duration: 97.128508ms
+    - id: 39
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/domains/cd5bc7a5-c035-4897-886e-5f6cc5838d59
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 210
+        uncompressed: false
+        body: '{"container_id":"9822575a-a230-47ab-96e5-ac82fcb42849","error_message":null,"hostname":"container.container-basic.scaleway-terraform.com","id":"cd5bc7a5-c035-4897-886e-5f6cc5838d59","status":"pending","url":""}'
+        headers:
+            Content-Length:
+                - "210"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:07:46 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 25808ea6-b683-4077-b064-635ea55760ec
+        status: 200 OK
+        code: 200
+        duration: 92.912555ms
+    - id: 40
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/domains/cd5bc7a5-c035-4897-886e-5f6cc5838d59
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 210
+        uncompressed: false
+        body: '{"container_id":"9822575a-a230-47ab-96e5-ac82fcb42849","error_message":null,"hostname":"container.container-basic.scaleway-terraform.com","id":"cd5bc7a5-c035-4897-886e-5f6cc5838d59","status":"pending","url":""}'
+        headers:
+            Content-Length:
+                - "210"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:07:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 7ed83ae7-cfa5-46e6-9d98-3d7b5036a714
+        status: 200 OK
+        code: 200
+        duration: 94.631052ms
+    - id: 41
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/domains/cd5bc7a5-c035-4897-886e-5f6cc5838d59
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 210
+        uncompressed: false
+        body: '{"container_id":"9822575a-a230-47ab-96e5-ac82fcb42849","error_message":null,"hostname":"container.container-basic.scaleway-terraform.com","id":"cd5bc7a5-c035-4897-886e-5f6cc5838d59","status":"pending","url":""}'
+        headers:
+            Content-Length:
+                - "210"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:07:57 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 0ec202cb-d8ad-4591-978f-2fd2f3ebb3eb
+        status: 200 OK
+        code: 200
+        duration: 94.002203ms
+    - id: 42
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/domains/cd5bc7a5-c035-4897-886e-5f6cc5838d59
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 210
+        uncompressed: false
+        body: '{"container_id":"9822575a-a230-47ab-96e5-ac82fcb42849","error_message":null,"hostname":"container.container-basic.scaleway-terraform.com","id":"cd5bc7a5-c035-4897-886e-5f6cc5838d59","status":"pending","url":""}'
+        headers:
+            Content-Length:
+                - "210"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:08:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f2cd644d-52ae-4844-92c2-4974e8161ebd
+        status: 200 OK
+        code: 200
+        duration: 110.850365ms
+    - id: 43
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/domains/cd5bc7a5-c035-4897-886e-5f6cc5838d59
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 210
+        uncompressed: false
+        body: '{"container_id":"9822575a-a230-47ab-96e5-ac82fcb42849","error_message":null,"hostname":"container.container-basic.scaleway-terraform.com","id":"cd5bc7a5-c035-4897-886e-5f6cc5838d59","status":"pending","url":""}'
+        headers:
+            Content-Length:
+                - "210"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:08:07 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - dae65b81-2b5b-46d8-b955-81ff3742efbb
+        status: 200 OK
+        code: 200
+        duration: 110.331362ms
+    - id: 44
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/domains/cd5bc7a5-c035-4897-886e-5f6cc5838d59
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 210
+        uncompressed: false
+        body: '{"container_id":"9822575a-a230-47ab-96e5-ac82fcb42849","error_message":null,"hostname":"container.container-basic.scaleway-terraform.com","id":"cd5bc7a5-c035-4897-886e-5f6cc5838d59","status":"pending","url":""}'
+        headers:
+            Content-Length:
+                - "210"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:08:12 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b38d4d86-fbe0-47a1-866b-81d80c32ff55
+        status: 200 OK
+        code: 200
+        duration: 100.808191ms
+    - id: 45
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/domains/cd5bc7a5-c035-4897-886e-5f6cc5838d59
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 210
+        uncompressed: false
+        body: '{"container_id":"9822575a-a230-47ab-96e5-ac82fcb42849","error_message":null,"hostname":"container.container-basic.scaleway-terraform.com","id":"cd5bc7a5-c035-4897-886e-5f6cc5838d59","status":"pending","url":""}'
+        headers:
+            Content-Length:
+                - "210"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:08:17 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 728ab8d4-313e-419f-afbb-091b15c71c9e
+        status: 200 OK
+        code: 200
+        duration: 93.136192ms
+    - id: 46
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/domains/cd5bc7a5-c035-4897-886e-5f6cc5838d59
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 210
+        uncompressed: false
+        body: '{"container_id":"9822575a-a230-47ab-96e5-ac82fcb42849","error_message":null,"hostname":"container.container-basic.scaleway-terraform.com","id":"cd5bc7a5-c035-4897-886e-5f6cc5838d59","status":"pending","url":""}'
+        headers:
+            Content-Length:
+                - "210"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:08:22 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 617c3b1a-a48e-4255-8247-2be1df97a35c
+        status: 200 OK
+        code: 200
+        duration: 87.350174ms
+    - id: 47
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/domains/cd5bc7a5-c035-4897-886e-5f6cc5838d59
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 210
+        uncompressed: false
+        body: '{"container_id":"9822575a-a230-47ab-96e5-ac82fcb42849","error_message":null,"hostname":"container.container-basic.scaleway-terraform.com","id":"cd5bc7a5-c035-4897-886e-5f6cc5838d59","status":"pending","url":""}'
+        headers:
+            Content-Length:
+                - "210"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:08:27 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 94c839db-b67a-43e9-8cd3-e723962beab3
+        status: 200 OK
+        code: 200
+        duration: 86.928986ms
+    - id: 48
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/domains/cd5bc7a5-c035-4897-886e-5f6cc5838d59
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 210
+        uncompressed: false
+        body: '{"container_id":"9822575a-a230-47ab-96e5-ac82fcb42849","error_message":null,"hostname":"container.container-basic.scaleway-terraform.com","id":"cd5bc7a5-c035-4897-886e-5f6cc5838d59","status":"pending","url":""}'
+        headers:
+            Content-Length:
+                - "210"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:08:32 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 4cbf0136-37fb-4e8b-b43f-5c2eeac97ff0
+        status: 200 OK
+        code: 200
+        duration: 114.758638ms
+    - id: 49
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/domains/cd5bc7a5-c035-4897-886e-5f6cc5838d59
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 210
+        uncompressed: false
+        body: '{"container_id":"9822575a-a230-47ab-96e5-ac82fcb42849","error_message":null,"hostname":"container.container-basic.scaleway-terraform.com","id":"cd5bc7a5-c035-4897-886e-5f6cc5838d59","status":"pending","url":""}'
+        headers:
+            Content-Length:
+                - "210"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:08:38 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - fd2a6fe2-5a62-4dc3-8c06-4830fb367ab3
+        status: 200 OK
+        code: 200
+        duration: 91.623448ms
+    - id: 50
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/domains/cd5bc7a5-c035-4897-886e-5f6cc5838d59
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 210
+        uncompressed: false
+        body: '{"container_id":"9822575a-a230-47ab-96e5-ac82fcb42849","error_message":null,"hostname":"container.container-basic.scaleway-terraform.com","id":"cd5bc7a5-c035-4897-886e-5f6cc5838d59","status":"pending","url":""}'
+        headers:
+            Content-Length:
+                - "210"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:08:43 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 38237e5f-c4ea-4937-811e-ee88be8a7b16
+        status: 200 OK
+        code: 200
+        duration: 116.224744ms
+    - id: 51
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/domains/cd5bc7a5-c035-4897-886e-5f6cc5838d59
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 210
+        uncompressed: false
+        body: '{"container_id":"9822575a-a230-47ab-96e5-ac82fcb42849","error_message":null,"hostname":"container.container-basic.scaleway-terraform.com","id":"cd5bc7a5-c035-4897-886e-5f6cc5838d59","status":"pending","url":""}'
+        headers:
+            Content-Length:
+                - "210"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:08:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - d8a2868f-51ab-4472-a7df-8825d9fafad0
+        status: 200 OK
+        code: 200
+        duration: 235.236351ms
+    - id: 52
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/domains/cd5bc7a5-c035-4897-886e-5f6cc5838d59
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 210
+        uncompressed: false
+        body: '{"container_id":"9822575a-a230-47ab-96e5-ac82fcb42849","error_message":null,"hostname":"container.container-basic.scaleway-terraform.com","id":"cd5bc7a5-c035-4897-886e-5f6cc5838d59","status":"pending","url":""}'
+        headers:
+            Content-Length:
+                - "210"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:08:53 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e0023613-7d62-42d4-bd96-4d32169cf7db
+        status: 200 OK
+        code: 200
+        duration: 112.071882ms
+    - id: 53
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/domains/cd5bc7a5-c035-4897-886e-5f6cc5838d59
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 210
+        uncompressed: false
+        body: '{"container_id":"9822575a-a230-47ab-96e5-ac82fcb42849","error_message":null,"hostname":"container.container-basic.scaleway-terraform.com","id":"cd5bc7a5-c035-4897-886e-5f6cc5838d59","status":"pending","url":""}'
+        headers:
+            Content-Length:
+                - "210"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:08:58 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 54812f6a-5cb8-4be8-89ba-1694e6cd757b
+        status: 200 OK
+        code: 200
+        duration: 124.86751ms
+    - id: 54
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/domains/cd5bc7a5-c035-4897-886e-5f6cc5838d59
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 210
+        uncompressed: false
+        body: '{"container_id":"9822575a-a230-47ab-96e5-ac82fcb42849","error_message":null,"hostname":"container.container-basic.scaleway-terraform.com","id":"cd5bc7a5-c035-4897-886e-5f6cc5838d59","status":"pending","url":""}'
+        headers:
+            Content-Length:
+                - "210"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:09:03 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 21c271b0-a4ff-40ee-9f11-9cd608d01f59
+        status: 200 OK
+        code: 200
+        duration: 114.232659ms
+    - id: 55
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/domains/cd5bc7a5-c035-4897-886e-5f6cc5838d59
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 210
+        uncompressed: false
+        body: '{"container_id":"9822575a-a230-47ab-96e5-ac82fcb42849","error_message":null,"hostname":"container.container-basic.scaleway-terraform.com","id":"cd5bc7a5-c035-4897-886e-5f6cc5838d59","status":"pending","url":""}'
+        headers:
+            Content-Length:
+                - "210"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:09:08 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ad904b0c-d3a2-429f-88d1-fffee0920795
+        status: 200 OK
+        code: 200
+        duration: 97.774469ms
+    - id: 56
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/domains/cd5bc7a5-c035-4897-886e-5f6cc5838d59
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 210
+        uncompressed: false
+        body: '{"container_id":"9822575a-a230-47ab-96e5-ac82fcb42849","error_message":null,"hostname":"container.container-basic.scaleway-terraform.com","id":"cd5bc7a5-c035-4897-886e-5f6cc5838d59","status":"pending","url":""}'
+        headers:
+            Content-Length:
+                - "210"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:09:13 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 842e6a69-9dcf-4f39-bbaa-4d66bf84c16e
+        status: 200 OK
+        code: 200
+        duration: 221.725625ms
+    - id: 57
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/domains/cd5bc7a5-c035-4897-886e-5f6cc5838d59
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 210
+        uncompressed: false
+        body: '{"container_id":"9822575a-a230-47ab-96e5-ac82fcb42849","error_message":null,"hostname":"container.container-basic.scaleway-terraform.com","id":"cd5bc7a5-c035-4897-886e-5f6cc5838d59","status":"pending","url":""}'
+        headers:
+            Content-Length:
+                - "210"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:09:19 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 37d97938-ba56-4db3-8815-b015f472a26b
+        status: 200 OK
+        code: 200
+        duration: 123.907654ms
+    - id: 58
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/domains/cd5bc7a5-c035-4897-886e-5f6cc5838d59
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 383
+        uncompressed: false
+        body: '{"container_id":"9822575a-a230-47ab-96e5-ac82fcb42849","error_message":"failed to create domain: check that the domain correctly points to the container URL (https://tfnsstrangewilsonhbofpena-tf-co-dazzling-cartwright.functions.fnc.fr-par.scw.cloud)","hostname":"container.container-basic.scaleway-terraform.com","id":"cd5bc7a5-c035-4897-886e-5f6cc5838d59","status":"error","url":""}'
+        headers:
+            Content-Length:
+                - "383"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:09:24 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3ee60177-9a17-4ebe-841b-dedc5d8787da
+        status: 200 OK
+        code: 200
+        duration: 106.57407ms
+    - id: 59
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/domains/cd5bc7a5-c035-4897-886e-5f6cc5838d59
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 383
+        uncompressed: false
+        body: '{"container_id":"9822575a-a230-47ab-96e5-ac82fcb42849","error_message":"failed to create domain: check that the domain correctly points to the container URL (https://tfnsstrangewilsonhbofpena-tf-co-dazzling-cartwright.functions.fnc.fr-par.scw.cloud)","hostname":"container.container-basic.scaleway-terraform.com","id":"cd5bc7a5-c035-4897-886e-5f6cc5838d59","status":"error","url":""}'
+        headers:
+            Content-Length:
+                - "383"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:09:24 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 75321019-574e-42ec-97f5-f2e86b3fbba7
+        status: 200 OK
+        code: 200
+        duration: 102.741205ms
+    - id: 60
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/domains/cd5bc7a5-c035-4897-886e-5f6cc5838d59
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 383
+        uncompressed: false
+        body: '{"container_id":"9822575a-a230-47ab-96e5-ac82fcb42849","error_message":"failed to create domain: check that the domain correctly points to the container URL (https://tfnsstrangewilsonhbofpena-tf-co-dazzling-cartwright.functions.fnc.fr-par.scw.cloud)","hostname":"container.container-basic.scaleway-terraform.com","id":"cd5bc7a5-c035-4897-886e-5f6cc5838d59","status":"error","url":""}'
+        headers:
+            Content-Length:
+                - "383"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:09:24 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 21d739f9-765a-401e-942a-8dc660cc9914
+        status: 200 OK
+        code: 200
+        duration: 100.26061ms
+    - id: 61
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/97800be4-3f61-4f2e-b568-790018772ed1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 585
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:41.286324Z","description":"","environment_variables":{},"error_message":null,"id":"97800be4-3f61-4f2e-b568-790018772ed1","name":"tf-ns-strange-wilson","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsstrangewilsonhbofpena","registry_namespace_id":"196bf838-61df-41bf-98c6-ad78b741053a","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:52.556806Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "585"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:09:24 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - a5bd6cee-e857-4c82-beb0-d72d6498ae3b
+        status: 200 OK
+        code: 200
+        duration: 77.007884ms
+    - id: 62
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/9822575a-a230-47ab-96e5-ac82fcb42849
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 922
+        uncompressed: false
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:58.583265Z","description":"","domain_name":"tfnsstrangewilsonhbofpena-tf-co-dazzling-cartwright.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"9822575a-a230-47ab-96e5-ac82fcb42849","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-dazzling-cartwright","namespace_id":"97800be4-3f61-4f2e-b568-790018772ed1","port":80,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":"2025-08-27T15:06:10.272896Z","region":"fr-par","registry_image":"nginx:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"ready","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:10.282216Z"}'
+        headers:
+            Content-Length:
+                - "922"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:09:25 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - a0cdfc9d-b933-49e8-808a-34a5b9d8d552
+        status: 200 OK
+        code: 200
+        duration: 90.193814ms
+    - id: 63
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/domain/v2beta1/dns-zones/container-basic.scaleway-terraform.com/records?id=74837750-e0d6-40d2-a1c1-946d35c2c81d&name=container&order_by=name_asc&page=1&type=CNAME
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 239
+        uncompressed: false
+        body: '{"records":[{"comment":null,"data":"tfnsstrangewilsonhbofpena-tf-co-dazzling-cartwright.functions.fnc.fr-par.scw.cloud.","id":"74837750-e0d6-40d2-a1c1-946d35c2c81d","name":"container","priority":0,"ttl":60,"type":"CNAME"}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "239"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:09:25 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 73ef6ffe-58a8-45dc-88cc-55e9b2160dcd
+        status: 200 OK
+        code: 200
+        duration: 95.91901ms
+    - id: 64
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zones=container-basic.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 356
+        uncompressed: false
+        body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"container-basic","updated_at":"2025-08-27T15:06:34Z"}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "356"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:09:25 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - af752e45-c4ff-450a-9f96-b2ceb7949884
+        status: 200 OK
+        code: 200
+        duration: 83.114988ms
+    - id: 65
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/domains/cd5bc7a5-c035-4897-886e-5f6cc5838d59
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 383
+        uncompressed: false
+        body: '{"container_id":"9822575a-a230-47ab-96e5-ac82fcb42849","error_message":"failed to create domain: check that the domain correctly points to the container URL (https://tfnsstrangewilsonhbofpena-tf-co-dazzling-cartwright.functions.fnc.fr-par.scw.cloud)","hostname":"container.container-basic.scaleway-terraform.com","id":"cd5bc7a5-c035-4897-886e-5f6cc5838d59","status":"error","url":""}'
+        headers:
+            Content-Length:
+                - "383"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:09:25 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 39a50815-775f-450a-ad6c-fda36b347a77
+        status: 200 OK
+        code: 200
+        duration: 102.57849ms
+    - id: 66
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/domains/cd5bc7a5-c035-4897-886e-5f6cc5838d59
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 383
+        uncompressed: false
+        body: '{"container_id":"9822575a-a230-47ab-96e5-ac82fcb42849","error_message":"failed to create domain: check that the domain correctly points to the container URL (https://tfnsstrangewilsonhbofpena-tf-co-dazzling-cartwright.functions.fnc.fr-par.scw.cloud)","hostname":"container.container-basic.scaleway-terraform.com","id":"cd5bc7a5-c035-4897-886e-5f6cc5838d59","status":"error","url":""}'
+        headers:
+            Content-Length:
+                - "383"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:09:25 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f792b3ad-6fd2-4d47-8ba1-9a3b09348d2b
+        status: 200 OK
+        code: 200
+        duration: 103.427995ms
+    - id: 67
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/domains/cd5bc7a5-c035-4897-886e-5f6cc5838d59
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 211
+        uncompressed: false
+        body: '{"container_id":"9822575a-a230-47ab-96e5-ac82fcb42849","error_message":null,"hostname":"container.container-basic.scaleway-terraform.com","id":"cd5bc7a5-c035-4897-886e-5f6cc5838d59","status":"deleting","url":""}'
+        headers:
+            Content-Length:
+                - "211"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:09:25 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 1dd77c9f-ae0f-4834-a60c-d64524415dd9
+        status: 200 OK
+        code: 200
+        duration: 108.99266ms
+    - id: 68
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1590,13 +3354,13 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"changes":[{"delete":{"id":"c12aeb73-838a-46ab-a445-a5b8e3d35ea6"}}],"return_all_records":false,"disallow_new_zone_creation":false}'
+        body: '{"changes":[{"delete":{"id":"74837750-e0d6-40d2-a1c1-946d35c2c81d"}}],"return_all_records":false,"disallow_new_zone_creation":false}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/domain/v2beta1/dns-zones/container-basic.scaleway-terraform.com/records
         method: PATCH
       response:
@@ -1616,7 +3380,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:34:18 GMT
+                - Wed, 27 Aug 2025 15:09:26 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -1626,11 +3390,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ce5956fb-664b-46a6-b6e6-a279065c57e1
+                - 420ba5c1-a52e-4bfa-8215-ce8117555a8d
         status: 200 OK
         code: 200
-        duration: 128.967125ms
-    - id: 33
+        duration: 114.854723ms
+    - id: 69
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1645,8 +3409,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/domain/v2beta1/dns-zones/container-basic.scaleway-terraform.com/records?name=&order_by=name_asc&type=unknown
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/9822575a-a230-47ab-96e5-ac82fcb42849
         method: GET
       response:
         proto: HTTP/2.0
@@ -1654,18 +3418,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 313
+        content_length: 922
         uncompressed: false
-        body: '{"records":[{"comment":null,"data":"ns0.dom.scw.cloud.","id":"41956f4a-8602-42e0-abd2-638de30baff4","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns1.dom.scw.cloud.","id":"f7f7f754-52ea-45e8-8540-becafab6af3b","name":"","priority":0,"ttl":1800,"type":"NS"}],"total_count":2}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:58.583265Z","description":"","domain_name":"tfnsstrangewilsonhbofpena-tf-co-dazzling-cartwright.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"9822575a-a230-47ab-96e5-ac82fcb42849","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-dazzling-cartwright","namespace_id":"97800be4-3f61-4f2e-b568-790018772ed1","port":80,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":"2025-08-27T15:06:10.272896Z","region":"fr-par","registry_image":"nginx:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"ready","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:10.282216Z"}'
         headers:
             Content-Length:
-                - "313"
+                - "922"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:34:18 GMT
+                - Wed, 27 Aug 2025 15:09:26 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -1675,11 +3439,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f36997ae-cc19-4246-98a9-0668bfc96ed7
+                - 0c2e8d3e-9305-4888-b7c3-b59423ddf9e0
         status: 200 OK
         code: 200
-        duration: 82.677375ms
-    - id: 34
+        duration: 107.509656ms
+    - id: 70
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1694,155 +3458,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=container-basic.scaleway-terraform.com&domain=&order_by=domain_asc
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 369
-        uncompressed: false
-        body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"container-basic","updated_at":"2025-06-11T12:34:18Z"}],"total_count":1}'
-        headers:
-            Content-Length:
-                - "369"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 11 Jun 2025 12:34:18 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 4685e2ca-9d40-4787-9e8e-a0d9a9b74fe6
-        status: 200 OK
-        code: 200
-        duration: 81.179125ms
-    - id: 35
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=container-basic.scaleway-terraform.com&domain=&order_by=domain_asc
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 369
-        uncompressed: false
-        body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"container-basic","updated_at":"2025-06-11T12:34:18Z"}],"total_count":1}'
-        headers:
-            Content-Length:
-                - "369"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 11 Jun 2025 12:34:23 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 51b27eae-7579-40c1-806c-46ce5370c157
-        status: 200 OK
-        code: 200
-        duration: 68.751542ms
-    - id: 36
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=container-basic.scaleway-terraform.com&domain=&order_by=domain_asc
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 368
-        uncompressed: false
-        body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"container-basic","updated_at":"2025-06-11T12:34:26Z"}],"total_count":1}'
-        headers:
-            Content-Length:
-                - "368"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 11 Jun 2025 12:34:28 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 5cedfd5b-a8d9-4b8c-aacc-999e90d110f2
-        status: 200 OK
-        code: 200
-        duration: 87.793792ms
-    - id: 37
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/domain/v2beta1/dns-zones/container-basic.scaleway-terraform.com?project_id=105bdce1-64c0-48ab-899d-868455867ecf
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/9822575a-a230-47ab-96e5-ac82fcb42849
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1850,18 +3467,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2
+        content_length: 928
         uncompressed: false
-        body: '{}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:58.583265Z","description":"","domain_name":"tfnsstrangewilsonhbofpena-tf-co-dazzling-cartwright.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"9822575a-a230-47ab-96e5-ac82fcb42849","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-dazzling-cartwright","namespace_id":"97800be4-3f61-4f2e-b568-790018772ed1","port":80,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":"2025-08-27T15:06:10.272896Z","region":"fr-par","registry_image":"nginx:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:09:26.299177568Z"}'
         headers:
             Content-Length:
-                - "2"
+                - "928"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:34:29 GMT
+                - Wed, 27 Aug 2025 15:09:26 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -1871,11 +3488,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3677a453-3193-4add-b9fc-731e567bbd97
+                - b57896d3-79f4-4a40-91b8-96ffdca140b7
         status: 200 OK
         code: 200
-        duration: 153.788083ms
-    - id: 38
+        duration: 153.757584ms
+    - id: 71
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1890,8 +3507,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/15f70a78-78fb-4ed1-a2cc-7cc9c7cfc366
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/97800be4-3f61-4f2e-b568-790018772ed1
         method: GET
       response:
         proto: HTTP/2.0
@@ -1899,18 +3516,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 949
+        content_length: 585
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-11T12:33:44.733303Z","description":"","domain_name":"tfnsmusingramanujanpkpx1suc-tf-co-trusting-wilbur.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"15f70a78-78fb-4ed1-a2cc-7cc9c7cfc366","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-trusting-wilbur","namespace_id":"bda727d4-9d0b-4b1f-9802-6db82804e02c","port":80,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":"2025-06-11T12:33:58.858933Z","region":"fr-par","registry_image":"nginx:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"ready","tags":[],"timeout":"300s","updated_at":"2025-06-11T12:33:58.872318Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.286324Z","description":"","environment_variables":{},"error_message":null,"id":"97800be4-3f61-4f2e-b568-790018772ed1","name":"tf-ns-strange-wilson","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsstrangewilsonhbofpena","registry_namespace_id":"196bf838-61df-41bf-98c6-ad78b741053a","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:52.556806Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "949"
+                - "585"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:34:29 GMT
+                - Wed, 27 Aug 2025 15:09:26 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -1920,11 +3537,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 60f2fee6-2f8d-4934-8eea-eb9b538089da
+                - f5676094-a456-4bc0-88b3-c90305d9cfdf
         status: 200 OK
         code: 200
-        duration: 83.343583ms
-    - id: 39
+        duration: 90.516881ms
+    - id: 72
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1939,8 +3556,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/15f70a78-78fb-4ed1-a2cc-7cc9c7cfc366
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/97800be4-3f61-4f2e-b568-790018772ed1
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1948,18 +3565,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 955
+        content_length: 591
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-11T12:33:44.733303Z","description":"","domain_name":"tfnsmusingramanujanpkpx1suc-tf-co-trusting-wilbur.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"15f70a78-78fb-4ed1-a2cc-7cc9c7cfc366","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-trusting-wilbur","namespace_id":"bda727d4-9d0b-4b1f-9802-6db82804e02c","port":80,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":"2025-06-11T12:33:58.858933Z","region":"fr-par","registry_image":"nginx:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2025-06-11T12:34:29.350040400Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.286324Z","description":"","environment_variables":{},"error_message":null,"id":"97800be4-3f61-4f2e-b568-790018772ed1","name":"tf-ns-strange-wilson","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsstrangewilsonhbofpena","registry_namespace_id":"196bf838-61df-41bf-98c6-ad78b741053a","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:09:26.555246194Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "955"
+                - "591"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:34:29 GMT
+                - Wed, 27 Aug 2025 15:09:26 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -1969,11 +3586,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 16e41d74-84f8-4303-b298-174d0602d0a7
+                - d6d756ec-861b-4633-bfb9-a1fbcffb09cd
         status: 200 OK
         code: 200
-        duration: 170.002208ms
-    - id: 40
+        duration: 229.646858ms
+    - id: 73
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1988,8 +3605,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/bda727d4-9d0b-4b1f-9802-6db82804e02c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/97800be4-3f61-4f2e-b568-790018772ed1
         method: GET
       response:
         proto: HTTP/2.0
@@ -1997,18 +3614,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 605
+        content_length: 588
         uncompressed: false
-        body: '{"created_at":"2025-06-11T12:33:38.809871Z","description":"","environment_variables":{},"error_message":null,"id":"bda727d4-9d0b-4b1f-9802-6db82804e02c","name":"tf-ns-musing-ramanujan","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsmusingramanujanpkpx1suc","registry_namespace_id":"3fabe0f3-47bf-4c53-a0f5-9c352bb9653c","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-11T12:33:43.385729Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2025-08-27T15:05:41.286324Z","description":"","environment_variables":{},"error_message":null,"id":"97800be4-3f61-4f2e-b568-790018772ed1","name":"tf-ns-strange-wilson","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsstrangewilsonhbofpena","registry_namespace_id":"196bf838-61df-41bf-98c6-ad78b741053a","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:09:26.555246Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "605"
+                - "588"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:34:29 GMT
+                - Wed, 27 Aug 2025 15:09:26 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -2018,11 +3635,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 173f5aaa-d013-4c96-8e9a-d6f2a9facfd4
+                - 8f1acede-d872-418b-9b4f-6653249e123a
         status: 200 OK
         code: 200
-        duration: 71.379458ms
-    - id: 41
+        duration: 88.574034ms
+    - id: 74
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2037,57 +3654,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/bda727d4-9d0b-4b1f-9802-6db82804e02c
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 611
-        uncompressed: false
-        body: '{"created_at":"2025-06-11T12:33:38.809871Z","description":"","environment_variables":{},"error_message":null,"id":"bda727d4-9d0b-4b1f-9802-6db82804e02c","name":"tf-ns-musing-ramanujan","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsmusingramanujanpkpx1suc","registry_namespace_id":"3fabe0f3-47bf-4c53-a0f5-9c352bb9653c","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-06-11T12:34:29.595177880Z","vpc_integration_activated":false}'
-        headers:
-            Content-Length:
-                - "611"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 11 Jun 2025 12:34:29 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - bd5aa2e9-4595-4769-b342-63b70021fc7b
-        status: 200 OK
-        code: 200
-        duration: 238.703916ms
-    - id: 42
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/bda727d4-9d0b-4b1f-9802-6db82804e02c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/97800be4-3f61-4f2e-b568-790018772ed1
         method: GET
       response:
         proto: HTTP/2.0
@@ -2095,18 +3663,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 608
+        content_length: 588
         uncompressed: false
-        body: '{"created_at":"2025-06-11T12:33:38.809871Z","description":"","environment_variables":{},"error_message":null,"id":"bda727d4-9d0b-4b1f-9802-6db82804e02c","name":"tf-ns-musing-ramanujan","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsmusingramanujanpkpx1suc","registry_namespace_id":"3fabe0f3-47bf-4c53-a0f5-9c352bb9653c","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-06-11T12:34:29.595178Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2025-08-27T15:05:41.286324Z","description":"","environment_variables":{},"error_message":null,"id":"97800be4-3f61-4f2e-b568-790018772ed1","name":"tf-ns-strange-wilson","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsstrangewilsonhbofpena","registry_namespace_id":"196bf838-61df-41bf-98c6-ad78b741053a","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:09:26.555246Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "608"
+                - "588"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:34:29 GMT
+                - Wed, 27 Aug 2025 15:09:31 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -2116,11 +3684,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - de34534c-3db9-49d4-b125-18845d4efff0
+                - ca90c00b-c057-4eff-8131-b3724157e22f
         status: 200 OK
         code: 200
-        duration: 81.800041ms
-    - id: 43
+        duration: 90.672424ms
+    - id: 75
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2135,8 +3703,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/bda727d4-9d0b-4b1f-9802-6db82804e02c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/97800be4-3f61-4f2e-b568-790018772ed1
         method: GET
       response:
         proto: HTTP/2.0
@@ -2144,18 +3712,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 608
+        content_length: 588
         uncompressed: false
-        body: '{"created_at":"2025-06-11T12:33:38.809871Z","description":"","environment_variables":{},"error_message":null,"id":"bda727d4-9d0b-4b1f-9802-6db82804e02c","name":"tf-ns-musing-ramanujan","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsmusingramanujanpkpx1suc","registry_namespace_id":"3fabe0f3-47bf-4c53-a0f5-9c352bb9653c","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-06-11T12:34:29.595178Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2025-08-27T15:05:41.286324Z","description":"","environment_variables":{},"error_message":null,"id":"97800be4-3f61-4f2e-b568-790018772ed1","name":"tf-ns-strange-wilson","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsstrangewilsonhbofpena","registry_namespace_id":"196bf838-61df-41bf-98c6-ad78b741053a","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:09:26.555246Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "608"
+                - "588"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:34:34 GMT
+                - Wed, 27 Aug 2025 15:09:36 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -2165,11 +3733,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b7766751-c9fe-4917-b3e4-0c5d39510c4a
+                - 693b3c99-6ca5-4132-80db-d0882392b780
         status: 200 OK
         code: 200
-        duration: 85.970541ms
-    - id: 44
+        duration: 103.724172ms
+    - id: 76
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2184,8 +3752,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/bda727d4-9d0b-4b1f-9802-6db82804e02c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/97800be4-3f61-4f2e-b568-790018772ed1
         method: GET
       response:
         proto: HTTP/2.0
@@ -2193,18 +3761,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 608
+        content_length: 588
         uncompressed: false
-        body: '{"created_at":"2025-06-11T12:33:38.809871Z","description":"","environment_variables":{},"error_message":null,"id":"bda727d4-9d0b-4b1f-9802-6db82804e02c","name":"tf-ns-musing-ramanujan","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsmusingramanujanpkpx1suc","registry_namespace_id":"3fabe0f3-47bf-4c53-a0f5-9c352bb9653c","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-06-11T12:34:29.595178Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2025-08-27T15:05:41.286324Z","description":"","environment_variables":{},"error_message":null,"id":"97800be4-3f61-4f2e-b568-790018772ed1","name":"tf-ns-strange-wilson","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsstrangewilsonhbofpena","registry_namespace_id":"196bf838-61df-41bf-98c6-ad78b741053a","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:09:26.555246Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "608"
+                - "588"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:34:40 GMT
+                - Wed, 27 Aug 2025 15:09:42 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -2214,11 +3782,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6c85371f-8906-48f6-944b-337be791baa5
+                - 055fc4b6-5b6e-461e-82c6-2939f30e3ba7
         status: 200 OK
         code: 200
-        duration: 146.27225ms
-    - id: 45
+        duration: 96.661186ms
+    - id: 77
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2233,8 +3801,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/bda727d4-9d0b-4b1f-9802-6db82804e02c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/97800be4-3f61-4f2e-b568-790018772ed1
         method: GET
       response:
         proto: HTTP/2.0
@@ -2242,18 +3810,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 608
+        content_length: 588
         uncompressed: false
-        body: '{"created_at":"2025-06-11T12:33:38.809871Z","description":"","environment_variables":{},"error_message":null,"id":"bda727d4-9d0b-4b1f-9802-6db82804e02c","name":"tf-ns-musing-ramanujan","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsmusingramanujanpkpx1suc","registry_namespace_id":"3fabe0f3-47bf-4c53-a0f5-9c352bb9653c","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-06-11T12:34:29.595178Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2025-08-27T15:05:41.286324Z","description":"","environment_variables":{},"error_message":null,"id":"97800be4-3f61-4f2e-b568-790018772ed1","name":"tf-ns-strange-wilson","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsstrangewilsonhbofpena","registry_namespace_id":"196bf838-61df-41bf-98c6-ad78b741053a","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:09:26.555246Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "608"
+                - "588"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:34:45 GMT
+                - Wed, 27 Aug 2025 15:09:47 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -2263,11 +3831,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e9a6a957-c6ac-4954-a34f-eae819fb6906
+                - 352127ed-08d4-425a-8a5e-fcd062fa4dc9
         status: 200 OK
         code: 200
-        duration: 87.475125ms
-    - id: 46
+        duration: 91.966245ms
+    - id: 78
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2282,8 +3850,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/bda727d4-9d0b-4b1f-9802-6db82804e02c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/97800be4-3f61-4f2e-b568-790018772ed1
         method: GET
       response:
         proto: HTTP/2.0
@@ -2291,18 +3859,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 608
+        content_length: 588
         uncompressed: false
-        body: '{"created_at":"2025-06-11T12:33:38.809871Z","description":"","environment_variables":{},"error_message":null,"id":"bda727d4-9d0b-4b1f-9802-6db82804e02c","name":"tf-ns-musing-ramanujan","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsmusingramanujanpkpx1suc","registry_namespace_id":"3fabe0f3-47bf-4c53-a0f5-9c352bb9653c","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-06-11T12:34:29.595178Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2025-08-27T15:05:41.286324Z","description":"","environment_variables":{},"error_message":null,"id":"97800be4-3f61-4f2e-b568-790018772ed1","name":"tf-ns-strange-wilson","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsstrangewilsonhbofpena","registry_namespace_id":"196bf838-61df-41bf-98c6-ad78b741053a","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:09:26.555246Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "608"
+                - "588"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:34:50 GMT
+                - Wed, 27 Aug 2025 15:09:52 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -2312,11 +3880,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e3b9cb21-5ada-456b-aa31-6c93175e663c
+                - 97ff3bb5-f746-4128-b5a9-412f2f6d185f
         status: 200 OK
         code: 200
-        duration: 86.117375ms
-    - id: 47
+        duration: 79.461935ms
+    - id: 79
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2331,8 +3899,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/bda727d4-9d0b-4b1f-9802-6db82804e02c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/97800be4-3f61-4f2e-b568-790018772ed1
         method: GET
       response:
         proto: HTTP/2.0
@@ -2340,18 +3908,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 608
+        content_length: 588
         uncompressed: false
-        body: '{"created_at":"2025-06-11T12:33:38.809871Z","description":"","environment_variables":{},"error_message":null,"id":"bda727d4-9d0b-4b1f-9802-6db82804e02c","name":"tf-ns-musing-ramanujan","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsmusingramanujanpkpx1suc","registry_namespace_id":"3fabe0f3-47bf-4c53-a0f5-9c352bb9653c","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-06-11T12:34:29.595178Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2025-08-27T15:05:41.286324Z","description":"","environment_variables":{},"error_message":null,"id":"97800be4-3f61-4f2e-b568-790018772ed1","name":"tf-ns-strange-wilson","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsstrangewilsonhbofpena","registry_namespace_id":"196bf838-61df-41bf-98c6-ad78b741053a","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:09:26.555246Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "608"
+                - "588"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:34:55 GMT
+                - Wed, 27 Aug 2025 15:09:57 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -2361,11 +3929,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ad5a67ad-1a38-4e73-a201-ef31b1ca08cb
+                - fb0d3111-d592-4450-b09a-c047aac2ee57
         status: 200 OK
         code: 200
-        duration: 172.661584ms
-    - id: 48
+        duration: 80.113398ms
+    - id: 80
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2380,8 +3948,57 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/bda727d4-9d0b-4b1f-9802-6db82804e02c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/97800be4-3f61-4f2e-b568-790018772ed1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 588
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:41.286324Z","description":"","environment_variables":{},"error_message":null,"id":"97800be4-3f61-4f2e-b568-790018772ed1","name":"tf-ns-strange-wilson","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsstrangewilsonhbofpena","registry_namespace_id":"196bf838-61df-41bf-98c6-ad78b741053a","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:09:26.555246Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "588"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:10:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f29e1fee-10df-4ce3-ac80-a8b692ec73a4
+        status: 200 OK
+        code: 200
+        duration: 96.477135ms
+    - id: 81
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/97800be4-3f61-4f2e-b568-790018772ed1
         method: GET
       response:
         proto: HTTP/2.0
@@ -2400,7 +4017,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:35:00 GMT
+                - Wed, 27 Aug 2025 15:10:07 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -2410,11 +4027,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 28522cd4-6b07-4d7b-b845-38aa5d1922d0
+                - dbe78da2-0e72-4a7d-bb4f-49ff30a81ff9
         status: 404 Not Found
         code: 404
-        duration: 26.896125ms
-    - id: 49
+        duration: 26.893241ms
+    - id: 82
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2429,8 +4046,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/domains/36d19db5-73d8-46e3-bf3e-5ed8ad4c9b9f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/domains/cd5bc7a5-c035-4897-886e-5f6cc5838d59
         method: GET
       response:
         proto: HTTP/2.0
@@ -2449,7 +4066,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:35:00 GMT
+                - Wed, 27 Aug 2025 15:10:07 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -2459,7 +4076,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - df861c43-f186-4146-8771-fb0c9365e54f
+                - 9fb5c050-53c3-4d94-8e17-0ffee788825c
         status: 404 Not Found
         code: 404
-        duration: 24.853584ms
+        duration: 26.283407ms

--- a/internal/services/container/testdata/namespace-basic.cassette.yaml
+++ b/internal/services/container/testdata/namespace-basic.cassette.yaml
@@ -6,19 +6,19 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 149
+        content_length: 181
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"test-cr-ns-01","environment_variables":{},"project_id":"6867048b-fe12-4e96-835e-41c79a39604b","secret_environment_variables":[],"tags":null}'
+        body: '{"name":"test-cr-ns-01","environment_variables":{},"project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","secret_environment_variables":[],"tags":null,"activate_vpc_integration":true}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces
         method: POST
       response:
@@ -27,20 +27,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 479
+        content_length: 498
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:13.753352673Z","description":"","environment_variables":{},"error_message":null,"id":"739ec6ae-53ee-40dd-949f-67bb90f5bceb","name":"test-cr-ns-01","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-04-28T09:37:13.753352673Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.893278559Z","description":"","environment_variables":{},"error_message":null,"id":"fe36e013-0701-45ac-8557-8b5c8bf88ca3","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:40.893278559Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "479"
+                - "498"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:13 GMT
+                - Wed, 27 Aug 2025 15:05:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f6f49077-4a2d-47e0-8883-f12b6cf7749a
+                - 840ecfdd-04d3-43f0-90ef-a5a971435082
         status: 200 OK
         code: 200
-        duration: 940.125833ms
+        duration: 4.933983078s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -67,8 +67,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/739ec6ae-53ee-40dd-949f-67bb90f5bceb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/fe36e013-0701-45ac-8557-8b5c8bf88ca3
         method: GET
       response:
         proto: HTTP/2.0
@@ -76,20 +76,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 473
+        content_length: 492
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:13.753353Z","description":"","environment_variables":{},"error_message":null,"id":"739ec6ae-53ee-40dd-949f-67bb90f5bceb","name":"test-cr-ns-01","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-04-28T09:37:13.753353Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.893279Z","description":"","environment_variables":{},"error_message":null,"id":"fe36e013-0701-45ac-8557-8b5c8bf88ca3","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:40.893279Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "473"
+                - "492"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:13 GMT
+                - Wed, 27 Aug 2025 15:05:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 55fdef32-82ed-4357-90ff-e4531709543c
+                - b1b8c533-9ecb-47da-935a-a28b45d9359e
         status: 200 OK
         code: 200
-        duration: 48.92875ms
+        duration: 72.286609ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -116,8 +116,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/739ec6ae-53ee-40dd-949f-67bb90f5bceb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/fe36e013-0701-45ac-8557-8b5c8bf88ca3
         method: GET
       response:
         proto: HTTP/2.0
@@ -125,20 +125,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 552
+        content_length: 492
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:13.753353Z","description":"","environment_variables":{},"error_message":null,"id":"739ec6ae-53ee-40dd-949f-67bb90f5bceb","name":"test-cr-ns-01","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01acrymz2v","registry_namespace_id":"82c49ce2-a6bf-4518-84b6-6ff9ad138bca","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-28T09:37:18.247914Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.893279Z","description":"","environment_variables":{},"error_message":null,"id":"fe36e013-0701-45ac-8557-8b5c8bf88ca3","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:43.801003Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "552"
+                - "492"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:18 GMT
+                - Wed, 27 Aug 2025 15:05:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -146,10 +146,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a19a29e7-a481-4dd5-be11-489ac261e09a
+                - 8af7b7ff-3efd-4b2a-807d-742bd5149af9
         status: 200 OK
         code: 200
-        duration: 44.407208ms
+        duration: 74.517175ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -165,8 +165,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/739ec6ae-53ee-40dd-949f-67bb90f5bceb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/fe36e013-0701-45ac-8557-8b5c8bf88ca3
         method: GET
       response:
         proto: HTTP/2.0
@@ -174,20 +174,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 552
+        content_length: 573
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:13.753353Z","description":"","environment_variables":{},"error_message":null,"id":"739ec6ae-53ee-40dd-949f-67bb90f5bceb","name":"test-cr-ns-01","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01acrymz2v","registry_namespace_id":"82c49ce2-a6bf-4518-84b6-6ff9ad138bca","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-28T09:37:18.247914Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.893279Z","description":"","environment_variables":{},"error_message":null,"id":"fe36e013-0701-45ac-8557-8b5c8bf88ca3","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01v0ub2dfr","registry_namespace_id":"7d818049-2cb7-4a3f-b528-c128b00545a5","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:47.361252Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "552"
+                - "573"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:18 GMT
+                - Wed, 27 Aug 2025 15:05:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -195,10 +195,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ffc49514-b5db-40ad-9d69-613b81b75606
+                - 11ad8e6d-ce4c-4e1d-8078-79bb3321510d
         status: 200 OK
         code: 200
-        duration: 42.209708ms
+        duration: 99.605413ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -214,8 +214,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/739ec6ae-53ee-40dd-949f-67bb90f5bceb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/fe36e013-0701-45ac-8557-8b5c8bf88ca3
         method: GET
       response:
         proto: HTTP/2.0
@@ -223,20 +223,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 552
+        content_length: 571
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:13.753353Z","description":"","environment_variables":{},"error_message":null,"id":"739ec6ae-53ee-40dd-949f-67bb90f5bceb","name":"test-cr-ns-01","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01acrymz2v","registry_namespace_id":"82c49ce2-a6bf-4518-84b6-6ff9ad138bca","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-28T09:37:18.247914Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.893279Z","description":"","environment_variables":{},"error_message":null,"id":"fe36e013-0701-45ac-8557-8b5c8bf88ca3","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01v0ub2dfr","registry_namespace_id":"7d818049-2cb7-4a3f-b528-c128b00545a5","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:52.776819Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "552"
+                - "571"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:19 GMT
+                - Wed, 27 Aug 2025 15:05:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -244,10 +244,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 538bf43a-bb40-4c97-bca6-7ecc116c27b2
+                - 69927b9a-35ed-4720-85ef-84e9f3287f5a
         status: 200 OK
         code: 200
-        duration: 48.126708ms
+        duration: 112.884853ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -263,8 +263,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/739ec6ae-53ee-40dd-949f-67bb90f5bceb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/fe36e013-0701-45ac-8557-8b5c8bf88ca3
         method: GET
       response:
         proto: HTTP/2.0
@@ -272,20 +272,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 552
+        content_length: 571
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:13.753353Z","description":"","environment_variables":{},"error_message":null,"id":"739ec6ae-53ee-40dd-949f-67bb90f5bceb","name":"test-cr-ns-01","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01acrymz2v","registry_namespace_id":"82c49ce2-a6bf-4518-84b6-6ff9ad138bca","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-28T09:37:18.247914Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.893279Z","description":"","environment_variables":{},"error_message":null,"id":"fe36e013-0701-45ac-8557-8b5c8bf88ca3","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01v0ub2dfr","registry_namespace_id":"7d818049-2cb7-4a3f-b528-c128b00545a5","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:52.776819Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "552"
+                - "571"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:19 GMT
+                - Wed, 27 Aug 2025 15:05:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -293,10 +293,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 212af531-cc97-4553-a63c-a465d28bd731
+                - af5dc1e8-cfac-4d2d-9bc7-8964b0135884
         status: 200 OK
         code: 200
-        duration: 46.133666ms
+        duration: 75.732749ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -312,8 +312,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/739ec6ae-53ee-40dd-949f-67bb90f5bceb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/fe36e013-0701-45ac-8557-8b5c8bf88ca3
         method: GET
       response:
         proto: HTTP/2.0
@@ -321,20 +321,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 552
+        content_length: 571
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:13.753353Z","description":"","environment_variables":{},"error_message":null,"id":"739ec6ae-53ee-40dd-949f-67bb90f5bceb","name":"test-cr-ns-01","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01acrymz2v","registry_namespace_id":"82c49ce2-a6bf-4518-84b6-6ff9ad138bca","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-28T09:37:18.247914Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.893279Z","description":"","environment_variables":{},"error_message":null,"id":"fe36e013-0701-45ac-8557-8b5c8bf88ca3","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01v0ub2dfr","registry_namespace_id":"7d818049-2cb7-4a3f-b528-c128b00545a5","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:52.776819Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "552"
+                - "571"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:19 GMT
+                - Wed, 27 Aug 2025 15:05:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -342,10 +342,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f632b3c8-978b-4378-a758-9cf785e67ba5
+                - 5cbe489f-e031-4c8b-8541-330df338793c
         status: 200 OK
         code: 200
-        duration: 40.675667ms
+        duration: 95.048745ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -361,8 +361,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/739ec6ae-53ee-40dd-949f-67bb90f5bceb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/fe36e013-0701-45ac-8557-8b5c8bf88ca3
         method: GET
       response:
         proto: HTTP/2.0
@@ -370,20 +370,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 552
+        content_length: 571
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:13.753353Z","description":"","environment_variables":{},"error_message":null,"id":"739ec6ae-53ee-40dd-949f-67bb90f5bceb","name":"test-cr-ns-01","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01acrymz2v","registry_namespace_id":"82c49ce2-a6bf-4518-84b6-6ff9ad138bca","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-28T09:37:18.247914Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.893279Z","description":"","environment_variables":{},"error_message":null,"id":"fe36e013-0701-45ac-8557-8b5c8bf88ca3","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01v0ub2dfr","registry_namespace_id":"7d818049-2cb7-4a3f-b528-c128b00545a5","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:52.776819Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "552"
+                - "571"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:19 GMT
+                - Wed, 27 Aug 2025 15:05:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -391,11 +391,109 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c1ace177-2738-41b8-97c9-04781f7b721c
+                - 92efdd55-6fed-40a1-b333-27488570b942
         status: 200 OK
         code: 200
-        duration: 33.972625ms
+        duration: 82.556464ms
     - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/fe36e013-0701-45ac-8557-8b5c8bf88ca3
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 571
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:40.893279Z","description":"","environment_variables":{},"error_message":null,"id":"fe36e013-0701-45ac-8557-8b5c8bf88ca3","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01v0ub2dfr","registry_namespace_id":"7d818049-2cb7-4a3f-b528-c128b00545a5","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:52.776819Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "571"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:05:57 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f8f7af10-9e40-4d08-bdad-4e463d7cd422
+        status: 200 OK
+        code: 200
+        duration: 281.486066ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/fe36e013-0701-45ac-8557-8b5c8bf88ca3
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 571
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:40.893279Z","description":"","environment_variables":{},"error_message":null,"id":"fe36e013-0701-45ac-8557-8b5c8bf88ca3","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01v0ub2dfr","registry_namespace_id":"7d818049-2cb7-4a3f-b528-c128b00545a5","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:52.776819Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "571"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:05:57 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - a118d0af-ff36-4abb-8e5d-034d710ff040
+        status: 200 OK
+        code: 200
+        duration: 88.013233ms
+    - id: 10
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -412,8 +510,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/739ec6ae-53ee-40dd-949f-67bb90f5bceb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/fe36e013-0701-45ac-8557-8b5c8bf88ca3
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -421,20 +519,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 582
+        content_length: 601
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:13.753353Z","description":"test container namespace 01","environment_variables":{},"error_message":null,"id":"739ec6ae-53ee-40dd-949f-67bb90f5bceb","name":"test-cr-ns-01","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01acrymz2v","registry_namespace_id":"82c49ce2-a6bf-4518-84b6-6ff9ad138bca","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-28T09:37:19.595200051Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.893279Z","description":"test container namespace 01","environment_variables":{},"error_message":null,"id":"fe36e013-0701-45ac-8557-8b5c8bf88ca3","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01v0ub2dfr","registry_namespace_id":"7d818049-2cb7-4a3f-b528-c128b00545a5","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:57.856087836Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "582"
+                - "601"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:19 GMT
+                - Wed, 27 Aug 2025 15:05:57 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -442,108 +540,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 75e691f8-62c1-4919-bea7-4c628d29a6d8
+                - b7af22ec-88ef-4fff-ba83-8d18406d21b1
         status: 200 OK
         code: 200
-        duration: 68.403875ms
-    - id: 9
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/739ec6ae-53ee-40dd-949f-67bb90f5bceb
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 579
-        uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:13.753353Z","description":"test container namespace 01","environment_variables":{},"error_message":null,"id":"739ec6ae-53ee-40dd-949f-67bb90f5bceb","name":"test-cr-ns-01","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01acrymz2v","registry_namespace_id":"82c49ce2-a6bf-4518-84b6-6ff9ad138bca","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-28T09:37:19.595200Z"}'
-        headers:
-            Content-Length:
-                - "579"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 28 Apr 2025 09:37:19 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 4c442b16-6283-4879-9df5-7ba86ddd93c2
-        status: 200 OK
-        code: 200
-        duration: 38.919834ms
-    - id: 10
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/739ec6ae-53ee-40dd-949f-67bb90f5bceb
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 579
-        uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:13.753353Z","description":"test container namespace 01","environment_variables":{},"error_message":null,"id":"739ec6ae-53ee-40dd-949f-67bb90f5bceb","name":"test-cr-ns-01","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01acrymz2v","registry_namespace_id":"82c49ce2-a6bf-4518-84b6-6ff9ad138bca","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-28T09:37:19.595200Z"}'
-        headers:
-            Content-Length:
-                - "579"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 28 Apr 2025 09:37:19 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - f0a7fcd3-9666-4903-bb62-40cfc94751a3
-        status: 200 OK
-        code: 200
-        duration: 40.549709ms
+        duration: 114.204961ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -559,8 +559,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/739ec6ae-53ee-40dd-949f-67bb90f5bceb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/fe36e013-0701-45ac-8557-8b5c8bf88ca3
         method: GET
       response:
         proto: HTTP/2.0
@@ -568,20 +568,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 579
+        content_length: 598
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:13.753353Z","description":"test container namespace 01","environment_variables":{},"error_message":null,"id":"739ec6ae-53ee-40dd-949f-67bb90f5bceb","name":"test-cr-ns-01","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01acrymz2v","registry_namespace_id":"82c49ce2-a6bf-4518-84b6-6ff9ad138bca","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-28T09:37:19.595200Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.893279Z","description":"test container namespace 01","environment_variables":{},"error_message":null,"id":"fe36e013-0701-45ac-8557-8b5c8bf88ca3","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01v0ub2dfr","registry_namespace_id":"7d818049-2cb7-4a3f-b528-c128b00545a5","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:57.856088Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "579"
+                - "598"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:19 GMT
+                - Wed, 27 Aug 2025 15:05:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -589,10 +589,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e6432589-07ba-4d2d-8eb5-3f5c8f8a2039
+                - e920761b-2eab-449f-9f3a-a891be965f7c
         status: 200 OK
         code: 200
-        duration: 122.280834ms
+        duration: 133.045664ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -608,8 +608,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/739ec6ae-53ee-40dd-949f-67bb90f5bceb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/fe36e013-0701-45ac-8557-8b5c8bf88ca3
         method: GET
       response:
         proto: HTTP/2.0
@@ -617,20 +617,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 579
+        content_length: 598
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:13.753353Z","description":"test container namespace 01","environment_variables":{},"error_message":null,"id":"739ec6ae-53ee-40dd-949f-67bb90f5bceb","name":"test-cr-ns-01","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01acrymz2v","registry_namespace_id":"82c49ce2-a6bf-4518-84b6-6ff9ad138bca","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-28T09:37:19.595200Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.893279Z","description":"test container namespace 01","environment_variables":{},"error_message":null,"id":"fe36e013-0701-45ac-8557-8b5c8bf88ca3","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01v0ub2dfr","registry_namespace_id":"7d818049-2cb7-4a3f-b528-c128b00545a5","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:57.856088Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "579"
+                - "598"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:20 GMT
+                - Wed, 27 Aug 2025 15:05:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -638,10 +638,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e4708dea-ce08-447d-9ace-c5cd3baf6858
+                - 3709cd9e-db47-4a07-937e-b665241f6547
         status: 200 OK
         code: 200
-        duration: 43.126584ms
+        duration: 96.148289ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -657,8 +657,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/739ec6ae-53ee-40dd-949f-67bb90f5bceb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/fe36e013-0701-45ac-8557-8b5c8bf88ca3
         method: GET
       response:
         proto: HTTP/2.0
@@ -666,20 +666,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 579
+        content_length: 598
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:13.753353Z","description":"test container namespace 01","environment_variables":{},"error_message":null,"id":"739ec6ae-53ee-40dd-949f-67bb90f5bceb","name":"test-cr-ns-01","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01acrymz2v","registry_namespace_id":"82c49ce2-a6bf-4518-84b6-6ff9ad138bca","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-28T09:37:19.595200Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.893279Z","description":"test container namespace 01","environment_variables":{},"error_message":null,"id":"fe36e013-0701-45ac-8557-8b5c8bf88ca3","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01v0ub2dfr","registry_namespace_id":"7d818049-2cb7-4a3f-b528-c128b00545a5","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:57.856088Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "579"
+                - "598"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:20 GMT
+                - Wed, 27 Aug 2025 15:05:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -687,11 +687,109 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8b4be421-2d09-4720-af44-5822c57ea879
+                - 4845d457-ed4c-40d3-acaa-07da37a94ddf
         status: 200 OK
         code: 200
-        duration: 40.036834ms
+        duration: 83.441574ms
     - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/fe36e013-0701-45ac-8557-8b5c8bf88ca3
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 598
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:40.893279Z","description":"test container namespace 01","environment_variables":{},"error_message":null,"id":"fe36e013-0701-45ac-8557-8b5c8bf88ca3","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01v0ub2dfr","registry_namespace_id":"7d818049-2cb7-4a3f-b528-c128b00545a5","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:57.856088Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "598"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:05:58 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e82896ac-6ea3-44b0-bcab-b47e194d8113
+        status: 200 OK
+        code: 200
+        duration: 85.328566ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/fe36e013-0701-45ac-8557-8b5c8bf88ca3
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 598
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:40.893279Z","description":"test container namespace 01","environment_variables":{},"error_message":null,"id":"fe36e013-0701-45ac-8557-8b5c8bf88ca3","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01v0ub2dfr","registry_namespace_id":"7d818049-2cb7-4a3f-b528-c128b00545a5","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:57.856088Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "598"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:05:59 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 09d5ce93-4199-4392-9d58-3f308ba8c765
+        status: 200 OK
+        code: 200
+        duration: 76.632207ms
+    - id: 16
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -708,8 +806,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/739ec6ae-53ee-40dd-949f-67bb90f5bceb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/fe36e013-0701-45ac-8557-8b5c8bf88ca3
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -717,20 +815,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 707
+        content_length: 725
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:13.753353Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"739ec6ae-53ee-40dd-949f-67bb90f5bceb","name":"test-cr-ns-01","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01acrymz2v","registry_namespace_id":"82c49ce2-a6bf-4518-84b6-6ff9ad138bca","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$KRi5fL1eXTZH0eN3A3+WSQ$Rw4ck/IGCoWLzol+x/oGWiffRVIfTWZP7H3kX3Kc9Dc","key":"test_secret"}],"status":"pending","tags":[],"updated_at":"2025-04-28T09:37:21.069278059Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.893279Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"fe36e013-0701-45ac-8557-8b5c8bf88ca3","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01v0ub2dfr","registry_namespace_id":"7d818049-2cb7-4a3f-b528-c128b00545a5","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$B6SfRhJ82SUrThHEaR7hZA$idtcyqNALsMPkFg+kobNUASAebMVR4QlM+yogRJmIUs","key":"test_secret"}],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:59.838562228Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "707"
+                - "725"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:21 GMT
+                - Wed, 27 Aug 2025 15:05:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -738,108 +836,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a1d96a53-0fbf-44e6-bb6e-19c56833c60d
+                - f4d27c50-8ac5-49f0-9c6e-83ac1515bd9a
         status: 200 OK
         code: 200
-        duration: 698.286791ms
-    - id: 15
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/739ec6ae-53ee-40dd-949f-67bb90f5bceb
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 704
-        uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:13.753353Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"739ec6ae-53ee-40dd-949f-67bb90f5bceb","name":"test-cr-ns-01","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01acrymz2v","registry_namespace_id":"82c49ce2-a6bf-4518-84b6-6ff9ad138bca","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$KRi5fL1eXTZH0eN3A3+WSQ$Rw4ck/IGCoWLzol+x/oGWiffRVIfTWZP7H3kX3Kc9Dc","key":"test_secret"}],"status":"pending","tags":[],"updated_at":"2025-04-28T09:37:21.069278Z"}'
-        headers:
-            Content-Length:
-                - "704"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 28 Apr 2025 09:37:21 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - d5de824e-ffd4-41e4-a9cc-e369241d9b58
-        status: 200 OK
-        code: 200
-        duration: 128.739792ms
-    - id: 16
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/739ec6ae-53ee-40dd-949f-67bb90f5bceb
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 702
-        uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:13.753353Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"739ec6ae-53ee-40dd-949f-67bb90f5bceb","name":"test-cr-ns-01","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01acrymz2v","registry_namespace_id":"82c49ce2-a6bf-4518-84b6-6ff9ad138bca","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$KRi5fL1eXTZH0eN3A3+WSQ$Rw4ck/IGCoWLzol+x/oGWiffRVIfTWZP7H3kX3Kc9Dc","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2025-04-28T09:37:21.417760Z"}'
-        headers:
-            Content-Length:
-                - "702"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 28 Apr 2025 09:37:26 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 793d9a52-9216-4a62-a999-23885afaedfb
-        status: 200 OK
-        code: 200
-        duration: 46.950208ms
+        duration: 416.787476ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -855,8 +855,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/739ec6ae-53ee-40dd-949f-67bb90f5bceb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/fe36e013-0701-45ac-8557-8b5c8bf88ca3
         method: GET
       response:
         proto: HTTP/2.0
@@ -864,20 +864,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 702
+        content_length: 722
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:13.753353Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"739ec6ae-53ee-40dd-949f-67bb90f5bceb","name":"test-cr-ns-01","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01acrymz2v","registry_namespace_id":"82c49ce2-a6bf-4518-84b6-6ff9ad138bca","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$KRi5fL1eXTZH0eN3A3+WSQ$Rw4ck/IGCoWLzol+x/oGWiffRVIfTWZP7H3kX3Kc9Dc","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2025-04-28T09:37:21.417760Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.893279Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"fe36e013-0701-45ac-8557-8b5c8bf88ca3","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01v0ub2dfr","registry_namespace_id":"7d818049-2cb7-4a3f-b528-c128b00545a5","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$B6SfRhJ82SUrThHEaR7hZA$idtcyqNALsMPkFg+kobNUASAebMVR4QlM+yogRJmIUs","key":"test_secret"}],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:59.838562Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "702"
+                - "722"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:26 GMT
+                - Wed, 27 Aug 2025 15:05:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -885,10 +885,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d1662dfd-d632-43ca-92b7-d19c5f03a4d0
+                - c67ede1d-4f63-4172-874e-da2d0092f01b
         status: 200 OK
         code: 200
-        duration: 44.639375ms
+        duration: 88.716724ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -904,8 +904,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/739ec6ae-53ee-40dd-949f-67bb90f5bceb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/fe36e013-0701-45ac-8557-8b5c8bf88ca3
         method: GET
       response:
         proto: HTTP/2.0
@@ -913,20 +913,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 702
+        content_length: 722
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:13.753353Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"739ec6ae-53ee-40dd-949f-67bb90f5bceb","name":"test-cr-ns-01","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01acrymz2v","registry_namespace_id":"82c49ce2-a6bf-4518-84b6-6ff9ad138bca","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$KRi5fL1eXTZH0eN3A3+WSQ$Rw4ck/IGCoWLzol+x/oGWiffRVIfTWZP7H3kX3Kc9Dc","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2025-04-28T09:37:21.417760Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.893279Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"fe36e013-0701-45ac-8557-8b5c8bf88ca3","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01v0ub2dfr","registry_namespace_id":"7d818049-2cb7-4a3f-b528-c128b00545a5","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$B6SfRhJ82SUrThHEaR7hZA$idtcyqNALsMPkFg+kobNUASAebMVR4QlM+yogRJmIUs","key":"test_secret"}],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:59.838562Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "702"
+                - "722"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:26 GMT
+                - Wed, 27 Aug 2025 15:06:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -934,10 +934,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7a65ac91-7732-4f20-894d-5462abc565e4
+                - 0d43d963-cd17-4897-81e1-e8567694fcaf
         status: 200 OK
         code: 200
-        duration: 46.469667ms
+        duration: 76.995291ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -953,8 +953,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/739ec6ae-53ee-40dd-949f-67bb90f5bceb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/fe36e013-0701-45ac-8557-8b5c8bf88ca3
         method: GET
       response:
         proto: HTTP/2.0
@@ -962,20 +962,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 702
+        content_length: 720
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:13.753353Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"739ec6ae-53ee-40dd-949f-67bb90f5bceb","name":"test-cr-ns-01","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01acrymz2v","registry_namespace_id":"82c49ce2-a6bf-4518-84b6-6ff9ad138bca","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$KRi5fL1eXTZH0eN3A3+WSQ$Rw4ck/IGCoWLzol+x/oGWiffRVIfTWZP7H3kX3Kc9Dc","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2025-04-28T09:37:21.417760Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.893279Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"fe36e013-0701-45ac-8557-8b5c8bf88ca3","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01v0ub2dfr","registry_namespace_id":"7d818049-2cb7-4a3f-b528-c128b00545a5","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$B6SfRhJ82SUrThHEaR7hZA$idtcyqNALsMPkFg+kobNUASAebMVR4QlM+yogRJmIUs","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:04.961122Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "702"
+                - "720"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:26 GMT
+                - Wed, 27 Aug 2025 15:06:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -983,10 +983,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3e2339e6-9849-4ed8-93c8-532437dadaa5
+                - 6374749f-833f-4ecb-8687-e55365e4753b
         status: 200 OK
         code: 200
-        duration: 39.5075ms
+        duration: 91.190249ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1002,8 +1002,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/739ec6ae-53ee-40dd-949f-67bb90f5bceb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/fe36e013-0701-45ac-8557-8b5c8bf88ca3
         method: GET
       response:
         proto: HTTP/2.0
@@ -1011,20 +1011,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 702
+        content_length: 720
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:13.753353Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"739ec6ae-53ee-40dd-949f-67bb90f5bceb","name":"test-cr-ns-01","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01acrymz2v","registry_namespace_id":"82c49ce2-a6bf-4518-84b6-6ff9ad138bca","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$KRi5fL1eXTZH0eN3A3+WSQ$Rw4ck/IGCoWLzol+x/oGWiffRVIfTWZP7H3kX3Kc9Dc","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2025-04-28T09:37:21.417760Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.893279Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"fe36e013-0701-45ac-8557-8b5c8bf88ca3","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01v0ub2dfr","registry_namespace_id":"7d818049-2cb7-4a3f-b528-c128b00545a5","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$B6SfRhJ82SUrThHEaR7hZA$idtcyqNALsMPkFg+kobNUASAebMVR4QlM+yogRJmIUs","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:04.961122Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "702"
+                - "720"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:27 GMT
+                - Wed, 27 Aug 2025 15:06:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1032,11 +1032,158 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - de736c76-3b6b-4d9f-884b-5654960299ed
+                - f3c77a43-7023-489f-a066-feec8d74a0d6
         status: 200 OK
         code: 200
-        duration: 41.441792ms
+        duration: 83.220723ms
     - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/fe36e013-0701-45ac-8557-8b5c8bf88ca3
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 720
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:40.893279Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"fe36e013-0701-45ac-8557-8b5c8bf88ca3","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01v0ub2dfr","registry_namespace_id":"7d818049-2cb7-4a3f-b528-c128b00545a5","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$B6SfRhJ82SUrThHEaR7hZA$idtcyqNALsMPkFg+kobNUASAebMVR4QlM+yogRJmIUs","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:04.961122Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "720"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:10 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 13100fbd-1168-46c1-84c7-13b3741e4e9c
+        status: 200 OK
+        code: 200
+        duration: 73.084503ms
+    - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/fe36e013-0701-45ac-8557-8b5c8bf88ca3
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 720
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:40.893279Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"fe36e013-0701-45ac-8557-8b5c8bf88ca3","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01v0ub2dfr","registry_namespace_id":"7d818049-2cb7-4a3f-b528-c128b00545a5","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$B6SfRhJ82SUrThHEaR7hZA$idtcyqNALsMPkFg+kobNUASAebMVR4QlM+yogRJmIUs","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:04.961122Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "720"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:11 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 584289c5-cabf-48cd-9bdc-afaedf7fc2c5
+        status: 200 OK
+        code: 200
+        duration: 93.950879ms
+    - id: 23
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/fe36e013-0701-45ac-8557-8b5c8bf88ca3
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 720
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:40.893279Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"fe36e013-0701-45ac-8557-8b5c8bf88ca3","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01v0ub2dfr","registry_namespace_id":"7d818049-2cb7-4a3f-b528-c128b00545a5","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$B6SfRhJ82SUrThHEaR7hZA$idtcyqNALsMPkFg+kobNUASAebMVR4QlM+yogRJmIUs","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:04.961122Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "720"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:11 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3812d071-8e2e-4f45-a1a9-379b76e47c9e
+        status: 200 OK
+        code: 200
+        duration: 94.991932ms
+    - id: 24
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1053,8 +1200,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/739ec6ae-53ee-40dd-949f-67bb90f5bceb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/fe36e013-0701-45ac-8557-8b5c8bf88ca3
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -1062,20 +1209,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 719
+        content_length: 736
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:13.753353Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"739ec6ae-53ee-40dd-949f-67bb90f5bceb","name":"test-cr-ns-01","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01acrymz2v","registry_namespace_id":"82c49ce2-a6bf-4518-84b6-6ff9ad138bca","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$KRi5fL1eXTZH0eN3A3+WSQ$Rw4ck/IGCoWLzol+x/oGWiffRVIfTWZP7H3kX3Kc9Dc","key":"test_secret"}],"status":"ready","tags":["tag1","tag2"],"updated_at":"2025-04-28T09:37:27.187070800Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.893279Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"fe36e013-0701-45ac-8557-8b5c8bf88ca3","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01v0ub2dfr","registry_namespace_id":"7d818049-2cb7-4a3f-b528-c128b00545a5","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$B6SfRhJ82SUrThHEaR7hZA$idtcyqNALsMPkFg+kobNUASAebMVR4QlM+yogRJmIUs","key":"test_secret"}],"status":"ready","tags":["tag1","tag2"],"updated_at":"2025-08-27T15:06:11.768591131Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "719"
+                - "736"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:27 GMT
+                - Wed, 27 Aug 2025 15:06:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1083,157 +1230,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4ce2019a-c52b-4956-b5ab-1b283e9b2ec9
+                - 4a8dfccd-ad43-43d4-957e-ff88a8dc653d
         status: 200 OK
         code: 200
-        duration: 60.668791ms
-    - id: 22
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/739ec6ae-53ee-40dd-949f-67bb90f5bceb
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 716
-        uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:13.753353Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"739ec6ae-53ee-40dd-949f-67bb90f5bceb","name":"test-cr-ns-01","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01acrymz2v","registry_namespace_id":"82c49ce2-a6bf-4518-84b6-6ff9ad138bca","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$KRi5fL1eXTZH0eN3A3+WSQ$Rw4ck/IGCoWLzol+x/oGWiffRVIfTWZP7H3kX3Kc9Dc","key":"test_secret"}],"status":"ready","tags":["tag1","tag2"],"updated_at":"2025-04-28T09:37:27.187071Z"}'
-        headers:
-            Content-Length:
-                - "716"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 28 Apr 2025 09:37:27 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 367abc25-e67a-4026-884e-828e3552149b
-        status: 200 OK
-        code: 200
-        duration: 41.673708ms
-    - id: 23
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/739ec6ae-53ee-40dd-949f-67bb90f5bceb
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 716
-        uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:13.753353Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"739ec6ae-53ee-40dd-949f-67bb90f5bceb","name":"test-cr-ns-01","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01acrymz2v","registry_namespace_id":"82c49ce2-a6bf-4518-84b6-6ff9ad138bca","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$KRi5fL1eXTZH0eN3A3+WSQ$Rw4ck/IGCoWLzol+x/oGWiffRVIfTWZP7H3kX3Kc9Dc","key":"test_secret"}],"status":"ready","tags":["tag1","tag2"],"updated_at":"2025-04-28T09:37:27.187071Z"}'
-        headers:
-            Content-Length:
-                - "716"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 28 Apr 2025 09:37:27 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 3103c2da-e99a-4549-91e4-d01a5bd11d6c
-        status: 200 OK
-        code: 200
-        duration: 46.42325ms
-    - id: 24
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/739ec6ae-53ee-40dd-949f-67bb90f5bceb
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 716
-        uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:13.753353Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"739ec6ae-53ee-40dd-949f-67bb90f5bceb","name":"test-cr-ns-01","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01acrymz2v","registry_namespace_id":"82c49ce2-a6bf-4518-84b6-6ff9ad138bca","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$KRi5fL1eXTZH0eN3A3+WSQ$Rw4ck/IGCoWLzol+x/oGWiffRVIfTWZP7H3kX3Kc9Dc","key":"test_secret"}],"status":"ready","tags":["tag1","tag2"],"updated_at":"2025-04-28T09:37:27.187071Z"}'
-        headers:
-            Content-Length:
-                - "716"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 28 Apr 2025 09:37:27 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - cdbc0871-c686-4d4d-a8da-87c4c05beb40
-        status: 200 OK
-        code: 200
-        duration: 64.640125ms
+        duration: 91.638801ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1249,8 +1249,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/739ec6ae-53ee-40dd-949f-67bb90f5bceb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/fe36e013-0701-45ac-8557-8b5c8bf88ca3
         method: GET
       response:
         proto: HTTP/2.0
@@ -1258,20 +1258,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 716
+        content_length: 733
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:13.753353Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"739ec6ae-53ee-40dd-949f-67bb90f5bceb","name":"test-cr-ns-01","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01acrymz2v","registry_namespace_id":"82c49ce2-a6bf-4518-84b6-6ff9ad138bca","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$KRi5fL1eXTZH0eN3A3+WSQ$Rw4ck/IGCoWLzol+x/oGWiffRVIfTWZP7H3kX3Kc9Dc","key":"test_secret"}],"status":"ready","tags":["tag1","tag2"],"updated_at":"2025-04-28T09:37:27.187071Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.893279Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"fe36e013-0701-45ac-8557-8b5c8bf88ca3","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01v0ub2dfr","registry_namespace_id":"7d818049-2cb7-4a3f-b528-c128b00545a5","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$B6SfRhJ82SUrThHEaR7hZA$idtcyqNALsMPkFg+kobNUASAebMVR4QlM+yogRJmIUs","key":"test_secret"}],"status":"ready","tags":["tag1","tag2"],"updated_at":"2025-08-27T15:06:11.768591Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "716"
+                - "733"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:27 GMT
+                - Wed, 27 Aug 2025 15:06:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1279,10 +1279,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ebe771e9-6ecc-44f6-a0f5-29d53b55f53e
+                - 024781d9-e621-46da-bde2-4e85ee93ab7d
         status: 200 OK
         code: 200
-        duration: 36.237917ms
+        duration: 79.913037ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1298,8 +1298,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/739ec6ae-53ee-40dd-949f-67bb90f5bceb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/fe36e013-0701-45ac-8557-8b5c8bf88ca3
         method: GET
       response:
         proto: HTTP/2.0
@@ -1307,20 +1307,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 716
+        content_length: 733
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:13.753353Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"739ec6ae-53ee-40dd-949f-67bb90f5bceb","name":"test-cr-ns-01","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01acrymz2v","registry_namespace_id":"82c49ce2-a6bf-4518-84b6-6ff9ad138bca","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$KRi5fL1eXTZH0eN3A3+WSQ$Rw4ck/IGCoWLzol+x/oGWiffRVIfTWZP7H3kX3Kc9Dc","key":"test_secret"}],"status":"ready","tags":["tag1","tag2"],"updated_at":"2025-04-28T09:37:27.187071Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.893279Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"fe36e013-0701-45ac-8557-8b5c8bf88ca3","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01v0ub2dfr","registry_namespace_id":"7d818049-2cb7-4a3f-b528-c128b00545a5","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$B6SfRhJ82SUrThHEaR7hZA$idtcyqNALsMPkFg+kobNUASAebMVR4QlM+yogRJmIUs","key":"test_secret"}],"status":"ready","tags":["tag1","tag2"],"updated_at":"2025-08-27T15:06:11.768591Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "716"
+                - "733"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:28 GMT
+                - Wed, 27 Aug 2025 15:06:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1328,11 +1328,158 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1ec0c9bd-d1b1-46cb-9668-563991f1a637
+                - e3ae868a-543f-426c-9e5c-16c082994d40
         status: 200 OK
         code: 200
-        duration: 42.183042ms
+        duration: 89.087534ms
     - id: 27
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/fe36e013-0701-45ac-8557-8b5c8bf88ca3
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 733
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:40.893279Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"fe36e013-0701-45ac-8557-8b5c8bf88ca3","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01v0ub2dfr","registry_namespace_id":"7d818049-2cb7-4a3f-b528-c128b00545a5","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$B6SfRhJ82SUrThHEaR7hZA$idtcyqNALsMPkFg+kobNUASAebMVR4QlM+yogRJmIUs","key":"test_secret"}],"status":"ready","tags":["tag1","tag2"],"updated_at":"2025-08-27T15:06:11.768591Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "733"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:12 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 177e4f3b-6e64-4230-8c82-a8ff5e951c38
+        status: 200 OK
+        code: 200
+        duration: 157.186171ms
+    - id: 28
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/fe36e013-0701-45ac-8557-8b5c8bf88ca3
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 733
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:40.893279Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"fe36e013-0701-45ac-8557-8b5c8bf88ca3","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01v0ub2dfr","registry_namespace_id":"7d818049-2cb7-4a3f-b528-c128b00545a5","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$B6SfRhJ82SUrThHEaR7hZA$idtcyqNALsMPkFg+kobNUASAebMVR4QlM+yogRJmIUs","key":"test_secret"}],"status":"ready","tags":["tag1","tag2"],"updated_at":"2025-08-27T15:06:11.768591Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "733"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:12 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b9bf72c6-acb5-4d5b-9add-031ebffbc9ee
+        status: 200 OK
+        code: 200
+        duration: 88.124306ms
+    - id: 29
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/fe36e013-0701-45ac-8557-8b5c8bf88ca3
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 733
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:40.893279Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"fe36e013-0701-45ac-8557-8b5c8bf88ca3","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01v0ub2dfr","registry_namespace_id":"7d818049-2cb7-4a3f-b528-c128b00545a5","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$B6SfRhJ82SUrThHEaR7hZA$idtcyqNALsMPkFg+kobNUASAebMVR4QlM+yogRJmIUs","key":"test_secret"}],"status":"ready","tags":["tag1","tag2"],"updated_at":"2025-08-27T15:06:11.768591Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "733"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:13 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b31c5566-23fa-4b57-b640-3c3eda14275f
+        status: 200 OK
+        code: 200
+        duration: 95.107119ms
+    - id: 30
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1349,8 +1496,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/739ec6ae-53ee-40dd-949f-67bb90f5bceb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/fe36e013-0701-45ac-8557-8b5c8bf88ca3
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -1358,20 +1505,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 557
+        content_length: 576
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:13.753353Z","description":"","environment_variables":{},"error_message":null,"id":"739ec6ae-53ee-40dd-949f-67bb90f5bceb","name":"test-cr-ns-01","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01acrymz2v","registry_namespace_id":"82c49ce2-a6bf-4518-84b6-6ff9ad138bca","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-04-28T09:37:28.235724290Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.893279Z","description":"","environment_variables":{},"error_message":null,"id":"fe36e013-0701-45ac-8557-8b5c8bf88ca3","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01v0ub2dfr","registry_namespace_id":"7d818049-2cb7-4a3f-b528-c128b00545a5","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:06:13.678630797Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "557"
+                - "576"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:28 GMT
+                - Wed, 27 Aug 2025 15:06:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1379,157 +1526,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ac16afb5-2be4-464a-bcd2-3ba2a081305c
+                - 456dfa1f-2a85-4455-b934-92421238bdc5
         status: 200 OK
         code: 200
-        duration: 63.553125ms
-    - id: 28
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/739ec6ae-53ee-40dd-949f-67bb90f5bceb
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 554
-        uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:13.753353Z","description":"","environment_variables":{},"error_message":null,"id":"739ec6ae-53ee-40dd-949f-67bb90f5bceb","name":"test-cr-ns-01","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01acrymz2v","registry_namespace_id":"82c49ce2-a6bf-4518-84b6-6ff9ad138bca","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-04-28T09:37:28.235724Z"}'
-        headers:
-            Content-Length:
-                - "554"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 28 Apr 2025 09:37:28 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - f023fad2-723c-4b53-83d9-f660164d1da9
-        status: 200 OK
-        code: 200
-        duration: 98.281166ms
-    - id: 29
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/739ec6ae-53ee-40dd-949f-67bb90f5bceb
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 552
-        uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:13.753353Z","description":"","environment_variables":{},"error_message":null,"id":"739ec6ae-53ee-40dd-949f-67bb90f5bceb","name":"test-cr-ns-01","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01acrymz2v","registry_namespace_id":"82c49ce2-a6bf-4518-84b6-6ff9ad138bca","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-28T09:37:28.662790Z"}'
-        headers:
-            Content-Length:
-                - "552"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 28 Apr 2025 09:37:33 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - da9c5b87-a600-40d7-96db-57bc47280256
-        status: 200 OK
-        code: 200
-        duration: 34.984125ms
-    - id: 30
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/739ec6ae-53ee-40dd-949f-67bb90f5bceb
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 552
-        uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:13.753353Z","description":"","environment_variables":{},"error_message":null,"id":"739ec6ae-53ee-40dd-949f-67bb90f5bceb","name":"test-cr-ns-01","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01acrymz2v","registry_namespace_id":"82c49ce2-a6bf-4518-84b6-6ff9ad138bca","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-28T09:37:28.662790Z"}'
-        headers:
-            Content-Length:
-                - "552"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 28 Apr 2025 09:37:33 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - a491c004-4d57-4f79-9ba6-98b07fc62d24
-        status: 200 OK
-        code: 200
-        duration: 45.157708ms
+        duration: 106.993454ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1545,8 +1545,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/739ec6ae-53ee-40dd-949f-67bb90f5bceb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/fe36e013-0701-45ac-8557-8b5c8bf88ca3
         method: GET
       response:
         proto: HTTP/2.0
@@ -1554,20 +1554,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 552
+        content_length: 573
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:13.753353Z","description":"","environment_variables":{},"error_message":null,"id":"739ec6ae-53ee-40dd-949f-67bb90f5bceb","name":"test-cr-ns-01","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01acrymz2v","registry_namespace_id":"82c49ce2-a6bf-4518-84b6-6ff9ad138bca","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-28T09:37:28.662790Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.893279Z","description":"","environment_variables":{},"error_message":null,"id":"fe36e013-0701-45ac-8557-8b5c8bf88ca3","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01v0ub2dfr","registry_namespace_id":"7d818049-2cb7-4a3f-b528-c128b00545a5","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:06:13.678631Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "552"
+                - "573"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:33 GMT
+                - Wed, 27 Aug 2025 15:06:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1575,10 +1575,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2c34046e-0dfb-414b-b0d0-49ed209645ee
+                - a9dadf27-41fb-429e-9a44-7b42ab616614
         status: 200 OK
         code: 200
-        duration: 35.700833ms
+        duration: 70.654754ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1594,8 +1594,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/739ec6ae-53ee-40dd-949f-67bb90f5bceb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/fe36e013-0701-45ac-8557-8b5c8bf88ca3
         method: GET
       response:
         proto: HTTP/2.0
@@ -1603,20 +1603,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 552
+        content_length: 571
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:13.753353Z","description":"","environment_variables":{},"error_message":null,"id":"739ec6ae-53ee-40dd-949f-67bb90f5bceb","name":"test-cr-ns-01","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01acrymz2v","registry_namespace_id":"82c49ce2-a6bf-4518-84b6-6ff9ad138bca","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-28T09:37:28.662790Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.893279Z","description":"","environment_variables":{},"error_message":null,"id":"fe36e013-0701-45ac-8557-8b5c8bf88ca3","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01v0ub2dfr","registry_namespace_id":"7d818049-2cb7-4a3f-b528-c128b00545a5","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:16.601008Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "552"
+                - "571"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:33 GMT
+                - Wed, 27 Aug 2025 15:06:18 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1624,10 +1624,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4d246ada-c85d-4cc7-8d79-210feef65085
+                - 35b3671c-da95-43be-9e99-8316a4f542e3
         status: 200 OK
         code: 200
-        duration: 44.099333ms
+        duration: 98.263774ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1643,8 +1643,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/739ec6ae-53ee-40dd-949f-67bb90f5bceb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/fe36e013-0701-45ac-8557-8b5c8bf88ca3
         method: GET
       response:
         proto: HTTP/2.0
@@ -1652,20 +1652,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 552
+        content_length: 571
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:13.753353Z","description":"","environment_variables":{},"error_message":null,"id":"739ec6ae-53ee-40dd-949f-67bb90f5bceb","name":"test-cr-ns-01","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01acrymz2v","registry_namespace_id":"82c49ce2-a6bf-4518-84b6-6ff9ad138bca","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-28T09:37:28.662790Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.893279Z","description":"","environment_variables":{},"error_message":null,"id":"fe36e013-0701-45ac-8557-8b5c8bf88ca3","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01v0ub2dfr","registry_namespace_id":"7d818049-2cb7-4a3f-b528-c128b00545a5","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:16.601008Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "552"
+                - "571"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:34 GMT
+                - Wed, 27 Aug 2025 15:06:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1673,10 +1673,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7f2bc39b-7847-45e4-8df0-9d5339b0ff2f
+                - 3ae9019b-c924-43f6-9624-3c6f5aa0c006
         status: 200 OK
         code: 200
-        duration: 38.279584ms
+        duration: 81.366667ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1692,29 +1692,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/739ec6ae-53ee-40dd-949f-67bb90f5bceb
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/fe36e013-0701-45ac-8557-8b5c8bf88ca3
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 558
+        content_length: 571
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:13.753353Z","description":"","environment_variables":{},"error_message":null,"id":"739ec6ae-53ee-40dd-949f-67bb90f5bceb","name":"test-cr-ns-01","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01acrymz2v","registry_namespace_id":"82c49ce2-a6bf-4518-84b6-6ff9ad138bca","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-04-28T09:37:34.159446628Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.893279Z","description":"","environment_variables":{},"error_message":null,"id":"fe36e013-0701-45ac-8557-8b5c8bf88ca3","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01v0ub2dfr","registry_namespace_id":"7d818049-2cb7-4a3f-b528-c128b00545a5","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:16.601008Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "558"
+                - "571"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:34 GMT
+                - Wed, 27 Aug 2025 15:06:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1722,10 +1722,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a08aebcf-aa87-444b-a57b-5c8efc6a744c
+                - c77540b9-03c3-4e44-9491-b6f48d21e7d6
         status: 200 OK
         code: 200
-        duration: 139.688708ms
+        duration: 86.011433ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1741,8 +1741,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/739ec6ae-53ee-40dd-949f-67bb90f5bceb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/fe36e013-0701-45ac-8557-8b5c8bf88ca3
         method: GET
       response:
         proto: HTTP/2.0
@@ -1750,20 +1750,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 555
+        content_length: 571
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:13.753353Z","description":"","environment_variables":{},"error_message":null,"id":"739ec6ae-53ee-40dd-949f-67bb90f5bceb","name":"test-cr-ns-01","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01acrymz2v","registry_namespace_id":"82c49ce2-a6bf-4518-84b6-6ff9ad138bca","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-04-28T09:37:34.159447Z"}'
+        body: '{"created_at":"2025-08-27T15:05:40.893279Z","description":"","environment_variables":{},"error_message":null,"id":"fe36e013-0701-45ac-8557-8b5c8bf88ca3","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01v0ub2dfr","registry_namespace_id":"7d818049-2cb7-4a3f-b528-c128b00545a5","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:16.601008Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "555"
+                - "571"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:34 GMT
+                - Wed, 27 Aug 2025 15:06:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1771,10 +1771,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2266fdb7-3150-41f4-821b-4c89fbfe3a26
+                - aae59d01-567d-435f-8350-74931fb26a5d
         status: 200 OK
         code: 200
-        duration: 42.500083ms
+        duration: 84.797875ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1790,8 +1790,155 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/739ec6ae-53ee-40dd-949f-67bb90f5bceb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/fe36e013-0701-45ac-8557-8b5c8bf88ca3
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 571
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:40.893279Z","description":"","environment_variables":{},"error_message":null,"id":"fe36e013-0701-45ac-8557-8b5c8bf88ca3","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01v0ub2dfr","registry_namespace_id":"7d818049-2cb7-4a3f-b528-c128b00545a5","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:16.601008Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "571"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:20 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - af2a4ce1-4370-4ce9-9ae0-841dca074dd0
+        status: 200 OK
+        code: 200
+        duration: 88.889063ms
+    - id: 37
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/fe36e013-0701-45ac-8557-8b5c8bf88ca3
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 577
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:40.893279Z","description":"","environment_variables":{},"error_message":null,"id":"fe36e013-0701-45ac-8557-8b5c8bf88ca3","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01v0ub2dfr","registry_namespace_id":"7d818049-2cb7-4a3f-b528-c128b00545a5","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:20.292044564Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "577"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:20 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 18542dd8-05a4-46bc-af84-f20840f628df
+        status: 200 OK
+        code: 200
+        duration: 232.411647ms
+    - id: 38
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/fe36e013-0701-45ac-8557-8b5c8bf88ca3
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 574
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:40.893279Z","description":"","environment_variables":{},"error_message":null,"id":"fe36e013-0701-45ac-8557-8b5c8bf88ca3","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01v0ub2dfr","registry_namespace_id":"7d818049-2cb7-4a3f-b528-c128b00545a5","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:20.292045Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "574"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:20 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 76fc0b82-f34d-4766-b3f7-a9d2ea7fb397
+        status: 200 OK
+        code: 200
+        duration: 85.05092ms
+    - id: 39
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/fe36e013-0701-45ac-8557-8b5c8bf88ca3
         method: GET
       response:
         proto: HTTP/2.0
@@ -1810,9 +1957,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:39 GMT
+                - Wed, 27 Aug 2025 15:06:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1820,28 +1967,28 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f7f0f30a-97fe-4dd6-bf36-642804578463
+                - beae24de-1bf6-453e-b2c7-be071eb8bfde
         status: 404 Not Found
         code: 404
-        duration: 27.829209ms
-    - id: 37
+        duration: 21.824705ms
+    - id: 40
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 203
+        content_length: 235
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-env-test","environment_variables":{"test":"test"},"project_id":"6867048b-fe12-4e96-835e-41c79a39604b","secret_environment_variables":[{"key":"test_secret","value":"test_secret"}],"tags":null}'
+        body: '{"name":"tf-env-test","environment_variables":{"test":"test"},"project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","secret_environment_variables":[{"key":"test_secret","value":"test_secret"}],"tags":null,"activate_vpc_integration":true}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces
         method: POST
       response:
@@ -1850,20 +1997,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 627
+        content_length: 645
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:39.730989705Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"9a02f592-bb53-4c3e-8336-012076fad92e","name":"tf-env-test","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$RbysG7vX6lPMWt+xB4q1gw$uwtwWV2BljRrn2CAsyExqOz0rBKOlPbJEKEeb0pJS1Y","key":"test_secret"}],"status":"pending","tags":[],"updated_at":"2025-04-28T09:37:39.730989705Z"}'
+        body: '{"created_at":"2025-08-27T15:06:26.624224702Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"f448ff7b-cbe1-4ca6-b781-bc383d1f16e7","name":"tf-env-test","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$p0eiLzrBOQw77v8ecVtW+g$meV1sSGfbzxOZmzK5QTRYw/spz6XszgOMidHgqmyPd4","key":"test_secret"}],"status":"pending","tags":[],"updated_at":"2025-08-27T15:06:26.624224702Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "627"
+                - "645"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:39 GMT
+                - Wed, 27 Aug 2025 15:06:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1871,157 +2018,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c5959480-abbe-419e-8194-2b1c534ef24f
+                - 3c5ce065-8a8a-45db-8d54-60145e850aac
         status: 200 OK
         code: 200
-        duration: 416.594209ms
-    - id: 38
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9a02f592-bb53-4c3e-8336-012076fad92e
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 621
-        uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:39.730990Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"9a02f592-bb53-4c3e-8336-012076fad92e","name":"tf-env-test","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$RbysG7vX6lPMWt+xB4q1gw$uwtwWV2BljRrn2CAsyExqOz0rBKOlPbJEKEeb0pJS1Y","key":"test_secret"}],"status":"pending","tags":[],"updated_at":"2025-04-28T09:37:39.730990Z"}'
-        headers:
-            Content-Length:
-                - "621"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 28 Apr 2025 09:37:39 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 9da9044d-51b5-4362-aa7b-f5162bbe2ee9
-        status: 200 OK
-        code: 200
-        duration: 44.407084ms
-    - id: 39
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9a02f592-bb53-4c3e-8336-012076fad92e
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 699
-        uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:39.730990Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"9a02f592-bb53-4c3e-8336-012076fad92e","name":"tf-env-test","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtest5lopdqs6","registry_namespace_id":"8143e3ee-48ef-4829-a20f-a477cf6c1bce","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$RbysG7vX6lPMWt+xB4q1gw$uwtwWV2BljRrn2CAsyExqOz0rBKOlPbJEKEeb0pJS1Y","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2025-04-28T09:37:41.144897Z"}'
-        headers:
-            Content-Length:
-                - "699"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 28 Apr 2025 09:37:44 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 6ca472dc-75ed-4d12-924f-cf15a1469295
-        status: 200 OK
-        code: 200
-        duration: 41.230083ms
-    - id: 40
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9a02f592-bb53-4c3e-8336-012076fad92e
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 699
-        uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:39.730990Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"9a02f592-bb53-4c3e-8336-012076fad92e","name":"tf-env-test","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtest5lopdqs6","registry_namespace_id":"8143e3ee-48ef-4829-a20f-a477cf6c1bce","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$RbysG7vX6lPMWt+xB4q1gw$uwtwWV2BljRrn2CAsyExqOz0rBKOlPbJEKEeb0pJS1Y","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2025-04-28T09:37:41.144897Z"}'
-        headers:
-            Content-Length:
-                - "699"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 28 Apr 2025 09:37:44 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 26e1343a-5c95-4b2d-92b7-3bb0962eac28
-        status: 200 OK
-        code: 200
-        duration: 50.429375ms
+        duration: 1.067919248s
     - id: 41
       request:
         proto: HTTP/1.1
@@ -2037,8 +2037,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9a02f592-bb53-4c3e-8336-012076fad92e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/f448ff7b-cbe1-4ca6-b781-bc383d1f16e7
         method: GET
       response:
         proto: HTTP/2.0
@@ -2046,20 +2046,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 699
+        content_length: 639
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:39.730990Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"9a02f592-bb53-4c3e-8336-012076fad92e","name":"tf-env-test","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtest5lopdqs6","registry_namespace_id":"8143e3ee-48ef-4829-a20f-a477cf6c1bce","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$RbysG7vX6lPMWt+xB4q1gw$uwtwWV2BljRrn2CAsyExqOz0rBKOlPbJEKEeb0pJS1Y","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2025-04-28T09:37:41.144897Z"}'
+        body: '{"created_at":"2025-08-27T15:06:26.624225Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"f448ff7b-cbe1-4ca6-b781-bc383d1f16e7","name":"tf-env-test","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$p0eiLzrBOQw77v8ecVtW+g$meV1sSGfbzxOZmzK5QTRYw/spz6XszgOMidHgqmyPd4","key":"test_secret"}],"status":"pending","tags":[],"updated_at":"2025-08-27T15:06:26.624225Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "699"
+                - "639"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:45 GMT
+                - Wed, 27 Aug 2025 15:06:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2067,10 +2067,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ad0015eb-253b-4e32-a259-23467ca5f35e
+                - 89e928b4-2a4b-4a6b-b784-28177e3cc204
         status: 200 OK
         code: 200
-        duration: 41.390625ms
+        duration: 80.791699ms
     - id: 42
       request:
         proto: HTTP/1.1
@@ -2086,8 +2086,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9a02f592-bb53-4c3e-8336-012076fad92e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/f448ff7b-cbe1-4ca6-b781-bc383d1f16e7
         method: GET
       response:
         proto: HTTP/2.0
@@ -2095,20 +2095,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 699
+        content_length: 717
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:39.730990Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"9a02f592-bb53-4c3e-8336-012076fad92e","name":"tf-env-test","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtest5lopdqs6","registry_namespace_id":"8143e3ee-48ef-4829-a20f-a477cf6c1bce","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$RbysG7vX6lPMWt+xB4q1gw$uwtwWV2BljRrn2CAsyExqOz0rBKOlPbJEKEeb0pJS1Y","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2025-04-28T09:37:41.144897Z"}'
+        body: '{"created_at":"2025-08-27T15:06:26.624225Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"f448ff7b-cbe1-4ca6-b781-bc383d1f16e7","name":"tf-env-test","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestzxhxhgvl","registry_namespace_id":"ecb388b1-8150-4a47-b5da-b43c6a91e350","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$p0eiLzrBOQw77v8ecVtW+g$meV1sSGfbzxOZmzK5QTRYw/spz6XszgOMidHgqmyPd4","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:27.992550Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "699"
+                - "717"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:45 GMT
+                - Wed, 27 Aug 2025 15:06:31 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2116,10 +2116,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - af2d2e74-9c97-438e-a4b0-caa84eb22bcd
+                - 050630f6-d704-483f-bf99-6b03781bb528
         status: 200 OK
         code: 200
-        duration: 58.445792ms
+        duration: 86.172428ms
     - id: 43
       request:
         proto: HTTP/1.1
@@ -2135,8 +2135,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9a02f592-bb53-4c3e-8336-012076fad92e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/f448ff7b-cbe1-4ca6-b781-bc383d1f16e7
         method: GET
       response:
         proto: HTTP/2.0
@@ -2144,20 +2144,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 699
+        content_length: 717
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:39.730990Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"9a02f592-bb53-4c3e-8336-012076fad92e","name":"tf-env-test","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtest5lopdqs6","registry_namespace_id":"8143e3ee-48ef-4829-a20f-a477cf6c1bce","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$RbysG7vX6lPMWt+xB4q1gw$uwtwWV2BljRrn2CAsyExqOz0rBKOlPbJEKEeb0pJS1Y","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2025-04-28T09:37:41.144897Z"}'
+        body: '{"created_at":"2025-08-27T15:06:26.624225Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"f448ff7b-cbe1-4ca6-b781-bc383d1f16e7","name":"tf-env-test","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestzxhxhgvl","registry_namespace_id":"ecb388b1-8150-4a47-b5da-b43c6a91e350","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$p0eiLzrBOQw77v8ecVtW+g$meV1sSGfbzxOZmzK5QTRYw/spz6XszgOMidHgqmyPd4","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:27.992550Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "699"
+                - "717"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:45 GMT
+                - Wed, 27 Aug 2025 15:06:31 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2165,10 +2165,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 57e2a45c-425c-440d-afeb-a75b1bccf1de
+                - 8f54f0fc-a7f7-44d3-a369-27f7937fec52
         status: 200 OK
         code: 200
-        duration: 42.731459ms
+        duration: 83.452764ms
     - id: 44
       request:
         proto: HTTP/1.1
@@ -2184,8 +2184,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9a02f592-bb53-4c3e-8336-012076fad92e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/f448ff7b-cbe1-4ca6-b781-bc383d1f16e7
         method: GET
       response:
         proto: HTTP/2.0
@@ -2193,20 +2193,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 699
+        content_length: 717
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:39.730990Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"9a02f592-bb53-4c3e-8336-012076fad92e","name":"tf-env-test","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtest5lopdqs6","registry_namespace_id":"8143e3ee-48ef-4829-a20f-a477cf6c1bce","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$RbysG7vX6lPMWt+xB4q1gw$uwtwWV2BljRrn2CAsyExqOz0rBKOlPbJEKEeb0pJS1Y","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2025-04-28T09:37:41.144897Z"}'
+        body: '{"created_at":"2025-08-27T15:06:26.624225Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"f448ff7b-cbe1-4ca6-b781-bc383d1f16e7","name":"tf-env-test","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestzxhxhgvl","registry_namespace_id":"ecb388b1-8150-4a47-b5da-b43c6a91e350","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$p0eiLzrBOQw77v8ecVtW+g$meV1sSGfbzxOZmzK5QTRYw/spz6XszgOMidHgqmyPd4","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:27.992550Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "699"
+                - "717"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:45 GMT
+                - Wed, 27 Aug 2025 15:06:32 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2214,11 +2214,158 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d5e778fd-da09-4277-af42-bb015ade2644
+                - 04d781b5-1106-4698-82a9-7064a342200b
         status: 200 OK
         code: 200
-        duration: 50.783583ms
+        duration: 90.251253ms
     - id: 45
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/f448ff7b-cbe1-4ca6-b781-bc383d1f16e7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 717
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:06:26.624225Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"f448ff7b-cbe1-4ca6-b781-bc383d1f16e7","name":"tf-env-test","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestzxhxhgvl","registry_namespace_id":"ecb388b1-8150-4a47-b5da-b43c6a91e350","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$p0eiLzrBOQw77v8ecVtW+g$meV1sSGfbzxOZmzK5QTRYw/spz6XszgOMidHgqmyPd4","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:27.992550Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "717"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:32 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 835bf68b-8ce5-4a3e-97f8-23ad0d2cd46d
+        status: 200 OK
+        code: 200
+        duration: 85.984595ms
+    - id: 46
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/f448ff7b-cbe1-4ca6-b781-bc383d1f16e7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 717
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:06:26.624225Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"f448ff7b-cbe1-4ca6-b781-bc383d1f16e7","name":"tf-env-test","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestzxhxhgvl","registry_namespace_id":"ecb388b1-8150-4a47-b5da-b43c6a91e350","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$p0eiLzrBOQw77v8ecVtW+g$meV1sSGfbzxOZmzK5QTRYw/spz6XszgOMidHgqmyPd4","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:27.992550Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "717"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:32 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - de6a73fd-8d16-4a47-a74b-33787f9a08ab
+        status: 200 OK
+        code: 200
+        duration: 86.782353ms
+    - id: 47
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/f448ff7b-cbe1-4ca6-b781-bc383d1f16e7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 717
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:06:26.624225Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"f448ff7b-cbe1-4ca6-b781-bc383d1f16e7","name":"tf-env-test","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestzxhxhgvl","registry_namespace_id":"ecb388b1-8150-4a47-b5da-b43c6a91e350","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$p0eiLzrBOQw77v8ecVtW+g$meV1sSGfbzxOZmzK5QTRYw/spz6XszgOMidHgqmyPd4","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:27.992550Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "717"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:33 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 185b269e-ac58-4140-a362-431724c1e7b3
+        status: 200 OK
+        code: 200
+        duration: 82.444443ms
+    - id: 48
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2235,8 +2382,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9a02f592-bb53-4c3e-8336-012076fad92e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/f448ff7b-cbe1-4ca6-b781-bc383d1f16e7
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -2244,20 +2391,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 701
+        content_length: 719
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:39.730990Z","description":"","environment_variables":{"foo":"bar"},"error_message":null,"id":"9a02f592-bb53-4c3e-8336-012076fad92e","name":"tf-env-test","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtest5lopdqs6","registry_namespace_id":"8143e3ee-48ef-4829-a20f-a477cf6c1bce","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$LRWZ4maW4VIqSDPxGsoe1w$vdGYUWrJHs2Ztq9Yecx62+BSDkn5ZYEvGYhAMVjU6tY","key":"foo_secret"}],"status":"pending","tags":[],"updated_at":"2025-04-28T09:37:46.245920682Z"}'
+        body: '{"created_at":"2025-08-27T15:06:26.624225Z","description":"","environment_variables":{"foo":"bar"},"error_message":null,"id":"f448ff7b-cbe1-4ca6-b781-bc383d1f16e7","name":"tf-env-test","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestzxhxhgvl","registry_namespace_id":"ecb388b1-8150-4a47-b5da-b43c6a91e350","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$w7hAhE+8fUjCtDVlB8I8DA$nez1WvvOe/f3kEIgJ279R+xOB+JbFVZW48j0AfA2OZE","key":"foo_secret"}],"status":"pending","tags":[],"updated_at":"2025-08-27T15:06:33.778860725Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "701"
+                - "719"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:46 GMT
+                - Wed, 27 Aug 2025 15:06:33 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2265,157 +2412,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d1ea07da-7db0-47cc-9647-ee9aec28bd7d
+                - 4e3aee36-6421-46dd-a8cd-762b0bf70d91
         status: 200 OK
         code: 200
-        duration: 415.2715ms
-    - id: 46
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9a02f592-bb53-4c3e-8336-012076fad92e
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 698
-        uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:39.730990Z","description":"","environment_variables":{"foo":"bar"},"error_message":null,"id":"9a02f592-bb53-4c3e-8336-012076fad92e","name":"tf-env-test","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtest5lopdqs6","registry_namespace_id":"8143e3ee-48ef-4829-a20f-a477cf6c1bce","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$LRWZ4maW4VIqSDPxGsoe1w$vdGYUWrJHs2Ztq9Yecx62+BSDkn5ZYEvGYhAMVjU6tY","key":"foo_secret"}],"status":"pending","tags":[],"updated_at":"2025-04-28T09:37:46.245921Z"}'
-        headers:
-            Content-Length:
-                - "698"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 28 Apr 2025 09:37:46 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - ac0adb03-f326-4af0-9ae8-0b01319c454b
-        status: 200 OK
-        code: 200
-        duration: 40.758916ms
-    - id: 47
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9a02f592-bb53-4c3e-8336-012076fad92e
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 696
-        uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:39.730990Z","description":"","environment_variables":{"foo":"bar"},"error_message":null,"id":"9a02f592-bb53-4c3e-8336-012076fad92e","name":"tf-env-test","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtest5lopdqs6","registry_namespace_id":"8143e3ee-48ef-4829-a20f-a477cf6c1bce","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$LRWZ4maW4VIqSDPxGsoe1w$vdGYUWrJHs2Ztq9Yecx62+BSDkn5ZYEvGYhAMVjU6tY","key":"foo_secret"}],"status":"ready","tags":[],"updated_at":"2025-04-28T09:37:46.615705Z"}'
-        headers:
-            Content-Length:
-                - "696"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 28 Apr 2025 09:37:51 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - c1c2889f-4f43-468c-9fbb-6b532dd57bc1
-        status: 200 OK
-        code: 200
-        duration: 47.420209ms
-    - id: 48
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9a02f592-bb53-4c3e-8336-012076fad92e
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 696
-        uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:39.730990Z","description":"","environment_variables":{"foo":"bar"},"error_message":null,"id":"9a02f592-bb53-4c3e-8336-012076fad92e","name":"tf-env-test","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtest5lopdqs6","registry_namespace_id":"8143e3ee-48ef-4829-a20f-a477cf6c1bce","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$LRWZ4maW4VIqSDPxGsoe1w$vdGYUWrJHs2Ztq9Yecx62+BSDkn5ZYEvGYhAMVjU6tY","key":"foo_secret"}],"status":"ready","tags":[],"updated_at":"2025-04-28T09:37:46.615705Z"}'
-        headers:
-            Content-Length:
-                - "696"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 28 Apr 2025 09:37:51 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 3a8d4cbd-8dcd-44d3-b8b1-33bcf58a6052
-        status: 200 OK
-        code: 200
-        duration: 36.080083ms
+        duration: 174.723621ms
     - id: 49
       request:
         proto: HTTP/1.1
@@ -2431,8 +2431,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9a02f592-bb53-4c3e-8336-012076fad92e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/f448ff7b-cbe1-4ca6-b781-bc383d1f16e7
         method: GET
       response:
         proto: HTTP/2.0
@@ -2440,20 +2440,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 696
+        content_length: 716
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:39.730990Z","description":"","environment_variables":{"foo":"bar"},"error_message":null,"id":"9a02f592-bb53-4c3e-8336-012076fad92e","name":"tf-env-test","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtest5lopdqs6","registry_namespace_id":"8143e3ee-48ef-4829-a20f-a477cf6c1bce","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$LRWZ4maW4VIqSDPxGsoe1w$vdGYUWrJHs2Ztq9Yecx62+BSDkn5ZYEvGYhAMVjU6tY","key":"foo_secret"}],"status":"ready","tags":[],"updated_at":"2025-04-28T09:37:46.615705Z"}'
+        body: '{"created_at":"2025-08-27T15:06:26.624225Z","description":"","environment_variables":{"foo":"bar"},"error_message":null,"id":"f448ff7b-cbe1-4ca6-b781-bc383d1f16e7","name":"tf-env-test","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestzxhxhgvl","registry_namespace_id":"ecb388b1-8150-4a47-b5da-b43c6a91e350","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$w7hAhE+8fUjCtDVlB8I8DA$nez1WvvOe/f3kEIgJ279R+xOB+JbFVZW48j0AfA2OZE","key":"foo_secret"}],"status":"pending","tags":[],"updated_at":"2025-08-27T15:06:33.778861Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "696"
+                - "716"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:51 GMT
+                - Wed, 27 Aug 2025 15:06:33 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2461,10 +2461,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bf48d08b-6b6e-4adf-ade7-35120137170d
+                - f6c20826-5301-46ad-b9b6-fbad3a910e57
         status: 200 OK
         code: 200
-        duration: 45.7015ms
+        duration: 82.521637ms
     - id: 50
       request:
         proto: HTTP/1.1
@@ -2480,8 +2480,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9a02f592-bb53-4c3e-8336-012076fad92e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/f448ff7b-cbe1-4ca6-b781-bc383d1f16e7
         method: GET
       response:
         proto: HTTP/2.0
@@ -2489,20 +2489,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 696
+        content_length: 716
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:39.730990Z","description":"","environment_variables":{"foo":"bar"},"error_message":null,"id":"9a02f592-bb53-4c3e-8336-012076fad92e","name":"tf-env-test","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtest5lopdqs6","registry_namespace_id":"8143e3ee-48ef-4829-a20f-a477cf6c1bce","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$LRWZ4maW4VIqSDPxGsoe1w$vdGYUWrJHs2Ztq9Yecx62+BSDkn5ZYEvGYhAMVjU6tY","key":"foo_secret"}],"status":"ready","tags":[],"updated_at":"2025-04-28T09:37:46.615705Z"}'
+        body: '{"created_at":"2025-08-27T15:06:26.624225Z","description":"","environment_variables":{"foo":"bar"},"error_message":null,"id":"f448ff7b-cbe1-4ca6-b781-bc383d1f16e7","name":"tf-env-test","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestzxhxhgvl","registry_namespace_id":"ecb388b1-8150-4a47-b5da-b43c6a91e350","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$w7hAhE+8fUjCtDVlB8I8DA$nez1WvvOe/f3kEIgJ279R+xOB+JbFVZW48j0AfA2OZE","key":"foo_secret"}],"status":"pending","tags":[],"updated_at":"2025-08-27T15:06:33.778861Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "696"
+                - "716"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:52 GMT
+                - Wed, 27 Aug 2025 15:06:38 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2510,10 +2510,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - eaffb402-4fa4-45bb-8176-e65688c45214
+                - 8d0cbc7e-0ea8-43cb-9cfd-6e76e10453a3
         status: 200 OK
         code: 200
-        duration: 42.792375ms
+        duration: 76.793199ms
     - id: 51
       request:
         proto: HTTP/1.1
@@ -2529,8 +2529,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9a02f592-bb53-4c3e-8336-012076fad92e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/f448ff7b-cbe1-4ca6-b781-bc383d1f16e7
         method: GET
       response:
         proto: HTTP/2.0
@@ -2538,20 +2538,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 696
+        content_length: 716
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:39.730990Z","description":"","environment_variables":{"foo":"bar"},"error_message":null,"id":"9a02f592-bb53-4c3e-8336-012076fad92e","name":"tf-env-test","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtest5lopdqs6","registry_namespace_id":"8143e3ee-48ef-4829-a20f-a477cf6c1bce","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$LRWZ4maW4VIqSDPxGsoe1w$vdGYUWrJHs2Ztq9Yecx62+BSDkn5ZYEvGYhAMVjU6tY","key":"foo_secret"}],"status":"ready","tags":[],"updated_at":"2025-04-28T09:37:46.615705Z"}'
+        body: '{"created_at":"2025-08-27T15:06:26.624225Z","description":"","environment_variables":{"foo":"bar"},"error_message":null,"id":"f448ff7b-cbe1-4ca6-b781-bc383d1f16e7","name":"tf-env-test","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestzxhxhgvl","registry_namespace_id":"ecb388b1-8150-4a47-b5da-b43c6a91e350","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$w7hAhE+8fUjCtDVlB8I8DA$nez1WvvOe/f3kEIgJ279R+xOB+JbFVZW48j0AfA2OZE","key":"foo_secret"}],"status":"pending","tags":[],"updated_at":"2025-08-27T15:06:33.778861Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "696"
+                - "716"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:52 GMT
+                - Wed, 27 Aug 2025 15:06:44 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2559,10 +2559,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3a7aef3d-0235-42b3-8d2b-9e86f1ccee9b
+                - 89c6c052-5b61-4d5a-84b9-1c18caad56f1
         status: 200 OK
         code: 200
-        duration: 47.004084ms
+        duration: 76.311145ms
     - id: 52
       request:
         proto: HTTP/1.1
@@ -2578,29 +2578,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9a02f592-bb53-4c3e-8336-012076fad92e
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/f448ff7b-cbe1-4ca6-b781-bc383d1f16e7
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 702
+        content_length: 714
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:39.730990Z","description":"","environment_variables":{"foo":"bar"},"error_message":null,"id":"9a02f592-bb53-4c3e-8336-012076fad92e","name":"tf-env-test","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtest5lopdqs6","registry_namespace_id":"8143e3ee-48ef-4829-a20f-a477cf6c1bce","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$LRWZ4maW4VIqSDPxGsoe1w$vdGYUWrJHs2Ztq9Yecx62+BSDkn5ZYEvGYhAMVjU6tY","key":"foo_secret"}],"status":"deleting","tags":[],"updated_at":"2025-04-28T09:37:52.408756115Z"}'
+        body: '{"created_at":"2025-08-27T15:06:26.624225Z","description":"","environment_variables":{"foo":"bar"},"error_message":null,"id":"f448ff7b-cbe1-4ca6-b781-bc383d1f16e7","name":"tf-env-test","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestzxhxhgvl","registry_namespace_id":"ecb388b1-8150-4a47-b5da-b43c6a91e350","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$w7hAhE+8fUjCtDVlB8I8DA$nez1WvvOe/f3kEIgJ279R+xOB+JbFVZW48j0AfA2OZE","key":"foo_secret"}],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:48.710886Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "702"
+                - "714"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:52 GMT
+                - Wed, 27 Aug 2025 15:06:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2608,10 +2608,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e8656e1b-a424-4310-a189-e49eb9e924bf
+                - 8562048b-711c-43d3-a2e8-85d5bc40394b
         status: 200 OK
         code: 200
-        duration: 170.253375ms
+        duration: 76.497005ms
     - id: 53
       request:
         proto: HTTP/1.1
@@ -2627,8 +2627,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9a02f592-bb53-4c3e-8336-012076fad92e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/f448ff7b-cbe1-4ca6-b781-bc383d1f16e7
         method: GET
       response:
         proto: HTTP/2.0
@@ -2636,20 +2636,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 699
+        content_length: 714
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:39.730990Z","description":"","environment_variables":{"foo":"bar"},"error_message":null,"id":"9a02f592-bb53-4c3e-8336-012076fad92e","name":"tf-env-test","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtest5lopdqs6","registry_namespace_id":"8143e3ee-48ef-4829-a20f-a477cf6c1bce","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$LRWZ4maW4VIqSDPxGsoe1w$vdGYUWrJHs2Ztq9Yecx62+BSDkn5ZYEvGYhAMVjU6tY","key":"foo_secret"}],"status":"deleting","tags":[],"updated_at":"2025-04-28T09:37:52.408756Z"}'
+        body: '{"created_at":"2025-08-27T15:06:26.624225Z","description":"","environment_variables":{"foo":"bar"},"error_message":null,"id":"f448ff7b-cbe1-4ca6-b781-bc383d1f16e7","name":"tf-env-test","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestzxhxhgvl","registry_namespace_id":"ecb388b1-8150-4a47-b5da-b43c6a91e350","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$w7hAhE+8fUjCtDVlB8I8DA$nez1WvvOe/f3kEIgJ279R+xOB+JbFVZW48j0AfA2OZE","key":"foo_secret"}],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:48.710886Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "699"
+                - "714"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:52 GMT
+                - Wed, 27 Aug 2025 15:06:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2657,10 +2657,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0ebe6c71-e6e3-4ae4-8439-f51d02d24992
+                - 2bbb90a9-9dc8-4817-9598-345a5554ce71
         status: 200 OK
         code: 200
-        duration: 43.80225ms
+        duration: 91.841662ms
     - id: 54
       request:
         proto: HTTP/1.1
@@ -2676,8 +2676,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/9a02f592-bb53-4c3e-8336-012076fad92e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/f448ff7b-cbe1-4ca6-b781-bc383d1f16e7
         method: GET
       response:
         proto: HTTP/2.0
@@ -2685,20 +2685,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 37
+        content_length: 714
         uncompressed: false
-        body: '{"message":"Namespace was not found"}'
+        body: '{"created_at":"2025-08-27T15:06:26.624225Z","description":"","environment_variables":{"foo":"bar"},"error_message":null,"id":"f448ff7b-cbe1-4ca6-b781-bc383d1f16e7","name":"tf-env-test","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestzxhxhgvl","registry_namespace_id":"ecb388b1-8150-4a47-b5da-b43c6a91e350","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$w7hAhE+8fUjCtDVlB8I8DA$nez1WvvOe/f3kEIgJ279R+xOB+JbFVZW48j0AfA2OZE","key":"foo_secret"}],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:48.710886Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "37"
+                - "714"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:57 GMT
+                - Wed, 27 Aug 2025 15:06:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2706,50 +2706,48 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e8b739ca-564b-4645-a35a-e1496adc3ef9
-        status: 404 Not Found
-        code: 404
-        duration: 24.26625ms
+                - c49c498c-ef58-4233-a57d-34bc958fc464
+        status: 200 OK
+        code: 200
+        duration: 92.265957ms
     - id: 55
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 159
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-tags-test","environment_variables":{},"project_id":"6867048b-fe12-4e96-835e-41c79a39604b","secret_environment_variables":[],"tags":["tag1","tag2"]}'
+        body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces
-        method: POST
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/f448ff7b-cbe1-4ca6-b781-bc383d1f16e7
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 492
+        content_length: 714
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:57.937650520Z","description":"","environment_variables":{},"error_message":null,"id":"8ded89b5-c41b-4bd5-97f9-7ae51c8a6e2d","name":"tf-tags-test","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":["tag1","tag2"],"updated_at":"2025-04-28T09:37:57.937650520Z"}'
+        body: '{"created_at":"2025-08-27T15:06:26.624225Z","description":"","environment_variables":{"foo":"bar"},"error_message":null,"id":"f448ff7b-cbe1-4ca6-b781-bc383d1f16e7","name":"tf-env-test","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestzxhxhgvl","registry_namespace_id":"ecb388b1-8150-4a47-b5da-b43c6a91e350","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$w7hAhE+8fUjCtDVlB8I8DA$nez1WvvOe/f3kEIgJ279R+xOB+JbFVZW48j0AfA2OZE","key":"foo_secret"}],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:48.710886Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "492"
+                - "714"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:57 GMT
+                - Wed, 27 Aug 2025 15:06:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2757,10 +2755,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4ad09d74-ea71-4e12-84b4-bd8e6a1f4600
+                - 938b8bf0-9c34-4f8c-977f-73b95219ccd2
         status: 200 OK
         code: 200
-        duration: 372.210083ms
+        duration: 78.590194ms
     - id: 56
       request:
         proto: HTTP/1.1
@@ -2776,8 +2774,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/8ded89b5-c41b-4bd5-97f9-7ae51c8a6e2d
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/f448ff7b-cbe1-4ca6-b781-bc383d1f16e7
         method: GET
       response:
         proto: HTTP/2.0
@@ -2785,20 +2783,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 486
+        content_length: 714
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:57.937651Z","description":"","environment_variables":{},"error_message":null,"id":"8ded89b5-c41b-4bd5-97f9-7ae51c8a6e2d","name":"tf-tags-test","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":["tag1","tag2"],"updated_at":"2025-04-28T09:37:57.937651Z"}'
+        body: '{"created_at":"2025-08-27T15:06:26.624225Z","description":"","environment_variables":{"foo":"bar"},"error_message":null,"id":"f448ff7b-cbe1-4ca6-b781-bc383d1f16e7","name":"tf-env-test","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestzxhxhgvl","registry_namespace_id":"ecb388b1-8150-4a47-b5da-b43c6a91e350","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$w7hAhE+8fUjCtDVlB8I8DA$nez1WvvOe/f3kEIgJ279R+xOB+JbFVZW48j0AfA2OZE","key":"foo_secret"}],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:48.710886Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "486"
+                - "714"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:58 GMT
+                - Wed, 27 Aug 2025 15:06:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2806,10 +2804,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e1a80dcb-aa4b-4aa4-b16f-295cd418057a
+                - 5404caff-b1c9-4df2-ad40-9862b06d64da
         status: 200 OK
         code: 200
-        duration: 41.985375ms
+        duration: 76.984561ms
     - id: 57
       request:
         proto: HTTP/1.1
@@ -2825,29 +2823,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/8ded89b5-c41b-4bd5-97f9-7ae51c8a6e2d
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/f448ff7b-cbe1-4ca6-b781-bc383d1f16e7
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 565
+        content_length: 720
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:57.937651Z","description":"","environment_variables":{},"error_message":null,"id":"8ded89b5-c41b-4bd5-97f9-7ae51c8a6e2d","name":"tf-tags-test","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftagstestsgcuq7pv","registry_namespace_id":"95ce605d-b219-4eae-acd5-08daf7097d65","secret_environment_variables":[],"status":"ready","tags":["tag1","tag2"],"updated_at":"2025-04-28T09:37:58.999022Z"}'
+        body: '{"created_at":"2025-08-27T15:06:26.624225Z","description":"","environment_variables":{"foo":"bar"},"error_message":null,"id":"f448ff7b-cbe1-4ca6-b781-bc383d1f16e7","name":"tf-env-test","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestzxhxhgvl","registry_namespace_id":"ecb388b1-8150-4a47-b5da-b43c6a91e350","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$w7hAhE+8fUjCtDVlB8I8DA$nez1WvvOe/f3kEIgJ279R+xOB+JbFVZW48j0AfA2OZE","key":"foo_secret"}],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:50.756838853Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "565"
+                - "720"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:38:03 GMT
+                - Wed, 27 Aug 2025 15:06:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2855,10 +2853,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5092675b-75e5-4dca-b11b-8b46d8b2142e
+                - 0e9078e8-a790-4a94-8365-a50a65777043
         status: 200 OK
         code: 200
-        duration: 41.212125ms
+        duration: 198.258435ms
     - id: 58
       request:
         proto: HTTP/1.1
@@ -2874,8 +2872,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/8ded89b5-c41b-4bd5-97f9-7ae51c8a6e2d
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/f448ff7b-cbe1-4ca6-b781-bc383d1f16e7
         method: GET
       response:
         proto: HTTP/2.0
@@ -2883,20 +2881,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 565
+        content_length: 717
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:57.937651Z","description":"","environment_variables":{},"error_message":null,"id":"8ded89b5-c41b-4bd5-97f9-7ae51c8a6e2d","name":"tf-tags-test","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftagstestsgcuq7pv","registry_namespace_id":"95ce605d-b219-4eae-acd5-08daf7097d65","secret_environment_variables":[],"status":"ready","tags":["tag1","tag2"],"updated_at":"2025-04-28T09:37:58.999022Z"}'
+        body: '{"created_at":"2025-08-27T15:06:26.624225Z","description":"","environment_variables":{"foo":"bar"},"error_message":null,"id":"f448ff7b-cbe1-4ca6-b781-bc383d1f16e7","name":"tf-env-test","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestzxhxhgvl","registry_namespace_id":"ecb388b1-8150-4a47-b5da-b43c6a91e350","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$w7hAhE+8fUjCtDVlB8I8DA$nez1WvvOe/f3kEIgJ279R+xOB+JbFVZW48j0AfA2OZE","key":"foo_secret"}],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:50.756839Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "565"
+                - "717"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:38:03 GMT
+                - Wed, 27 Aug 2025 15:06:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2904,10 +2902,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 64f62a78-fb2f-4da9-b25f-0ea1b21349aa
+                - bd754cff-c0f1-4629-8ec9-8a74258976f3
         status: 200 OK
         code: 200
-        duration: 40.801334ms
+        duration: 78.935352ms
     - id: 59
       request:
         proto: HTTP/1.1
@@ -2923,8 +2921,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/8ded89b5-c41b-4bd5-97f9-7ae51c8a6e2d
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/f448ff7b-cbe1-4ca6-b781-bc383d1f16e7
         method: GET
       response:
         proto: HTTP/2.0
@@ -2932,20 +2930,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 565
+        content_length: 37
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:57.937651Z","description":"","environment_variables":{},"error_message":null,"id":"8ded89b5-c41b-4bd5-97f9-7ae51c8a6e2d","name":"tf-tags-test","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftagstestsgcuq7pv","registry_namespace_id":"95ce605d-b219-4eae-acd5-08daf7097d65","secret_environment_variables":[],"status":"ready","tags":["tag1","tag2"],"updated_at":"2025-04-28T09:37:58.999022Z"}'
+        body: '{"message":"Namespace was not found"}'
         headers:
             Content-Length:
-                - "565"
+                - "37"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:38:03 GMT
+                - Wed, 27 Aug 2025 15:06:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2953,48 +2951,50 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 71b1e850-a7b9-41c8-8d61-7c08ff8c8007
-        status: 200 OK
-        code: 200
-        duration: 46.912792ms
+                - f7897dfa-e54b-491e-adb5-73ad9dfb06d4
+        status: 404 Not Found
+        code: 404
+        duration: 23.453704ms
     - id: 60
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 191
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"name":"tf-tags-test","environment_variables":{},"project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","secret_environment_variables":[],"tags":["tag1","tag2"],"activate_vpc_integration":true}'
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/8ded89b5-c41b-4bd5-97f9-7ae51c8a6e2d
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 565
+        content_length: 510
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:57.937651Z","description":"","environment_variables":{},"error_message":null,"id":"8ded89b5-c41b-4bd5-97f9-7ae51c8a6e2d","name":"tf-tags-test","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftagstestsgcuq7pv","registry_namespace_id":"95ce605d-b219-4eae-acd5-08daf7097d65","secret_environment_variables":[],"status":"ready","tags":["tag1","tag2"],"updated_at":"2025-04-28T09:37:58.999022Z"}'
+        body: '{"created_at":"2025-08-27T15:06:56.993388311Z","description":"","environment_variables":{},"error_message":null,"id":"c331fa07-923e-41cd-b5bd-e1c04cc64171","name":"tf-tags-test","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":["tag1","tag2"],"updated_at":"2025-08-27T15:06:56.993388311Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "565"
+                - "510"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:38:03 GMT
+                - Wed, 27 Aug 2025 15:06:57 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3002,10 +3002,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 391eda36-6f08-4182-b95a-51933f22e174
+                - a2131baa-c585-4c79-961c-33eb5d578b02
         status: 200 OK
         code: 200
-        duration: 45.790625ms
+        duration: 1.031416953s
     - id: 61
       request:
         proto: HTTP/1.1
@@ -3021,8 +3021,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/8ded89b5-c41b-4bd5-97f9-7ae51c8a6e2d
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c331fa07-923e-41cd-b5bd-e1c04cc64171
         method: GET
       response:
         proto: HTTP/2.0
@@ -3030,20 +3030,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 565
+        content_length: 504
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:57.937651Z","description":"","environment_variables":{},"error_message":null,"id":"8ded89b5-c41b-4bd5-97f9-7ae51c8a6e2d","name":"tf-tags-test","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftagstestsgcuq7pv","registry_namespace_id":"95ce605d-b219-4eae-acd5-08daf7097d65","secret_environment_variables":[],"status":"ready","tags":["tag1","tag2"],"updated_at":"2025-04-28T09:37:58.999022Z"}'
+        body: '{"created_at":"2025-08-27T15:06:56.993388Z","description":"","environment_variables":{},"error_message":null,"id":"c331fa07-923e-41cd-b5bd-e1c04cc64171","name":"tf-tags-test","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":["tag1","tag2"],"updated_at":"2025-08-27T15:06:56.993388Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "565"
+                - "504"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:38:03 GMT
+                - Wed, 27 Aug 2025 15:06:57 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3051,10 +3051,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d96af51a-43b4-41ea-9b25-4b3d9208469c
+                - 7528cd71-6f06-4559-9323-a8e27216341f
         status: 200 OK
         code: 200
-        duration: 43.0265ms
+        duration: 103.987667ms
     - id: 62
       request:
         proto: HTTP/1.1
@@ -3070,29 +3070,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/8ded89b5-c41b-4bd5-97f9-7ae51c8a6e2d
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c331fa07-923e-41cd-b5bd-e1c04cc64171
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 571
+        content_length: 504
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:57.937651Z","description":"","environment_variables":{},"error_message":null,"id":"8ded89b5-c41b-4bd5-97f9-7ae51c8a6e2d","name":"tf-tags-test","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftagstestsgcuq7pv","registry_namespace_id":"95ce605d-b219-4eae-acd5-08daf7097d65","secret_environment_variables":[],"status":"deleting","tags":["tag1","tag2"],"updated_at":"2025-04-28T09:38:03.755499205Z"}'
+        body: '{"created_at":"2025-08-27T15:06:56.993388Z","description":"","environment_variables":{},"error_message":null,"id":"c331fa07-923e-41cd-b5bd-e1c04cc64171","name":"tf-tags-test","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":["tag1","tag2"],"updated_at":"2025-08-27T15:07:01.949029Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "571"
+                - "504"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:38:03 GMT
+                - Wed, 27 Aug 2025 15:07:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3100,10 +3100,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b143d840-c715-449d-a0e1-8485508b2380
+                - 43473bde-9e13-41c3-aa3f-c47f4d16a101
         status: 200 OK
         code: 200
-        duration: 153.455292ms
+        duration: 83.474803ms
     - id: 63
       request:
         proto: HTTP/1.1
@@ -3119,8 +3119,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/8ded89b5-c41b-4bd5-97f9-7ae51c8a6e2d
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c331fa07-923e-41cd-b5bd-e1c04cc64171
         method: GET
       response:
         proto: HTTP/2.0
@@ -3128,20 +3128,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 568
+        content_length: 504
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:57.937651Z","description":"","environment_variables":{},"error_message":null,"id":"8ded89b5-c41b-4bd5-97f9-7ae51c8a6e2d","name":"tf-tags-test","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftagstestsgcuq7pv","registry_namespace_id":"95ce605d-b219-4eae-acd5-08daf7097d65","secret_environment_variables":[],"status":"deleting","tags":["tag1","tag2"],"updated_at":"2025-04-28T09:38:03.755499Z"}'
+        body: '{"created_at":"2025-08-27T15:06:56.993388Z","description":"","environment_variables":{},"error_message":null,"id":"c331fa07-923e-41cd-b5bd-e1c04cc64171","name":"tf-tags-test","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":["tag1","tag2"],"updated_at":"2025-08-27T15:07:01.949029Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "568"
+                - "504"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:38:03 GMT
+                - Wed, 27 Aug 2025 15:07:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3149,10 +3149,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1d11a1e1-fe64-45ea-9ddf-e1d21242c80f
+                - 4ad15ae8-7086-43ee-9f10-e08203813f16
         status: 200 OK
         code: 200
-        duration: 37.782375ms
+        duration: 87.62333ms
     - id: 64
       request:
         proto: HTTP/1.1
@@ -3168,8 +3168,449 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/8ded89b5-c41b-4bd5-97f9-7ae51c8a6e2d
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c331fa07-923e-41cd-b5bd-e1c04cc64171
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 504
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:06:56.993388Z","description":"","environment_variables":{},"error_message":null,"id":"c331fa07-923e-41cd-b5bd-e1c04cc64171","name":"tf-tags-test","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":["tag1","tag2"],"updated_at":"2025-08-27T15:07:01.949029Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "504"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:07:12 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 95f3e69f-5d12-4837-8d88-7a74eba77ffd
+        status: 200 OK
+        code: 200
+        duration: 77.357425ms
+    - id: 65
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c331fa07-923e-41cd-b5bd-e1c04cc64171
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 504
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:06:56.993388Z","description":"","environment_variables":{},"error_message":null,"id":"c331fa07-923e-41cd-b5bd-e1c04cc64171","name":"tf-tags-test","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":["tag1","tag2"],"updated_at":"2025-08-27T15:07:01.949029Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "504"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:07:17 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 03d881cc-74ed-42a3-bda7-7e9051c32458
+        status: 200 OK
+        code: 200
+        duration: 112.357802ms
+    - id: 66
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c331fa07-923e-41cd-b5bd-e1c04cc64171
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 583
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:06:56.993388Z","description":"","environment_variables":{},"error_message":null,"id":"c331fa07-923e-41cd-b5bd-e1c04cc64171","name":"tf-tags-test","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftagstestc0t1djn0","registry_namespace_id":"7a8dee8b-ceac-4be6-a2bb-5db5e47a8f17","secret_environment_variables":[],"status":"ready","tags":["tag1","tag2"],"updated_at":"2025-08-27T15:07:17.756933Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "583"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:07:22 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f9d1c6a6-26c0-4be8-a30e-fc53f702cb92
+        status: 200 OK
+        code: 200
+        duration: 86.898774ms
+    - id: 67
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c331fa07-923e-41cd-b5bd-e1c04cc64171
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 583
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:06:56.993388Z","description":"","environment_variables":{},"error_message":null,"id":"c331fa07-923e-41cd-b5bd-e1c04cc64171","name":"tf-tags-test","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftagstestc0t1djn0","registry_namespace_id":"7a8dee8b-ceac-4be6-a2bb-5db5e47a8f17","secret_environment_variables":[],"status":"ready","tags":["tag1","tag2"],"updated_at":"2025-08-27T15:07:17.756933Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "583"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:07:22 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 80980386-c0d2-4e8c-920a-77a6c7cfbc51
+        status: 200 OK
+        code: 200
+        duration: 81.069183ms
+    - id: 68
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c331fa07-923e-41cd-b5bd-e1c04cc64171
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 583
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:06:56.993388Z","description":"","environment_variables":{},"error_message":null,"id":"c331fa07-923e-41cd-b5bd-e1c04cc64171","name":"tf-tags-test","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftagstestc0t1djn0","registry_namespace_id":"7a8dee8b-ceac-4be6-a2bb-5db5e47a8f17","secret_environment_variables":[],"status":"ready","tags":["tag1","tag2"],"updated_at":"2025-08-27T15:07:17.756933Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "583"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:07:22 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 25a5683f-183a-47ec-8960-f0680fb96a04
+        status: 200 OK
+        code: 200
+        duration: 100.118954ms
+    - id: 69
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c331fa07-923e-41cd-b5bd-e1c04cc64171
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 583
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:06:56.993388Z","description":"","environment_variables":{},"error_message":null,"id":"c331fa07-923e-41cd-b5bd-e1c04cc64171","name":"tf-tags-test","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftagstestc0t1djn0","registry_namespace_id":"7a8dee8b-ceac-4be6-a2bb-5db5e47a8f17","secret_environment_variables":[],"status":"ready","tags":["tag1","tag2"],"updated_at":"2025-08-27T15:07:17.756933Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "583"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:07:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 9c974ee9-983d-4b5e-a33b-ba8122c1e045
+        status: 200 OK
+        code: 200
+        duration: 78.341895ms
+    - id: 70
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c331fa07-923e-41cd-b5bd-e1c04cc64171
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 583
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:06:56.993388Z","description":"","environment_variables":{},"error_message":null,"id":"c331fa07-923e-41cd-b5bd-e1c04cc64171","name":"tf-tags-test","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftagstestc0t1djn0","registry_namespace_id":"7a8dee8b-ceac-4be6-a2bb-5db5e47a8f17","secret_environment_variables":[],"status":"ready","tags":["tag1","tag2"],"updated_at":"2025-08-27T15:07:17.756933Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "583"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:07:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 080317c5-c03a-4e49-9ed5-3ebee7866040
+        status: 200 OK
+        code: 200
+        duration: 108.891057ms
+    - id: 71
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c331fa07-923e-41cd-b5bd-e1c04cc64171
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 589
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:06:56.993388Z","description":"","environment_variables":{},"error_message":null,"id":"c331fa07-923e-41cd-b5bd-e1c04cc64171","name":"tf-tags-test","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftagstestc0t1djn0","registry_namespace_id":"7a8dee8b-ceac-4be6-a2bb-5db5e47a8f17","secret_environment_variables":[],"status":"deleting","tags":["tag1","tag2"],"updated_at":"2025-08-27T15:07:23.746499898Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "589"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:07:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 2259c150-9144-4b0b-af12-773239f5b2cb
+        status: 200 OK
+        code: 200
+        duration: 200.765588ms
+    - id: 72
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c331fa07-923e-41cd-b5bd-e1c04cc64171
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 586
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:06:56.993388Z","description":"","environment_variables":{},"error_message":null,"id":"c331fa07-923e-41cd-b5bd-e1c04cc64171","name":"tf-tags-test","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftagstestc0t1djn0","registry_namespace_id":"7a8dee8b-ceac-4be6-a2bb-5db5e47a8f17","secret_environment_variables":[],"status":"deleting","tags":["tag1","tag2"],"updated_at":"2025-08-27T15:07:23.746500Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "586"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:07:24 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 10a54ce6-3bae-492c-b230-7091e1d8141e
+        status: 200 OK
+        code: 200
+        duration: 79.753595ms
+    - id: 73
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c331fa07-923e-41cd-b5bd-e1c04cc64171
         method: GET
       response:
         proto: HTTP/2.0
@@ -3188,9 +3629,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:38:08 GMT
+                - Wed, 27 Aug 2025 15:07:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3198,11 +3639,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9454a8be-e4df-413c-a19a-12a0c95d6f8a
+                - 64d96351-d10c-45e8-a792-e3e7dbf5a28e
         status: 404 Not Found
         code: 404
-        duration: 30.16975ms
-    - id: 65
+        duration: 22.809347ms
+    - id: 74
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3217,8 +3658,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/8ded89b5-c41b-4bd5-97f9-7ae51c8a6e2d
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c331fa07-923e-41cd-b5bd-e1c04cc64171
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -3237,9 +3678,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:38:08 GMT
+                - Wed, 27 Aug 2025 15:07:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3247,7 +3688,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d4be074a-c63a-4590-8f4c-9dfa7b9ed98c
+                - a45572b0-cbae-45c8-b1e5-82a508a065c2
         status: 404 Not Found
         code: 404
-        duration: 25.412083ms
+        duration: 26.714085ms

--- a/internal/services/container/testdata/namespace-destroy-registry.cassette.yaml
+++ b/internal/services/container/testdata/namespace-destroy-registry.cassette.yaml
@@ -6,19 +6,19 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 149
+        content_length: 181
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"test-cr-ns-01","environment_variables":{},"project_id":"6867048b-fe12-4e96-835e-41c79a39604b","secret_environment_variables":[],"tags":null}'
+        body: '{"name":"test-cr-ns-01","environment_variables":{},"project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","secret_environment_variables":[],"tags":null,"activate_vpc_integration":true}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/containers/v1beta1/regions/pl-waw/namespaces
         method: POST
       response:
@@ -27,20 +27,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 479
+        content_length: 498
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:13.373444566Z","description":"","environment_variables":{},"error_message":null,"id":"86805fb7-b304-4d12-a85b-8ed65b1da533","name":"test-cr-ns-01","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"pl-waw","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-04-28T09:37:13.373444566Z"}'
+        body: '{"created_at":"2025-08-27T15:05:36.584874842Z","description":"","environment_variables":{},"error_message":null,"id":"db70992c-2a2c-4814-aacb-177e0bb24811","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"pl-waw","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:36.584874842Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "479"
+                - "498"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:13 GMT
+                - Wed, 27 Aug 2025 15:05:36 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7d48ed9f-8f07-4639-b668-10a27270f440
+                - ae508d95-069e-4c93-8f0f-642cb02948ac
         status: 200 OK
         code: 200
-        duration: 612.678875ms
+        duration: 586.613204ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -67,8 +67,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/pl-waw/namespaces/86805fb7-b304-4d12-a85b-8ed65b1da533
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/pl-waw/namespaces/db70992c-2a2c-4814-aacb-177e0bb24811
         method: GET
       response:
         proto: HTTP/2.0
@@ -76,20 +76,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 473
+        content_length: 492
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:13.373445Z","description":"","environment_variables":{},"error_message":null,"id":"86805fb7-b304-4d12-a85b-8ed65b1da533","name":"test-cr-ns-01","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"pl-waw","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-04-28T09:37:13.373445Z"}'
+        body: '{"created_at":"2025-08-27T15:05:36.584875Z","description":"","environment_variables":{},"error_message":null,"id":"db70992c-2a2c-4814-aacb-177e0bb24811","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"pl-waw","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:36.584875Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "473"
+                - "492"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:13 GMT
+                - Wed, 27 Aug 2025 15:05:36 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8dd65f39-36cb-4e44-a235-eacd1ace30f3
+                - fbc7a0c1-e31e-4512-83f2-3e38e2169273
         status: 200 OK
         code: 200
-        duration: 77.662833ms
+        duration: 142.853578ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -116,8 +116,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/pl-waw/namespaces/86805fb7-b304-4d12-a85b-8ed65b1da533
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/pl-waw/namespaces/db70992c-2a2c-4814-aacb-177e0bb24811
         method: GET
       response:
         proto: HTTP/2.0
@@ -125,20 +125,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 552
+        content_length: 571
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:13.373445Z","description":"","environment_variables":{},"error_message":null,"id":"86805fb7-b304-4d12-a85b-8ed65b1da533","name":"test-cr-ns-01","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"pl-waw","registry_endpoint":"rg.pl-waw.scw.cloud/funcscwtestcrns01fwkhkytu","registry_namespace_id":"0bdb7279-8038-475e-9273-81c0a57b5145","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-28T09:37:15.687114Z"}'
+        body: '{"created_at":"2025-08-27T15:05:36.584875Z","description":"","environment_variables":{},"error_message":null,"id":"db70992c-2a2c-4814-aacb-177e0bb24811","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"pl-waw","registry_endpoint":"rg.pl-waw.scw.cloud/funcscwtestcrns014sddxwi8","registry_namespace_id":"92042684-d388-4004-90a9-a01589db81d3","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:37.901206Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "552"
+                - "571"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:18 GMT
+                - Wed, 27 Aug 2025 15:05:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -146,10 +146,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 91471a48-d6b3-43aa-8894-fc68e85664a2
+                - 66575403-2922-4e56-a2dd-2a5d669e60f6
         status: 200 OK
         code: 200
-        duration: 95.354333ms
+        duration: 156.867206ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -165,8 +165,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/pl-waw/namespaces/86805fb7-b304-4d12-a85b-8ed65b1da533
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/pl-waw/namespaces/db70992c-2a2c-4814-aacb-177e0bb24811
         method: GET
       response:
         proto: HTTP/2.0
@@ -174,20 +174,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 552
+        content_length: 571
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:13.373445Z","description":"","environment_variables":{},"error_message":null,"id":"86805fb7-b304-4d12-a85b-8ed65b1da533","name":"test-cr-ns-01","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"pl-waw","registry_endpoint":"rg.pl-waw.scw.cloud/funcscwtestcrns01fwkhkytu","registry_namespace_id":"0bdb7279-8038-475e-9273-81c0a57b5145","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-28T09:37:15.687114Z"}'
+        body: '{"created_at":"2025-08-27T15:05:36.584875Z","description":"","environment_variables":{},"error_message":null,"id":"db70992c-2a2c-4814-aacb-177e0bb24811","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"pl-waw","registry_endpoint":"rg.pl-waw.scw.cloud/funcscwtestcrns014sddxwi8","registry_namespace_id":"92042684-d388-4004-90a9-a01589db81d3","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:37.901206Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "552"
+                - "571"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:18 GMT
+                - Wed, 27 Aug 2025 15:05:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -195,10 +195,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6ace1008-a9a6-4fcc-99e4-978df88f8072
+                - e8ad4fe6-a589-48ac-8aaf-f675b672f9ff
         status: 200 OK
         code: 200
-        duration: 83.564625ms
+        duration: 178.58588ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -214,8 +214,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/pl-waw/namespaces/86805fb7-b304-4d12-a85b-8ed65b1da533
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/pl-waw/namespaces/db70992c-2a2c-4814-aacb-177e0bb24811
         method: GET
       response:
         proto: HTTP/2.0
@@ -223,20 +223,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 552
+        content_length: 571
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:13.373445Z","description":"","environment_variables":{},"error_message":null,"id":"86805fb7-b304-4d12-a85b-8ed65b1da533","name":"test-cr-ns-01","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"pl-waw","registry_endpoint":"rg.pl-waw.scw.cloud/funcscwtestcrns01fwkhkytu","registry_namespace_id":"0bdb7279-8038-475e-9273-81c0a57b5145","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-28T09:37:15.687114Z"}'
+        body: '{"created_at":"2025-08-27T15:05:36.584875Z","description":"","environment_variables":{},"error_message":null,"id":"db70992c-2a2c-4814-aacb-177e0bb24811","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"pl-waw","registry_endpoint":"rg.pl-waw.scw.cloud/funcscwtestcrns014sddxwi8","registry_namespace_id":"92042684-d388-4004-90a9-a01589db81d3","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:37.901206Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "552"
+                - "571"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:18 GMT
+                - Wed, 27 Aug 2025 15:05:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -244,10 +244,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d7860a70-406d-44a2-ba2a-9133fa23eb35
+                - e86f12a5-637e-48ea-b851-7cbed276d76a
         status: 200 OK
         code: 200
-        duration: 78.753125ms
+        duration: 124.197115ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -263,8 +263,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/pl-waw/namespaces/86805fb7-b304-4d12-a85b-8ed65b1da533
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/pl-waw/namespaces/db70992c-2a2c-4814-aacb-177e0bb24811
         method: GET
       response:
         proto: HTTP/2.0
@@ -272,20 +272,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 552
+        content_length: 571
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:13.373445Z","description":"","environment_variables":{},"error_message":null,"id":"86805fb7-b304-4d12-a85b-8ed65b1da533","name":"test-cr-ns-01","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"pl-waw","registry_endpoint":"rg.pl-waw.scw.cloud/funcscwtestcrns01fwkhkytu","registry_namespace_id":"0bdb7279-8038-475e-9273-81c0a57b5145","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-28T09:37:15.687114Z"}'
+        body: '{"created_at":"2025-08-27T15:05:36.584875Z","description":"","environment_variables":{},"error_message":null,"id":"db70992c-2a2c-4814-aacb-177e0bb24811","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"pl-waw","registry_endpoint":"rg.pl-waw.scw.cloud/funcscwtestcrns014sddxwi8","registry_namespace_id":"92042684-d388-4004-90a9-a01589db81d3","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:37.901206Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "552"
+                - "571"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:19 GMT
+                - Wed, 27 Aug 2025 15:05:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -293,10 +293,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0b2b8f00-c3cd-4b55-b40f-1ac166a7e842
+                - 39cb8f50-41ca-4b58-a2b1-521e229af39b
         status: 200 OK
         code: 200
-        duration: 80.4255ms
+        duration: 140.594844ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -312,8 +312,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/pl-waw/namespaces/86805fb7-b304-4d12-a85b-8ed65b1da533
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/pl-waw/namespaces/db70992c-2a2c-4814-aacb-177e0bb24811
         method: GET
       response:
         proto: HTTP/2.0
@@ -321,20 +321,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 552
+        content_length: 571
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:13.373445Z","description":"","environment_variables":{},"error_message":null,"id":"86805fb7-b304-4d12-a85b-8ed65b1da533","name":"test-cr-ns-01","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"pl-waw","registry_endpoint":"rg.pl-waw.scw.cloud/funcscwtestcrns01fwkhkytu","registry_namespace_id":"0bdb7279-8038-475e-9273-81c0a57b5145","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-28T09:37:15.687114Z"}'
+        body: '{"created_at":"2025-08-27T15:05:36.584875Z","description":"","environment_variables":{},"error_message":null,"id":"db70992c-2a2c-4814-aacb-177e0bb24811","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"pl-waw","registry_endpoint":"rg.pl-waw.scw.cloud/funcscwtestcrns014sddxwi8","registry_namespace_id":"92042684-d388-4004-90a9-a01589db81d3","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:37.901206Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "552"
+                - "571"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:19 GMT
+                - Wed, 27 Aug 2025 15:05:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -342,10 +342,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8a252653-4faf-4cb0-9f9b-cb9b1fae341c
+                - f9a686a8-2206-41e7-af80-51b5f07a5eb9
         status: 200 OK
         code: 200
-        duration: 93.500584ms
+        duration: 150.605899ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -361,8 +361,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/pl-waw/namespaces/86805fb7-b304-4d12-a85b-8ed65b1da533
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/pl-waw/namespaces/db70992c-2a2c-4814-aacb-177e0bb24811
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -370,20 +370,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 558
+        content_length: 577
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:13.373445Z","description":"","environment_variables":{},"error_message":null,"id":"86805fb7-b304-4d12-a85b-8ed65b1da533","name":"test-cr-ns-01","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"pl-waw","registry_endpoint":"rg.pl-waw.scw.cloud/funcscwtestcrns01fwkhkytu","registry_namespace_id":"0bdb7279-8038-475e-9273-81c0a57b5145","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-04-28T09:37:19.419427189Z"}'
+        body: '{"created_at":"2025-08-27T15:05:36.584875Z","description":"","environment_variables":{},"error_message":null,"id":"db70992c-2a2c-4814-aacb-177e0bb24811","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"pl-waw","registry_endpoint":"rg.pl-waw.scw.cloud/funcscwtestcrns014sddxwi8","registry_namespace_id":"92042684-d388-4004-90a9-a01589db81d3","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:43.325393775Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "558"
+                - "577"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:19 GMT
+                - Wed, 27 Aug 2025 15:05:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -391,10 +391,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ff74de60-0ff8-48e4-8597-c8036021b352
+                - 44abe998-76bc-4e7d-b2b0-331e6e7f6553
         status: 200 OK
         code: 200
-        duration: 161.167792ms
+        duration: 232.889958ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -410,8 +410,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/pl-waw/namespaces/86805fb7-b304-4d12-a85b-8ed65b1da533
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/pl-waw/namespaces/db70992c-2a2c-4814-aacb-177e0bb24811
         method: GET
       response:
         proto: HTTP/2.0
@@ -419,20 +419,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 555
+        content_length: 574
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:13.373445Z","description":"","environment_variables":{},"error_message":null,"id":"86805fb7-b304-4d12-a85b-8ed65b1da533","name":"test-cr-ns-01","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"pl-waw","registry_endpoint":"rg.pl-waw.scw.cloud/funcscwtestcrns01fwkhkytu","registry_namespace_id":"0bdb7279-8038-475e-9273-81c0a57b5145","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-04-28T09:37:19.419427Z"}'
+        body: '{"created_at":"2025-08-27T15:05:36.584875Z","description":"","environment_variables":{},"error_message":null,"id":"db70992c-2a2c-4814-aacb-177e0bb24811","name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"pl-waw","registry_endpoint":"rg.pl-waw.scw.cloud/funcscwtestcrns014sddxwi8","registry_namespace_id":"92042684-d388-4004-90a9-a01589db81d3","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:43.325394Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "555"
+                - "574"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:19 GMT
+                - Wed, 27 Aug 2025 15:05:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -440,10 +440,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b7656c4e-a357-440b-ac00-820d6a2427dd
+                - 712f5c14-a270-440e-a8f8-b02060e592a8
         status: 200 OK
         code: 200
-        duration: 76.237667ms
+        duration: 135.006988ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -459,8 +459,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/pl-waw/namespaces/86805fb7-b304-4d12-a85b-8ed65b1da533
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/pl-waw/namespaces/db70992c-2a2c-4814-aacb-177e0bb24811
         method: GET
       response:
         proto: HTTP/2.0
@@ -479,9 +479,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:24 GMT
+                - Wed, 27 Aug 2025 15:05:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -489,10 +489,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 126984ad-ac26-430a-bdf0-f452d8143a29
+                - 3e018f26-5a87-49d4-a570-571ccb421659
         status: 404 Not Found
         code: 404
-        duration: 58.403833ms
+        duration: 59.376625ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -508,8 +508,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/0bdb7279-8038-475e-9273-81c0a57b5145
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/92042684-d388-4004-90a9-a01589db81d3
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -528,9 +528,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:24 GMT
+                - Wed, 27 Aug 2025 15:05:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -538,10 +538,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 045ed963-0ea9-48bc-8952-f298acb8bf07
+                - 1f969570-6858-41ac-a8ee-ca93afbda706
         status: 404 Not Found
         code: 404
-        duration: 62.03975ms
+        duration: 61.147299ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -557,8 +557,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/0bdb7279-8038-475e-9273-81c0a57b5145
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/92042684-d388-4004-90a9-a01589db81d3
         method: GET
       response:
         proto: HTTP/2.0
@@ -577,9 +577,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:24 GMT
+                - Wed, 27 Aug 2025 15:05:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -587,10 +587,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b4a0f524-da22-4e3f-a0f2-84ae3222f373
+                - 024aef1a-f61f-42b7-8c1f-88d459895b10
         status: 404 Not Found
         code: 404
-        duration: 57.103375ms
+        duration: 58.134626ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -606,8 +606,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/pl-waw/namespaces/86805fb7-b304-4d12-a85b-8ed65b1da533
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/pl-waw/namespaces/db70992c-2a2c-4814-aacb-177e0bb24811
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -626,9 +626,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:24 GMT
+                - Wed, 27 Aug 2025 15:05:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -636,10 +636,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a3801d67-3e3d-4939-a432-3be30ae4cc61
+                - f8826bf9-9fa7-4da6-8a0f-7e430194313b
         status: 404 Not Found
         code: 404
-        duration: 60.133084ms
+        duration: 61.515279ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -655,8 +655,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/0bdb7279-8038-475e-9273-81c0a57b5145
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/92042684-d388-4004-90a9-a01589db81d3
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -675,9 +675,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:24 GMT
+                - Wed, 27 Aug 2025 15:05:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -685,7 +685,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0657c86c-1f5a-4ebc-a8fa-afd1f3f7790d
+                - 76417054-66c5-412f-92d7-9c6d947c0849
         status: 404 Not Found
         code: 404
-        duration: 64.37275ms
+        duration: 60.238112ms

--- a/internal/services/container/testdata/namespace-secret-management.cassette.yaml
+++ b/internal/services/container/testdata/namespace-secret-management.cassette.yaml
@@ -6,19 +6,19 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 221
+        content_length: 253
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"test-secret-ns","environment_variables":{},"project_id":"6867048b-fe12-4e96-835e-41c79a39604b","secret_environment_variables":[{"key":"SECRET_2","value":"value2"},{"key":"SECRET_1","value":"value1"}],"tags":null}'
+        body: '{"name":"test-secret-ns","environment_variables":{},"project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","secret_environment_variables":[{"key":"SECRET_2","value":"value2"},{"key":"SECRET_1","value":"value1"}],"tags":null,"activate_vpc_integration":true}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces
         method: POST
       response:
@@ -27,20 +27,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 750
+        content_length: 766
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:14.091018389Z","description":"","environment_variables":{},"error_message":null,"id":"731c9efa-a0ca-41d3-9f4b-dd0255aa426a","name":"test-secret-ns","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$CQZQjDm9jPa/jPMNe//MUA$UCuaruLHHsw5FLfElD6NcX7jnhyw3KnN3F4TfNmf3Kg","key":"SECRET_2"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$dj82rMT7WUj6InUn7AJK5Q$6rKtK8ZSH8pduhhg1Ga0XpQsstTW29H8Lo7rggcXzUg","key":"SECRET_1"}],"status":"pending","tags":[],"updated_at":"2025-04-28T09:37:14.091018389Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.465618877Z","description":"","environment_variables":{},"error_message":null,"id":"1485b2ec-4ea1-45e3-8daf-ce30ee313880","name":"test-secret-ns","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$KvLQF7t0+sl1TquheAEJdQ$keV09aqt5cf4flyON/yzUF6LCvcu4ZWPKl+IJk2GkU0","key":"SECRET_2"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$bWGAwxM/2UBStSx4BLPl4A$SbLs3B089xJnSUkl4qcV172LvcnrU8bwbHibYUjm+zM","key":"SECRET_1"}],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:41.465618877Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "750"
+                - "766"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:14 GMT
+                - Wed, 27 Aug 2025 15:05:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0cdb6a0e-3fa4-429a-8cb7-d9f6af565ff1
+                - 7dd9ce04-1fec-487d-b264-03e8bbe0a301
         status: 200 OK
         code: 200
-        duration: 1.277447792s
+        duration: 5.53132291s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -67,8 +67,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/731c9efa-a0ca-41d3-9f4b-dd0255aa426a
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/1485b2ec-4ea1-45e3-8daf-ce30ee313880
         method: GET
       response:
         proto: HTTP/2.0
@@ -76,20 +76,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 744
+        content_length: 760
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:14.091018Z","description":"","environment_variables":{},"error_message":null,"id":"731c9efa-a0ca-41d3-9f4b-dd0255aa426a","name":"test-secret-ns","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$CQZQjDm9jPa/jPMNe//MUA$UCuaruLHHsw5FLfElD6NcX7jnhyw3KnN3F4TfNmf3Kg","key":"SECRET_2"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$dj82rMT7WUj6InUn7AJK5Q$6rKtK8ZSH8pduhhg1Ga0XpQsstTW29H8Lo7rggcXzUg","key":"SECRET_1"}],"status":"pending","tags":[],"updated_at":"2025-04-28T09:37:14.091018Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.465619Z","description":"","environment_variables":{},"error_message":null,"id":"1485b2ec-4ea1-45e3-8daf-ce30ee313880","name":"test-secret-ns","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$KvLQF7t0+sl1TquheAEJdQ$keV09aqt5cf4flyON/yzUF6LCvcu4ZWPKl+IJk2GkU0","key":"SECRET_2"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$bWGAwxM/2UBStSx4BLPl4A$SbLs3B089xJnSUkl4qcV172LvcnrU8bwbHibYUjm+zM","key":"SECRET_1"}],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:41.465619Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "744"
+                - "760"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:14 GMT
+                - Wed, 27 Aug 2025 15:05:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 897a8fe4-09e7-4c44-b747-cd8b79e0a088
+                - 8a1aaed3-b0c9-45b6-8fe2-cd01235110a5
         status: 200 OK
         code: 200
-        duration: 42.667083ms
+        duration: 79.775741ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -116,8 +116,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/731c9efa-a0ca-41d3-9f4b-dd0255aa426a
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/1485b2ec-4ea1-45e3-8daf-ce30ee313880
         method: GET
       response:
         proto: HTTP/2.0
@@ -125,20 +125,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 825
+        content_length: 843
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:14.091018Z","description":"","environment_variables":{},"error_message":null,"id":"731c9efa-a0ca-41d3-9f4b-dd0255aa426a","name":"test-secret-ns","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestsecretnsijc6fszy","registry_namespace_id":"bf7f1926-fdf0-4dba-934a-1d84dcf10735","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$CQZQjDm9jPa/jPMNe//MUA$UCuaruLHHsw5FLfElD6NcX7jnhyw3KnN3F4TfNmf3Kg","key":"SECRET_2"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$dj82rMT7WUj6InUn7AJK5Q$6rKtK8ZSH8pduhhg1Ga0XpQsstTW29H8Lo7rggcXzUg","key":"SECRET_1"}],"status":"ready","tags":[],"updated_at":"2025-04-28T09:37:18.789257Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.465619Z","description":"","environment_variables":{},"error_message":null,"id":"1485b2ec-4ea1-45e3-8daf-ce30ee313880","name":"test-secret-ns","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestsecretnsofs225fm","registry_namespace_id":"cb22f8e7-0bdd-4388-b727-4e433106a9cb","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$KvLQF7t0+sl1TquheAEJdQ$keV09aqt5cf4flyON/yzUF6LCvcu4ZWPKl+IJk2GkU0","key":"SECRET_2"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$bWGAwxM/2UBStSx4BLPl4A$SbLs3B089xJnSUkl4qcV172LvcnrU8bwbHibYUjm+zM","key":"SECRET_1"}],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:46.134106Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "825"
+                - "843"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:19 GMT
+                - Wed, 27 Aug 2025 15:05:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -146,10 +146,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 042d996f-9f29-457d-8c5f-0c4f1d8943f8
+                - ea94f89b-5954-47ae-b9ba-2394736032a1
         status: 200 OK
         code: 200
-        duration: 40.868583ms
+        duration: 83.756883ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -165,8 +165,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/731c9efa-a0ca-41d3-9f4b-dd0255aa426a
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/1485b2ec-4ea1-45e3-8daf-ce30ee313880
         method: GET
       response:
         proto: HTTP/2.0
@@ -174,20 +174,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 825
+        content_length: 841
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:14.091018Z","description":"","environment_variables":{},"error_message":null,"id":"731c9efa-a0ca-41d3-9f4b-dd0255aa426a","name":"test-secret-ns","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestsecretnsijc6fszy","registry_namespace_id":"bf7f1926-fdf0-4dba-934a-1d84dcf10735","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$CQZQjDm9jPa/jPMNe//MUA$UCuaruLHHsw5FLfElD6NcX7jnhyw3KnN3F4TfNmf3Kg","key":"SECRET_2"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$dj82rMT7WUj6InUn7AJK5Q$6rKtK8ZSH8pduhhg1Ga0XpQsstTW29H8Lo7rggcXzUg","key":"SECRET_1"}],"status":"ready","tags":[],"updated_at":"2025-04-28T09:37:18.789257Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.465619Z","description":"","environment_variables":{},"error_message":null,"id":"1485b2ec-4ea1-45e3-8daf-ce30ee313880","name":"test-secret-ns","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestsecretnsofs225fm","registry_namespace_id":"cb22f8e7-0bdd-4388-b727-4e433106a9cb","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$KvLQF7t0+sl1TquheAEJdQ$keV09aqt5cf4flyON/yzUF6LCvcu4ZWPKl+IJk2GkU0","key":"SECRET_2"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$bWGAwxM/2UBStSx4BLPl4A$SbLs3B089xJnSUkl4qcV172LvcnrU8bwbHibYUjm+zM","key":"SECRET_1"}],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:47.879392Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "825"
+                - "841"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:19 GMT
+                - Wed, 27 Aug 2025 15:05:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -195,10 +195,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 46d26ad5-54eb-4386-bf8d-50a268571d4f
+                - 91198f80-fc2c-4702-a243-d02a325f4ceb
         status: 200 OK
         code: 200
-        duration: 34.753542ms
+        duration: 95.776448ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -214,8 +214,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/731c9efa-a0ca-41d3-9f4b-dd0255aa426a
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/1485b2ec-4ea1-45e3-8daf-ce30ee313880
         method: GET
       response:
         proto: HTTP/2.0
@@ -223,20 +223,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 825
+        content_length: 841
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:14.091018Z","description":"","environment_variables":{},"error_message":null,"id":"731c9efa-a0ca-41d3-9f4b-dd0255aa426a","name":"test-secret-ns","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestsecretnsijc6fszy","registry_namespace_id":"bf7f1926-fdf0-4dba-934a-1d84dcf10735","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$CQZQjDm9jPa/jPMNe//MUA$UCuaruLHHsw5FLfElD6NcX7jnhyw3KnN3F4TfNmf3Kg","key":"SECRET_2"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$dj82rMT7WUj6InUn7AJK5Q$6rKtK8ZSH8pduhhg1Ga0XpQsstTW29H8Lo7rggcXzUg","key":"SECRET_1"}],"status":"ready","tags":[],"updated_at":"2025-04-28T09:37:18.789257Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.465619Z","description":"","environment_variables":{},"error_message":null,"id":"1485b2ec-4ea1-45e3-8daf-ce30ee313880","name":"test-secret-ns","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestsecretnsofs225fm","registry_namespace_id":"cb22f8e7-0bdd-4388-b727-4e433106a9cb","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$KvLQF7t0+sl1TquheAEJdQ$keV09aqt5cf4flyON/yzUF6LCvcu4ZWPKl+IJk2GkU0","key":"SECRET_2"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$bWGAwxM/2UBStSx4BLPl4A$SbLs3B089xJnSUkl4qcV172LvcnrU8bwbHibYUjm+zM","key":"SECRET_1"}],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:47.879392Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "825"
+                - "841"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:19 GMT
+                - Wed, 27 Aug 2025 15:05:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -244,10 +244,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7e28a0a1-b1fe-4a29-b245-836df1c7c29d
+                - d711cf5c-04d3-49ce-bb38-01ff6f99a513
         status: 200 OK
         code: 200
-        duration: 37.309792ms
+        duration: 72.260743ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -263,8 +263,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/731c9efa-a0ca-41d3-9f4b-dd0255aa426a
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/1485b2ec-4ea1-45e3-8daf-ce30ee313880
         method: GET
       response:
         proto: HTTP/2.0
@@ -272,20 +272,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 825
+        content_length: 841
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:14.091018Z","description":"","environment_variables":{},"error_message":null,"id":"731c9efa-a0ca-41d3-9f4b-dd0255aa426a","name":"test-secret-ns","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestsecretnsijc6fszy","registry_namespace_id":"bf7f1926-fdf0-4dba-934a-1d84dcf10735","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$CQZQjDm9jPa/jPMNe//MUA$UCuaruLHHsw5FLfElD6NcX7jnhyw3KnN3F4TfNmf3Kg","key":"SECRET_2"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$dj82rMT7WUj6InUn7AJK5Q$6rKtK8ZSH8pduhhg1Ga0XpQsstTW29H8Lo7rggcXzUg","key":"SECRET_1"}],"status":"ready","tags":[],"updated_at":"2025-04-28T09:37:18.789257Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.465619Z","description":"","environment_variables":{},"error_message":null,"id":"1485b2ec-4ea1-45e3-8daf-ce30ee313880","name":"test-secret-ns","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestsecretnsofs225fm","registry_namespace_id":"cb22f8e7-0bdd-4388-b727-4e433106a9cb","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$KvLQF7t0+sl1TquheAEJdQ$keV09aqt5cf4flyON/yzUF6LCvcu4ZWPKl+IJk2GkU0","key":"SECRET_2"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$bWGAwxM/2UBStSx4BLPl4A$SbLs3B089xJnSUkl4qcV172LvcnrU8bwbHibYUjm+zM","key":"SECRET_1"}],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:47.879392Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "825"
+                - "841"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:19 GMT
+                - Wed, 27 Aug 2025 15:05:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -293,10 +293,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 68197867-b755-4049-985d-f56a0dd732ec
+                - 5224bdea-7247-4f4b-9f30-aa1fde22b581
         status: 200 OK
         code: 200
-        duration: 45.953833ms
+        duration: 89.670641ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -312,8 +312,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/731c9efa-a0ca-41d3-9f4b-dd0255aa426a
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/1485b2ec-4ea1-45e3-8daf-ce30ee313880
         method: GET
       response:
         proto: HTTP/2.0
@@ -321,20 +321,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 825
+        content_length: 841
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:14.091018Z","description":"","environment_variables":{},"error_message":null,"id":"731c9efa-a0ca-41d3-9f4b-dd0255aa426a","name":"test-secret-ns","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestsecretnsijc6fszy","registry_namespace_id":"bf7f1926-fdf0-4dba-934a-1d84dcf10735","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$CQZQjDm9jPa/jPMNe//MUA$UCuaruLHHsw5FLfElD6NcX7jnhyw3KnN3F4TfNmf3Kg","key":"SECRET_2"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$dj82rMT7WUj6InUn7AJK5Q$6rKtK8ZSH8pduhhg1Ga0XpQsstTW29H8Lo7rggcXzUg","key":"SECRET_1"}],"status":"ready","tags":[],"updated_at":"2025-04-28T09:37:18.789257Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.465619Z","description":"","environment_variables":{},"error_message":null,"id":"1485b2ec-4ea1-45e3-8daf-ce30ee313880","name":"test-secret-ns","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestsecretnsofs225fm","registry_namespace_id":"cb22f8e7-0bdd-4388-b727-4e433106a9cb","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$KvLQF7t0+sl1TquheAEJdQ$keV09aqt5cf4flyON/yzUF6LCvcu4ZWPKl+IJk2GkU0","key":"SECRET_2"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$bWGAwxM/2UBStSx4BLPl4A$SbLs3B089xJnSUkl4qcV172LvcnrU8bwbHibYUjm+zM","key":"SECRET_1"}],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:47.879392Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "825"
+                - "841"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:19 GMT
+                - Wed, 27 Aug 2025 15:05:52 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -342,10 +342,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 84ddba75-bbd8-4927-b1b9-a5e66f354196
+                - 4d48327f-761a-44ea-8bbc-ed006b484c68
         status: 200 OK
         code: 200
-        duration: 45.20425ms
+        duration: 110.121477ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -361,8 +361,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/731c9efa-a0ca-41d3-9f4b-dd0255aa426a
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/1485b2ec-4ea1-45e3-8daf-ce30ee313880
         method: GET
       response:
         proto: HTTP/2.0
@@ -370,20 +370,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 825
+        content_length: 841
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:14.091018Z","description":"","environment_variables":{},"error_message":null,"id":"731c9efa-a0ca-41d3-9f4b-dd0255aa426a","name":"test-secret-ns","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestsecretnsijc6fszy","registry_namespace_id":"bf7f1926-fdf0-4dba-934a-1d84dcf10735","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$CQZQjDm9jPa/jPMNe//MUA$UCuaruLHHsw5FLfElD6NcX7jnhyw3KnN3F4TfNmf3Kg","key":"SECRET_2"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$dj82rMT7WUj6InUn7AJK5Q$6rKtK8ZSH8pduhhg1Ga0XpQsstTW29H8Lo7rggcXzUg","key":"SECRET_1"}],"status":"ready","tags":[],"updated_at":"2025-04-28T09:37:18.789257Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.465619Z","description":"","environment_variables":{},"error_message":null,"id":"1485b2ec-4ea1-45e3-8daf-ce30ee313880","name":"test-secret-ns","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestsecretnsofs225fm","registry_namespace_id":"cb22f8e7-0bdd-4388-b727-4e433106a9cb","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$KvLQF7t0+sl1TquheAEJdQ$keV09aqt5cf4flyON/yzUF6LCvcu4ZWPKl+IJk2GkU0","key":"SECRET_2"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$bWGAwxM/2UBStSx4BLPl4A$SbLs3B089xJnSUkl4qcV172LvcnrU8bwbHibYUjm+zM","key":"SECRET_1"}],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:47.879392Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "825"
+                - "841"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:20 GMT
+                - Wed, 27 Aug 2025 15:05:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -391,11 +391,60 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ab929070-6725-44c6-b326-21c0d3233770
+                - a18c8632-20f5-4158-8a90-8e155010a43a
         status: 200 OK
         code: 200
-        duration: 51.015541ms
+        duration: 77.090697ms
     - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/1485b2ec-4ea1-45e3-8daf-ce30ee313880
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 841
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:41.465619Z","description":"","environment_variables":{},"error_message":null,"id":"1485b2ec-4ea1-45e3-8daf-ce30ee313880","name":"test-secret-ns","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestsecretnsofs225fm","registry_namespace_id":"cb22f8e7-0bdd-4388-b727-4e433106a9cb","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$KvLQF7t0+sl1TquheAEJdQ$keV09aqt5cf4flyON/yzUF6LCvcu4ZWPKl+IJk2GkU0","key":"SECRET_2"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$bWGAwxM/2UBStSx4BLPl4A$SbLs3B089xJnSUkl4qcV172LvcnrU8bwbHibYUjm+zM","key":"SECRET_1"}],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:47.879392Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "841"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:05:53 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 4c5a14a9-b242-4161-b2f5-c66b6441f462
+        status: 200 OK
+        code: 200
+        duration: 92.214946ms
+    - id: 9
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -412,8 +461,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/731c9efa-a0ca-41d3-9f4b-dd0255aa426a
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/1485b2ec-4ea1-45e3-8daf-ce30ee313880
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -421,20 +470,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 830
+        content_length: 846
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:14.091018Z","description":"","environment_variables":{},"error_message":null,"id":"731c9efa-a0ca-41d3-9f4b-dd0255aa426a","name":"test-secret-ns","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestsecretnsijc6fszy","registry_namespace_id":"bf7f1926-fdf0-4dba-934a-1d84dcf10735","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$gvxkpz+bTb1/rdfFcBm3xQ$c45TEyRMVqEqB4vqQhaGboSLpgDTyPAl6GN+aDZQOvM","key":"SECRET_2"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$dj82rMT7WUj6InUn7AJK5Q$6rKtK8ZSH8pduhhg1Ga0XpQsstTW29H8Lo7rggcXzUg","key":"SECRET_1"}],"status":"pending","tags":[],"updated_at":"2025-04-28T09:37:21.022173785Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.465619Z","description":"","environment_variables":{},"error_message":null,"id":"1485b2ec-4ea1-45e3-8daf-ce30ee313880","name":"test-secret-ns","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestsecretnsofs225fm","registry_namespace_id":"cb22f8e7-0bdd-4388-b727-4e433106a9cb","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$klCr1qR+7NtazmnkPvxswA$9kur/u3DHmBptWnYWC5GrDZUP1/Rmptbua74+zlD6SY","key":"SECRET_2"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$bWGAwxM/2UBStSx4BLPl4A$SbLs3B089xJnSUkl4qcV172LvcnrU8bwbHibYUjm+zM","key":"SECRET_1"}],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:54.167302909Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "830"
+                - "846"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:21 GMT
+                - Wed, 27 Aug 2025 15:05:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -442,59 +491,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fd7fa342-2a0f-455b-abe0-7f83d0faea64
+                - 3adc0284-39c9-4167-a6a9-ce7b0fde1344
         status: 200 OK
         code: 200
-        duration: 815.442459ms
-    - id: 9
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/731c9efa-a0ca-41d3-9f4b-dd0255aa426a
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 827
-        uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:14.091018Z","description":"","environment_variables":{},"error_message":null,"id":"731c9efa-a0ca-41d3-9f4b-dd0255aa426a","name":"test-secret-ns","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestsecretnsijc6fszy","registry_namespace_id":"bf7f1926-fdf0-4dba-934a-1d84dcf10735","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$gvxkpz+bTb1/rdfFcBm3xQ$c45TEyRMVqEqB4vqQhaGboSLpgDTyPAl6GN+aDZQOvM","key":"SECRET_2"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$dj82rMT7WUj6InUn7AJK5Q$6rKtK8ZSH8pduhhg1Ga0XpQsstTW29H8Lo7rggcXzUg","key":"SECRET_1"}],"status":"pending","tags":[],"updated_at":"2025-04-28T09:37:21.022174Z"}'
-        headers:
-            Content-Length:
-                - "827"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 28 Apr 2025 09:37:21 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - e48fda1d-a7c0-4ef7-94fc-e4022ee53902
-        status: 200 OK
-        code: 200
-        duration: 97.503375ms
+        duration: 334.983578ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -510,8 +510,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/731c9efa-a0ca-41d3-9f4b-dd0255aa426a
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/1485b2ec-4ea1-45e3-8daf-ce30ee313880
         method: GET
       response:
         proto: HTTP/2.0
@@ -519,20 +519,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 825
+        content_length: 843
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:14.091018Z","description":"","environment_variables":{},"error_message":null,"id":"731c9efa-a0ca-41d3-9f4b-dd0255aa426a","name":"test-secret-ns","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestsecretnsijc6fszy","registry_namespace_id":"bf7f1926-fdf0-4dba-934a-1d84dcf10735","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$gvxkpz+bTb1/rdfFcBm3xQ$c45TEyRMVqEqB4vqQhaGboSLpgDTyPAl6GN+aDZQOvM","key":"SECRET_2"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$dj82rMT7WUj6InUn7AJK5Q$6rKtK8ZSH8pduhhg1Ga0XpQsstTW29H8Lo7rggcXzUg","key":"SECRET_1"}],"status":"ready","tags":[],"updated_at":"2025-04-28T09:37:21.402805Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.465619Z","description":"","environment_variables":{},"error_message":null,"id":"1485b2ec-4ea1-45e3-8daf-ce30ee313880","name":"test-secret-ns","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestsecretnsofs225fm","registry_namespace_id":"cb22f8e7-0bdd-4388-b727-4e433106a9cb","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$klCr1qR+7NtazmnkPvxswA$9kur/u3DHmBptWnYWC5GrDZUP1/Rmptbua74+zlD6SY","key":"SECRET_2"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$bWGAwxM/2UBStSx4BLPl4A$SbLs3B089xJnSUkl4qcV172LvcnrU8bwbHibYUjm+zM","key":"SECRET_1"}],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:54.167303Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "825"
+                - "843"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:26 GMT
+                - Wed, 27 Aug 2025 15:05:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -540,10 +540,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a8142d97-8e6e-4b57-a5db-856163a800f6
+                - 42c09de1-e521-4aaa-8227-30acbac45929
         status: 200 OK
         code: 200
-        duration: 51.030542ms
+        duration: 77.911087ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -559,8 +559,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/731c9efa-a0ca-41d3-9f4b-dd0255aa426a
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/1485b2ec-4ea1-45e3-8daf-ce30ee313880
         method: GET
       response:
         proto: HTTP/2.0
@@ -568,20 +568,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 825
+        content_length: 841
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:14.091018Z","description":"","environment_variables":{},"error_message":null,"id":"731c9efa-a0ca-41d3-9f4b-dd0255aa426a","name":"test-secret-ns","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestsecretnsijc6fszy","registry_namespace_id":"bf7f1926-fdf0-4dba-934a-1d84dcf10735","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$gvxkpz+bTb1/rdfFcBm3xQ$c45TEyRMVqEqB4vqQhaGboSLpgDTyPAl6GN+aDZQOvM","key":"SECRET_2"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$dj82rMT7WUj6InUn7AJK5Q$6rKtK8ZSH8pduhhg1Ga0XpQsstTW29H8Lo7rggcXzUg","key":"SECRET_1"}],"status":"ready","tags":[],"updated_at":"2025-04-28T09:37:21.402805Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.465619Z","description":"","environment_variables":{},"error_message":null,"id":"1485b2ec-4ea1-45e3-8daf-ce30ee313880","name":"test-secret-ns","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestsecretnsofs225fm","registry_namespace_id":"cb22f8e7-0bdd-4388-b727-4e433106a9cb","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$klCr1qR+7NtazmnkPvxswA$9kur/u3DHmBptWnYWC5GrDZUP1/Rmptbua74+zlD6SY","key":"SECRET_2"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$bWGAwxM/2UBStSx4BLPl4A$SbLs3B089xJnSUkl4qcV172LvcnrU8bwbHibYUjm+zM","key":"SECRET_1"}],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:54.594283Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "825"
+                - "841"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:26 GMT
+                - Wed, 27 Aug 2025 15:05:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -589,10 +589,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 52c76302-3881-41d5-9493-741184f68989
+                - 04ed5dd9-0e9b-44e2-a91b-f58a17716605
         status: 200 OK
         code: 200
-        duration: 40.753541ms
+        duration: 91.51813ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -608,8 +608,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/731c9efa-a0ca-41d3-9f4b-dd0255aa426a
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/1485b2ec-4ea1-45e3-8daf-ce30ee313880
         method: GET
       response:
         proto: HTTP/2.0
@@ -617,20 +617,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 825
+        content_length: 841
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:14.091018Z","description":"","environment_variables":{},"error_message":null,"id":"731c9efa-a0ca-41d3-9f4b-dd0255aa426a","name":"test-secret-ns","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestsecretnsijc6fszy","registry_namespace_id":"bf7f1926-fdf0-4dba-934a-1d84dcf10735","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$gvxkpz+bTb1/rdfFcBm3xQ$c45TEyRMVqEqB4vqQhaGboSLpgDTyPAl6GN+aDZQOvM","key":"SECRET_2"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$dj82rMT7WUj6InUn7AJK5Q$6rKtK8ZSH8pduhhg1Ga0XpQsstTW29H8Lo7rggcXzUg","key":"SECRET_1"}],"status":"ready","tags":[],"updated_at":"2025-04-28T09:37:21.402805Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.465619Z","description":"","environment_variables":{},"error_message":null,"id":"1485b2ec-4ea1-45e3-8daf-ce30ee313880","name":"test-secret-ns","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestsecretnsofs225fm","registry_namespace_id":"cb22f8e7-0bdd-4388-b727-4e433106a9cb","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$klCr1qR+7NtazmnkPvxswA$9kur/u3DHmBptWnYWC5GrDZUP1/Rmptbua74+zlD6SY","key":"SECRET_2"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$bWGAwxM/2UBStSx4BLPl4A$SbLs3B089xJnSUkl4qcV172LvcnrU8bwbHibYUjm+zM","key":"SECRET_1"}],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:54.594283Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "825"
+                - "841"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:26 GMT
+                - Wed, 27 Aug 2025 15:05:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -638,10 +638,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 04659221-02cd-4fc3-82cd-91c4ca3db054
+                - 13bfa39b-3a89-47ea-9bc8-b5cb8ff714f5
         status: 200 OK
         code: 200
-        duration: 37.185792ms
+        duration: 148.840644ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -657,8 +657,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/731c9efa-a0ca-41d3-9f4b-dd0255aa426a
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/1485b2ec-4ea1-45e3-8daf-ce30ee313880
         method: GET
       response:
         proto: HTTP/2.0
@@ -666,20 +666,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 825
+        content_length: 841
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:14.091018Z","description":"","environment_variables":{},"error_message":null,"id":"731c9efa-a0ca-41d3-9f4b-dd0255aa426a","name":"test-secret-ns","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestsecretnsijc6fszy","registry_namespace_id":"bf7f1926-fdf0-4dba-934a-1d84dcf10735","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$gvxkpz+bTb1/rdfFcBm3xQ$c45TEyRMVqEqB4vqQhaGboSLpgDTyPAl6GN+aDZQOvM","key":"SECRET_2"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$dj82rMT7WUj6InUn7AJK5Q$6rKtK8ZSH8pduhhg1Ga0XpQsstTW29H8Lo7rggcXzUg","key":"SECRET_1"}],"status":"ready","tags":[],"updated_at":"2025-04-28T09:37:21.402805Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.465619Z","description":"","environment_variables":{},"error_message":null,"id":"1485b2ec-4ea1-45e3-8daf-ce30ee313880","name":"test-secret-ns","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestsecretnsofs225fm","registry_namespace_id":"cb22f8e7-0bdd-4388-b727-4e433106a9cb","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$klCr1qR+7NtazmnkPvxswA$9kur/u3DHmBptWnYWC5GrDZUP1/Rmptbua74+zlD6SY","key":"SECRET_2"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$bWGAwxM/2UBStSx4BLPl4A$SbLs3B089xJnSUkl4qcV172LvcnrU8bwbHibYUjm+zM","key":"SECRET_1"}],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:54.594283Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "825"
+                - "841"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:26 GMT
+                - Wed, 27 Aug 2025 15:06:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -687,10 +687,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 419c1466-0dc3-466b-87dc-453be3c2c77c
+                - 5a33ffc4-cd85-473e-8239-e22c33fe1e89
         status: 200 OK
         code: 200
-        duration: 42.392167ms
+        duration: 88.92809ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -706,8 +706,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/731c9efa-a0ca-41d3-9f4b-dd0255aa426a
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/1485b2ec-4ea1-45e3-8daf-ce30ee313880
         method: GET
       response:
         proto: HTTP/2.0
@@ -715,20 +715,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 825
+        content_length: 841
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:14.091018Z","description":"","environment_variables":{},"error_message":null,"id":"731c9efa-a0ca-41d3-9f4b-dd0255aa426a","name":"test-secret-ns","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestsecretnsijc6fszy","registry_namespace_id":"bf7f1926-fdf0-4dba-934a-1d84dcf10735","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$gvxkpz+bTb1/rdfFcBm3xQ$c45TEyRMVqEqB4vqQhaGboSLpgDTyPAl6GN+aDZQOvM","key":"SECRET_2"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$dj82rMT7WUj6InUn7AJK5Q$6rKtK8ZSH8pduhhg1Ga0XpQsstTW29H8Lo7rggcXzUg","key":"SECRET_1"}],"status":"ready","tags":[],"updated_at":"2025-04-28T09:37:21.402805Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.465619Z","description":"","environment_variables":{},"error_message":null,"id":"1485b2ec-4ea1-45e3-8daf-ce30ee313880","name":"test-secret-ns","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestsecretnsofs225fm","registry_namespace_id":"cb22f8e7-0bdd-4388-b727-4e433106a9cb","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$klCr1qR+7NtazmnkPvxswA$9kur/u3DHmBptWnYWC5GrDZUP1/Rmptbua74+zlD6SY","key":"SECRET_2"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$bWGAwxM/2UBStSx4BLPl4A$SbLs3B089xJnSUkl4qcV172LvcnrU8bwbHibYUjm+zM","key":"SECRET_1"}],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:54.594283Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "825"
+                - "841"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:27 GMT
+                - Wed, 27 Aug 2025 15:06:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -736,11 +736,60 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d547d679-55af-4287-81d0-40bde5985c13
+                - 8a0ee709-63fc-44df-817f-bf8b591f75b6
         status: 200 OK
         code: 200
-        duration: 35.631875ms
+        duration: 79.454543ms
     - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/1485b2ec-4ea1-45e3-8daf-ce30ee313880
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 841
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:41.465619Z","description":"","environment_variables":{},"error_message":null,"id":"1485b2ec-4ea1-45e3-8daf-ce30ee313880","name":"test-secret-ns","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestsecretnsofs225fm","registry_namespace_id":"cb22f8e7-0bdd-4388-b727-4e433106a9cb","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$klCr1qR+7NtazmnkPvxswA$9kur/u3DHmBptWnYWC5GrDZUP1/Rmptbua74+zlD6SY","key":"SECRET_2"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$bWGAwxM/2UBStSx4BLPl4A$SbLs3B089xJnSUkl4qcV172LvcnrU8bwbHibYUjm+zM","key":"SECRET_1"}],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:54.594283Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "841"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:01 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 69fe7f62-6b0e-40b8-8a44-c60228a08307
+        status: 200 OK
+        code: 200
+        duration: 79.816453ms
+    - id: 16
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -757,8 +806,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/731c9efa-a0ca-41d3-9f4b-dd0255aa426a
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/1485b2ec-4ea1-45e3-8daf-ce30ee313880
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -766,20 +815,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 834
+        content_length: 850
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:14.091018Z","description":"","environment_variables":{},"error_message":null,"id":"731c9efa-a0ca-41d3-9f4b-dd0255aa426a","name":"test-secret-ns","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestsecretnsijc6fszy","registry_namespace_id":"bf7f1926-fdf0-4dba-934a-1d84dcf10735","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$gvxkpz+bTb1/rdfFcBm3xQ$c45TEyRMVqEqB4vqQhaGboSLpgDTyPAl6GN+aDZQOvM","key":"SECRET_2"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$icbf3UMyvu6n6d0NcokI3g$hgwJhGCwgqogQ62+56JXjAGCVWpQhtfJ0Aiok9ij/Lw","key":"SECRET_KEY_1"}],"status":"pending","tags":[],"updated_at":"2025-04-28T09:37:27.726057197Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.465619Z","description":"","environment_variables":{},"error_message":null,"id":"1485b2ec-4ea1-45e3-8daf-ce30ee313880","name":"test-secret-ns","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestsecretnsofs225fm","registry_namespace_id":"cb22f8e7-0bdd-4388-b727-4e433106a9cb","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$rmoKbzsA+yG7CYn/oNIamA$myrsUcLnGb0Qma3vVLYxoTN6rgR6cBGYiY/bP2FfQL8","key":"SECRET_KEY_1"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$klCr1qR+7NtazmnkPvxswA$9kur/u3DHmBptWnYWC5GrDZUP1/Rmptbua74+zlD6SY","key":"SECRET_2"}],"status":"pending","tags":[],"updated_at":"2025-08-27T15:06:01.784339272Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "834"
+                - "850"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:27 GMT
+                - Wed, 27 Aug 2025 15:06:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -787,59 +836,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 52fc5a30-a3c8-4736-a322-bf64f5aed9ba
+                - 549472b3-c85c-4e3d-819c-97b7834286f4
         status: 200 OK
         code: 200
-        duration: 448.466834ms
-    - id: 16
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/731c9efa-a0ca-41d3-9f4b-dd0255aa426a
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 831
-        uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:14.091018Z","description":"","environment_variables":{},"error_message":null,"id":"731c9efa-a0ca-41d3-9f4b-dd0255aa426a","name":"test-secret-ns","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestsecretnsijc6fszy","registry_namespace_id":"bf7f1926-fdf0-4dba-934a-1d84dcf10735","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$gvxkpz+bTb1/rdfFcBm3xQ$c45TEyRMVqEqB4vqQhaGboSLpgDTyPAl6GN+aDZQOvM","key":"SECRET_2"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$icbf3UMyvu6n6d0NcokI3g$hgwJhGCwgqogQ62+56JXjAGCVWpQhtfJ0Aiok9ij/Lw","key":"SECRET_KEY_1"}],"status":"pending","tags":[],"updated_at":"2025-04-28T09:37:27.726057Z"}'
-        headers:
-            Content-Length:
-                - "831"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 28 Apr 2025 09:37:27 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - fb245785-b381-4ff3-950a-cedd7f4070c4
-        status: 200 OK
-        code: 200
-        duration: 38.161375ms
+        duration: 175.341473ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -855,8 +855,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/731c9efa-a0ca-41d3-9f4b-dd0255aa426a
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/1485b2ec-4ea1-45e3-8daf-ce30ee313880
         method: GET
       response:
         proto: HTTP/2.0
@@ -864,20 +864,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 829
+        content_length: 847
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:14.091018Z","description":"","environment_variables":{},"error_message":null,"id":"731c9efa-a0ca-41d3-9f4b-dd0255aa426a","name":"test-secret-ns","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestsecretnsijc6fszy","registry_namespace_id":"bf7f1926-fdf0-4dba-934a-1d84dcf10735","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$gvxkpz+bTb1/rdfFcBm3xQ$c45TEyRMVqEqB4vqQhaGboSLpgDTyPAl6GN+aDZQOvM","key":"SECRET_2"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$icbf3UMyvu6n6d0NcokI3g$hgwJhGCwgqogQ62+56JXjAGCVWpQhtfJ0Aiok9ij/Lw","key":"SECRET_KEY_1"}],"status":"ready","tags":[],"updated_at":"2025-04-28T09:37:28.170790Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.465619Z","description":"","environment_variables":{},"error_message":null,"id":"1485b2ec-4ea1-45e3-8daf-ce30ee313880","name":"test-secret-ns","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestsecretnsofs225fm","registry_namespace_id":"cb22f8e7-0bdd-4388-b727-4e433106a9cb","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$rmoKbzsA+yG7CYn/oNIamA$myrsUcLnGb0Qma3vVLYxoTN6rgR6cBGYiY/bP2FfQL8","key":"SECRET_KEY_1"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$klCr1qR+7NtazmnkPvxswA$9kur/u3DHmBptWnYWC5GrDZUP1/Rmptbua74+zlD6SY","key":"SECRET_2"}],"status":"pending","tags":[],"updated_at":"2025-08-27T15:06:01.784339Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "829"
+                - "847"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:32 GMT
+                - Wed, 27 Aug 2025 15:06:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -885,10 +885,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 66033ce0-8069-48ef-9dce-61c35256715a
+                - 18992361-6fc0-4e0b-a0ef-2367e7c2d953
         status: 200 OK
         code: 200
-        duration: 51.026ms
+        duration: 87.142851ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -904,8 +904,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/731c9efa-a0ca-41d3-9f4b-dd0255aa426a
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/1485b2ec-4ea1-45e3-8daf-ce30ee313880
         method: GET
       response:
         proto: HTTP/2.0
@@ -913,20 +913,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 829
+        content_length: 845
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:14.091018Z","description":"","environment_variables":{},"error_message":null,"id":"731c9efa-a0ca-41d3-9f4b-dd0255aa426a","name":"test-secret-ns","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestsecretnsijc6fszy","registry_namespace_id":"bf7f1926-fdf0-4dba-934a-1d84dcf10735","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$gvxkpz+bTb1/rdfFcBm3xQ$c45TEyRMVqEqB4vqQhaGboSLpgDTyPAl6GN+aDZQOvM","key":"SECRET_2"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$icbf3UMyvu6n6d0NcokI3g$hgwJhGCwgqogQ62+56JXjAGCVWpQhtfJ0Aiok9ij/Lw","key":"SECRET_KEY_1"}],"status":"ready","tags":[],"updated_at":"2025-04-28T09:37:28.170790Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.465619Z","description":"","environment_variables":{},"error_message":null,"id":"1485b2ec-4ea1-45e3-8daf-ce30ee313880","name":"test-secret-ns","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestsecretnsofs225fm","registry_namespace_id":"cb22f8e7-0bdd-4388-b727-4e433106a9cb","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$rmoKbzsA+yG7CYn/oNIamA$myrsUcLnGb0Qma3vVLYxoTN6rgR6cBGYiY/bP2FfQL8","key":"SECRET_KEY_1"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$klCr1qR+7NtazmnkPvxswA$9kur/u3DHmBptWnYWC5GrDZUP1/Rmptbua74+zlD6SY","key":"SECRET_2"}],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:05.382968Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "829"
+                - "845"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:32 GMT
+                - Wed, 27 Aug 2025 15:06:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -934,10 +934,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 02c43a79-a066-4406-83ec-b5a4c5113f39
+                - f97925c9-5817-4b16-8eb2-4266c50c747e
         status: 200 OK
         code: 200
-        duration: 38.57375ms
+        duration: 82.693323ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -953,8 +953,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/731c9efa-a0ca-41d3-9f4b-dd0255aa426a
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/1485b2ec-4ea1-45e3-8daf-ce30ee313880
         method: GET
       response:
         proto: HTTP/2.0
@@ -962,20 +962,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 829
+        content_length: 845
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:14.091018Z","description":"","environment_variables":{},"error_message":null,"id":"731c9efa-a0ca-41d3-9f4b-dd0255aa426a","name":"test-secret-ns","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestsecretnsijc6fszy","registry_namespace_id":"bf7f1926-fdf0-4dba-934a-1d84dcf10735","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$gvxkpz+bTb1/rdfFcBm3xQ$c45TEyRMVqEqB4vqQhaGboSLpgDTyPAl6GN+aDZQOvM","key":"SECRET_2"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$icbf3UMyvu6n6d0NcokI3g$hgwJhGCwgqogQ62+56JXjAGCVWpQhtfJ0Aiok9ij/Lw","key":"SECRET_KEY_1"}],"status":"ready","tags":[],"updated_at":"2025-04-28T09:37:28.170790Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.465619Z","description":"","environment_variables":{},"error_message":null,"id":"1485b2ec-4ea1-45e3-8daf-ce30ee313880","name":"test-secret-ns","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestsecretnsofs225fm","registry_namespace_id":"cb22f8e7-0bdd-4388-b727-4e433106a9cb","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$rmoKbzsA+yG7CYn/oNIamA$myrsUcLnGb0Qma3vVLYxoTN6rgR6cBGYiY/bP2FfQL8","key":"SECRET_KEY_1"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$klCr1qR+7NtazmnkPvxswA$9kur/u3DHmBptWnYWC5GrDZUP1/Rmptbua74+zlD6SY","key":"SECRET_2"}],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:05.382968Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "829"
+                - "845"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:33 GMT
+                - Wed, 27 Aug 2025 15:06:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -983,10 +983,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ff6325e9-e990-4c76-af93-1a6ee66537e9
+                - cf83b54d-e9ed-487a-bc29-62a169ce6096
         status: 200 OK
         code: 200
-        duration: 42.937292ms
+        duration: 81.756526ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1002,8 +1002,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/731c9efa-a0ca-41d3-9f4b-dd0255aa426a
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/1485b2ec-4ea1-45e3-8daf-ce30ee313880
         method: GET
       response:
         proto: HTTP/2.0
@@ -1011,20 +1011,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 829
+        content_length: 845
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:14.091018Z","description":"","environment_variables":{},"error_message":null,"id":"731c9efa-a0ca-41d3-9f4b-dd0255aa426a","name":"test-secret-ns","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestsecretnsijc6fszy","registry_namespace_id":"bf7f1926-fdf0-4dba-934a-1d84dcf10735","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$gvxkpz+bTb1/rdfFcBm3xQ$c45TEyRMVqEqB4vqQhaGboSLpgDTyPAl6GN+aDZQOvM","key":"SECRET_2"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$icbf3UMyvu6n6d0NcokI3g$hgwJhGCwgqogQ62+56JXjAGCVWpQhtfJ0Aiok9ij/Lw","key":"SECRET_KEY_1"}],"status":"ready","tags":[],"updated_at":"2025-04-28T09:37:28.170790Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.465619Z","description":"","environment_variables":{},"error_message":null,"id":"1485b2ec-4ea1-45e3-8daf-ce30ee313880","name":"test-secret-ns","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestsecretnsofs225fm","registry_namespace_id":"cb22f8e7-0bdd-4388-b727-4e433106a9cb","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$rmoKbzsA+yG7CYn/oNIamA$myrsUcLnGb0Qma3vVLYxoTN6rgR6cBGYiY/bP2FfQL8","key":"SECRET_KEY_1"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$klCr1qR+7NtazmnkPvxswA$9kur/u3DHmBptWnYWC5GrDZUP1/Rmptbua74+zlD6SY","key":"SECRET_2"}],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:05.382968Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "829"
+                - "845"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:33 GMT
+                - Wed, 27 Aug 2025 15:06:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1032,10 +1032,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6ac92e71-7fd6-498c-8b47-8161a1aceef9
+                - 1f07793f-5c4a-4214-8601-91edac1ccbf4
         status: 200 OK
         code: 200
-        duration: 39.639458ms
+        duration: 100.220212ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1051,29 +1051,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/731c9efa-a0ca-41d3-9f4b-dd0255aa426a
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/1485b2ec-4ea1-45e3-8daf-ce30ee313880
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 835
+        content_length: 845
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:14.091018Z","description":"","environment_variables":{},"error_message":null,"id":"731c9efa-a0ca-41d3-9f4b-dd0255aa426a","name":"test-secret-ns","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestsecretnsijc6fszy","registry_namespace_id":"bf7f1926-fdf0-4dba-934a-1d84dcf10735","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$gvxkpz+bTb1/rdfFcBm3xQ$c45TEyRMVqEqB4vqQhaGboSLpgDTyPAl6GN+aDZQOvM","key":"SECRET_2"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$icbf3UMyvu6n6d0NcokI3g$hgwJhGCwgqogQ62+56JXjAGCVWpQhtfJ0Aiok9ij/Lw","key":"SECRET_KEY_1"}],"status":"deleting","tags":[],"updated_at":"2025-04-28T09:37:33.617110558Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.465619Z","description":"","environment_variables":{},"error_message":null,"id":"1485b2ec-4ea1-45e3-8daf-ce30ee313880","name":"test-secret-ns","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestsecretnsofs225fm","registry_namespace_id":"cb22f8e7-0bdd-4388-b727-4e433106a9cb","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$rmoKbzsA+yG7CYn/oNIamA$myrsUcLnGb0Qma3vVLYxoTN6rgR6cBGYiY/bP2FfQL8","key":"SECRET_KEY_1"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$klCr1qR+7NtazmnkPvxswA$9kur/u3DHmBptWnYWC5GrDZUP1/Rmptbua74+zlD6SY","key":"SECRET_2"}],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:05.382968Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "835"
+                - "845"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:33 GMT
+                - Wed, 27 Aug 2025 15:06:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1081,10 +1081,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e5046c0f-18f5-4478-a147-23c7da03486f
+                - 7426e92f-96eb-46e8-a01c-f790e702220a
         status: 200 OK
         code: 200
-        duration: 153.83575ms
+        duration: 85.685397ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1100,29 +1100,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/731c9efa-a0ca-41d3-9f4b-dd0255aa426a
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/1485b2ec-4ea1-45e3-8daf-ce30ee313880
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 832
+        content_length: 851
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:37:14.091018Z","description":"","environment_variables":{},"error_message":null,"id":"731c9efa-a0ca-41d3-9f4b-dd0255aa426a","name":"test-secret-ns","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestsecretnsijc6fszy","registry_namespace_id":"bf7f1926-fdf0-4dba-934a-1d84dcf10735","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$gvxkpz+bTb1/rdfFcBm3xQ$c45TEyRMVqEqB4vqQhaGboSLpgDTyPAl6GN+aDZQOvM","key":"SECRET_2"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$icbf3UMyvu6n6d0NcokI3g$hgwJhGCwgqogQ62+56JXjAGCVWpQhtfJ0Aiok9ij/Lw","key":"SECRET_KEY_1"}],"status":"deleting","tags":[],"updated_at":"2025-04-28T09:37:33.617111Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.465619Z","description":"","environment_variables":{},"error_message":null,"id":"1485b2ec-4ea1-45e3-8daf-ce30ee313880","name":"test-secret-ns","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestsecretnsofs225fm","registry_namespace_id":"cb22f8e7-0bdd-4388-b727-4e433106a9cb","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$rmoKbzsA+yG7CYn/oNIamA$myrsUcLnGb0Qma3vVLYxoTN6rgR6cBGYiY/bP2FfQL8","key":"SECRET_KEY_1"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$klCr1qR+7NtazmnkPvxswA$9kur/u3DHmBptWnYWC5GrDZUP1/Rmptbua74+zlD6SY","key":"SECRET_2"}],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:08.397304835Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "832"
+                - "851"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:33 GMT
+                - Wed, 27 Aug 2025 15:06:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1130,10 +1130,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0d802364-f934-47ee-821e-6c0e9db4aaa4
+                - 884307b3-561a-4a75-bd9e-20a532aead56
         status: 200 OK
         code: 200
-        duration: 38.682667ms
+        duration: 158.249103ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1149,8 +1149,57 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/731c9efa-a0ca-41d3-9f4b-dd0255aa426a
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/1485b2ec-4ea1-45e3-8daf-ce30ee313880
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 848
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:41.465619Z","description":"","environment_variables":{},"error_message":null,"id":"1485b2ec-4ea1-45e3-8daf-ce30ee313880","name":"test-secret-ns","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestsecretnsofs225fm","registry_namespace_id":"cb22f8e7-0bdd-4388-b727-4e433106a9cb","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$rmoKbzsA+yG7CYn/oNIamA$myrsUcLnGb0Qma3vVLYxoTN6rgR6cBGYiY/bP2FfQL8","key":"SECRET_KEY_1"},{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$klCr1qR+7NtazmnkPvxswA$9kur/u3DHmBptWnYWC5GrDZUP1/Rmptbua74+zlD6SY","key":"SECRET_2"}],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:08.397305Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "848"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:08 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 551a2117-df7a-41eb-9141-09fc3803c2dd
+        status: 200 OK
+        code: 200
+        duration: 88.978177ms
+    - id: 24
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/1485b2ec-4ea1-45e3-8daf-ce30ee313880
         method: GET
       response:
         proto: HTTP/2.0
@@ -1169,9 +1218,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:38 GMT
+                - Wed, 27 Aug 2025 15:06:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1179,11 +1228,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 80755b9e-1cc3-4173-b614-a6d8d27a314e
+                - 5f0fba15-dff0-4d33-9f03-4d9bf52eac20
         status: 404 Not Found
         code: 404
-        duration: 25.536875ms
-    - id: 24
+        duration: 31.65453ms
+    - id: 25
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1198,8 +1247,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/731c9efa-a0ca-41d3-9f4b-dd0255aa426a
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/1485b2ec-4ea1-45e3-8daf-ce30ee313880
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1218,9 +1267,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:37:38 GMT
+                - Wed, 27 Aug 2025 15:06:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1228,7 +1277,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d68078df-86e3-43b1-8ae9-df313fd71c8c
+                - 21842936-174e-4360-8544-06cb4177b7dc
         status: 404 Not Found
         code: 404
-        duration: 131.237208ms
+        duration: 25.150875ms

--- a/internal/services/container/testdata/namespace-vpc-integration.cassette.yaml
+++ b/internal/services/container/testdata/namespace-vpc-integration.cassette.yaml
@@ -6,13 +6,13 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 153
+        content_length: 150
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-pn-musing-chatterjee","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"subnets":null,"default_route_propagation_enabled":false}'
+        body: '{"name":"tf-pn-pensive-galois","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","tags":[],"subnets":null,"default_route_propagation_enabled":false}'
         form: {}
         headers:
             Content-Type:
@@ -27,20 +27,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1068
+        content_length: 1065
         uncompressed: false
-        body: '{"created_at":"2025-08-27T14:01:37.966124Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"1510a03d-65c6-4fb4-ad5f-e10774ccf565","name":"tf-pn-musing-chatterjee","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-08-27T14:01:37.966124Z","id":"504966e9-c06d-4586-91da-f503ffe8974e","private_network_id":"1510a03d-65c6-4fb4-ad5f-e10774ccf565","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.4.0/22","updated_at":"2025-08-27T14:01:37.966124Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-08-27T14:01:37.966124Z","id":"52043d70-ee6a-4801-bc3b-d21486df6925","private_network_id":"1510a03d-65c6-4fb4-ad5f-e10774ccf565","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:b5ee::/64","updated_at":"2025-08-27T14:01:37.966124Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-08-27T14:01:37.966124Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+        body: '{"created_at":"2025-08-27T15:05:36.152051Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"b3c3c64b-8111-4fd7-91ba-792cb0f36cdb","name":"tf-pn-pensive-galois","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","subnets":[{"created_at":"2025-08-27T15:05:36.152051Z","id":"88d99377-0b6a-489b-9b82-11f9d78419c5","private_network_id":"b3c3c64b-8111-4fd7-91ba-792cb0f36cdb","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","subnet":"172.16.8.0/22","updated_at":"2025-08-27T15:05:36.152051Z","vpc_id":"bfef8344-f496-473e-af67-31ea9afc407c"},{"created_at":"2025-08-27T15:05:36.152051Z","id":"a3e83579-c651-4648-87b2-5c39a546ed11","private_network_id":"b3c3c64b-8111-4fd7-91ba-792cb0f36cdb","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","subnet":"fde7:767f:1bb5:98d9::/64","updated_at":"2025-08-27T15:05:36.152051Z","vpc_id":"bfef8344-f496-473e-af67-31ea9afc407c"}],"tags":[],"updated_at":"2025-08-27T15:05:36.152051Z","vpc_id":"bfef8344-f496-473e-af67-31ea9afc407c"}'
         headers:
             Content-Length:
-                - "1068"
+                - "1065"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:01:38 GMT
+                - Wed, 27 Aug 2025 15:05:36 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f25221d5-f64a-4c42-8544-ff4b269c0b65
+                - e17dd70c-af51-4d59-9e16-888876d4a347
         status: 200 OK
         code: 200
-        duration: 905.880226ms
+        duration: 945.992298ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -68,7 +68,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/1510a03d-65c6-4fb4-ad5f-e10774ccf565
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b3c3c64b-8111-4fd7-91ba-792cb0f36cdb
         method: GET
       response:
         proto: HTTP/2.0
@@ -76,20 +76,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1068
+        content_length: 1065
         uncompressed: false
-        body: '{"created_at":"2025-08-27T14:01:37.966124Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"1510a03d-65c6-4fb4-ad5f-e10774ccf565","name":"tf-pn-musing-chatterjee","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-08-27T14:01:37.966124Z","id":"504966e9-c06d-4586-91da-f503ffe8974e","private_network_id":"1510a03d-65c6-4fb4-ad5f-e10774ccf565","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.4.0/22","updated_at":"2025-08-27T14:01:37.966124Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-08-27T14:01:37.966124Z","id":"52043d70-ee6a-4801-bc3b-d21486df6925","private_network_id":"1510a03d-65c6-4fb4-ad5f-e10774ccf565","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:b5ee::/64","updated_at":"2025-08-27T14:01:37.966124Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-08-27T14:01:37.966124Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+        body: '{"created_at":"2025-08-27T15:05:36.152051Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"b3c3c64b-8111-4fd7-91ba-792cb0f36cdb","name":"tf-pn-pensive-galois","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","subnets":[{"created_at":"2025-08-27T15:05:36.152051Z","id":"88d99377-0b6a-489b-9b82-11f9d78419c5","private_network_id":"b3c3c64b-8111-4fd7-91ba-792cb0f36cdb","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","subnet":"172.16.8.0/22","updated_at":"2025-08-27T15:05:36.152051Z","vpc_id":"bfef8344-f496-473e-af67-31ea9afc407c"},{"created_at":"2025-08-27T15:05:36.152051Z","id":"a3e83579-c651-4648-87b2-5c39a546ed11","private_network_id":"b3c3c64b-8111-4fd7-91ba-792cb0f36cdb","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","subnet":"fde7:767f:1bb5:98d9::/64","updated_at":"2025-08-27T15:05:36.152051Z","vpc_id":"bfef8344-f496-473e-af67-31ea9afc407c"}],"tags":[],"updated_at":"2025-08-27T15:05:36.152051Z","vpc_id":"bfef8344-f496-473e-af67-31ea9afc407c"}'
         headers:
             Content-Length:
-                - "1068"
+                - "1065"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:01:38 GMT
+                - Wed, 27 Aug 2025 15:05:37 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,22 +97,22 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 66d35c4d-5960-445f-926a-b397ff509fd4
+                - c1fa7d34-7ad2-4bd3-84a1-fc5f88f48a25
         status: 200 OK
         code: 200
-        duration: 26.798263ms
+        duration: 104.079454ms
     - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 188
+        content_length: 186
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-ns-brave-mccarthy","environment_variables":{},"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","secret_environment_variables":[],"tags":null,"activate_vpc_integration":true}'
+        body: '{"name":"tf-ns-musing-kalam","environment_variables":{},"project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","secret_environment_variables":[],"tags":null,"activate_vpc_integration":true}'
         form: {}
         headers:
             Content-Type:
@@ -127,20 +127,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 505
+        content_length: 503
         uncompressed: false
-        body: '{"created_at":"2025-08-27T14:01:39.604469939Z","description":"","environment_variables":{},"error_message":null,"id":"03e50d0f-56d9-451b-ab35-5392d4489fbf","name":"tf-ns-brave-mccarthy","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T14:01:39.604469939Z","vpc_integration_activated":true}'
+        body: '{"created_at":"2025-08-27T15:05:41.346205317Z","description":"","environment_variables":{},"error_message":null,"id":"95c0fd0f-9afe-4c03-80ef-557a38a2e187","name":"tf-ns-musing-kalam","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:41.346205317Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "505"
+                - "503"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:01:39 GMT
+                - Wed, 27 Aug 2025 15:05:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -148,10 +148,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b2f20928-28a7-42cf-9570-71244f4818a8
+                - f3249f85-8487-4a85-96d9-bf8269356e12
         status: 200 OK
         code: 200
-        duration: 1.982691746s
+        duration: 5.320374105s
     - id: 3
       request:
         proto: HTTP/1.1
@@ -168,7 +168,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/03e50d0f-56d9-451b-ab35-5392d4489fbf
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/95c0fd0f-9afe-4c03-80ef-557a38a2e187
         method: GET
       response:
         proto: HTTP/2.0
@@ -176,20 +176,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 499
+        content_length: 497
         uncompressed: false
-        body: '{"created_at":"2025-08-27T14:01:39.604470Z","description":"","environment_variables":{},"error_message":null,"id":"03e50d0f-56d9-451b-ab35-5392d4489fbf","name":"tf-ns-brave-mccarthy","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T14:01:39.604470Z","vpc_integration_activated":true}'
+        body: '{"created_at":"2025-08-27T15:05:41.346205Z","description":"","environment_variables":{},"error_message":null,"id":"95c0fd0f-9afe-4c03-80ef-557a38a2e187","name":"tf-ns-musing-kalam","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:41.346205Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "499"
+                - "497"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:01:39 GMT
+                - Wed, 27 Aug 2025 15:05:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -197,10 +197,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9938f8fc-ffd9-4b21-b348-4ab6910d1157
+                - 8db27455-471c-4034-81cd-104896ae0194
         status: 200 OK
         code: 200
-        duration: 47.16435ms
+        duration: 102.373534ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -217,7 +217,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/03e50d0f-56d9-451b-ab35-5392d4489fbf
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/95c0fd0f-9afe-4c03-80ef-557a38a2e187
         method: GET
       response:
         proto: HTTP/2.0
@@ -225,20 +225,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 585
+        content_length: 497
         uncompressed: false
-        body: '{"created_at":"2025-08-27T14:01:39.604470Z","description":"","environment_variables":{},"error_message":null,"id":"03e50d0f-56d9-451b-ab35-5392d4489fbf","name":"tf-ns-brave-mccarthy","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsbravemccarthyq2moobr5","registry_namespace_id":"4d198aa0-b6e1-4b87-ab10-9870e543dda6","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T14:01:44.355471Z","vpc_integration_activated":true}'
+        body: '{"created_at":"2025-08-27T15:05:41.346205Z","description":"","environment_variables":{},"error_message":null,"id":"95c0fd0f-9afe-4c03-80ef-557a38a2e187","name":"tf-ns-musing-kalam","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:41.346205Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "585"
+                - "497"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:01:44 GMT
+                - Wed, 27 Aug 2025 15:05:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -246,10 +246,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9e81f712-eb99-4f24-a11b-01473b791603
+                - 1b14aef6-0034-4a18-8fde-9e9ae41277f1
         status: 200 OK
         code: 200
-        duration: 47.998387ms
+        duration: 78.390264ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -266,7 +266,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/03e50d0f-56d9-451b-ab35-5392d4489fbf
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/95c0fd0f-9afe-4c03-80ef-557a38a2e187
         method: GET
       response:
         proto: HTTP/2.0
@@ -274,20 +274,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 585
+        content_length: 497
         uncompressed: false
-        body: '{"created_at":"2025-08-27T14:01:39.604470Z","description":"","environment_variables":{},"error_message":null,"id":"03e50d0f-56d9-451b-ab35-5392d4489fbf","name":"tf-ns-brave-mccarthy","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsbravemccarthyq2moobr5","registry_namespace_id":"4d198aa0-b6e1-4b87-ab10-9870e543dda6","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T14:01:44.355471Z","vpc_integration_activated":true}'
+        body: '{"created_at":"2025-08-27T15:05:41.346205Z","description":"","environment_variables":{},"error_message":null,"id":"95c0fd0f-9afe-4c03-80ef-557a38a2e187","name":"tf-ns-musing-kalam","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:51.306215Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "585"
+                - "497"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:01:44 GMT
+                - Wed, 27 Aug 2025 15:05:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -295,10 +295,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a5b27789-f0af-4921-bb8a-dd19d4e215a1
+                - 230acc99-bad6-47d8-838d-087b084afe51
         status: 200 OK
         code: 200
-        duration: 63.249736ms
+        duration: 91.208376ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -315,7 +315,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/03e50d0f-56d9-451b-ab35-5392d4489fbf
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/95c0fd0f-9afe-4c03-80ef-557a38a2e187
         method: GET
       response:
         proto: HTTP/2.0
@@ -323,20 +323,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 585
+        content_length: 581
         uncompressed: false
-        body: '{"created_at":"2025-08-27T14:01:39.604470Z","description":"","environment_variables":{},"error_message":null,"id":"03e50d0f-56d9-451b-ab35-5392d4489fbf","name":"tf-ns-brave-mccarthy","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsbravemccarthyq2moobr5","registry_namespace_id":"4d198aa0-b6e1-4b87-ab10-9870e543dda6","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T14:01:44.355471Z","vpc_integration_activated":true}'
+        body: '{"created_at":"2025-08-27T15:05:41.346205Z","description":"","environment_variables":{},"error_message":null,"id":"95c0fd0f-9afe-4c03-80ef-557a38a2e187","name":"tf-ns-musing-kalam","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsmusingkalamif5vsq3b","registry_namespace_id":"dad34880-024c-4081-aadd-8ae2d0306c79","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:53.445671Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "585"
+                - "581"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:01:45 GMT
+                - Wed, 27 Aug 2025 15:05:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -344,50 +344,48 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 53c04132-7693-45f8-907e-53c72eb06bfa
+                - 366d4bba-1559-4b3e-b91c-00aca25f1f68
         status: 200 OK
         code: 200
-        duration: 47.222939ms
+        duration: 82.931597ms
     - id: 7
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 242
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"namespace_id":"03e50d0f-56d9-451b-ab35-5392d4489fbf","name":"tf-co-wizardly-kowalevski","privacy":"public","protocol":"http1","secret_environment_variables":null,"http_option":"enabled","sandbox":"v1","tags":null,"command":null,"args":null}'
+        body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers
-        method: POST
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/95c0fd0f-9afe-4c03-80ef-557a38a2e187
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 980
+        content_length: 581
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T14:01:45.494935898Z","description":"","domain_name":"tfnsbravemccarthyq2moobr5-tf-co-wizardly-kowalevski.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"2e7019af-d628-4889-b30f-b346fe6fa0c8","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-wizardly-kowalevski","namespace_id":"03e50d0f-56d9-451b-ab35-5392d4489fbf","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsbravemccarthyq2moobr5/tf-co-wizardly-kowalevski:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T14:01:45.494935898Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.346205Z","description":"","environment_variables":{},"error_message":null,"id":"95c0fd0f-9afe-4c03-80ef-557a38a2e187","name":"tf-ns-musing-kalam","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsmusingkalamif5vsq3b","registry_namespace_id":"dad34880-024c-4081-aadd-8ae2d0306c79","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:53.445671Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "980"
+                - "581"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:01:45 GMT
+                - Wed, 27 Aug 2025 15:05:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -395,10 +393,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a7d01535-f1d2-4d42-9e4e-07d483add3b2
+                - d6800f5d-78a8-40ab-b951-1844bf98d300
         status: 200 OK
         code: 200
-        duration: 489.159179ms
+        duration: 83.166719ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -415,7 +413,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/2e7019af-d628-4889-b30f-b346fe6fa0c8
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/95c0fd0f-9afe-4c03-80ef-557a38a2e187
         method: GET
       response:
         proto: HTTP/2.0
@@ -423,20 +421,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 974
+        content_length: 581
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T14:01:45.494936Z","description":"","domain_name":"tfnsbravemccarthyq2moobr5-tf-co-wizardly-kowalevski.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"2e7019af-d628-4889-b30f-b346fe6fa0c8","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-wizardly-kowalevski","namespace_id":"03e50d0f-56d9-451b-ab35-5392d4489fbf","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsbravemccarthyq2moobr5/tf-co-wizardly-kowalevski:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T14:01:45.494936Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.346205Z","description":"","environment_variables":{},"error_message":null,"id":"95c0fd0f-9afe-4c03-80ef-557a38a2e187","name":"tf-ns-musing-kalam","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsmusingkalamif5vsq3b","registry_namespace_id":"dad34880-024c-4081-aadd-8ae2d0306c79","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:53.445671Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "974"
+                - "581"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:01:45 GMT
+                - Wed, 27 Aug 2025 15:05:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -444,48 +442,50 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1db62f36-52a8-40b6-9773-14b06de0eded
+                - 7c505281-4e62-45ff-8e5a-1b486bcd2cad
         status: 200 OK
         code: 200
-        duration: 66.89981ms
+        duration: 76.861186ms
     - id: 9
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 234
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"namespace_id":"95c0fd0f-9afe-4c03-80ef-557a38a2e187","name":"tf-co-sharp-curie","privacy":"public","protocol":"http1","secret_environment_variables":null,"http_option":"enabled","sandbox":"v1","tags":null,"command":null,"args":null}'
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/03e50d0f-56d9-451b-ab35-5392d4489fbf
-        method: GET
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 585
+        content_length: 952
         uncompressed: false
-        body: '{"created_at":"2025-08-27T14:01:39.604470Z","description":"","environment_variables":{},"error_message":null,"id":"03e50d0f-56d9-451b-ab35-5392d4489fbf","name":"tf-ns-brave-mccarthy","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsbravemccarthyq2moobr5","registry_namespace_id":"4d198aa0-b6e1-4b87-ab10-9870e543dda6","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T14:01:44.355471Z","vpc_integration_activated":true}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:58.490381047Z","description":"","domain_name":"tfnsmusingkalamif5vsq3b-tf-co-sharp-curie.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f2ae88c1-6bf4-4bbe-804d-27eb540f8fec","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-sharp-curie","namespace_id":"95c0fd0f-9afe-4c03-80ef-557a38a2e187","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsmusingkalamif5vsq3b/tf-co-sharp-curie:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:58.490381047Z"}'
         headers:
             Content-Length:
-                - "585"
+                - "952"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:01:45 GMT
+                - Wed, 27 Aug 2025 15:05:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -493,10 +493,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 30b7ec15-540a-4a40-bbb1-18ac54f0b024
+                - dc441ed9-a828-41ad-83d7-10c791d0db6b
         status: 200 OK
         code: 200
-        duration: 49.727899ms
+        duration: 1.723452816s
     - id: 10
       request:
         proto: HTTP/1.1
@@ -513,7 +513,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/03e50d0f-56d9-451b-ab35-5392d4489fbf
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f2ae88c1-6bf4-4bbe-804d-27eb540f8fec
         method: GET
       response:
         proto: HTTP/2.0
@@ -521,20 +521,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 585
+        content_length: 946
         uncompressed: false
-        body: '{"created_at":"2025-08-27T14:01:39.604470Z","description":"","environment_variables":{},"error_message":null,"id":"03e50d0f-56d9-451b-ab35-5392d4489fbf","name":"tf-ns-brave-mccarthy","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsbravemccarthyq2moobr5","registry_namespace_id":"4d198aa0-b6e1-4b87-ab10-9870e543dda6","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T14:01:44.355471Z","vpc_integration_activated":true}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:58.490381Z","description":"","domain_name":"tfnsmusingkalamif5vsq3b-tf-co-sharp-curie.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f2ae88c1-6bf4-4bbe-804d-27eb540f8fec","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-sharp-curie","namespace_id":"95c0fd0f-9afe-4c03-80ef-557a38a2e187","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsmusingkalamif5vsq3b/tf-co-sharp-curie:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:58.490381Z"}'
         headers:
             Content-Length:
-                - "585"
+                - "946"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:01:46 GMT
+                - Wed, 27 Aug 2025 15:05:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -542,10 +542,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c858e34f-d284-432e-8541-6c9d77c0e465
+                - c8e109ac-27ae-454f-b101-a4a9d3f29bb0
         status: 200 OK
         code: 200
-        duration: 43.931318ms
+        duration: 106.790438ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -562,7 +562,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/1510a03d-65c6-4fb4-ad5f-e10774ccf565
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/95c0fd0f-9afe-4c03-80ef-557a38a2e187
         method: GET
       response:
         proto: HTTP/2.0
@@ -570,20 +570,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1068
+        content_length: 581
         uncompressed: false
-        body: '{"created_at":"2025-08-27T14:01:37.966124Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"1510a03d-65c6-4fb4-ad5f-e10774ccf565","name":"tf-pn-musing-chatterjee","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-08-27T14:01:37.966124Z","id":"504966e9-c06d-4586-91da-f503ffe8974e","private_network_id":"1510a03d-65c6-4fb4-ad5f-e10774ccf565","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.4.0/22","updated_at":"2025-08-27T14:01:37.966124Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-08-27T14:01:37.966124Z","id":"52043d70-ee6a-4801-bc3b-d21486df6925","private_network_id":"1510a03d-65c6-4fb4-ad5f-e10774ccf565","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:b5ee::/64","updated_at":"2025-08-27T14:01:37.966124Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-08-27T14:01:37.966124Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+        body: '{"created_at":"2025-08-27T15:05:41.346205Z","description":"","environment_variables":{},"error_message":null,"id":"95c0fd0f-9afe-4c03-80ef-557a38a2e187","name":"tf-ns-musing-kalam","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsmusingkalamif5vsq3b","registry_namespace_id":"dad34880-024c-4081-aadd-8ae2d0306c79","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:53.445671Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "1068"
+                - "581"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:01:46 GMT
+                - Wed, 27 Aug 2025 15:05:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -591,10 +591,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 16218a19-ea90-4292-844c-5fc47a6eac9b
+                - 578f8a00-f14f-4726-b481-8b6c2cd349dc
         status: 200 OK
         code: 200
-        duration: 48.660191ms
+        duration: 84.496945ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -611,7 +611,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/2e7019af-d628-4889-b30f-b346fe6fa0c8
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b3c3c64b-8111-4fd7-91ba-792cb0f36cdb
         method: GET
       response:
         proto: HTTP/2.0
@@ -619,20 +619,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 974
+        content_length: 1065
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T14:01:45.494936Z","description":"","domain_name":"tfnsbravemccarthyq2moobr5-tf-co-wizardly-kowalevski.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"2e7019af-d628-4889-b30f-b346fe6fa0c8","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-wizardly-kowalevski","namespace_id":"03e50d0f-56d9-451b-ab35-5392d4489fbf","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsbravemccarthyq2moobr5/tf-co-wizardly-kowalevski:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T14:01:45.494936Z"}'
+        body: '{"created_at":"2025-08-27T15:05:36.152051Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"b3c3c64b-8111-4fd7-91ba-792cb0f36cdb","name":"tf-pn-pensive-galois","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","subnets":[{"created_at":"2025-08-27T15:05:36.152051Z","id":"88d99377-0b6a-489b-9b82-11f9d78419c5","private_network_id":"b3c3c64b-8111-4fd7-91ba-792cb0f36cdb","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","subnet":"172.16.8.0/22","updated_at":"2025-08-27T15:05:36.152051Z","vpc_id":"bfef8344-f496-473e-af67-31ea9afc407c"},{"created_at":"2025-08-27T15:05:36.152051Z","id":"a3e83579-c651-4648-87b2-5c39a546ed11","private_network_id":"b3c3c64b-8111-4fd7-91ba-792cb0f36cdb","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","subnet":"fde7:767f:1bb5:98d9::/64","updated_at":"2025-08-27T15:05:36.152051Z","vpc_id":"bfef8344-f496-473e-af67-31ea9afc407c"}],"tags":[],"updated_at":"2025-08-27T15:05:36.152051Z","vpc_id":"bfef8344-f496-473e-af67-31ea9afc407c"}'
         headers:
             Content-Length:
-                - "974"
+                - "1065"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:01:46 GMT
+                - Wed, 27 Aug 2025 15:05:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -640,10 +640,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f6e2a556-3fef-4e52-8759-5e6a74d2f5bc
+                - becbe6b6-ac47-4328-be69-f640ca56a38c
         status: 200 OK
         code: 200
-        duration: 48.512334ms
+        duration: 85.2027ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -660,7 +660,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/1510a03d-65c6-4fb4-ad5f-e10774ccf565
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/95c0fd0f-9afe-4c03-80ef-557a38a2e187
         method: GET
       response:
         proto: HTTP/2.0
@@ -668,20 +668,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1068
+        content_length: 581
         uncompressed: false
-        body: '{"created_at":"2025-08-27T14:01:37.966124Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"1510a03d-65c6-4fb4-ad5f-e10774ccf565","name":"tf-pn-musing-chatterjee","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-08-27T14:01:37.966124Z","id":"504966e9-c06d-4586-91da-f503ffe8974e","private_network_id":"1510a03d-65c6-4fb4-ad5f-e10774ccf565","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.4.0/22","updated_at":"2025-08-27T14:01:37.966124Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-08-27T14:01:37.966124Z","id":"52043d70-ee6a-4801-bc3b-d21486df6925","private_network_id":"1510a03d-65c6-4fb4-ad5f-e10774ccf565","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:b5ee::/64","updated_at":"2025-08-27T14:01:37.966124Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-08-27T14:01:37.966124Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+        body: '{"created_at":"2025-08-27T15:05:41.346205Z","description":"","environment_variables":{},"error_message":null,"id":"95c0fd0f-9afe-4c03-80ef-557a38a2e187","name":"tf-ns-musing-kalam","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsmusingkalamif5vsq3b","registry_namespace_id":"dad34880-024c-4081-aadd-8ae2d0306c79","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:53.445671Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "1068"
+                - "581"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:01:46 GMT
+                - Wed, 27 Aug 2025 15:05:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -689,10 +689,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0e8b7524-1636-4703-ba09-667014c5878a
+                - cb2d33ea-e2a6-453c-9f84-c3f6421a96cb
         status: 200 OK
         code: 200
-        duration: 21.417684ms
+        duration: 133.306735ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -709,7 +709,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/03e50d0f-56d9-451b-ab35-5392d4489fbf
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f2ae88c1-6bf4-4bbe-804d-27eb540f8fec
         method: GET
       response:
         proto: HTTP/2.0
@@ -717,20 +717,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 585
+        content_length: 946
         uncompressed: false
-        body: '{"created_at":"2025-08-27T14:01:39.604470Z","description":"","environment_variables":{},"error_message":null,"id":"03e50d0f-56d9-451b-ab35-5392d4489fbf","name":"tf-ns-brave-mccarthy","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsbravemccarthyq2moobr5","registry_namespace_id":"4d198aa0-b6e1-4b87-ab10-9870e543dda6","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T14:01:44.355471Z","vpc_integration_activated":true}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:58.490381Z","description":"","domain_name":"tfnsmusingkalamif5vsq3b-tf-co-sharp-curie.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f2ae88c1-6bf4-4bbe-804d-27eb540f8fec","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-sharp-curie","namespace_id":"95c0fd0f-9afe-4c03-80ef-557a38a2e187","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsmusingkalamif5vsq3b/tf-co-sharp-curie:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:58.490381Z"}'
         headers:
             Content-Length:
-                - "585"
+                - "946"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:01:46 GMT
+                - Wed, 27 Aug 2025 15:05:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -738,10 +738,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 695ded65-89a1-416d-bfa2-65b602f3b1f2
+                - b3cc50de-9102-4d04-9717-f8639452ec23
         status: 200 OK
         code: 200
-        duration: 44.705234ms
+        duration: 103.812109ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -758,7 +758,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/2e7019af-d628-4889-b30f-b346fe6fa0c8
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b3c3c64b-8111-4fd7-91ba-792cb0f36cdb
         method: GET
       response:
         proto: HTTP/2.0
@@ -766,20 +766,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 974
+        content_length: 1065
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T14:01:45.494936Z","description":"","domain_name":"tfnsbravemccarthyq2moobr5-tf-co-wizardly-kowalevski.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"2e7019af-d628-4889-b30f-b346fe6fa0c8","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-wizardly-kowalevski","namespace_id":"03e50d0f-56d9-451b-ab35-5392d4489fbf","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsbravemccarthyq2moobr5/tf-co-wizardly-kowalevski:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T14:01:45.494936Z"}'
+        body: '{"created_at":"2025-08-27T15:05:36.152051Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"b3c3c64b-8111-4fd7-91ba-792cb0f36cdb","name":"tf-pn-pensive-galois","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","subnets":[{"created_at":"2025-08-27T15:05:36.152051Z","id":"88d99377-0b6a-489b-9b82-11f9d78419c5","private_network_id":"b3c3c64b-8111-4fd7-91ba-792cb0f36cdb","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","subnet":"172.16.8.0/22","updated_at":"2025-08-27T15:05:36.152051Z","vpc_id":"bfef8344-f496-473e-af67-31ea9afc407c"},{"created_at":"2025-08-27T15:05:36.152051Z","id":"a3e83579-c651-4648-87b2-5c39a546ed11","private_network_id":"b3c3c64b-8111-4fd7-91ba-792cb0f36cdb","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","subnet":"fde7:767f:1bb5:98d9::/64","updated_at":"2025-08-27T15:05:36.152051Z","vpc_id":"bfef8344-f496-473e-af67-31ea9afc407c"}],"tags":[],"updated_at":"2025-08-27T15:05:36.152051Z","vpc_id":"bfef8344-f496-473e-af67-31ea9afc407c"}'
         headers:
             Content-Length:
-                - "974"
+                - "1065"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:01:46 GMT
+                - Wed, 27 Aug 2025 15:05:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -787,10 +787,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 372324b9-c2c6-4edc-9f57-2d7e9b551ef5
+                - ed6fc0cb-35d1-4d8c-8d15-175f756be2c6
         status: 200 OK
         code: 200
-        duration: 56.80108ms
+        duration: 25.047491ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -807,7 +807,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/03e50d0f-56d9-451b-ab35-5392d4489fbf
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/95c0fd0f-9afe-4c03-80ef-557a38a2e187
         method: GET
       response:
         proto: HTTP/2.0
@@ -815,20 +815,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 585
+        content_length: 581
         uncompressed: false
-        body: '{"created_at":"2025-08-27T14:01:39.604470Z","description":"","environment_variables":{},"error_message":null,"id":"03e50d0f-56d9-451b-ab35-5392d4489fbf","name":"tf-ns-brave-mccarthy","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsbravemccarthyq2moobr5","registry_namespace_id":"4d198aa0-b6e1-4b87-ab10-9870e543dda6","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T14:01:44.355471Z","vpc_integration_activated":true}'
+        body: '{"created_at":"2025-08-27T15:05:41.346205Z","description":"","environment_variables":{},"error_message":null,"id":"95c0fd0f-9afe-4c03-80ef-557a38a2e187","name":"tf-ns-musing-kalam","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsmusingkalamif5vsq3b","registry_namespace_id":"dad34880-024c-4081-aadd-8ae2d0306c79","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:53.445671Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "585"
+                - "581"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:01:46 GMT
+                - Wed, 27 Aug 2025 15:05:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -836,10 +836,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 645c4cec-4b59-4dea-bc3f-6542fd81943b
+                - 82c571a9-a414-49ee-a9ed-cdb79c475a1e
         status: 200 OK
         code: 200
-        duration: 46.150182ms
+        duration: 76.376438ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -856,7 +856,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/2e7019af-d628-4889-b30f-b346fe6fa0c8
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f2ae88c1-6bf4-4bbe-804d-27eb540f8fec
         method: GET
       response:
         proto: HTTP/2.0
@@ -864,20 +864,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 974
+        content_length: 946
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T14:01:45.494936Z","description":"","domain_name":"tfnsbravemccarthyq2moobr5-tf-co-wizardly-kowalevski.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"2e7019af-d628-4889-b30f-b346fe6fa0c8","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-wizardly-kowalevski","namespace_id":"03e50d0f-56d9-451b-ab35-5392d4489fbf","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsbravemccarthyq2moobr5/tf-co-wizardly-kowalevski:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T14:01:45.494936Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:58.490381Z","description":"","domain_name":"tfnsmusingkalamif5vsq3b-tf-co-sharp-curie.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f2ae88c1-6bf4-4bbe-804d-27eb540f8fec","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-sharp-curie","namespace_id":"95c0fd0f-9afe-4c03-80ef-557a38a2e187","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsmusingkalamif5vsq3b/tf-co-sharp-curie:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:58.490381Z"}'
         headers:
             Content-Length:
-                - "974"
+                - "946"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:01:47 GMT
+                - Wed, 27 Aug 2025 15:05:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -885,50 +885,48 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b944d096-4d95-4893-95af-2b7439aaa79b
+                - ef426aaa-801a-4e2f-833b-a7a4a9e228f2
         status: 200 OK
         code: 200
-        duration: 74.819903ms
+        duration: 81.585672ms
     - id: 18
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 219
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"privacy":"unknown_privacy","protocol":"unknown_protocol","secret_environment_variables":null,"http_option":"unknown_http_option","sandbox":"unknown_sandbox","private_network_id":"1510a03d-65c6-4fb4-ad5f-e10774ccf565"}'
+        body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/2e7019af-d628-4889-b30f-b346fe6fa0c8
-        method: PATCH
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/95c0fd0f-9afe-4c03-80ef-557a38a2e187
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1011
+        content_length: 581
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T14:01:45.494936Z","description":"","domain_name":"tfnsbravemccarthyq2moobr5-tf-co-wizardly-kowalevski.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"2e7019af-d628-4889-b30f-b346fe6fa0c8","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-wizardly-kowalevski","namespace_id":"03e50d0f-56d9-451b-ab35-5392d4489fbf","port":8080,"privacy":"public","private_network_id":"1510a03d-65c6-4fb4-ad5f-e10774ccf565","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsbravemccarthyq2moobr5/tf-co-wizardly-kowalevski:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T14:01:47.277068217Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.346205Z","description":"","environment_variables":{},"error_message":null,"id":"95c0fd0f-9afe-4c03-80ef-557a38a2e187","name":"tf-ns-musing-kalam","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsmusingkalamif5vsq3b","registry_namespace_id":"dad34880-024c-4081-aadd-8ae2d0306c79","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:53.445671Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "1011"
+                - "581"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:01:47 GMT
+                - Wed, 27 Aug 2025 15:06:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -936,10 +934,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 98a70a73-1346-4f43-8091-eec39b76b24d
+                - c46142f2-217f-4ce4-8a50-4a3317ec44b6
         status: 200 OK
         code: 200
-        duration: 286.973882ms
+        duration: 77.222526ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -956,7 +954,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/2e7019af-d628-4889-b30f-b346fe6fa0c8
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f2ae88c1-6bf4-4bbe-804d-27eb540f8fec
         method: GET
       response:
         proto: HTTP/2.0
@@ -964,20 +962,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1008
+        content_length: 946
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T14:01:45.494936Z","description":"","domain_name":"tfnsbravemccarthyq2moobr5-tf-co-wizardly-kowalevski.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"2e7019af-d628-4889-b30f-b346fe6fa0c8","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-wizardly-kowalevski","namespace_id":"03e50d0f-56d9-451b-ab35-5392d4489fbf","port":8080,"privacy":"public","private_network_id":"1510a03d-65c6-4fb4-ad5f-e10774ccf565","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsbravemccarthyq2moobr5/tf-co-wizardly-kowalevski:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T14:01:47.277068Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:58.490381Z","description":"","domain_name":"tfnsmusingkalamif5vsq3b-tf-co-sharp-curie.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f2ae88c1-6bf4-4bbe-804d-27eb540f8fec","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-sharp-curie","namespace_id":"95c0fd0f-9afe-4c03-80ef-557a38a2e187","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsmusingkalamif5vsq3b/tf-co-sharp-curie:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:58.490381Z"}'
         headers:
             Content-Length:
-                - "1008"
+                - "946"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:01:47 GMT
+                - Wed, 27 Aug 2025 15:06:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -985,48 +983,50 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7640e023-d6bd-4ded-91d7-f7c282d3464d
+                - 98ad17af-20c1-4f37-be5d-b07641860637
         status: 200 OK
         code: 200
-        duration: 49.653079ms
+        duration: 97.433831ms
     - id: 20
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 219
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"privacy":"unknown_privacy","protocol":"unknown_protocol","secret_environment_variables":null,"http_option":"unknown_http_option","sandbox":"unknown_sandbox","private_network_id":"b3c3c64b-8111-4fd7-91ba-792cb0f36cdb"}'
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/2e7019af-d628-4889-b30f-b346fe6fa0c8
-        method: GET
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f2ae88c1-6bf4-4bbe-804d-27eb540f8fec
+        method: PATCH
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1008
+        content_length: 983
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T14:01:45.494936Z","description":"","domain_name":"tfnsbravemccarthyq2moobr5-tf-co-wizardly-kowalevski.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"2e7019af-d628-4889-b30f-b346fe6fa0c8","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-wizardly-kowalevski","namespace_id":"03e50d0f-56d9-451b-ab35-5392d4489fbf","port":8080,"privacy":"public","private_network_id":"1510a03d-65c6-4fb4-ad5f-e10774ccf565","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsbravemccarthyq2moobr5/tf-co-wizardly-kowalevski:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T14:01:47.277068Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:58.490381Z","description":"","domain_name":"tfnsmusingkalamif5vsq3b-tf-co-sharp-curie.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f2ae88c1-6bf4-4bbe-804d-27eb540f8fec","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-sharp-curie","namespace_id":"95c0fd0f-9afe-4c03-80ef-557a38a2e187","port":8080,"privacy":"public","private_network_id":"b3c3c64b-8111-4fd7-91ba-792cb0f36cdb","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsmusingkalamif5vsq3b/tf-co-sharp-curie:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:00.971376722Z"}'
         headers:
             Content-Length:
-                - "1008"
+                - "983"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:01:52 GMT
+                - Wed, 27 Aug 2025 15:06:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1034,10 +1034,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - dfa3f0d5-6e15-4e41-a805-42fecd40451b
+                - f7936839-c4a5-4b9c-96c7-458fee8767b8
         status: 200 OK
         code: 200
-        duration: 57.029689ms
+        duration: 488.722952ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1054,7 +1054,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/2e7019af-d628-4889-b30f-b346fe6fa0c8
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f2ae88c1-6bf4-4bbe-804d-27eb540f8fec
         method: GET
       response:
         proto: HTTP/2.0
@@ -1062,20 +1062,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1046
+        content_length: 980
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T14:01:45.494936Z","description":"","domain_name":"tfnsbravemccarthyq2moobr5-tf-co-wizardly-kowalevski.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"2e7019af-d628-4889-b30f-b346fe6fa0c8","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-wizardly-kowalevski","namespace_id":"03e50d0f-56d9-451b-ab35-5392d4489fbf","port":8080,"privacy":"public","private_network_id":"1510a03d-65c6-4fb4-ad5f-e10774ccf565","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsbravemccarthyq2moobr5/tf-co-wizardly-kowalevski:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T14:01:53.727044Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:58.490381Z","description":"","domain_name":"tfnsmusingkalamif5vsq3b-tf-co-sharp-curie.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f2ae88c1-6bf4-4bbe-804d-27eb540f8fec","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-sharp-curie","namespace_id":"95c0fd0f-9afe-4c03-80ef-557a38a2e187","port":8080,"privacy":"public","private_network_id":"b3c3c64b-8111-4fd7-91ba-792cb0f36cdb","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsmusingkalamif5vsq3b/tf-co-sharp-curie:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:00.971377Z"}'
         headers:
             Content-Length:
-                - "1046"
+                - "980"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:01:57 GMT
+                - Wed, 27 Aug 2025 15:06:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1083,10 +1083,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9ccc3d41-b6f1-4f32-a956-a6d0de8cc27b
+                - 90cdbf96-26f5-48d2-a35a-1c3bd0f002a8
         status: 200 OK
         code: 200
-        duration: 56.811939ms
+        duration: 103.602467ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1103,7 +1103,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/2e7019af-d628-4889-b30f-b346fe6fa0c8
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f2ae88c1-6bf4-4bbe-804d-27eb540f8fec
         method: GET
       response:
         proto: HTTP/2.0
@@ -1111,20 +1111,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1046
+        content_length: 980
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T14:01:45.494936Z","description":"","domain_name":"tfnsbravemccarthyq2moobr5-tf-co-wizardly-kowalevski.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"2e7019af-d628-4889-b30f-b346fe6fa0c8","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-wizardly-kowalevski","namespace_id":"03e50d0f-56d9-451b-ab35-5392d4489fbf","port":8080,"privacy":"public","private_network_id":"1510a03d-65c6-4fb4-ad5f-e10774ccf565","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsbravemccarthyq2moobr5/tf-co-wizardly-kowalevski:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T14:01:53.727044Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:58.490381Z","description":"","domain_name":"tfnsmusingkalamif5vsq3b-tf-co-sharp-curie.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f2ae88c1-6bf4-4bbe-804d-27eb540f8fec","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-sharp-curie","namespace_id":"95c0fd0f-9afe-4c03-80ef-557a38a2e187","port":8080,"privacy":"public","private_network_id":"b3c3c64b-8111-4fd7-91ba-792cb0f36cdb","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsmusingkalamif5vsq3b/tf-co-sharp-curie:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:00.971377Z"}'
         headers:
             Content-Length:
-                - "1046"
+                - "980"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:01:57 GMT
+                - Wed, 27 Aug 2025 15:06:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1132,10 +1132,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9b8a5238-1397-442c-b7de-bca41d6b9ce8
+                - 494ea41b-b756-4322-9bba-e509aebf7eed
         status: 200 OK
         code: 200
-        duration: 51.385955ms
+        duration: 105.604305ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1152,7 +1152,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/03e50d0f-56d9-451b-ab35-5392d4489fbf
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f2ae88c1-6bf4-4bbe-804d-27eb540f8fec
         method: GET
       response:
         proto: HTTP/2.0
@@ -1160,20 +1160,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 585
+        content_length: 1018
         uncompressed: false
-        body: '{"created_at":"2025-08-27T14:01:39.604470Z","description":"","environment_variables":{},"error_message":null,"id":"03e50d0f-56d9-451b-ab35-5392d4489fbf","name":"tf-ns-brave-mccarthy","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsbravemccarthyq2moobr5","registry_namespace_id":"4d198aa0-b6e1-4b87-ab10-9870e543dda6","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T14:01:44.355471Z","vpc_integration_activated":true}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:58.490381Z","description":"","domain_name":"tfnsmusingkalamif5vsq3b-tf-co-sharp-curie.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f2ae88c1-6bf4-4bbe-804d-27eb540f8fec","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-sharp-curie","namespace_id":"95c0fd0f-9afe-4c03-80ef-557a38a2e187","port":8080,"privacy":"public","private_network_id":"b3c3c64b-8111-4fd7-91ba-792cb0f36cdb","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsmusingkalamif5vsq3b/tf-co-sharp-curie:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:07.532624Z"}'
         headers:
             Content-Length:
-                - "585"
+                - "1018"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:01:57 GMT
+                - Wed, 27 Aug 2025 15:06:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1181,10 +1181,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 69b74f25-6a81-4121-b41e-1422a3c0d27b
+                - ad58648c-4c6e-44e8-b936-f82eb07634d6
         status: 200 OK
         code: 200
-        duration: 54.662797ms
+        duration: 107.82316ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1201,7 +1201,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/2e7019af-d628-4889-b30f-b346fe6fa0c8
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f2ae88c1-6bf4-4bbe-804d-27eb540f8fec
         method: GET
       response:
         proto: HTTP/2.0
@@ -1209,20 +1209,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1046
+        content_length: 1018
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T14:01:45.494936Z","description":"","domain_name":"tfnsbravemccarthyq2moobr5-tf-co-wizardly-kowalevski.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"2e7019af-d628-4889-b30f-b346fe6fa0c8","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-wizardly-kowalevski","namespace_id":"03e50d0f-56d9-451b-ab35-5392d4489fbf","port":8080,"privacy":"public","private_network_id":"1510a03d-65c6-4fb4-ad5f-e10774ccf565","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsbravemccarthyq2moobr5/tf-co-wizardly-kowalevski:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T14:01:53.727044Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:58.490381Z","description":"","domain_name":"tfnsmusingkalamif5vsq3b-tf-co-sharp-curie.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f2ae88c1-6bf4-4bbe-804d-27eb540f8fec","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-sharp-curie","namespace_id":"95c0fd0f-9afe-4c03-80ef-557a38a2e187","port":8080,"privacy":"public","private_network_id":"b3c3c64b-8111-4fd7-91ba-792cb0f36cdb","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsmusingkalamif5vsq3b/tf-co-sharp-curie:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:07.532624Z"}'
         headers:
             Content-Length:
-                - "1046"
+                - "1018"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:01:57 GMT
+                - Wed, 27 Aug 2025 15:06:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1230,10 +1230,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2cd5b46f-6c98-447f-a6cd-3806f8b08229
+                - f2b2d129-1603-42e0-a97a-f05cfcf522f4
         status: 200 OK
         code: 200
-        duration: 52.418206ms
+        duration: 122.191924ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1250,7 +1250,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/1510a03d-65c6-4fb4-ad5f-e10774ccf565
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/95c0fd0f-9afe-4c03-80ef-557a38a2e187
         method: GET
       response:
         proto: HTTP/2.0
@@ -1258,20 +1258,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1068
+        content_length: 581
         uncompressed: false
-        body: '{"created_at":"2025-08-27T14:01:37.966124Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"1510a03d-65c6-4fb4-ad5f-e10774ccf565","name":"tf-pn-musing-chatterjee","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-08-27T14:01:37.966124Z","id":"504966e9-c06d-4586-91da-f503ffe8974e","private_network_id":"1510a03d-65c6-4fb4-ad5f-e10774ccf565","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.4.0/22","updated_at":"2025-08-27T14:01:37.966124Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-08-27T14:01:37.966124Z","id":"52043d70-ee6a-4801-bc3b-d21486df6925","private_network_id":"1510a03d-65c6-4fb4-ad5f-e10774ccf565","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:b5ee::/64","updated_at":"2025-08-27T14:01:37.966124Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-08-27T14:01:37.966124Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+        body: '{"created_at":"2025-08-27T15:05:41.346205Z","description":"","environment_variables":{},"error_message":null,"id":"95c0fd0f-9afe-4c03-80ef-557a38a2e187","name":"tf-ns-musing-kalam","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsmusingkalamif5vsq3b","registry_namespace_id":"dad34880-024c-4081-aadd-8ae2d0306c79","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:53.445671Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "1068"
+                - "581"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:01:58 GMT
+                - Wed, 27 Aug 2025 15:06:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1279,10 +1279,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 35f8b144-a4cd-4844-876a-2f44cd2a1bb2
+                - fb92e6a1-a119-421d-9ecd-96faf85c09ca
         status: 200 OK
         code: 200
-        duration: 25.413427ms
+        duration: 75.591387ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1299,7 +1299,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/03e50d0f-56d9-451b-ab35-5392d4489fbf
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f2ae88c1-6bf4-4bbe-804d-27eb540f8fec
         method: GET
       response:
         proto: HTTP/2.0
@@ -1307,20 +1307,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 585
+        content_length: 1018
         uncompressed: false
-        body: '{"created_at":"2025-08-27T14:01:39.604470Z","description":"","environment_variables":{},"error_message":null,"id":"03e50d0f-56d9-451b-ab35-5392d4489fbf","name":"tf-ns-brave-mccarthy","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsbravemccarthyq2moobr5","registry_namespace_id":"4d198aa0-b6e1-4b87-ab10-9870e543dda6","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T14:01:44.355471Z","vpc_integration_activated":true}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:58.490381Z","description":"","domain_name":"tfnsmusingkalamif5vsq3b-tf-co-sharp-curie.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f2ae88c1-6bf4-4bbe-804d-27eb540f8fec","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-sharp-curie","namespace_id":"95c0fd0f-9afe-4c03-80ef-557a38a2e187","port":8080,"privacy":"public","private_network_id":"b3c3c64b-8111-4fd7-91ba-792cb0f36cdb","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsmusingkalamif5vsq3b/tf-co-sharp-curie:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:07.532624Z"}'
         headers:
             Content-Length:
-                - "585"
+                - "1018"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:01:58 GMT
+                - Wed, 27 Aug 2025 15:06:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1328,10 +1328,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d2045da3-f5e0-443e-8b56-2ee424299f9e
+                - 478e372a-9f36-4042-a330-392a8031768e
         status: 200 OK
         code: 200
-        duration: 64.85379ms
+        duration: 83.265978ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1348,7 +1348,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/2e7019af-d628-4889-b30f-b346fe6fa0c8
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b3c3c64b-8111-4fd7-91ba-792cb0f36cdb
         method: GET
       response:
         proto: HTTP/2.0
@@ -1356,20 +1356,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1046
+        content_length: 1065
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T14:01:45.494936Z","description":"","domain_name":"tfnsbravemccarthyq2moobr5-tf-co-wizardly-kowalevski.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"2e7019af-d628-4889-b30f-b346fe6fa0c8","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-wizardly-kowalevski","namespace_id":"03e50d0f-56d9-451b-ab35-5392d4489fbf","port":8080,"privacy":"public","private_network_id":"1510a03d-65c6-4fb4-ad5f-e10774ccf565","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsbravemccarthyq2moobr5/tf-co-wizardly-kowalevski:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T14:01:53.727044Z"}'
+        body: '{"created_at":"2025-08-27T15:05:36.152051Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"b3c3c64b-8111-4fd7-91ba-792cb0f36cdb","name":"tf-pn-pensive-galois","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","subnets":[{"created_at":"2025-08-27T15:05:36.152051Z","id":"88d99377-0b6a-489b-9b82-11f9d78419c5","private_network_id":"b3c3c64b-8111-4fd7-91ba-792cb0f36cdb","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","subnet":"172.16.8.0/22","updated_at":"2025-08-27T15:05:36.152051Z","vpc_id":"bfef8344-f496-473e-af67-31ea9afc407c"},{"created_at":"2025-08-27T15:05:36.152051Z","id":"a3e83579-c651-4648-87b2-5c39a546ed11","private_network_id":"b3c3c64b-8111-4fd7-91ba-792cb0f36cdb","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","subnet":"fde7:767f:1bb5:98d9::/64","updated_at":"2025-08-27T15:05:36.152051Z","vpc_id":"bfef8344-f496-473e-af67-31ea9afc407c"}],"tags":[],"updated_at":"2025-08-27T15:05:36.152051Z","vpc_id":"bfef8344-f496-473e-af67-31ea9afc407c"}'
         headers:
             Content-Length:
-                - "1046"
+                - "1065"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:01:58 GMT
+                - Wed, 27 Aug 2025 15:06:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1377,10 +1377,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4041e361-6ea7-4ffd-a486-80389aea6690
+                - 6aa42977-c18a-4162-bda3-960792b98d67
         status: 200 OK
         code: 200
-        duration: 46.627307ms
+        duration: 83.210745ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1397,7 +1397,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/2e7019af-d628-4889-b30f-b346fe6fa0c8
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/95c0fd0f-9afe-4c03-80ef-557a38a2e187
         method: GET
       response:
         proto: HTTP/2.0
@@ -1405,20 +1405,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1046
+        content_length: 581
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T14:01:45.494936Z","description":"","domain_name":"tfnsbravemccarthyq2moobr5-tf-co-wizardly-kowalevski.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"2e7019af-d628-4889-b30f-b346fe6fa0c8","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-wizardly-kowalevski","namespace_id":"03e50d0f-56d9-451b-ab35-5392d4489fbf","port":8080,"privacy":"public","private_network_id":"1510a03d-65c6-4fb4-ad5f-e10774ccf565","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsbravemccarthyq2moobr5/tf-co-wizardly-kowalevski:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T14:01:53.727044Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.346205Z","description":"","environment_variables":{},"error_message":null,"id":"95c0fd0f-9afe-4c03-80ef-557a38a2e187","name":"tf-ns-musing-kalam","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsmusingkalamif5vsq3b","registry_namespace_id":"dad34880-024c-4081-aadd-8ae2d0306c79","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:53.445671Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "1046"
+                - "581"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:01:58 GMT
+                - Wed, 27 Aug 2025 15:06:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1426,10 +1426,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 75b667aa-96bc-438f-8940-bb312eb84a14
+                - 35e6de29-af5a-4fee-9530-9991a9bbaa68
         status: 200 OK
         code: 200
-        duration: 64.905227ms
+        duration: 109.233287ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1446,28 +1446,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/2e7019af-d628-4889-b30f-b346fe6fa0c8
-        method: DELETE
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f2ae88c1-6bf4-4bbe-804d-27eb540f8fec
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1012
+        content_length: 1018
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T14:01:45.494936Z","description":"","domain_name":"tfnsbravemccarthyq2moobr5-tf-co-wizardly-kowalevski.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"2e7019af-d628-4889-b30f-b346fe6fa0c8","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-wizardly-kowalevski","namespace_id":"03e50d0f-56d9-451b-ab35-5392d4489fbf","port":8080,"privacy":"public","private_network_id":"1510a03d-65c6-4fb4-ad5f-e10774ccf565","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsbravemccarthyq2moobr5/tf-co-wizardly-kowalevski:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2025-08-27T14:01:58.623392698Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:58.490381Z","description":"","domain_name":"tfnsmusingkalamif5vsq3b-tf-co-sharp-curie.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f2ae88c1-6bf4-4bbe-804d-27eb540f8fec","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-sharp-curie","namespace_id":"95c0fd0f-9afe-4c03-80ef-557a38a2e187","port":8080,"privacy":"public","private_network_id":"b3c3c64b-8111-4fd7-91ba-792cb0f36cdb","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsmusingkalamif5vsq3b/tf-co-sharp-curie:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:07.532624Z"}'
         headers:
             Content-Length:
-                - "1012"
+                - "1018"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:01:58 GMT
+                - Wed, 27 Aug 2025 15:06:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1475,10 +1475,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 95dfe4af-6431-40df-87be-a63623401da3
+                - 7a75b12e-e804-4c05-a4c3-60d803f16031
         status: 200 OK
         code: 200
-        duration: 153.004908ms
+        duration: 91.291599ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1495,7 +1495,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/03e50d0f-56d9-451b-ab35-5392d4489fbf
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f2ae88c1-6bf4-4bbe-804d-27eb540f8fec
         method: GET
       response:
         proto: HTTP/2.0
@@ -1503,20 +1503,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 585
+        content_length: 1018
         uncompressed: false
-        body: '{"created_at":"2025-08-27T14:01:39.604470Z","description":"","environment_variables":{},"error_message":null,"id":"03e50d0f-56d9-451b-ab35-5392d4489fbf","name":"tf-ns-brave-mccarthy","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsbravemccarthyq2moobr5","registry_namespace_id":"4d198aa0-b6e1-4b87-ab10-9870e543dda6","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T14:01:44.355471Z","vpc_integration_activated":true}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:58.490381Z","description":"","domain_name":"tfnsmusingkalamif5vsq3b-tf-co-sharp-curie.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f2ae88c1-6bf4-4bbe-804d-27eb540f8fec","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-sharp-curie","namespace_id":"95c0fd0f-9afe-4c03-80ef-557a38a2e187","port":8080,"privacy":"public","private_network_id":"b3c3c64b-8111-4fd7-91ba-792cb0f36cdb","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsmusingkalamif5vsq3b/tf-co-sharp-curie:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:07.532624Z"}'
         headers:
             Content-Length:
-                - "585"
+                - "1018"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:01:58 GMT
+                - Wed, 27 Aug 2025 15:06:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1524,10 +1524,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 383ed9b3-7986-419f-9f76-dc1d28e93305
+                - f7a4429e-8c07-4402-b8f6-d56e75b63898
         status: 200 OK
         code: 200
-        duration: 47.365825ms
+        duration: 117.237357ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1544,7 +1544,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/03e50d0f-56d9-451b-ab35-5392d4489fbf
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/f2ae88c1-6bf4-4bbe-804d-27eb540f8fec
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1552,20 +1552,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 591
+        content_length: 984
         uncompressed: false
-        body: '{"created_at":"2025-08-27T14:01:39.604470Z","description":"","environment_variables":{},"error_message":null,"id":"03e50d0f-56d9-451b-ab35-5392d4489fbf","name":"tf-ns-brave-mccarthy","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsbravemccarthyq2moobr5","registry_namespace_id":"4d198aa0-b6e1-4b87-ab10-9870e543dda6","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T14:01:58.807118836Z","vpc_integration_activated":true}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:05:58.490381Z","description":"","domain_name":"tfnsmusingkalamif5vsq3b-tf-co-sharp-curie.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"f2ae88c1-6bf4-4bbe-804d-27eb540f8fec","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-sharp-curie","namespace_id":"95c0fd0f-9afe-4c03-80ef-557a38a2e187","port":8080,"privacy":"public","private_network_id":"b3c3c64b-8111-4fd7-91ba-792cb0f36cdb","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsmusingkalamif5vsq3b/tf-co-sharp-curie:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:12.773924774Z"}'
         headers:
             Content-Length:
-                - "591"
+                - "984"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:01:59 GMT
+                - Wed, 27 Aug 2025 15:06:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1573,10 +1573,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c723dc76-fd2f-438b-9267-69d9eb2c8b81
+                - c938e5d8-464e-4c62-918d-68dde844390c
         status: 200 OK
         code: 200
-        duration: 261.769306ms
+        duration: 242.721888ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1593,7 +1593,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/03e50d0f-56d9-451b-ab35-5392d4489fbf
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/95c0fd0f-9afe-4c03-80ef-557a38a2e187
         method: GET
       response:
         proto: HTTP/2.0
@@ -1601,20 +1601,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 588
+        content_length: 581
         uncompressed: false
-        body: '{"created_at":"2025-08-27T14:01:39.604470Z","description":"","environment_variables":{},"error_message":null,"id":"03e50d0f-56d9-451b-ab35-5392d4489fbf","name":"tf-ns-brave-mccarthy","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsbravemccarthyq2moobr5","registry_namespace_id":"4d198aa0-b6e1-4b87-ab10-9870e543dda6","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T14:01:58.807119Z","vpc_integration_activated":true}'
+        body: '{"created_at":"2025-08-27T15:05:41.346205Z","description":"","environment_variables":{},"error_message":null,"id":"95c0fd0f-9afe-4c03-80ef-557a38a2e187","name":"tf-ns-musing-kalam","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsmusingkalamif5vsq3b","registry_namespace_id":"dad34880-024c-4081-aadd-8ae2d0306c79","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:53.445671Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "588"
+                - "581"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:01:59 GMT
+                - Wed, 27 Aug 2025 15:06:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1622,10 +1622,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 63d718f6-6af5-4665-ab8d-d159e6f79e8e
+                - f9791b67-acc2-466a-9742-0c5e8db1d27e
         status: 200 OK
         code: 200
-        duration: 51.788972ms
+        duration: 75.202437ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1642,7 +1642,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/1510a03d-65c6-4fb4-ad5f-e10774ccf565
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/95c0fd0f-9afe-4c03-80ef-557a38a2e187
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1650,18 +1650,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 587
         uncompressed: false
-        body: ""
+        body: '{"created_at":"2025-08-27T15:05:41.346205Z","description":"","environment_variables":{},"error_message":null,"id":"95c0fd0f-9afe-4c03-80ef-557a38a2e187","name":"tf-ns-musing-kalam","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsmusingkalamif5vsq3b","registry_namespace_id":"dad34880-024c-4081-aadd-8ae2d0306c79","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:13.047569561Z","vpc_integration_activated":true}'
         headers:
+            Content-Length:
+                - "587"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:02:00 GMT
+                - Wed, 27 Aug 2025 15:06:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1669,10 +1671,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 83fc352d-ed42-4d5e-8c30-5bebb09f259e
-        status: 204 No Content
-        code: 204
-        duration: 1.720224371s
+                - 777f1bde-c75e-4061-bc76-e9f9294915ab
+        status: 200 OK
+        code: 200
+        duration: 529.49971ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1689,7 +1691,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/03e50d0f-56d9-451b-ab35-5392d4489fbf
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/95c0fd0f-9afe-4c03-80ef-557a38a2e187
         method: GET
       response:
         proto: HTTP/2.0
@@ -1697,20 +1699,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 588
+        content_length: 584
         uncompressed: false
-        body: '{"created_at":"2025-08-27T14:01:39.604470Z","description":"","environment_variables":{},"error_message":null,"id":"03e50d0f-56d9-451b-ab35-5392d4489fbf","name":"tf-ns-brave-mccarthy","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsbravemccarthyq2moobr5","registry_namespace_id":"4d198aa0-b6e1-4b87-ab10-9870e543dda6","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T14:01:58.807119Z","vpc_integration_activated":true}'
+        body: '{"created_at":"2025-08-27T15:05:41.346205Z","description":"","environment_variables":{},"error_message":null,"id":"95c0fd0f-9afe-4c03-80ef-557a38a2e187","name":"tf-ns-musing-kalam","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsmusingkalamif5vsq3b","registry_namespace_id":"dad34880-024c-4081-aadd-8ae2d0306c79","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:13.047570Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "588"
+                - "584"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:02:04 GMT
+                - Wed, 27 Aug 2025 15:06:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1718,10 +1720,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7a3a28b5-0a96-476a-bd91-76ce74ceacbf
+                - bdf03945-18f9-496a-a8d1-cd31a1485e5f
         status: 200 OK
         code: 200
-        duration: 48.752722ms
+        duration: 105.453765ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1738,28 +1740,26 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/03e50d0f-56d9-451b-ab35-5392d4489fbf
-        method: GET
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b3c3c64b-8111-4fd7-91ba-792cb0f36cdb
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 588
+        content_length: 0
         uncompressed: false
-        body: '{"created_at":"2025-08-27T14:01:39.604470Z","description":"","environment_variables":{},"error_message":null,"id":"03e50d0f-56d9-451b-ab35-5392d4489fbf","name":"tf-ns-brave-mccarthy","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsbravemccarthyq2moobr5","registry_namespace_id":"4d198aa0-b6e1-4b87-ab10-9870e543dda6","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T14:01:58.807119Z","vpc_integration_activated":true}'
+        body: ""
         headers:
-            Content-Length:
-                - "588"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:02:09 GMT
+                - Wed, 27 Aug 2025 15:06:14 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1767,10 +1767,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9bf6a0c6-fd6f-44c5-beca-072287febfa3
-        status: 200 OK
-        code: 200
-        duration: 52.242374ms
+                - 61cea18f-32d1-47d4-97f2-c104149db667
+        status: 204 No Content
+        code: 204
+        duration: 1.423627788s
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1787,7 +1787,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/03e50d0f-56d9-451b-ab35-5392d4489fbf
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/95c0fd0f-9afe-4c03-80ef-557a38a2e187
         method: GET
       response:
         proto: HTTP/2.0
@@ -1795,20 +1795,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 588
+        content_length: 584
         uncompressed: false
-        body: '{"created_at":"2025-08-27T14:01:39.604470Z","description":"","environment_variables":{},"error_message":null,"id":"03e50d0f-56d9-451b-ab35-5392d4489fbf","name":"tf-ns-brave-mccarthy","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsbravemccarthyq2moobr5","registry_namespace_id":"4d198aa0-b6e1-4b87-ab10-9870e543dda6","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T14:01:58.807119Z","vpc_integration_activated":true}'
+        body: '{"created_at":"2025-08-27T15:05:41.346205Z","description":"","environment_variables":{},"error_message":null,"id":"95c0fd0f-9afe-4c03-80ef-557a38a2e187","name":"tf-ns-musing-kalam","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsmusingkalamif5vsq3b","registry_namespace_id":"dad34880-024c-4081-aadd-8ae2d0306c79","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:13.047570Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "588"
+                - "584"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:02:14 GMT
+                - Wed, 27 Aug 2025 15:06:18 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1816,10 +1816,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a17110bb-6e6c-4ca5-82c4-a5628d0afdf1
+                - ee8973a7-a203-4433-b21b-a3f1a54980dd
         status: 200 OK
         code: 200
-        duration: 47.497721ms
+        duration: 94.548673ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1836,7 +1836,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/03e50d0f-56d9-451b-ab35-5392d4489fbf
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/95c0fd0f-9afe-4c03-80ef-557a38a2e187
         method: GET
       response:
         proto: HTTP/2.0
@@ -1844,20 +1844,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 588
+        content_length: 584
         uncompressed: false
-        body: '{"created_at":"2025-08-27T14:01:39.604470Z","description":"","environment_variables":{},"error_message":null,"id":"03e50d0f-56d9-451b-ab35-5392d4489fbf","name":"tf-ns-brave-mccarthy","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsbravemccarthyq2moobr5","registry_namespace_id":"4d198aa0-b6e1-4b87-ab10-9870e543dda6","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T14:01:58.807119Z","vpc_integration_activated":true}'
+        body: '{"created_at":"2025-08-27T15:05:41.346205Z","description":"","environment_variables":{},"error_message":null,"id":"95c0fd0f-9afe-4c03-80ef-557a38a2e187","name":"tf-ns-musing-kalam","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsmusingkalamif5vsq3b","registry_namespace_id":"dad34880-024c-4081-aadd-8ae2d0306c79","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:13.047570Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "588"
+                - "584"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:02:19 GMT
+                - Wed, 27 Aug 2025 15:06:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1865,10 +1865,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0e58c3fc-5e53-4cb5-91e9-ed20f451f6d2
+                - 3972201b-c9a8-4b13-95fa-a84d58d85e81
         status: 200 OK
         code: 200
-        duration: 53.099654ms
+        duration: 77.587456ms
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1885,56 +1885,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/03e50d0f-56d9-451b-ab35-5392d4489fbf
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 588
-        uncompressed: false
-        body: '{"created_at":"2025-08-27T14:01:39.604470Z","description":"","environment_variables":{},"error_message":null,"id":"03e50d0f-56d9-451b-ab35-5392d4489fbf","name":"tf-ns-brave-mccarthy","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsbravemccarthyq2moobr5","registry_namespace_id":"4d198aa0-b6e1-4b87-ab10-9870e543dda6","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T14:01:58.807119Z","vpc_integration_activated":true}'
-        headers:
-            Content-Length:
-                - "588"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 27 Aug 2025 14:02:24 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - b4f64d2a-ee75-4f3b-95bf-aa2614959597
-        status: 200 OK
-        code: 200
-        duration: 55.324156ms
-    - id: 39
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/03e50d0f-56d9-451b-ab35-5392d4489fbf
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/95c0fd0f-9afe-4c03-80ef-557a38a2e187
         method: GET
       response:
         proto: HTTP/2.0
@@ -1953,9 +1904,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:02:29 GMT
+                - Wed, 27 Aug 2025 15:06:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1963,11 +1914,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 58f5110f-b566-4f6b-a9e8-f185bfc3d0f3
+                - 8aef6faf-a221-479d-b9bc-589b9054ff46
         status: 404 Not Found
         code: 404
-        duration: 27.513734ms
-    - id: 40
+        duration: 23.470333ms
+    - id: 39
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1983,7 +1934,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/03e50d0f-56d9-451b-ab35-5392d4489fbf
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/95c0fd0f-9afe-4c03-80ef-557a38a2e187
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -2002,9 +1953,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:02:29 GMT
+                - Wed, 27 Aug 2025 15:06:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2012,11 +1963,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0c4beb0b-a501-4cbb-8b32-c9b03807a205
+                - 973bb49b-69f3-4acf-b48a-e87ac8b2bcbf
         status: 404 Not Found
         code: 404
-        duration: 18.927028ms
-    - id: 41
+        duration: 21.485048ms
+    - id: 40
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2032,7 +1983,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/03e50d0f-56d9-451b-ab35-5392d4489fbf
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/95c0fd0f-9afe-4c03-80ef-557a38a2e187
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -2051,9 +2002,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:02:29 GMT
+                - Wed, 27 Aug 2025 15:06:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2061,11 +2012,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bb768030-b4a5-4fbb-8a59-f90f0d777f5d
+                - 2731fcd1-86e0-46b5-9100-6390801cec8e
         status: 404 Not Found
         code: 404
-        duration: 23.261929ms
-    - id: 42
+        duration: 20.877448ms
+    - id: 41
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2081,7 +2032,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/1510a03d-65c6-4fb4-ad5f-e10774ccf565
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b3c3c64b-8111-4fd7-91ba-792cb0f36cdb
         method: GET
       response:
         proto: HTTP/2.0
@@ -2091,7 +2042,7 @@ interactions:
         trailer: {}
         content_length: 136
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"private_network","resource_id":"1510a03d-65c6-4fb4-ad5f-e10774ccf565","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"private_network","resource_id":"b3c3c64b-8111-4fd7-91ba-792cb0f36cdb","type":"not_found"}'
         headers:
             Content-Length:
                 - "136"
@@ -2100,9 +2051,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:02:29 GMT
+                - Wed, 27 Aug 2025 15:06:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2110,7 +2061,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 042705a5-7d55-466d-a50a-233fe5407cf8
+                - a047a1c4-61fa-4b6a-a4ac-982f28517d59
         status: 404 Not Found
         code: 404
-        duration: 23.291314ms
+        duration: 22.997115ms

--- a/internal/services/container/testdata/namespace-vpc-integration.cassette.yaml
+++ b/internal/services/container/testdata/namespace-vpc-integration.cassette.yaml
@@ -6,20 +6,20 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 186
+        content_length: 153
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-ns-dreamy-bohr","environment_variables":{},"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","secret_environment_variables":[],"tags":null,"activate_vpc_integration":false}'
+        body: '{"name":"tf-pn-musing-chatterjee","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"subnets":null,"default_route_propagation_enabled":false}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
         method: POST
       response:
         proto: HTTP/2.0
@@ -27,20 +27,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 518
+        content_length: 1068
         uncompressed: false
-        body: '{"created_at":"2025-06-12T15:37:36.195110285Z","description":"","environment_variables":{},"error_message":null,"id":"042eadee-2132-44c8-bc71-36edef3f629e","name":"tf-ns-dreamy-bohr","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-06-12T15:37:36.195110285Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2025-08-27T14:01:37.966124Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"1510a03d-65c6-4fb4-ad5f-e10774ccf565","name":"tf-pn-musing-chatterjee","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-08-27T14:01:37.966124Z","id":"504966e9-c06d-4586-91da-f503ffe8974e","private_network_id":"1510a03d-65c6-4fb4-ad5f-e10774ccf565","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.4.0/22","updated_at":"2025-08-27T14:01:37.966124Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-08-27T14:01:37.966124Z","id":"52043d70-ee6a-4801-bc3b-d21486df6925","private_network_id":"1510a03d-65c6-4fb4-ad5f-e10774ccf565","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:b5ee::/64","updated_at":"2025-08-27T14:01:37.966124Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-08-27T14:01:37.966124Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
         headers:
             Content-Length:
-                - "518"
+                - "1068"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 12 Jun 2025 15:37:36 GMT
+                - Wed, 27 Aug 2025 14:01:38 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 156ed324-81f9-415d-b87f-3b311c36b60d
+                - f25221d5-f64a-4c42-8544-ff4b269c0b65
         status: 200 OK
         code: 200
-        duration: 614.411207ms
+        duration: 905.880226ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -68,7 +68,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/042eadee-2132-44c8-bc71-36edef3f629e
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/1510a03d-65c6-4fb4-ad5f-e10774ccf565
         method: GET
       response:
         proto: HTTP/2.0
@@ -76,20 +76,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 512
+        content_length: 1068
         uncompressed: false
-        body: '{"created_at":"2025-06-12T15:37:36.195110Z","description":"","environment_variables":{},"error_message":null,"id":"042eadee-2132-44c8-bc71-36edef3f629e","name":"tf-ns-dreamy-bohr","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-06-12T15:37:36.195110Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2025-08-27T14:01:37.966124Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"1510a03d-65c6-4fb4-ad5f-e10774ccf565","name":"tf-pn-musing-chatterjee","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-08-27T14:01:37.966124Z","id":"504966e9-c06d-4586-91da-f503ffe8974e","private_network_id":"1510a03d-65c6-4fb4-ad5f-e10774ccf565","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.4.0/22","updated_at":"2025-08-27T14:01:37.966124Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-08-27T14:01:37.966124Z","id":"52043d70-ee6a-4801-bc3b-d21486df6925","private_network_id":"1510a03d-65c6-4fb4-ad5f-e10774ccf565","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:b5ee::/64","updated_at":"2025-08-27T14:01:37.966124Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-08-27T14:01:37.966124Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
         headers:
             Content-Length:
-                - "512"
+                - "1068"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 12 Jun 2025 15:37:36 GMT
+                - Wed, 27 Aug 2025 14:01:38 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,29 +97,29 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 764ee6f6-898a-49c0-af52-ea292bd82b76
+                - 66d35c4d-5960-445f-926a-b397ff509fd4
         status: 200 OK
         code: 200
-        duration: 38.471879ms
+        duration: 26.798263ms
     - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 154
+        content_length: 188
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-pn-fervent-goldwasser","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"subnets":null,"default_route_propagation_enabled":false}'
+        body: '{"name":"tf-ns-brave-mccarthy","environment_variables":{},"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","secret_environment_variables":[],"tags":null,"activate_vpc_integration":true}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces
         method: POST
       response:
         proto: HTTP/2.0
@@ -127,20 +127,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1094
+        content_length: 505
         uncompressed: false
-        body: '{"created_at":"2025-06-12T15:37:35.776479Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"defa2ddd-f588-426e-b9a8-9c9a1fa7e231","name":"tf-pn-fervent-goldwasser","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-06-12T15:37:35.776479Z","id":"a2de567e-8b38-400a-8753-2f25a169541d","private_network_id":"defa2ddd-f588-426e-b9a8-9c9a1fa7e231","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.28.0/22","updated_at":"2025-06-12T15:37:35.776479Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-06-12T15:37:35.776479Z","id":"684ab2a7-d28c-439b-9bf8-2f16ef28f0f8","private_network_id":"defa2ddd-f588-426e-b9a8-9c9a1fa7e231","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:36c0::/64","updated_at":"2025-06-12T15:37:35.776479Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-06-12T15:37:35.776479Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+        body: '{"created_at":"2025-08-27T14:01:39.604469939Z","description":"","environment_variables":{},"error_message":null,"id":"03e50d0f-56d9-451b-ab35-5392d4489fbf","name":"tf-ns-brave-mccarthy","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T14:01:39.604469939Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "1094"
+                - "505"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 12 Jun 2025 15:37:36 GMT
+                - Wed, 27 Aug 2025 14:01:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -148,10 +148,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 39258f8b-60c7-4f48-a0c8-366d5bcf7fc1
+                - b2f20928-28a7-42cf-9570-71244f4818a8
         status: 200 OK
         code: 200
-        duration: 818.630863ms
+        duration: 1.982691746s
     - id: 3
       request:
         proto: HTTP/1.1
@@ -168,7 +168,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/defa2ddd-f588-426e-b9a8-9c9a1fa7e231
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/03e50d0f-56d9-451b-ab35-5392d4489fbf
         method: GET
       response:
         proto: HTTP/2.0
@@ -176,20 +176,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1094
+        content_length: 499
         uncompressed: false
-        body: '{"created_at":"2025-06-12T15:37:35.776479Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"defa2ddd-f588-426e-b9a8-9c9a1fa7e231","name":"tf-pn-fervent-goldwasser","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-06-12T15:37:35.776479Z","id":"a2de567e-8b38-400a-8753-2f25a169541d","private_network_id":"defa2ddd-f588-426e-b9a8-9c9a1fa7e231","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.28.0/22","updated_at":"2025-06-12T15:37:35.776479Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-06-12T15:37:35.776479Z","id":"684ab2a7-d28c-439b-9bf8-2f16ef28f0f8","private_network_id":"defa2ddd-f588-426e-b9a8-9c9a1fa7e231","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:36c0::/64","updated_at":"2025-06-12T15:37:35.776479Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-06-12T15:37:35.776479Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+        body: '{"created_at":"2025-08-27T14:01:39.604470Z","description":"","environment_variables":{},"error_message":null,"id":"03e50d0f-56d9-451b-ab35-5392d4489fbf","name":"tf-ns-brave-mccarthy","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T14:01:39.604470Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "1094"
+                - "499"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 12 Jun 2025 15:37:36 GMT
+                - Wed, 27 Aug 2025 14:01:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -197,10 +197,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4edcb603-b953-4955-98e4-2fd81c89b8ad
+                - 9938f8fc-ffd9-4b21-b348-4ab6910d1157
         status: 200 OK
         code: 200
-        duration: 55.553093ms
+        duration: 47.16435ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -217,7 +217,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/042eadee-2132-44c8-bc71-36edef3f629e
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/03e50d0f-56d9-451b-ab35-5392d4489fbf
         method: GET
       response:
         proto: HTTP/2.0
@@ -225,20 +225,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 595
+        content_length: 585
         uncompressed: false
-        body: '{"created_at":"2025-06-12T15:37:36.195110Z","description":"","environment_variables":{},"error_message":null,"id":"042eadee-2132-44c8-bc71-36edef3f629e","name":"tf-ns-dreamy-bohr","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsdreamybohr12kvm0zg","registry_namespace_id":"d4b44e5d-46b5-46a2-9359-b216ac445b96","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-12T15:37:38.005939Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2025-08-27T14:01:39.604470Z","description":"","environment_variables":{},"error_message":null,"id":"03e50d0f-56d9-451b-ab35-5392d4489fbf","name":"tf-ns-brave-mccarthy","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsbravemccarthyq2moobr5","registry_namespace_id":"4d198aa0-b6e1-4b87-ab10-9870e543dda6","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T14:01:44.355471Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "595"
+                - "585"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 12 Jun 2025 15:37:41 GMT
+                - Wed, 27 Aug 2025 14:01:44 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -246,10 +246,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - dc7bae18-5eb4-4b76-b9d0-3ccc8d98ed16
+                - 9e81f712-eb99-4f24-a11b-01473b791603
         status: 200 OK
         code: 200
-        duration: 48.325822ms
+        duration: 47.998387ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -266,7 +266,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/042eadee-2132-44c8-bc71-36edef3f629e
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/03e50d0f-56d9-451b-ab35-5392d4489fbf
         method: GET
       response:
         proto: HTTP/2.0
@@ -274,20 +274,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 595
+        content_length: 585
         uncompressed: false
-        body: '{"created_at":"2025-06-12T15:37:36.195110Z","description":"","environment_variables":{},"error_message":null,"id":"042eadee-2132-44c8-bc71-36edef3f629e","name":"tf-ns-dreamy-bohr","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsdreamybohr12kvm0zg","registry_namespace_id":"d4b44e5d-46b5-46a2-9359-b216ac445b96","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-12T15:37:38.005939Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2025-08-27T14:01:39.604470Z","description":"","environment_variables":{},"error_message":null,"id":"03e50d0f-56d9-451b-ab35-5392d4489fbf","name":"tf-ns-brave-mccarthy","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsbravemccarthyq2moobr5","registry_namespace_id":"4d198aa0-b6e1-4b87-ab10-9870e543dda6","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T14:01:44.355471Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "595"
+                - "585"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 12 Jun 2025 15:37:41 GMT
+                - Wed, 27 Aug 2025 14:01:44 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -295,10 +295,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6e4d4f01-9523-4fb8-aee5-500bf268e3e0
+                - a5b27789-f0af-4921-bb8a-dd19d4e215a1
         status: 200 OK
         code: 200
-        duration: 42.416146ms
+        duration: 63.249736ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -315,7 +315,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/042eadee-2132-44c8-bc71-36edef3f629e
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/03e50d0f-56d9-451b-ab35-5392d4489fbf
         method: GET
       response:
         proto: HTTP/2.0
@@ -323,20 +323,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 595
+        content_length: 585
         uncompressed: false
-        body: '{"created_at":"2025-06-12T15:37:36.195110Z","description":"","environment_variables":{},"error_message":null,"id":"042eadee-2132-44c8-bc71-36edef3f629e","name":"tf-ns-dreamy-bohr","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsdreamybohr12kvm0zg","registry_namespace_id":"d4b44e5d-46b5-46a2-9359-b216ac445b96","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-12T15:37:38.005939Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2025-08-27T14:01:39.604470Z","description":"","environment_variables":{},"error_message":null,"id":"03e50d0f-56d9-451b-ab35-5392d4489fbf","name":"tf-ns-brave-mccarthy","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsbravemccarthyq2moobr5","registry_namespace_id":"4d198aa0-b6e1-4b87-ab10-9870e543dda6","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T14:01:44.355471Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "595"
+                - "585"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 12 Jun 2025 15:37:41 GMT
+                - Wed, 27 Aug 2025 14:01:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -344,22 +344,22 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6d1b4af3-8ad9-45df-9a58-9d4e6b9f96d9
+                - 53c04132-7693-45f8-907e-53c72eb06bfa
         status: 200 OK
         code: 200
-        duration: 274.503158ms
+        duration: 47.222939ms
     - id: 7
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 235
+        content_length: 242
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"namespace_id":"042eadee-2132-44c8-bc71-36edef3f629e","name":"tf-co-jovial-dirac","privacy":"public","protocol":"http1","secret_environment_variables":null,"http_option":"enabled","sandbox":"v1","tags":null,"command":null,"args":null}'
+        body: '{"namespace_id":"03e50d0f-56d9-451b-ab35-5392d4489fbf","name":"tf-co-wizardly-kowalevski","privacy":"public","protocol":"http1","secret_environment_variables":null,"http_option":"enabled","sandbox":"v1","tags":null,"command":null,"args":null}'
         form: {}
         headers:
             Content-Type:
@@ -374,20 +374,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 986
+        content_length: 980
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-12T15:37:41.830705644Z","description":"","domain_name":"tfnsdreamybohr12kvm0zg-tf-co-jovial-dirac.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"484195a3-2d06-4e91-97d1-7bb2012cf139","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-jovial-dirac","namespace_id":"042eadee-2132-44c8-bc71-36edef3f629e","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsdreamybohr12kvm0zg/tf-co-jovial-dirac:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-12T15:37:41.830705644Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T14:01:45.494935898Z","description":"","domain_name":"tfnsbravemccarthyq2moobr5-tf-co-wizardly-kowalevski.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"2e7019af-d628-4889-b30f-b346fe6fa0c8","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-wizardly-kowalevski","namespace_id":"03e50d0f-56d9-451b-ab35-5392d4489fbf","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsbravemccarthyq2moobr5/tf-co-wizardly-kowalevski:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T14:01:45.494935898Z"}'
         headers:
             Content-Length:
-                - "986"
+                - "980"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 12 Jun 2025 15:37:41 GMT
+                - Wed, 27 Aug 2025 14:01:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -395,10 +395,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f3c6782f-73bc-4daa-8549-ede8ee65f166
+                - a7d01535-f1d2-4d42-9e4e-07d483add3b2
         status: 200 OK
         code: 200
-        duration: 233.465512ms
+        duration: 489.159179ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -415,7 +415,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/484195a3-2d06-4e91-97d1-7bb2012cf139
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/2e7019af-d628-4889-b30f-b346fe6fa0c8
         method: GET
       response:
         proto: HTTP/2.0
@@ -423,20 +423,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 980
+        content_length: 974
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-12T15:37:41.830706Z","description":"","domain_name":"tfnsdreamybohr12kvm0zg-tf-co-jovial-dirac.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"484195a3-2d06-4e91-97d1-7bb2012cf139","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-jovial-dirac","namespace_id":"042eadee-2132-44c8-bc71-36edef3f629e","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsdreamybohr12kvm0zg/tf-co-jovial-dirac:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-12T15:37:41.830706Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T14:01:45.494936Z","description":"","domain_name":"tfnsbravemccarthyq2moobr5-tf-co-wizardly-kowalevski.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"2e7019af-d628-4889-b30f-b346fe6fa0c8","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-wizardly-kowalevski","namespace_id":"03e50d0f-56d9-451b-ab35-5392d4489fbf","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsbravemccarthyq2moobr5/tf-co-wizardly-kowalevski:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T14:01:45.494936Z"}'
         headers:
             Content-Length:
-                - "980"
+                - "974"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 12 Jun 2025 15:37:41 GMT
+                - Wed, 27 Aug 2025 14:01:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -444,10 +444,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a92c5bb1-2fea-48ee-a9e1-2e920a05053d
+                - 1db62f36-52a8-40b6-9773-14b06de0eded
         status: 200 OK
         code: 200
-        duration: 58.319226ms
+        duration: 66.89981ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -464,7 +464,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/042eadee-2132-44c8-bc71-36edef3f629e
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/03e50d0f-56d9-451b-ab35-5392d4489fbf
         method: GET
       response:
         proto: HTTP/2.0
@@ -472,20 +472,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 595
+        content_length: 585
         uncompressed: false
-        body: '{"created_at":"2025-06-12T15:37:36.195110Z","description":"","environment_variables":{},"error_message":null,"id":"042eadee-2132-44c8-bc71-36edef3f629e","name":"tf-ns-dreamy-bohr","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsdreamybohr12kvm0zg","registry_namespace_id":"d4b44e5d-46b5-46a2-9359-b216ac445b96","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-12T15:37:38.005939Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2025-08-27T14:01:39.604470Z","description":"","environment_variables":{},"error_message":null,"id":"03e50d0f-56d9-451b-ab35-5392d4489fbf","name":"tf-ns-brave-mccarthy","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsbravemccarthyq2moobr5","registry_namespace_id":"4d198aa0-b6e1-4b87-ab10-9870e543dda6","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T14:01:44.355471Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "595"
+                - "585"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 12 Jun 2025 15:37:42 GMT
+                - Wed, 27 Aug 2025 14:01:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -493,10 +493,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 239c55d6-c396-4fdc-b797-de26718c89e1
+                - 30b7ec15-540a-4a40-bbb1-18ac54f0b024
         status: 200 OK
         code: 200
-        duration: 53.141855ms
+        duration: 49.727899ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -513,7 +513,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/defa2ddd-f588-426e-b9a8-9c9a1fa7e231
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/03e50d0f-56d9-451b-ab35-5392d4489fbf
         method: GET
       response:
         proto: HTTP/2.0
@@ -521,20 +521,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1094
+        content_length: 585
         uncompressed: false
-        body: '{"created_at":"2025-06-12T15:37:35.776479Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"defa2ddd-f588-426e-b9a8-9c9a1fa7e231","name":"tf-pn-fervent-goldwasser","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-06-12T15:37:35.776479Z","id":"a2de567e-8b38-400a-8753-2f25a169541d","private_network_id":"defa2ddd-f588-426e-b9a8-9c9a1fa7e231","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.28.0/22","updated_at":"2025-06-12T15:37:35.776479Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-06-12T15:37:35.776479Z","id":"684ab2a7-d28c-439b-9bf8-2f16ef28f0f8","private_network_id":"defa2ddd-f588-426e-b9a8-9c9a1fa7e231","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:36c0::/64","updated_at":"2025-06-12T15:37:35.776479Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-06-12T15:37:35.776479Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+        body: '{"created_at":"2025-08-27T14:01:39.604470Z","description":"","environment_variables":{},"error_message":null,"id":"03e50d0f-56d9-451b-ab35-5392d4489fbf","name":"tf-ns-brave-mccarthy","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsbravemccarthyq2moobr5","registry_namespace_id":"4d198aa0-b6e1-4b87-ab10-9870e543dda6","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T14:01:44.355471Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "1094"
+                - "585"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 12 Jun 2025 15:37:42 GMT
+                - Wed, 27 Aug 2025 14:01:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -542,10 +542,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8def2d18-60d0-4764-8967-a936c601caf5
+                - c858e34f-d284-432e-8541-6c9d77c0e465
         status: 200 OK
         code: 200
-        duration: 39.502394ms
+        duration: 43.931318ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -562,7 +562,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/042eadee-2132-44c8-bc71-36edef3f629e
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/1510a03d-65c6-4fb4-ad5f-e10774ccf565
         method: GET
       response:
         proto: HTTP/2.0
@@ -570,20 +570,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 595
+        content_length: 1068
         uncompressed: false
-        body: '{"created_at":"2025-06-12T15:37:36.195110Z","description":"","environment_variables":{},"error_message":null,"id":"042eadee-2132-44c8-bc71-36edef3f629e","name":"tf-ns-dreamy-bohr","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsdreamybohr12kvm0zg","registry_namespace_id":"d4b44e5d-46b5-46a2-9359-b216ac445b96","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-12T15:37:38.005939Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2025-08-27T14:01:37.966124Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"1510a03d-65c6-4fb4-ad5f-e10774ccf565","name":"tf-pn-musing-chatterjee","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-08-27T14:01:37.966124Z","id":"504966e9-c06d-4586-91da-f503ffe8974e","private_network_id":"1510a03d-65c6-4fb4-ad5f-e10774ccf565","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.4.0/22","updated_at":"2025-08-27T14:01:37.966124Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-08-27T14:01:37.966124Z","id":"52043d70-ee6a-4801-bc3b-d21486df6925","private_network_id":"1510a03d-65c6-4fb4-ad5f-e10774ccf565","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:b5ee::/64","updated_at":"2025-08-27T14:01:37.966124Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-08-27T14:01:37.966124Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
         headers:
             Content-Length:
-                - "595"
+                - "1068"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 12 Jun 2025 15:37:42 GMT
+                - Wed, 27 Aug 2025 14:01:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -591,10 +591,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - de71a10f-93d1-4309-b747-bdd023cf019c
+                - 16218a19-ea90-4292-844c-5fc47a6eac9b
         status: 200 OK
         code: 200
-        duration: 45.314438ms
+        duration: 48.660191ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -611,7 +611,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/484195a3-2d06-4e91-97d1-7bb2012cf139
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/2e7019af-d628-4889-b30f-b346fe6fa0c8
         method: GET
       response:
         proto: HTTP/2.0
@@ -619,20 +619,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 980
+        content_length: 974
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-12T15:37:41.830706Z","description":"","domain_name":"tfnsdreamybohr12kvm0zg-tf-co-jovial-dirac.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"484195a3-2d06-4e91-97d1-7bb2012cf139","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-jovial-dirac","namespace_id":"042eadee-2132-44c8-bc71-36edef3f629e","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsdreamybohr12kvm0zg/tf-co-jovial-dirac:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-12T15:37:41.830706Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T14:01:45.494936Z","description":"","domain_name":"tfnsbravemccarthyq2moobr5-tf-co-wizardly-kowalevski.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"2e7019af-d628-4889-b30f-b346fe6fa0c8","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-wizardly-kowalevski","namespace_id":"03e50d0f-56d9-451b-ab35-5392d4489fbf","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsbravemccarthyq2moobr5/tf-co-wizardly-kowalevski:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T14:01:45.494936Z"}'
         headers:
             Content-Length:
-                - "980"
+                - "974"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 12 Jun 2025 15:37:42 GMT
+                - Wed, 27 Aug 2025 14:01:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -640,10 +640,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2623a5b1-3799-43bc-a80f-8b5525b112c1
+                - f6e2a556-3fef-4e52-8759-5e6a74d2f5bc
         status: 200 OK
         code: 200
-        duration: 98.205592ms
+        duration: 48.512334ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -660,7 +660,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/defa2ddd-f588-426e-b9a8-9c9a1fa7e231
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/1510a03d-65c6-4fb4-ad5f-e10774ccf565
         method: GET
       response:
         proto: HTTP/2.0
@@ -668,20 +668,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1094
+        content_length: 1068
         uncompressed: false
-        body: '{"created_at":"2025-06-12T15:37:35.776479Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"defa2ddd-f588-426e-b9a8-9c9a1fa7e231","name":"tf-pn-fervent-goldwasser","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-06-12T15:37:35.776479Z","id":"a2de567e-8b38-400a-8753-2f25a169541d","private_network_id":"defa2ddd-f588-426e-b9a8-9c9a1fa7e231","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.28.0/22","updated_at":"2025-06-12T15:37:35.776479Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-06-12T15:37:35.776479Z","id":"684ab2a7-d28c-439b-9bf8-2f16ef28f0f8","private_network_id":"defa2ddd-f588-426e-b9a8-9c9a1fa7e231","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:36c0::/64","updated_at":"2025-06-12T15:37:35.776479Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-06-12T15:37:35.776479Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+        body: '{"created_at":"2025-08-27T14:01:37.966124Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"1510a03d-65c6-4fb4-ad5f-e10774ccf565","name":"tf-pn-musing-chatterjee","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-08-27T14:01:37.966124Z","id":"504966e9-c06d-4586-91da-f503ffe8974e","private_network_id":"1510a03d-65c6-4fb4-ad5f-e10774ccf565","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.4.0/22","updated_at":"2025-08-27T14:01:37.966124Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-08-27T14:01:37.966124Z","id":"52043d70-ee6a-4801-bc3b-d21486df6925","private_network_id":"1510a03d-65c6-4fb4-ad5f-e10774ccf565","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:b5ee::/64","updated_at":"2025-08-27T14:01:37.966124Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-08-27T14:01:37.966124Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
         headers:
             Content-Length:
-                - "1094"
+                - "1068"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 12 Jun 2025 15:37:43 GMT
+                - Wed, 27 Aug 2025 14:01:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -689,10 +689,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 989a6389-726c-4fe0-9585-c58f3d23f7cc
+                - 0e8b7524-1636-4703-ba09-667014c5878a
         status: 200 OK
         code: 200
-        duration: 36.353932ms
+        duration: 21.417684ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -709,7 +709,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/042eadee-2132-44c8-bc71-36edef3f629e
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/03e50d0f-56d9-451b-ab35-5392d4489fbf
         method: GET
       response:
         proto: HTTP/2.0
@@ -717,20 +717,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 595
+        content_length: 585
         uncompressed: false
-        body: '{"created_at":"2025-06-12T15:37:36.195110Z","description":"","environment_variables":{},"error_message":null,"id":"042eadee-2132-44c8-bc71-36edef3f629e","name":"tf-ns-dreamy-bohr","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsdreamybohr12kvm0zg","registry_namespace_id":"d4b44e5d-46b5-46a2-9359-b216ac445b96","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-12T15:37:38.005939Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2025-08-27T14:01:39.604470Z","description":"","environment_variables":{},"error_message":null,"id":"03e50d0f-56d9-451b-ab35-5392d4489fbf","name":"tf-ns-brave-mccarthy","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsbravemccarthyq2moobr5","registry_namespace_id":"4d198aa0-b6e1-4b87-ab10-9870e543dda6","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T14:01:44.355471Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "595"
+                - "585"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 12 Jun 2025 15:37:43 GMT
+                - Wed, 27 Aug 2025 14:01:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -738,10 +738,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 55960c32-e324-4278-b042-d962aeceb73a
+                - 695ded65-89a1-416d-bfa2-65b602f3b1f2
         status: 200 OK
         code: 200
-        duration: 48.663546ms
+        duration: 44.705234ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -758,7 +758,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/484195a3-2d06-4e91-97d1-7bb2012cf139
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/2e7019af-d628-4889-b30f-b346fe6fa0c8
         method: GET
       response:
         proto: HTTP/2.0
@@ -766,20 +766,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 980
+        content_length: 974
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-12T15:37:41.830706Z","description":"","domain_name":"tfnsdreamybohr12kvm0zg-tf-co-jovial-dirac.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"484195a3-2d06-4e91-97d1-7bb2012cf139","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-jovial-dirac","namespace_id":"042eadee-2132-44c8-bc71-36edef3f629e","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsdreamybohr12kvm0zg/tf-co-jovial-dirac:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-12T15:37:41.830706Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T14:01:45.494936Z","description":"","domain_name":"tfnsbravemccarthyq2moobr5-tf-co-wizardly-kowalevski.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"2e7019af-d628-4889-b30f-b346fe6fa0c8","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-wizardly-kowalevski","namespace_id":"03e50d0f-56d9-451b-ab35-5392d4489fbf","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsbravemccarthyq2moobr5/tf-co-wizardly-kowalevski:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T14:01:45.494936Z"}'
         headers:
             Content-Length:
-                - "980"
+                - "974"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 12 Jun 2025 15:37:43 GMT
+                - Wed, 27 Aug 2025 14:01:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -787,10 +787,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 143fc3c3-93db-4282-8d05-475e5048abe7
+                - 372324b9-c2c6-4edc-9f57-2d7e9b551ef5
         status: 200 OK
         code: 200
-        duration: 51.66361ms
+        duration: 56.80108ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -807,7 +807,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/042eadee-2132-44c8-bc71-36edef3f629e
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/03e50d0f-56d9-451b-ab35-5392d4489fbf
         method: GET
       response:
         proto: HTTP/2.0
@@ -815,20 +815,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 595
+        content_length: 585
         uncompressed: false
-        body: '{"created_at":"2025-06-12T15:37:36.195110Z","description":"","environment_variables":{},"error_message":null,"id":"042eadee-2132-44c8-bc71-36edef3f629e","name":"tf-ns-dreamy-bohr","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsdreamybohr12kvm0zg","registry_namespace_id":"d4b44e5d-46b5-46a2-9359-b216ac445b96","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-12T15:37:38.005939Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2025-08-27T14:01:39.604470Z","description":"","environment_variables":{},"error_message":null,"id":"03e50d0f-56d9-451b-ab35-5392d4489fbf","name":"tf-ns-brave-mccarthy","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsbravemccarthyq2moobr5","registry_namespace_id":"4d198aa0-b6e1-4b87-ab10-9870e543dda6","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T14:01:44.355471Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "595"
+                - "585"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 12 Jun 2025 15:37:44 GMT
+                - Wed, 27 Aug 2025 14:01:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -836,10 +836,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 53ca7dff-8a82-4676-86a4-98e0e5859d78
+                - 645c4cec-4b59-4dea-bc3f-6542fd81943b
         status: 200 OK
         code: 200
-        duration: 43.203595ms
+        duration: 46.150182ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -856,7 +856,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/484195a3-2d06-4e91-97d1-7bb2012cf139
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/2e7019af-d628-4889-b30f-b346fe6fa0c8
         method: GET
       response:
         proto: HTTP/2.0
@@ -864,20 +864,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 980
+        content_length: 974
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-12T15:37:41.830706Z","description":"","domain_name":"tfnsdreamybohr12kvm0zg-tf-co-jovial-dirac.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"484195a3-2d06-4e91-97d1-7bb2012cf139","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-jovial-dirac","namespace_id":"042eadee-2132-44c8-bc71-36edef3f629e","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsdreamybohr12kvm0zg/tf-co-jovial-dirac:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-12T15:37:41.830706Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T14:01:45.494936Z","description":"","domain_name":"tfnsbravemccarthyq2moobr5-tf-co-wizardly-kowalevski.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"2e7019af-d628-4889-b30f-b346fe6fa0c8","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-wizardly-kowalevski","namespace_id":"03e50d0f-56d9-451b-ab35-5392d4489fbf","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsbravemccarthyq2moobr5/tf-co-wizardly-kowalevski:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T14:01:45.494936Z"}'
         headers:
             Content-Length:
-                - "980"
+                - "974"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 12 Jun 2025 15:37:44 GMT
+                - Wed, 27 Aug 2025 14:01:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -885,10 +885,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ce648131-b9ce-4a0d-a5d7-b6e5bfdf43d6
+                - b944d096-4d95-4893-95af-2b7439aaa79b
         status: 200 OK
         code: 200
-        duration: 93.333914ms
+        duration: 74.819903ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -900,14 +900,14 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"privacy":"unknown_privacy","protocol":"unknown_protocol","secret_environment_variables":null,"http_option":"unknown_http_option","sandbox":"unknown_sandbox","private_network_id":"defa2ddd-f588-426e-b9a8-9c9a1fa7e231"}'
+        body: '{"privacy":"unknown_privacy","protocol":"unknown_protocol","secret_environment_variables":null,"http_option":"unknown_http_option","sandbox":"unknown_sandbox","private_network_id":"1510a03d-65c6-4fb4-ad5f-e10774ccf565"}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/484195a3-2d06-4e91-97d1-7bb2012cf139
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/2e7019af-d628-4889-b30f-b346fe6fa0c8
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -915,20 +915,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 121
+        content_length: 1011
         uncompressed: false
-        body: '{"message":"Application can''t be attached to private network, vpc integration must be activated on its parent namespace"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T14:01:45.494936Z","description":"","domain_name":"tfnsbravemccarthyq2moobr5-tf-co-wizardly-kowalevski.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"2e7019af-d628-4889-b30f-b346fe6fa0c8","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-wizardly-kowalevski","namespace_id":"03e50d0f-56d9-451b-ab35-5392d4489fbf","port":8080,"privacy":"public","private_network_id":"1510a03d-65c6-4fb4-ad5f-e10774ccf565","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsbravemccarthyq2moobr5/tf-co-wizardly-kowalevski:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T14:01:47.277068217Z"}'
         headers:
             Content-Length:
-                - "121"
+                - "1011"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 12 Jun 2025 15:37:44 GMT
+                - Wed, 27 Aug 2025 14:01:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -936,10 +936,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d3b7c8ba-8e96-476b-970e-27ba92704224
-        status: 400 Bad Request
-        code: 400
-        duration: 34.793321ms
+                - 98a70a73-1346-4f43-8091-eec39b76b24d
+        status: 200 OK
+        code: 200
+        duration: 286.973882ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -956,7 +956,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/042eadee-2132-44c8-bc71-36edef3f629e
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/2e7019af-d628-4889-b30f-b346fe6fa0c8
         method: GET
       response:
         proto: HTTP/2.0
@@ -964,20 +964,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 595
+        content_length: 1008
         uncompressed: false
-        body: '{"created_at":"2025-06-12T15:37:36.195110Z","description":"","environment_variables":{},"error_message":null,"id":"042eadee-2132-44c8-bc71-36edef3f629e","name":"tf-ns-dreamy-bohr","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsdreamybohr12kvm0zg","registry_namespace_id":"d4b44e5d-46b5-46a2-9359-b216ac445b96","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-12T15:37:38.005939Z","vpc_integration_activated":false}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T14:01:45.494936Z","description":"","domain_name":"tfnsbravemccarthyq2moobr5-tf-co-wizardly-kowalevski.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"2e7019af-d628-4889-b30f-b346fe6fa0c8","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-wizardly-kowalevski","namespace_id":"03e50d0f-56d9-451b-ab35-5392d4489fbf","port":8080,"privacy":"public","private_network_id":"1510a03d-65c6-4fb4-ad5f-e10774ccf565","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsbravemccarthyq2moobr5/tf-co-wizardly-kowalevski:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T14:01:47.277068Z"}'
         headers:
             Content-Length:
-                - "595"
+                - "1008"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 12 Jun 2025 15:37:45 GMT
+                - Wed, 27 Aug 2025 14:01:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -985,10 +985,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5ba53c39-4426-4678-acee-9f67d339d57a
+                - 7640e023-d6bd-4ded-91d7-f7c282d3464d
         status: 200 OK
         code: 200
-        duration: 42.805316ms
+        duration: 49.653079ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1005,7 +1005,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/defa2ddd-f588-426e-b9a8-9c9a1fa7e231
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/2e7019af-d628-4889-b30f-b346fe6fa0c8
         method: GET
       response:
         proto: HTTP/2.0
@@ -1013,20 +1013,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1094
+        content_length: 1008
         uncompressed: false
-        body: '{"created_at":"2025-06-12T15:37:35.776479Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"defa2ddd-f588-426e-b9a8-9c9a1fa7e231","name":"tf-pn-fervent-goldwasser","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-06-12T15:37:35.776479Z","id":"a2de567e-8b38-400a-8753-2f25a169541d","private_network_id":"defa2ddd-f588-426e-b9a8-9c9a1fa7e231","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.28.0/22","updated_at":"2025-06-12T15:37:35.776479Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-06-12T15:37:35.776479Z","id":"684ab2a7-d28c-439b-9bf8-2f16ef28f0f8","private_network_id":"defa2ddd-f588-426e-b9a8-9c9a1fa7e231","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:36c0::/64","updated_at":"2025-06-12T15:37:35.776479Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-06-12T15:37:35.776479Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T14:01:45.494936Z","description":"","domain_name":"tfnsbravemccarthyq2moobr5-tf-co-wizardly-kowalevski.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"2e7019af-d628-4889-b30f-b346fe6fa0c8","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-wizardly-kowalevski","namespace_id":"03e50d0f-56d9-451b-ab35-5392d4489fbf","port":8080,"privacy":"public","private_network_id":"1510a03d-65c6-4fb4-ad5f-e10774ccf565","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsbravemccarthyq2moobr5/tf-co-wizardly-kowalevski:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T14:01:47.277068Z"}'
         headers:
             Content-Length:
-                - "1094"
+                - "1008"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 12 Jun 2025 15:37:45 GMT
+                - Wed, 27 Aug 2025 14:01:52 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1034,10 +1034,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 69dba08e-2591-4b2b-a775-a46d663082dd
+                - dfa3f0d5-6e15-4e41-a805-42fecd40451b
         status: 200 OK
         code: 200
-        duration: 71.571271ms
+        duration: 57.029689ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1054,7 +1054,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/484195a3-2d06-4e91-97d1-7bb2012cf139
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/2e7019af-d628-4889-b30f-b346fe6fa0c8
         method: GET
       response:
         proto: HTTP/2.0
@@ -1062,20 +1062,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 980
+        content_length: 1046
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-12T15:37:41.830706Z","description":"","domain_name":"tfnsdreamybohr12kvm0zg-tf-co-jovial-dirac.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"484195a3-2d06-4e91-97d1-7bb2012cf139","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-jovial-dirac","namespace_id":"042eadee-2132-44c8-bc71-36edef3f629e","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsdreamybohr12kvm0zg/tf-co-jovial-dirac:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-12T15:37:41.830706Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T14:01:45.494936Z","description":"","domain_name":"tfnsbravemccarthyq2moobr5-tf-co-wizardly-kowalevski.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"2e7019af-d628-4889-b30f-b346fe6fa0c8","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-wizardly-kowalevski","namespace_id":"03e50d0f-56d9-451b-ab35-5392d4489fbf","port":8080,"privacy":"public","private_network_id":"1510a03d-65c6-4fb4-ad5f-e10774ccf565","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsbravemccarthyq2moobr5/tf-co-wizardly-kowalevski:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T14:01:53.727044Z"}'
         headers:
             Content-Length:
-                - "980"
+                - "1046"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 12 Jun 2025 15:37:45 GMT
+                - Wed, 27 Aug 2025 14:01:57 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1083,10 +1083,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 001843d4-1fb3-4016-b981-7095ced4d1ac
+                - 9ccc3d41-b6f1-4f32-a956-a6d0de8cc27b
         status: 200 OK
         code: 200
-        duration: 50.142503ms
+        duration: 56.811939ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1103,7 +1103,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/484195a3-2d06-4e91-97d1-7bb2012cf139
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/2e7019af-d628-4889-b30f-b346fe6fa0c8
         method: GET
       response:
         proto: HTTP/2.0
@@ -1111,20 +1111,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 980
+        content_length: 1046
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-12T15:37:41.830706Z","description":"","domain_name":"tfnsdreamybohr12kvm0zg-tf-co-jovial-dirac.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"484195a3-2d06-4e91-97d1-7bb2012cf139","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-jovial-dirac","namespace_id":"042eadee-2132-44c8-bc71-36edef3f629e","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsdreamybohr12kvm0zg/tf-co-jovial-dirac:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-12T15:37:41.830706Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T14:01:45.494936Z","description":"","domain_name":"tfnsbravemccarthyq2moobr5-tf-co-wizardly-kowalevski.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"2e7019af-d628-4889-b30f-b346fe6fa0c8","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-wizardly-kowalevski","namespace_id":"03e50d0f-56d9-451b-ab35-5392d4489fbf","port":8080,"privacy":"public","private_network_id":"1510a03d-65c6-4fb4-ad5f-e10774ccf565","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsbravemccarthyq2moobr5/tf-co-wizardly-kowalevski:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T14:01:53.727044Z"}'
         headers:
             Content-Length:
-                - "980"
+                - "1046"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 12 Jun 2025 15:37:46 GMT
+                - Wed, 27 Aug 2025 14:01:57 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1132,10 +1132,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a5fc13b5-3c71-4793-8d58-94c7769721f0
+                - 9b8a5238-1397-442c-b7de-bca41d6b9ce8
         status: 200 OK
         code: 200
-        duration: 53.445365ms
+        duration: 51.385955ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1152,28 +1152,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/484195a3-2d06-4e91-97d1-7bb2012cf139
-        method: DELETE
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/03e50d0f-56d9-451b-ab35-5392d4489fbf
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 984
+        content_length: 585
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-12T15:37:41.830706Z","description":"","domain_name":"tfnsdreamybohr12kvm0zg-tf-co-jovial-dirac.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"484195a3-2d06-4e91-97d1-7bb2012cf139","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-jovial-dirac","namespace_id":"042eadee-2132-44c8-bc71-36edef3f629e","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsdreamybohr12kvm0zg/tf-co-jovial-dirac:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2025-06-12T15:37:46.197022739Z"}'
+        body: '{"created_at":"2025-08-27T14:01:39.604470Z","description":"","environment_variables":{},"error_message":null,"id":"03e50d0f-56d9-451b-ab35-5392d4489fbf","name":"tf-ns-brave-mccarthy","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsbravemccarthyq2moobr5","registry_namespace_id":"4d198aa0-b6e1-4b87-ab10-9870e543dda6","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T14:01:44.355471Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "984"
+                - "585"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 12 Jun 2025 15:37:46 GMT
+                - Wed, 27 Aug 2025 14:01:57 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1181,10 +1181,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3bed24cb-8b33-451a-8ff8-9242c4945ed9
+                - 69b74f25-6a81-4121-b41e-1422a3c0d27b
         status: 200 OK
         code: 200
-        duration: 132.445244ms
+        duration: 54.662797ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1201,7 +1201,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/042eadee-2132-44c8-bc71-36edef3f629e
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/2e7019af-d628-4889-b30f-b346fe6fa0c8
         method: GET
       response:
         proto: HTTP/2.0
@@ -1209,20 +1209,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 595
+        content_length: 1046
         uncompressed: false
-        body: '{"created_at":"2025-06-12T15:37:36.195110Z","description":"","environment_variables":{},"error_message":null,"id":"042eadee-2132-44c8-bc71-36edef3f629e","name":"tf-ns-dreamy-bohr","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsdreamybohr12kvm0zg","registry_namespace_id":"d4b44e5d-46b5-46a2-9359-b216ac445b96","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-12T15:37:38.005939Z","vpc_integration_activated":false}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T14:01:45.494936Z","description":"","domain_name":"tfnsbravemccarthyq2moobr5-tf-co-wizardly-kowalevski.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"2e7019af-d628-4889-b30f-b346fe6fa0c8","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-wizardly-kowalevski","namespace_id":"03e50d0f-56d9-451b-ab35-5392d4489fbf","port":8080,"privacy":"public","private_network_id":"1510a03d-65c6-4fb4-ad5f-e10774ccf565","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsbravemccarthyq2moobr5/tf-co-wizardly-kowalevski:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T14:01:53.727044Z"}'
         headers:
             Content-Length:
-                - "595"
+                - "1046"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 12 Jun 2025 15:37:46 GMT
+                - Wed, 27 Aug 2025 14:01:57 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1230,10 +1230,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 01e38fcb-1316-46c0-b0e4-5d181c78f633
+                - 2cd5b46f-6c98-447f-a6cd-3806f8b08229
         status: 200 OK
         code: 200
-        duration: 44.223009ms
+        duration: 52.418206ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1250,28 +1250,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/042eadee-2132-44c8-bc71-36edef3f629e
-        method: DELETE
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/1510a03d-65c6-4fb4-ad5f-e10774ccf565
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 601
+        content_length: 1068
         uncompressed: false
-        body: '{"created_at":"2025-06-12T15:37:36.195110Z","description":"","environment_variables":{},"error_message":null,"id":"042eadee-2132-44c8-bc71-36edef3f629e","name":"tf-ns-dreamy-bohr","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsdreamybohr12kvm0zg","registry_namespace_id":"d4b44e5d-46b5-46a2-9359-b216ac445b96","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-06-12T15:37:46.368858184Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2025-08-27T14:01:37.966124Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"1510a03d-65c6-4fb4-ad5f-e10774ccf565","name":"tf-pn-musing-chatterjee","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-08-27T14:01:37.966124Z","id":"504966e9-c06d-4586-91da-f503ffe8974e","private_network_id":"1510a03d-65c6-4fb4-ad5f-e10774ccf565","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.4.0/22","updated_at":"2025-08-27T14:01:37.966124Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-08-27T14:01:37.966124Z","id":"52043d70-ee6a-4801-bc3b-d21486df6925","private_network_id":"1510a03d-65c6-4fb4-ad5f-e10774ccf565","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:b5ee::/64","updated_at":"2025-08-27T14:01:37.966124Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-08-27T14:01:37.966124Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
         headers:
             Content-Length:
-                - "601"
+                - "1068"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 12 Jun 2025 15:37:46 GMT
+                - Wed, 27 Aug 2025 14:01:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1279,10 +1279,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3ee3b5d2-b7ef-4f8f-8d44-8ccfb187fafa
+                - 35f8b144-a4cd-4844-876a-2f44cd2a1bb2
         status: 200 OK
         code: 200
-        duration: 181.030563ms
+        duration: 25.413427ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1299,7 +1299,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/042eadee-2132-44c8-bc71-36edef3f629e
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/03e50d0f-56d9-451b-ab35-5392d4489fbf
         method: GET
       response:
         proto: HTTP/2.0
@@ -1307,20 +1307,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 598
+        content_length: 585
         uncompressed: false
-        body: '{"created_at":"2025-06-12T15:37:36.195110Z","description":"","environment_variables":{},"error_message":null,"id":"042eadee-2132-44c8-bc71-36edef3f629e","name":"tf-ns-dreamy-bohr","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsdreamybohr12kvm0zg","registry_namespace_id":"d4b44e5d-46b5-46a2-9359-b216ac445b96","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-06-12T15:37:46.368858Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2025-08-27T14:01:39.604470Z","description":"","environment_variables":{},"error_message":null,"id":"03e50d0f-56d9-451b-ab35-5392d4489fbf","name":"tf-ns-brave-mccarthy","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsbravemccarthyq2moobr5","registry_namespace_id":"4d198aa0-b6e1-4b87-ab10-9870e543dda6","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T14:01:44.355471Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "598"
+                - "585"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 12 Jun 2025 15:37:46 GMT
+                - Wed, 27 Aug 2025 14:01:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1328,10 +1328,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8c942b16-33a2-45e5-89b7-2e1715cb03af
+                - d2045da3-f5e0-443e-8b56-2ee424299f9e
         status: 200 OK
         code: 200
-        duration: 46.223595ms
+        duration: 64.85379ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1348,7 +1348,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/042eadee-2132-44c8-bc71-36edef3f629e
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/2e7019af-d628-4889-b30f-b346fe6fa0c8
         method: GET
       response:
         proto: HTTP/2.0
@@ -1356,20 +1356,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 598
+        content_length: 1046
         uncompressed: false
-        body: '{"created_at":"2025-06-12T15:37:36.195110Z","description":"","environment_variables":{},"error_message":null,"id":"042eadee-2132-44c8-bc71-36edef3f629e","name":"tf-ns-dreamy-bohr","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsdreamybohr12kvm0zg","registry_namespace_id":"d4b44e5d-46b5-46a2-9359-b216ac445b96","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-06-12T15:37:46.368858Z","vpc_integration_activated":false}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T14:01:45.494936Z","description":"","domain_name":"tfnsbravemccarthyq2moobr5-tf-co-wizardly-kowalevski.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"2e7019af-d628-4889-b30f-b346fe6fa0c8","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-wizardly-kowalevski","namespace_id":"03e50d0f-56d9-451b-ab35-5392d4489fbf","port":8080,"privacy":"public","private_network_id":"1510a03d-65c6-4fb4-ad5f-e10774ccf565","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsbravemccarthyq2moobr5/tf-co-wizardly-kowalevski:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T14:01:53.727044Z"}'
         headers:
             Content-Length:
-                - "598"
+                - "1046"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 12 Jun 2025 15:37:51 GMT
+                - Wed, 27 Aug 2025 14:01:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1377,10 +1377,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8887c99e-f320-4c5b-a4c1-5d60bbd87705
+                - 4041e361-6ea7-4ffd-a486-80389aea6690
         status: 200 OK
         code: 200
-        duration: 44.901602ms
+        duration: 46.627307ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1397,7 +1397,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/042eadee-2132-44c8-bc71-36edef3f629e
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/2e7019af-d628-4889-b30f-b346fe6fa0c8
         method: GET
       response:
         proto: HTTP/2.0
@@ -1405,20 +1405,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 598
+        content_length: 1046
         uncompressed: false
-        body: '{"created_at":"2025-06-12T15:37:36.195110Z","description":"","environment_variables":{},"error_message":null,"id":"042eadee-2132-44c8-bc71-36edef3f629e","name":"tf-ns-dreamy-bohr","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsdreamybohr12kvm0zg","registry_namespace_id":"d4b44e5d-46b5-46a2-9359-b216ac445b96","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-06-12T15:37:46.368858Z","vpc_integration_activated":false}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T14:01:45.494936Z","description":"","domain_name":"tfnsbravemccarthyq2moobr5-tf-co-wizardly-kowalevski.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"Image was not found in container registry.","health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"2e7019af-d628-4889-b30f-b346fe6fa0c8","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-wizardly-kowalevski","namespace_id":"03e50d0f-56d9-451b-ab35-5392d4489fbf","port":8080,"privacy":"public","private_network_id":"1510a03d-65c6-4fb4-ad5f-e10774ccf565","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsbravemccarthyq2moobr5/tf-co-wizardly-kowalevski:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T14:01:53.727044Z"}'
         headers:
             Content-Length:
-                - "598"
+                - "1046"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 12 Jun 2025 15:37:56 GMT
+                - Wed, 27 Aug 2025 14:01:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1426,10 +1426,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 737c3c07-1b58-4493-9ad5-f90041de4e33
+                - 75b667aa-96bc-438f-8940-bb312eb84a14
         status: 200 OK
         code: 200
-        duration: 47.659711ms
+        duration: 64.905227ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1446,7 +1446,56 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/042eadee-2132-44c8-bc71-36edef3f629e
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/2e7019af-d628-4889-b30f-b346fe6fa0c8
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1012
+        uncompressed: false
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T14:01:45.494936Z","description":"","domain_name":"tfnsbravemccarthyq2moobr5-tf-co-wizardly-kowalevski.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"2e7019af-d628-4889-b30f-b346fe6fa0c8","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-wizardly-kowalevski","namespace_id":"03e50d0f-56d9-451b-ab35-5392d4489fbf","port":8080,"privacy":"public","private_network_id":"1510a03d-65c6-4fb4-ad5f-e10774ccf565","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsbravemccarthyq2moobr5/tf-co-wizardly-kowalevski:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2025-08-27T14:01:58.623392698Z"}'
+        headers:
+            Content-Length:
+                - "1012"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 14:01:58 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 95dfe4af-6431-40df-87be-a63623401da3
+        status: 200 OK
+        code: 200
+        duration: 153.004908ms
+    - id: 30
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/03e50d0f-56d9-451b-ab35-5392d4489fbf
         method: GET
       response:
         proto: HTTP/2.0
@@ -1454,20 +1503,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 37
+        content_length: 585
         uncompressed: false
-        body: '{"message":"Namespace was not found"}'
+        body: '{"created_at":"2025-08-27T14:01:39.604470Z","description":"","environment_variables":{},"error_message":null,"id":"03e50d0f-56d9-451b-ab35-5392d4489fbf","name":"tf-ns-brave-mccarthy","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsbravemccarthyq2moobr5","registry_namespace_id":"4d198aa0-b6e1-4b87-ab10-9870e543dda6","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T14:01:44.355471Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "37"
+                - "585"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 12 Jun 2025 15:38:01 GMT
+                - Wed, 27 Aug 2025 14:01:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1475,61 +1524,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8418a7b7-bb23-4eb4-bb9d-bcd4119e1257
-        status: 404 Not Found
-        code: 404
-        duration: 31.132447ms
-    - id: 30
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 187
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"name":"tf-ns-funny-ritchie","environment_variables":{},"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","secret_environment_variables":[],"tags":null,"activate_vpc_integration":true}'
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 519
-        uncompressed: false
-        body: '{"created_at":"2025-06-12T15:38:01.889167238Z","description":"","environment_variables":{},"error_message":null,"id":"2348dd8b-d057-4f7c-9458-2e956a1de0b0","name":"tf-ns-funny-ritchie","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-06-12T15:38:01.889167238Z","vpc_integration_activated":true}'
-        headers:
-            Content-Length:
-                - "519"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Thu, 12 Jun 2025 15:38:01 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 0f23ec10-a66d-4178-9e35-52764cee6df4
+                - 383ed9b3-7986-419f-9f76-dc1d28e93305
         status: 200 OK
         code: 200
-        duration: 219.556944ms
+        duration: 47.365825ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1546,28 +1544,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2348dd8b-d057-4f7c-9458-2e956a1de0b0
-        method: GET
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/03e50d0f-56d9-451b-ab35-5392d4489fbf
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 513
+        content_length: 591
         uncompressed: false
-        body: '{"created_at":"2025-06-12T15:38:01.889167Z","description":"","environment_variables":{},"error_message":null,"id":"2348dd8b-d057-4f7c-9458-2e956a1de0b0","name":"tf-ns-funny-ritchie","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-06-12T15:38:01.889167Z","vpc_integration_activated":true}'
+        body: '{"created_at":"2025-08-27T14:01:39.604470Z","description":"","environment_variables":{},"error_message":null,"id":"03e50d0f-56d9-451b-ab35-5392d4489fbf","name":"tf-ns-brave-mccarthy","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsbravemccarthyq2moobr5","registry_namespace_id":"4d198aa0-b6e1-4b87-ab10-9870e543dda6","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T14:01:58.807118836Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "513"
+                - "591"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 12 Jun 2025 15:38:01 GMT
+                - Wed, 27 Aug 2025 14:01:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1575,10 +1573,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 62bd427e-a28a-4542-86ba-6bca68f0d79d
+                - c723dc76-fd2f-438b-9267-69d9eb2c8b81
         status: 200 OK
         code: 200
-        duration: 43.630646ms
+        duration: 261.769306ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1595,7 +1593,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2348dd8b-d057-4f7c-9458-2e956a1de0b0
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/03e50d0f-56d9-451b-ab35-5392d4489fbf
         method: GET
       response:
         proto: HTTP/2.0
@@ -1603,20 +1601,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 513
+        content_length: 588
         uncompressed: false
-        body: '{"created_at":"2025-06-12T15:38:01.889167Z","description":"","environment_variables":{},"error_message":null,"id":"2348dd8b-d057-4f7c-9458-2e956a1de0b0","name":"tf-ns-funny-ritchie","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-06-12T15:38:01.889167Z","vpc_integration_activated":true}'
+        body: '{"created_at":"2025-08-27T14:01:39.604470Z","description":"","environment_variables":{},"error_message":null,"id":"03e50d0f-56d9-451b-ab35-5392d4489fbf","name":"tf-ns-brave-mccarthy","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsbravemccarthyq2moobr5","registry_namespace_id":"4d198aa0-b6e1-4b87-ab10-9870e543dda6","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T14:01:58.807119Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "513"
+                - "588"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 12 Jun 2025 15:38:06 GMT
+                - Wed, 27 Aug 2025 14:01:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1624,10 +1622,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - aaf0239a-ab0a-4afe-8c02-e8db9a888c38
+                - 63d718f6-6af5-4665-ab8d-d159e6f79e8e
         status: 200 OK
         code: 200
-        duration: 87.517652ms
+        duration: 51.788972ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1644,28 +1642,26 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2348dd8b-d057-4f7c-9458-2e956a1de0b0
-        method: GET
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/1510a03d-65c6-4fb4-ad5f-e10774ccf565
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 513
+        content_length: 0
         uncompressed: false
-        body: '{"created_at":"2025-06-12T15:38:01.889167Z","description":"","environment_variables":{},"error_message":null,"id":"2348dd8b-d057-4f7c-9458-2e956a1de0b0","name":"tf-ns-funny-ritchie","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-06-12T15:38:01.889167Z","vpc_integration_activated":true}'
+        body: ""
         headers:
-            Content-Length:
-                - "513"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 12 Jun 2025 15:38:12 GMT
+                - Wed, 27 Aug 2025 14:02:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1673,10 +1669,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 60f4fff3-62a3-45ea-9d3a-6d8ce94a702e
-        status: 200 OK
-        code: 200
-        duration: 43.487988ms
+                - 83fc352d-ed42-4d5e-8c30-5bebb09f259e
+        status: 204 No Content
+        code: 204
+        duration: 1.720224371s
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1693,7 +1689,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2348dd8b-d057-4f7c-9458-2e956a1de0b0
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/03e50d0f-56d9-451b-ab35-5392d4489fbf
         method: GET
       response:
         proto: HTTP/2.0
@@ -1701,20 +1697,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 598
+        content_length: 588
         uncompressed: false
-        body: '{"created_at":"2025-06-12T15:38:01.889167Z","description":"","environment_variables":{},"error_message":null,"id":"2348dd8b-d057-4f7c-9458-2e956a1de0b0","name":"tf-ns-funny-ritchie","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsfunnyritchieh1ety0mb","registry_namespace_id":"228e784c-9ffe-4826-9b65-3be0c0d3bf96","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-12T15:38:15.041147Z","vpc_integration_activated":true}'
+        body: '{"created_at":"2025-08-27T14:01:39.604470Z","description":"","environment_variables":{},"error_message":null,"id":"03e50d0f-56d9-451b-ab35-5392d4489fbf","name":"tf-ns-brave-mccarthy","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsbravemccarthyq2moobr5","registry_namespace_id":"4d198aa0-b6e1-4b87-ab10-9870e543dda6","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T14:01:58.807119Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "598"
+                - "588"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 12 Jun 2025 15:38:17 GMT
+                - Wed, 27 Aug 2025 14:02:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1722,10 +1718,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4e623d82-1c31-4e0a-970e-b72cca7af517
+                - 7a3a28b5-0a96-476a-bd91-76ce74ceacbf
         status: 200 OK
         code: 200
-        duration: 37.709228ms
+        duration: 48.752722ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1742,7 +1738,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2348dd8b-d057-4f7c-9458-2e956a1de0b0
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/03e50d0f-56d9-451b-ab35-5392d4489fbf
         method: GET
       response:
         proto: HTTP/2.0
@@ -1750,20 +1746,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 598
+        content_length: 588
         uncompressed: false
-        body: '{"created_at":"2025-06-12T15:38:01.889167Z","description":"","environment_variables":{},"error_message":null,"id":"2348dd8b-d057-4f7c-9458-2e956a1de0b0","name":"tf-ns-funny-ritchie","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsfunnyritchieh1ety0mb","registry_namespace_id":"228e784c-9ffe-4826-9b65-3be0c0d3bf96","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-12T15:38:15.041147Z","vpc_integration_activated":true}'
+        body: '{"created_at":"2025-08-27T14:01:39.604470Z","description":"","environment_variables":{},"error_message":null,"id":"03e50d0f-56d9-451b-ab35-5392d4489fbf","name":"tf-ns-brave-mccarthy","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsbravemccarthyq2moobr5","registry_namespace_id":"4d198aa0-b6e1-4b87-ab10-9870e543dda6","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T14:01:58.807119Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "598"
+                - "588"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 12 Jun 2025 15:38:17 GMT
+                - Wed, 27 Aug 2025 14:02:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1771,10 +1767,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9c069f44-2ef3-4033-abcf-9ab21f0e59cd
+                - 9bf6a0c6-fd6f-44c5-beca-072287febfa3
         status: 200 OK
         code: 200
-        duration: 57.622217ms
+        duration: 52.242374ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1791,7 +1787,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2348dd8b-d057-4f7c-9458-2e956a1de0b0
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/03e50d0f-56d9-451b-ab35-5392d4489fbf
         method: GET
       response:
         proto: HTTP/2.0
@@ -1799,20 +1795,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 598
+        content_length: 588
         uncompressed: false
-        body: '{"created_at":"2025-06-12T15:38:01.889167Z","description":"","environment_variables":{},"error_message":null,"id":"2348dd8b-d057-4f7c-9458-2e956a1de0b0","name":"tf-ns-funny-ritchie","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsfunnyritchieh1ety0mb","registry_namespace_id":"228e784c-9ffe-4826-9b65-3be0c0d3bf96","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-12T15:38:15.041147Z","vpc_integration_activated":true}'
+        body: '{"created_at":"2025-08-27T14:01:39.604470Z","description":"","environment_variables":{},"error_message":null,"id":"03e50d0f-56d9-451b-ab35-5392d4489fbf","name":"tf-ns-brave-mccarthy","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsbravemccarthyq2moobr5","registry_namespace_id":"4d198aa0-b6e1-4b87-ab10-9870e543dda6","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T14:01:58.807119Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "598"
+                - "588"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 12 Jun 2025 15:38:17 GMT
+                - Wed, 27 Aug 2025 14:02:14 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1820,50 +1816,48 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e1a75678-b1c3-46c6-aae3-30370840f431
+                - a17110bb-6e6c-4ca5-82c4-a5628d0afdf1
         status: 200 OK
         code: 200
-        duration: 44.399199ms
+        duration: 47.497721ms
     - id: 37
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 295
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"namespace_id":"2348dd8b-d057-4f7c-9458-2e956a1de0b0","name":"tf-co-elegant-cray","privacy":"public","protocol":"http1","secret_environment_variables":null,"http_option":"enabled","sandbox":"v1","tags":null,"private_network_id":"defa2ddd-f588-426e-b9a8-9c9a1fa7e231","command":null,"args":null}'
+        body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers
-        method: POST
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/03e50d0f-56d9-451b-ab35-5392d4489fbf
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1024
+        content_length: 588
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-12T15:38:17.578577732Z","description":"","domain_name":"tfnsfunnyritchieh1ety0mb-tf-co-elegant-cray.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"167120ac-d715-4a3a-8bac-0cb5ac86e7f3","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-elegant-cray","namespace_id":"2348dd8b-d057-4f7c-9458-2e956a1de0b0","port":8080,"privacy":"public","private_network_id":"defa2ddd-f588-426e-b9a8-9c9a1fa7e231","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsfunnyritchieh1ety0mb/tf-co-elegant-cray:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-12T15:38:17.578577732Z"}'
+        body: '{"created_at":"2025-08-27T14:01:39.604470Z","description":"","environment_variables":{},"error_message":null,"id":"03e50d0f-56d9-451b-ab35-5392d4489fbf","name":"tf-ns-brave-mccarthy","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsbravemccarthyq2moobr5","registry_namespace_id":"4d198aa0-b6e1-4b87-ab10-9870e543dda6","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T14:01:58.807119Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "1024"
+                - "588"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 12 Jun 2025 15:38:17 GMT
+                - Wed, 27 Aug 2025 14:02:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1871,10 +1865,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c35da8f2-02bc-4a80-a268-ed0064dbe8e4
+                - 0e58c3fc-5e53-4cb5-91e9-ed20f451f6d2
         status: 200 OK
         code: 200
-        duration: 374.125568ms
+        duration: 53.099654ms
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1891,7 +1885,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/167120ac-d715-4a3a-8bac-0cb5ac86e7f3
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/03e50d0f-56d9-451b-ab35-5392d4489fbf
         method: GET
       response:
         proto: HTTP/2.0
@@ -1899,20 +1893,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1018
+        content_length: 588
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-12T15:38:17.578578Z","description":"","domain_name":"tfnsfunnyritchieh1ety0mb-tf-co-elegant-cray.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"167120ac-d715-4a3a-8bac-0cb5ac86e7f3","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-elegant-cray","namespace_id":"2348dd8b-d057-4f7c-9458-2e956a1de0b0","port":8080,"privacy":"public","private_network_id":"defa2ddd-f588-426e-b9a8-9c9a1fa7e231","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsfunnyritchieh1ety0mb/tf-co-elegant-cray:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-12T15:38:17.578578Z"}'
+        body: '{"created_at":"2025-08-27T14:01:39.604470Z","description":"","environment_variables":{},"error_message":null,"id":"03e50d0f-56d9-451b-ab35-5392d4489fbf","name":"tf-ns-brave-mccarthy","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsbravemccarthyq2moobr5","registry_namespace_id":"4d198aa0-b6e1-4b87-ab10-9870e543dda6","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T14:01:58.807119Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "1018"
+                - "588"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 12 Jun 2025 15:38:17 GMT
+                - Wed, 27 Aug 2025 14:02:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1920,10 +1914,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 03fc631c-0847-43c7-b5f1-bae237819e6e
+                - b4f64d2a-ee75-4f3b-95bf-aa2614959597
         status: 200 OK
         code: 200
-        duration: 68.411276ms
+        duration: 55.324156ms
     - id: 39
       request:
         proto: HTTP/1.1
@@ -1940,7 +1934,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2348dd8b-d057-4f7c-9458-2e956a1de0b0
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/03e50d0f-56d9-451b-ab35-5392d4489fbf
         method: GET
       response:
         proto: HTTP/2.0
@@ -1948,20 +1942,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 598
+        content_length: 37
         uncompressed: false
-        body: '{"created_at":"2025-06-12T15:38:01.889167Z","description":"","environment_variables":{},"error_message":null,"id":"2348dd8b-d057-4f7c-9458-2e956a1de0b0","name":"tf-ns-funny-ritchie","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsfunnyritchieh1ety0mb","registry_namespace_id":"228e784c-9ffe-4826-9b65-3be0c0d3bf96","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-12T15:38:15.041147Z","vpc_integration_activated":true}'
+        body: '{"message":"Namespace was not found"}'
         headers:
             Content-Length:
-                - "598"
+                - "37"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 12 Jun 2025 15:38:17 GMT
+                - Wed, 27 Aug 2025 14:02:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1969,10 +1963,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5d4a5631-805f-4a1b-afa6-f72eb8dcfd96
-        status: 200 OK
-        code: 200
-        duration: 49.382466ms
+                - 58f5110f-b566-4f6b-a9e8-f185bfc3d0f3
+        status: 404 Not Found
+        code: 404
+        duration: 27.513734ms
     - id: 40
       request:
         proto: HTTP/1.1
@@ -1989,28 +1983,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/167120ac-d715-4a3a-8bac-0cb5ac86e7f3
-        method: GET
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/03e50d0f-56d9-451b-ab35-5392d4489fbf
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1018
+        content_length: 37
         uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-12T15:38:17.578578Z","description":"","domain_name":"tfnsfunnyritchieh1ety0mb-tf-co-elegant-cray.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"167120ac-d715-4a3a-8bac-0cb5ac86e7f3","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-elegant-cray","namespace_id":"2348dd8b-d057-4f7c-9458-2e956a1de0b0","port":8080,"privacy":"public","private_network_id":"defa2ddd-f588-426e-b9a8-9c9a1fa7e231","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsfunnyritchieh1ety0mb/tf-co-elegant-cray:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-12T15:38:17.578578Z"}'
+        body: '{"message":"Namespace was not found"}'
         headers:
             Content-Length:
-                - "1018"
+                - "37"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 12 Jun 2025 15:38:17 GMT
+                - Wed, 27 Aug 2025 14:02:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2018,10 +2012,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f6940b51-c0a2-4d6c-852d-f51ac18ff32e
-        status: 200 OK
-        code: 200
-        duration: 56.344409ms
+                - 0c4beb0b-a501-4cbb-8b32-c9b03807a205
+        status: 404 Not Found
+        code: 404
+        duration: 18.927028ms
     - id: 41
       request:
         proto: HTTP/1.1
@@ -2038,789 +2032,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/defa2ddd-f588-426e-b9a8-9c9a1fa7e231
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 1094
-        uncompressed: false
-        body: '{"created_at":"2025-06-12T15:37:35.776479Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"defa2ddd-f588-426e-b9a8-9c9a1fa7e231","name":"tf-pn-fervent-goldwasser","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-06-12T15:37:35.776479Z","id":"a2de567e-8b38-400a-8753-2f25a169541d","private_network_id":"defa2ddd-f588-426e-b9a8-9c9a1fa7e231","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.28.0/22","updated_at":"2025-06-12T15:37:35.776479Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-06-12T15:37:35.776479Z","id":"684ab2a7-d28c-439b-9bf8-2f16ef28f0f8","private_network_id":"defa2ddd-f588-426e-b9a8-9c9a1fa7e231","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:36c0::/64","updated_at":"2025-06-12T15:37:35.776479Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-06-12T15:37:35.776479Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
-        headers:
-            Content-Length:
-                - "1094"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Thu, 12 Jun 2025 15:38:18 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - b7b2e02f-390f-41cb-a512-5d7dd0cf0595
-        status: 200 OK
-        code: 200
-        duration: 44.764976ms
-    - id: 42
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2348dd8b-d057-4f7c-9458-2e956a1de0b0
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 598
-        uncompressed: false
-        body: '{"created_at":"2025-06-12T15:38:01.889167Z","description":"","environment_variables":{},"error_message":null,"id":"2348dd8b-d057-4f7c-9458-2e956a1de0b0","name":"tf-ns-funny-ritchie","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsfunnyritchieh1ety0mb","registry_namespace_id":"228e784c-9ffe-4826-9b65-3be0c0d3bf96","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-12T15:38:15.041147Z","vpc_integration_activated":true}'
-        headers:
-            Content-Length:
-                - "598"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Thu, 12 Jun 2025 15:38:18 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - ff7c0ea6-5dc2-42c0-bcb8-29595d6d8535
-        status: 200 OK
-        code: 200
-        duration: 45.541564ms
-    - id: 43
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/167120ac-d715-4a3a-8bac-0cb5ac86e7f3
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 1018
-        uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-12T15:38:17.578578Z","description":"","domain_name":"tfnsfunnyritchieh1ety0mb-tf-co-elegant-cray.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"167120ac-d715-4a3a-8bac-0cb5ac86e7f3","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-elegant-cray","namespace_id":"2348dd8b-d057-4f7c-9458-2e956a1de0b0","port":8080,"privacy":"public","private_network_id":"defa2ddd-f588-426e-b9a8-9c9a1fa7e231","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsfunnyritchieh1ety0mb/tf-co-elegant-cray:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-12T15:38:17.578578Z"}'
-        headers:
-            Content-Length:
-                - "1018"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Thu, 12 Jun 2025 15:38:18 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 798fa5c4-cc3c-4602-bdec-62fa658751c8
-        status: 200 OK
-        code: 200
-        duration: 108.049906ms
-    - id: 44
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/167120ac-d715-4a3a-8bac-0cb5ac86e7f3
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 1018
-        uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-12T15:38:17.578578Z","description":"","domain_name":"tfnsfunnyritchieh1ety0mb-tf-co-elegant-cray.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"167120ac-d715-4a3a-8bac-0cb5ac86e7f3","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-elegant-cray","namespace_id":"2348dd8b-d057-4f7c-9458-2e956a1de0b0","port":8080,"privacy":"public","private_network_id":"defa2ddd-f588-426e-b9a8-9c9a1fa7e231","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsfunnyritchieh1ety0mb/tf-co-elegant-cray:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-12T15:38:17.578578Z"}'
-        headers:
-            Content-Length:
-                - "1018"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Thu, 12 Jun 2025 15:38:19 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - c891da4f-5b10-4948-b96a-992e30a0cb0c
-        status: 200 OK
-        code: 200
-        duration: 49.570679ms
-    - id: 45
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/167120ac-d715-4a3a-8bac-0cb5ac86e7f3
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 1022
-        uncompressed: false
-        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-06-12T15:38:17.578578Z","description":"","domain_name":"tfnsfunnyritchieh1ety0mb-tf-co-elegant-cray.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"167120ac-d715-4a3a-8bac-0cb5ac86e7f3","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-elegant-cray","namespace_id":"2348dd8b-d057-4f7c-9458-2e956a1de0b0","port":8080,"privacy":"public","private_network_id":"defa2ddd-f588-426e-b9a8-9c9a1fa7e231","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsfunnyritchieh1ety0mb/tf-co-elegant-cray:latest","sandbox":"v1","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2025-06-12T15:38:19.844533553Z"}'
-        headers:
-            Content-Length:
-                - "1022"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Thu, 12 Jun 2025 15:38:19 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 09f359ec-6fd0-4383-a470-c1ad7d6f1989
-        status: 200 OK
-        code: 200
-        duration: 146.334323ms
-    - id: 46
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2348dd8b-d057-4f7c-9458-2e956a1de0b0
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 598
-        uncompressed: false
-        body: '{"created_at":"2025-06-12T15:38:01.889167Z","description":"","environment_variables":{},"error_message":null,"id":"2348dd8b-d057-4f7c-9458-2e956a1de0b0","name":"tf-ns-funny-ritchie","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsfunnyritchieh1ety0mb","registry_namespace_id":"228e784c-9ffe-4826-9b65-3be0c0d3bf96","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-12T15:38:15.041147Z","vpc_integration_activated":true}'
-        headers:
-            Content-Length:
-                - "598"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Thu, 12 Jun 2025 15:38:19 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 3416a002-d140-4874-831c-9c4a4749e5b6
-        status: 200 OK
-        code: 200
-        duration: 67.41202ms
-    - id: 47
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2348dd8b-d057-4f7c-9458-2e956a1de0b0
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 604
-        uncompressed: false
-        body: '{"created_at":"2025-06-12T15:38:01.889167Z","description":"","environment_variables":{},"error_message":null,"id":"2348dd8b-d057-4f7c-9458-2e956a1de0b0","name":"tf-ns-funny-ritchie","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsfunnyritchieh1ety0mb","registry_namespace_id":"228e784c-9ffe-4826-9b65-3be0c0d3bf96","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-06-12T15:38:20.052791395Z","vpc_integration_activated":true}'
-        headers:
-            Content-Length:
-                - "604"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Thu, 12 Jun 2025 15:38:20 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 71588b5c-6952-4ef1-9fa0-742a709c0427
-        status: 200 OK
-        code: 200
-        duration: 205.466987ms
-    - id: 48
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2348dd8b-d057-4f7c-9458-2e956a1de0b0
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 601
-        uncompressed: false
-        body: '{"created_at":"2025-06-12T15:38:01.889167Z","description":"","environment_variables":{},"error_message":null,"id":"2348dd8b-d057-4f7c-9458-2e956a1de0b0","name":"tf-ns-funny-ritchie","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsfunnyritchieh1ety0mb","registry_namespace_id":"228e784c-9ffe-4826-9b65-3be0c0d3bf96","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-06-12T15:38:20.052791Z","vpc_integration_activated":true}'
-        headers:
-            Content-Length:
-                - "601"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Thu, 12 Jun 2025 15:38:20 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - b1fdce57-4bef-46a3-8ed8-8bf51789b607
-        status: 200 OK
-        code: 200
-        duration: 47.479793ms
-    - id: 49
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/defa2ddd-f588-426e-b9a8-9c9a1fa7e231
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 0
-        uncompressed: false
-        body: ""
-        headers:
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Thu, 12 Jun 2025 15:38:21 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 9e30e23f-285a-4079-8f82-2155f082a681
-        status: 204 No Content
-        code: 204
-        duration: 1.308240842s
-    - id: 50
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2348dd8b-d057-4f7c-9458-2e956a1de0b0
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 601
-        uncompressed: false
-        body: '{"created_at":"2025-06-12T15:38:01.889167Z","description":"","environment_variables":{},"error_message":null,"id":"2348dd8b-d057-4f7c-9458-2e956a1de0b0","name":"tf-ns-funny-ritchie","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsfunnyritchieh1ety0mb","registry_namespace_id":"228e784c-9ffe-4826-9b65-3be0c0d3bf96","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-06-12T15:38:20.052791Z","vpc_integration_activated":true}'
-        headers:
-            Content-Length:
-                - "601"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Thu, 12 Jun 2025 15:38:25 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 04aed6dd-6e22-47e0-be35-995e01dfa12b
-        status: 200 OK
-        code: 200
-        duration: 52.888549ms
-    - id: 51
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2348dd8b-d057-4f7c-9458-2e956a1de0b0
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 601
-        uncompressed: false
-        body: '{"created_at":"2025-06-12T15:38:01.889167Z","description":"","environment_variables":{},"error_message":null,"id":"2348dd8b-d057-4f7c-9458-2e956a1de0b0","name":"tf-ns-funny-ritchie","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsfunnyritchieh1ety0mb","registry_namespace_id":"228e784c-9ffe-4826-9b65-3be0c0d3bf96","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-06-12T15:38:20.052791Z","vpc_integration_activated":true}'
-        headers:
-            Content-Length:
-                - "601"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Thu, 12 Jun 2025 15:38:30 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 2483bb26-e884-4f91-90b7-9d421d88269a
-        status: 200 OK
-        code: 200
-        duration: 49.217887ms
-    - id: 52
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2348dd8b-d057-4f7c-9458-2e956a1de0b0
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 601
-        uncompressed: false
-        body: '{"created_at":"2025-06-12T15:38:01.889167Z","description":"","environment_variables":{},"error_message":null,"id":"2348dd8b-d057-4f7c-9458-2e956a1de0b0","name":"tf-ns-funny-ritchie","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsfunnyritchieh1ety0mb","registry_namespace_id":"228e784c-9ffe-4826-9b65-3be0c0d3bf96","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-06-12T15:38:20.052791Z","vpc_integration_activated":true}'
-        headers:
-            Content-Length:
-                - "601"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Thu, 12 Jun 2025 15:38:35 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - e22c1c58-b125-47e7-809f-b44d90374989
-        status: 200 OK
-        code: 200
-        duration: 47.690578ms
-    - id: 53
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2348dd8b-d057-4f7c-9458-2e956a1de0b0
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 601
-        uncompressed: false
-        body: '{"created_at":"2025-06-12T15:38:01.889167Z","description":"","environment_variables":{},"error_message":null,"id":"2348dd8b-d057-4f7c-9458-2e956a1de0b0","name":"tf-ns-funny-ritchie","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsfunnyritchieh1ety0mb","registry_namespace_id":"228e784c-9ffe-4826-9b65-3be0c0d3bf96","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-06-12T15:38:20.052791Z","vpc_integration_activated":true}'
-        headers:
-            Content-Length:
-                - "601"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Thu, 12 Jun 2025 15:38:40 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - e0036ec6-487f-48a6-8412-c3dc79297f5f
-        status: 200 OK
-        code: 200
-        duration: 48.166131ms
-    - id: 54
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2348dd8b-d057-4f7c-9458-2e956a1de0b0
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 601
-        uncompressed: false
-        body: '{"created_at":"2025-06-12T15:38:01.889167Z","description":"","environment_variables":{},"error_message":null,"id":"2348dd8b-d057-4f7c-9458-2e956a1de0b0","name":"tf-ns-funny-ritchie","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsfunnyritchieh1ety0mb","registry_namespace_id":"228e784c-9ffe-4826-9b65-3be0c0d3bf96","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-06-12T15:38:20.052791Z","vpc_integration_activated":true}'
-        headers:
-            Content-Length:
-                - "601"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Thu, 12 Jun 2025 15:38:45 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 79783d46-6944-4a2d-b1c2-5cbf0afed9a4
-        status: 200 OK
-        code: 200
-        duration: 44.351679ms
-    - id: 55
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2348dd8b-d057-4f7c-9458-2e956a1de0b0
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 37
-        uncompressed: false
-        body: '{"message":"Namespace was not found"}'
-        headers:
-            Content-Length:
-                - "37"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Thu, 12 Jun 2025 15:38:50 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 499c0614-79c8-4227-95b6-908a0f5637f7
-        status: 404 Not Found
-        code: 404
-        duration: 36.72567ms
-    - id: 56
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/2348dd8b-d057-4f7c-9458-2e956a1de0b0
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 37
-        uncompressed: false
-        body: '{"message":"Namespace was not found"}'
-        headers:
-            Content-Length:
-                - "37"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Thu, 12 Jun 2025 15:38:50 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 385e928c-0820-4c0d-875a-a66715461cc3
-        status: 404 Not Found
-        code: 404
-        duration: 29.086877ms
-    - id: 57
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/2348dd8b-d057-4f7c-9458-2e956a1de0b0
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/03e50d0f-56d9-451b-ab35-5392d4489fbf
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -2839,9 +2051,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 12 Jun 2025 15:38:50 GMT
+                - Wed, 27 Aug 2025 14:02:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2849,11 +2061,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 413d581a-ab99-4f49-91ff-3ddbf061214c
+                - bb768030-b4a5-4fbb-8a59-f90f0d777f5d
         status: 404 Not Found
         code: 404
-        duration: 29.590282ms
-    - id: 58
+        duration: 23.261929ms
+    - id: 42
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2869,7 +2081,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/defa2ddd-f588-426e-b9a8-9c9a1fa7e231
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/1510a03d-65c6-4fb4-ad5f-e10774ccf565
         method: GET
       response:
         proto: HTTP/2.0
@@ -2879,7 +2091,7 @@ interactions:
         trailer: {}
         content_length: 136
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"private_network","resource_id":"defa2ddd-f588-426e-b9a8-9c9a1fa7e231","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"private_network","resource_id":"1510a03d-65c6-4fb4-ad5f-e10774ccf565","type":"not_found"}'
         headers:
             Content-Length:
                 - "136"
@@ -2888,9 +2100,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 12 Jun 2025 15:38:50 GMT
+                - Wed, 27 Aug 2025 14:02:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2898,7 +2110,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 408364b0-a7eb-4961-936a-1cc91758122d
+                - 042705a5-7d55-466d-a50a-233fe5407cf8
         status: 404 Not Found
         code: 404
-        duration: 31.99134ms
+        duration: 23.291314ms

--- a/internal/services/container/testdata/token-basic.cassette.yaml
+++ b/internal/services/container/testdata/token-basic.cassette.yaml
@@ -6,19 +6,19 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 159
+        content_length: 191
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"test-container-token-ns","environment_variables":{},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","secret_environment_variables":[],"tags":null}'
+        body: '{"name":"test-container-token-ns","environment_variables":{},"project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","secret_environment_variables":[],"tags":null,"activate_vpc_integration":true}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces
         method: POST
       response:
@@ -27,20 +27,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 489
+        content_length: 508
         uncompressed: false
-        body: '{"created_at":"2025-01-27T14:28:17.230570372Z","description":"","environment_variables":{},"error_message":null,"id":"99e97ccb-1674-4512-be2f-49af20af694f","name":"test-container-token-ns","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-27T14:28:17.230570372Z"}'
+        body: '{"created_at":"2025-08-27T15:05:50.219203381Z","description":"","environment_variables":{},"error_message":null,"id":"bb0c03ad-4243-4a03-bbcb-83721935a599","name":"test-container-token-ns","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:50.219203381Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "489"
+                - "508"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:28:17 GMT
+                - Wed, 27 Aug 2025 15:05:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2d641884-e93d-45cd-b1ff-14af3e2adf03
+                - d0e3a4c9-88f6-4bfa-8169-f7fb1b45e588
         status: 200 OK
         code: 200
-        duration: 591.061917ms
+        duration: 821.913515ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -67,8 +67,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/99e97ccb-1674-4512-be2f-49af20af694f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/bb0c03ad-4243-4a03-bbcb-83721935a599
         method: GET
       response:
         proto: HTTP/2.0
@@ -76,20 +76,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 483
+        content_length: 502
         uncompressed: false
-        body: '{"created_at":"2025-01-27T14:28:17.230570Z","description":"","environment_variables":{},"error_message":null,"id":"99e97ccb-1674-4512-be2f-49af20af694f","name":"test-container-token-ns","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-27T14:28:17.230570Z"}'
+        body: '{"created_at":"2025-08-27T15:05:50.219203Z","description":"","environment_variables":{},"error_message":null,"id":"bb0c03ad-4243-4a03-bbcb-83721935a599","name":"test-container-token-ns","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:50.219203Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "483"
+                - "502"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:28:17 GMT
+                - Wed, 27 Aug 2025 15:05:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7219b46d-2ce3-4770-aded-5f5746a819c1
+                - c66e60bd-570e-428f-9228-9fd08137d7fe
         status: 200 OK
         code: 200
-        duration: 91.709334ms
+        duration: 99.95045ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -116,8 +116,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/99e97ccb-1674-4512-be2f-49af20af694f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/bb0c03ad-4243-4a03-bbcb-83721935a599
         method: GET
       response:
         proto: HTTP/2.0
@@ -125,20 +125,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 483
+        content_length: 593
         uncompressed: false
-        body: '{"created_at":"2025-01-27T14:28:17.230570Z","description":"","environment_variables":{},"error_message":null,"id":"99e97ccb-1674-4512-be2f-49af20af694f","name":"test-container-token-ns","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-27T14:28:17.230570Z"}'
+        body: '{"created_at":"2025-08-27T15:05:50.219203Z","description":"","environment_variables":{},"error_message":null,"id":"bb0c03ad-4243-4a03-bbcb-83721935a599","name":"test-container-token-ns","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcontainertokenns4sheziip","registry_namespace_id":"325af02a-d343-4174-b32c-963f10295b52","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:53.356484Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "483"
+                - "593"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:28:22 GMT
+                - Wed, 27 Aug 2025 15:05:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -146,10 +146,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 456b68bb-8243-4e15-b10f-85b9d7d5ceff
+                - 7b692d3b-e999-4de1-ae29-7b5c0c8dddcf
         status: 200 OK
         code: 200
-        duration: 80.357125ms
+        duration: 89.936692ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -165,8 +165,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/99e97ccb-1674-4512-be2f-49af20af694f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/bb0c03ad-4243-4a03-bbcb-83721935a599
         method: GET
       response:
         proto: HTTP/2.0
@@ -174,20 +174,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 483
+        content_length: 593
         uncompressed: false
-        body: '{"created_at":"2025-01-27T14:28:17.230570Z","description":"","environment_variables":{},"error_message":null,"id":"99e97ccb-1674-4512-be2f-49af20af694f","name":"test-container-token-ns","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-27T14:28:24.437985Z"}'
+        body: '{"created_at":"2025-08-27T15:05:50.219203Z","description":"","environment_variables":{},"error_message":null,"id":"bb0c03ad-4243-4a03-bbcb-83721935a599","name":"test-container-token-ns","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcontainertokenns4sheziip","registry_namespace_id":"325af02a-d343-4174-b32c-963f10295b52","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:53.356484Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "483"
+                - "593"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:28:27 GMT
+                - Wed, 27 Aug 2025 15:06:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -195,10 +195,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a84f9ad7-490c-4cc2-adc2-b170a2368f52
+                - a396e574-9e18-49d5-87be-a34986e7ba5b
         status: 200 OK
         code: 200
-        duration: 62.295333ms
+        duration: 83.948156ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -214,8 +214,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/99e97ccb-1674-4512-be2f-49af20af694f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/bb0c03ad-4243-4a03-bbcb-83721935a599
         method: GET
       response:
         proto: HTTP/2.0
@@ -223,20 +223,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 483
+        content_length: 591
         uncompressed: false
-        body: '{"created_at":"2025-01-27T14:28:17.230570Z","description":"","environment_variables":{},"error_message":null,"id":"99e97ccb-1674-4512-be2f-49af20af694f","name":"test-container-token-ns","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-27T14:28:24.437985Z"}'
+        body: '{"created_at":"2025-08-27T15:05:50.219203Z","description":"","environment_variables":{},"error_message":null,"id":"bb0c03ad-4243-4a03-bbcb-83721935a599","name":"test-container-token-ns","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcontainertokenns4sheziip","registry_namespace_id":"325af02a-d343-4174-b32c-963f10295b52","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:04.519616Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "483"
+                - "591"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:28:32 GMT
+                - Wed, 27 Aug 2025 15:06:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -244,10 +244,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 73863718-974a-4c55-8a79-94ecb9b56909
+                - 1f18a0b1-181b-4b3f-8f33-581de66b7743
         status: 200 OK
         code: 200
-        duration: 88.281208ms
+        duration: 77.311663ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -263,8 +263,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/99e97ccb-1674-4512-be2f-49af20af694f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/bb0c03ad-4243-4a03-bbcb-83721935a599
         method: GET
       response:
         proto: HTTP/2.0
@@ -272,20 +272,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 483
+        content_length: 591
         uncompressed: false
-        body: '{"created_at":"2025-01-27T14:28:17.230570Z","description":"","environment_variables":{},"error_message":null,"id":"99e97ccb-1674-4512-be2f-49af20af694f","name":"test-container-token-ns","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-27T14:28:24.437985Z"}'
+        body: '{"created_at":"2025-08-27T15:05:50.219203Z","description":"","environment_variables":{},"error_message":null,"id":"bb0c03ad-4243-4a03-bbcb-83721935a599","name":"test-container-token-ns","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcontainertokenns4sheziip","registry_namespace_id":"325af02a-d343-4174-b32c-963f10295b52","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:04.519616Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "483"
+                - "591"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:28:37 GMT
+                - Wed, 27 Aug 2025 15:06:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -293,10 +293,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 58486ef6-6350-41e1-bd1a-5bace861d46a
+                - c7655593-a394-4368-9861-be90fd776a13
         status: 200 OK
         code: 200
-        duration: 67.386333ms
+        duration: 89.676226ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -312,8 +312,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/99e97ccb-1674-4512-be2f-49af20af694f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/bb0c03ad-4243-4a03-bbcb-83721935a599
         method: GET
       response:
         proto: HTTP/2.0
@@ -321,20 +321,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 483
+        content_length: 591
         uncompressed: false
-        body: '{"created_at":"2025-01-27T14:28:17.230570Z","description":"","environment_variables":{},"error_message":null,"id":"99e97ccb-1674-4512-be2f-49af20af694f","name":"test-container-token-ns","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-27T14:28:24.437985Z"}'
+        body: '{"created_at":"2025-08-27T15:05:50.219203Z","description":"","environment_variables":{},"error_message":null,"id":"bb0c03ad-4243-4a03-bbcb-83721935a599","name":"test-container-token-ns","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcontainertokenns4sheziip","registry_namespace_id":"325af02a-d343-4174-b32c-963f10295b52","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:04.519616Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "483"
+                - "591"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:28:42 GMT
+                - Wed, 27 Aug 2025 15:06:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -342,48 +342,50 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5ff5da6b-c154-48c2-97dd-ba839dd7e695
+                - 4299e1a8-e4e1-46c8-b02c-70a15f973717
         status: 200 OK
         code: 200
-        duration: 70.163125ms
+        duration: 91.064491ms
     - id: 7
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 96
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"namespace_id":"bb0c03ad-4243-4a03-bbcb-83721935a599","expires_at":"2025-08-28T17:05:34+02:00"}'
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/99e97ccb-1674-4512-be2f-49af20af694f
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/tokens
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 483
+        content_length: 2050
         uncompressed: false
-        body: '{"created_at":"2025-01-27T14:28:17.230570Z","description":"","environment_variables":{},"error_message":null,"id":"99e97ccb-1674-4512-be2f-49af20af694f","name":"test-container-token-ns","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-27T14:28:24.437985Z"}'
+        body: '{"description":"","expires_at":"2025-08-28T15:05:34Z","id":"e39d6f5e-edc4-488e-8121-101c6dfaa778","namespace_id":"bb0c03ad-4243-4a03-bbcb-83721935a599","public_key":"-----BEGIN RSA PUBLIC KEY-----\nMIICCgKCAgEA4rTYdVC9XWWAI/9OhYcUgAgvJS1jwLgElJAuqrJSQxtrVIPbHYee\nslhB//O+MgyS+jG+mlNizi901QksIg2qcO9yqgBczYwZUn4vsiX7kOABtLMR5b1n\nLxafptwAiaYYIJT5+OXZ84NhVW/y1atZH3lcc1SqBGYExesfLyWW+8zdRRGNwTtf\nJ7aF7r88H5Ahxwy/o/2yoCJZaFaJifSGEeQJLZs4vZljwUgJUCA5qWEGydeAoZJv\n5kJCu0Flrxi5DS/JT2PsIa4SO25fH9xodusxMH7faYWpEqajNtQS7EWtCgbLsPgl\nZbagozrNPAuOIVo96BKP680pxa4XfOd7/SMM3fdSf7NSHGncdzE0/6cCvmqrh9qQ\nzU66N7GwIDo9lM2YQOlYaVmndq20W5/9ZGkj9lY+fkNWzeaHE8N1Js2UDd8KzPE0\nMAdmBYlDyaWz9qV5LRuGHcC0XXjXHZ0uLMxoxF1YK03vWBHy24A6L/eUOzGUQCGK\nxWzaFLx82e30AaH4EWwtj3lWzvdFE240344i1HafflAuTeswNFakMSUVXQEEx/aN\nffa946zR9mF9mIok8OnZXHZ1JpKvD5kwlNKvy++AMv4wC6Eyt/rLC+r9sjd2pPdL\n/tfAQn9w7e6hv5nXsHHGTYr7kZZbPJ4qs8N0xNQl4XNG7RN8yU20RNUCAwEAAQ==\n-----END RSA PUBLIC KEY-----\n","status":"creating","token":"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJhcHBsaWNhdGlvbl9jbGFpbSI6W3sibmFtZXNwYWNlX2lkIjoiYmIwYzAzYWQtNDI0My00YTAzLWJiY2ItODM3MjE5MzVhNTk5IiwiYXBwbGljYXRpb25faWQiOiIifV0sInZlcnNpb24iOjIsImF1ZCI6ImZ1bmN0aW9ucyIsImV4cCI6MTc1NjM5MzUzNCwianRpIjoiZTM5ZDZmNWUtZWRjNC00ODhlLTgxMjEtMTAxYzZkZmFhNzc4IiwiaWF0IjoxNzU2MzA3MTY1LCJpc3MiOiJTQ0FMRVdBWSIsIm5iZiI6MTc1NjMwNzE2NSwic3ViIjoidG9rZW4ifQ.xvEw44b9CxssNYULIZsHC-IJ1LMbeg7xosRuzG0OBV07anmSySUcTDvhIr29kN6M0XPmzngGAafOGYOE-axdoZgDJNQrXEpuI108NaBiXAGa611qkx4-wfY9zDGPPU6m-SGzAajxD31IyfJiAzyauA7uBmLON0et-V5rJtL0_UIYGDi2NSpVK9k761F9eu9Xbb9XV8wouPJaBPHhxfAZi803mCiejilN-t5bAiUaBDaAUIC96vUgjNAeRGAHmaGxwPRCkKvexJ8asN6tW05QHMothZ-fG20CaxeYr8Od8BPLUxPYU7Iy5hN9qUeUawDghefcf_4qCI9uamJe_KdM5emNVbu9RdKMZ7EWMfXrWUo6GQCgtYjXx5ZulOiEoRFiQBp6pZ4eGzw8EdBszw3KWrmXesZmCIhTGlaX2-H49MhwOttzvxciTiVM4aLCwAw9s45v97EPSdOLinbjr9P4hJTLsRMy8Tu5Mg--HEV26jSWB2wRAsSDgp5evWVbI4ncviQPsmbvUgQRvjPxn8lz8e2fKHhIRbLiOPSVSDiS2_vpveHJohWK5gjRMPPBTQ8JIsSr3Z8JeVLf5ko_-DWadEK4ZwrfjQORVdSW8Qb5fPGv2-HD2UoPC13ICz_UmWq1OoECpuTme8Bz8SS5oeSJj4efbVMVHhYHQEmbbqaUGzE"}'
         headers:
             Content-Length:
-                - "483"
+                - "2050"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:28:47 GMT
+                - Wed, 27 Aug 2025 15:06:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -391,10 +393,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b6ed354d-6c68-4030-b723-d46380055ceb
+                - 2d1c2721-7baa-4a6f-beca-01f6408a3ddb
         status: 200 OK
         code: 200
-        duration: 67.98625ms
+        duration: 281.882057ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -410,8 +412,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/99e97ccb-1674-4512-be2f-49af20af694f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/tokens/e39d6f5e-edc4-488e-8121-101c6dfaa778
         method: GET
       response:
         proto: HTTP/2.0
@@ -419,20 +421,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 572
+        content_length: 207
         uncompressed: false
-        body: '{"created_at":"2025-01-27T14:28:17.230570Z","description":"","environment_variables":{},"error_message":null,"id":"99e97ccb-1674-4512-be2f-49af20af694f","name":"test-container-token-ns","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcontainertokennsiwvvoenn","registry_namespace_id":"e5a96d6f-6d9d-4fe3-9e29-0ba82637aab0","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-27T14:28:50.388662Z"}'
+        body: '{"description":"","expires_at":"2025-08-28T15:05:34Z","id":"e39d6f5e-edc4-488e-8121-101c6dfaa778","namespace_id":"bb0c03ad-4243-4a03-bbcb-83721935a599","public_key":"","status":"creating","token":"\u003chidden\u003e"}'
         headers:
             Content-Length:
-                - "572"
+                - "207"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:28:52 GMT
+                - Wed, 27 Aug 2025 15:06:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -440,48 +442,50 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 31b5e28d-f42a-45fc-91aa-0bde0651890f
+                - 6d4f7426-84f1-47f6-af4b-1f85405c2139
         status: 200 OK
         code: 200
-        duration: 78.24ms
+        duration: 88.361488ms
     - id: 9
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 259
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"namespace_id":"bb0c03ad-4243-4a03-bbcb-83721935a599","name":"tf-co-condescending-aryabhata","privacy":"public","protocol":"http1","secret_environment_variables":null,"http_option":"enabled","sandbox":"unknown_sandbox","tags":null,"command":null,"args":null}'
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/99e97ccb-1674-4512-be2f-49af20af694f
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 572
+        content_length: 998
         uncompressed: false
-        body: '{"created_at":"2025-01-27T14:28:17.230570Z","description":"","environment_variables":{},"error_message":null,"id":"99e97ccb-1674-4512-be2f-49af20af694f","name":"test-container-token-ns","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcontainertokennsiwvvoenn","registry_namespace_id":"e5a96d6f-6d9d-4fe3-9e29-0ba82637aab0","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-27T14:28:50.388662Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:06.590067148Z","description":"","domain_name":"testcontainertokenns4sheziip-tf-co-condescending-aryabhata.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"12e72f95-3f8c-4b83-bc75-752f74cdfedc","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-condescending-aryabhata","namespace_id":"bb0c03ad-4243-4a03-bbcb-83721935a599","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtestcontainertokenns4sheziip/tf-co-condescending-aryabhata:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:06.590067148Z"}'
         headers:
             Content-Length:
-                - "572"
+                - "998"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:28:53 GMT
+                - Wed, 27 Aug 2025 15:06:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -489,10 +493,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - eba74dde-f194-4375-ab3c-0735fc444ff4
+                - b3a86659-0f5e-45d8-8b96-2f553b64795c
         status: 200 OK
         code: 200
-        duration: 92.020791ms
+        duration: 887.876887ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -508,8 +512,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/99e97ccb-1674-4512-be2f-49af20af694f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/12e72f95-3f8c-4b83-bc75-752f74cdfedc
         method: GET
       response:
         proto: HTTP/2.0
@@ -517,20 +521,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 572
+        content_length: 992
         uncompressed: false
-        body: '{"created_at":"2025-01-27T14:28:17.230570Z","description":"","environment_variables":{},"error_message":null,"id":"99e97ccb-1674-4512-be2f-49af20af694f","name":"test-container-token-ns","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcontainertokennsiwvvoenn","registry_namespace_id":"e5a96d6f-6d9d-4fe3-9e29-0ba82637aab0","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-27T14:28:50.388662Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:06.590067Z","description":"","domain_name":"testcontainertokenns4sheziip-tf-co-condescending-aryabhata.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"12e72f95-3f8c-4b83-bc75-752f74cdfedc","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-condescending-aryabhata","namespace_id":"bb0c03ad-4243-4a03-bbcb-83721935a599","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtestcontainertokenns4sheziip/tf-co-condescending-aryabhata:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:06.590067Z"}'
         headers:
             Content-Length:
-                - "572"
+                - "992"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:28:53 GMT
+                - Wed, 27 Aug 2025 15:06:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -538,28 +542,28 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4c1d8eeb-4f8c-4887-8500-bab643742c5d
+                - 9cf688f2-80e0-4dce-8570-6138ed692b77
         status: 200 OK
         code: 200
-        duration: 60.911083ms
+        duration: 117.232546ms
     - id: 11
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 96
+        content_length: 55
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"namespace_id":"99e97ccb-1674-4512-be2f-49af20af694f","expires_at":"2025-01-28T15:28:16+01:00"}'
+        body: '{"container_id":"12e72f95-3f8c-4b83-bc75-752f74cdfedc"}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/tokens
         method: POST
       response:
@@ -568,20 +572,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2056
+        content_length: 2009
         uncompressed: false
-        body: '{"description":"","expires_at":"2025-01-28T14:28:16Z","id":"b32fb58d-ca08-435d-974e-3b1ae1ad02a4","namespace_id":"99e97ccb-1674-4512-be2f-49af20af694f","public_key":"-----BEGIN RSA PUBLIC KEY-----\nMIICCgKCAgEArst9TSyYxe7APQ5/oaaT547c/XNpZQgxuhjSUMlKWqZlh6EK+qdi\nmslJOGZnJ4yXorLQGLHAXMhU0B5lGFXGfLGjJE4RPa3B39CwYUkRN9p7vKJWCyMI\nuoFu+ayeHoGvWgyWypwAnIV+H8C9rjKOzByfXgWxQAjwPDnbOi6mt7lDuGjlVGHu\nBBC/gPVC1fvGwREgzls8H16XXj4QA5izY/lB5rKbS87kacWamGCWXOVeKLCX6Lfl\nBU/gtV5puq/8nZ5IHsWSOmn7jAuB3A9Jkx/5bd0DlY3yIbBmb/awvX/PVhQPhQhk\nEqgDj+N0ahtoaByI4SeQrHij73jcXxCPpZj92+OVao1DV+pPc8VHYpSVgcy60+iT\nDhGeQo6zTvDfvanzwmeESH2RN0XWA/0N3awyNNXk4y6zc+4OrKJ0A1gy8J7JBwuq\n72F0pv99t8TnRi9XlqCD4Q/6EM7zBQiv5axqieSUBC9IIGQVcPkjFrmy/lHOvedU\ngcGyFdUMZPJXZdK0iu2aghRFq88D47mEoP39k6eiTzmKZjTgK13fGYZFxVAgnuyW\nKsThygTsvyV66TQfg38pCw0sIYYE3pEXguEEMHQMOEqLc9RywCfgdsmQnjWOQ6/V\n2HsST12d9ude8I+IUh1WXSkXVzUE1nrYopsnTl792G6W6GN3juXoOOsCAwEAAQ==\n-----END RSA PUBLIC KEY-----\n","status":"creating","token":"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJhcHBsaWNhdGlvbl9jbGFpbSI6W3sibmFtZXNwYWNlX2lkIjoiOTllOTdjY2ItMTY3NC00NTEyLWJlMmYtNDlhZjIwYWY2OTRmIiwiYXBwbGljYXRpb25faWQiOiIifV0sInZlcnNpb24iOjIsImF1ZCI6ImZ1bmN0aW9ucyIsImV4cCI6MTczODA3NDQ5NiwianRpIjoiYjMyZmI1OGQtY2EwOC00MzVkLTk3NGUtM2IxYWUxYWQwMmE0IiwiaWF0IjoxNzM3OTg4MTMzLCJpc3MiOiJTQ0FMRVdBWSIsIm5iZiI6MTczNzk4ODEzMywic3ViIjoidG9rZW4ifQ.V3tbRm0-Q_UOceOMUIuSrfWyU01a5WMQFwDjGVNpnJ_c9R87mU0jmdUGv9oZ686t6W1X9UQxT7_WbMJ4f6ppP1PF2WcfaHTSGdC0NwbwBbYXb90pwcKo5otoFejhGb_7KZ87L7Od70tvGoiXC7r7A3w-syUb58jL6jAFMRsSLvfeiQ7s3p1KvHP2Iw6Qesx6UiGiQOGgV3kJF9XVgZkWCui7RPa36d8dBEDh9goxajDYCTYzYe9IGzbumV1ut3Lis2CmeS6guZo8x-CQ4CgK5dId7hBGe3Hzyf8qH1k5Ej5xDEgYr-MvqI49RKGdl6ZFSMre_MBKpmpYmveqrEbtXsIGSsYgHB0hOg8obhdbTPQd2vBt7kd87pQkyd_QgDN2SiWFim7yhTSD9YVYN6Weo0TmxWh4SPH4eUeqqVC8E0EijAfUlnKYxbNiQV1RFs2c7Esm_xln_tSfBe9Lpv3oJ3RCQziKuLLBTINmWddzPltnoLNJrdkoe7m8AEHV0VOIQhyldogB0w-IdquV0isQANkN3B6YKFs6m7i8M3bj6oF2ghAnyCE3IpIbQVH-O1exslJGaPhNA-tsxaL5bpJ_6iTU_MYJO66fguz87IZapX44SE2ubVj_qRYn9gGPJzf4Za_Z_Em6YJSxiOQD1QA_NCXlUvwV9lQm3clqIUUbKPc"}'
+        body: '{"container_id":"12e72f95-3f8c-4b83-bc75-752f74cdfedc","description":"","expires_at":null,"id":"e345de0a-9a63-4a34-ad95-5a145ecb376e","public_key":"-----BEGIN RSA PUBLIC KEY-----\nMIICCgKCAgEA4rTYdVC9XWWAI/9OhYcUgAgvJS1jwLgElJAuqrJSQxtrVIPbHYee\nslhB//O+MgyS+jG+mlNizi901QksIg2qcO9yqgBczYwZUn4vsiX7kOABtLMR5b1n\nLxafptwAiaYYIJT5+OXZ84NhVW/y1atZH3lcc1SqBGYExesfLyWW+8zdRRGNwTtf\nJ7aF7r88H5Ahxwy/o/2yoCJZaFaJifSGEeQJLZs4vZljwUgJUCA5qWEGydeAoZJv\n5kJCu0Flrxi5DS/JT2PsIa4SO25fH9xodusxMH7faYWpEqajNtQS7EWtCgbLsPgl\nZbagozrNPAuOIVo96BKP680pxa4XfOd7/SMM3fdSf7NSHGncdzE0/6cCvmqrh9qQ\nzU66N7GwIDo9lM2YQOlYaVmndq20W5/9ZGkj9lY+fkNWzeaHE8N1Js2UDd8KzPE0\nMAdmBYlDyaWz9qV5LRuGHcC0XXjXHZ0uLMxoxF1YK03vWBHy24A6L/eUOzGUQCGK\nxWzaFLx82e30AaH4EWwtj3lWzvdFE240344i1HafflAuTeswNFakMSUVXQEEx/aN\nffa946zR9mF9mIok8OnZXHZ1JpKvD5kwlNKvy++AMv4wC6Eyt/rLC+r9sjd2pPdL\n/tfAQn9w7e6hv5nXsHHGTYr7kZZbPJ4qs8N0xNQl4XNG7RN8yU20RNUCAwEAAQ==\n-----END RSA PUBLIC KEY-----\n","status":"creating","token":"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJhcHBsaWNhdGlvbl9jbGFpbSI6W3sibmFtZXNwYWNlX2lkIjoiIiwiYXBwbGljYXRpb25faWQiOiIxMmU3MmY5NS0zZjhjLTRiODMtYmM3NS03NTJmNzRjZGZlZGMifV0sInZlcnNpb24iOjIsImF1ZCI6ImZ1bmN0aW9ucyIsImp0aSI6ImUzNDVkZTBhLTlhNjMtNGEzNC1hZDk1LTVhMTQ1ZWNiMzc2ZSIsImlhdCI6MTc1NjMwNzE2NiwiaXNzIjoiU0NBTEVXQVkiLCJuYmYiOjE3NTYzMDcxNjYsInN1YiI6InRva2VuIn0.oLirO0Z6t2txZMjRa7MYdyhTg5-OQJbJHtgAp-d3crCBiLrm5Sat5piLwK9QDgeqvQ5fxovnY8dFFoN69X4ZqkdCR4D9v70iHUvkhx2srAO2_1XeCjkfdQwi8-7BY01smnewCgPcrBvGyNN4ToRd-cUd1cfdll7_PMJSX14Ynb0B_g96XcJtQsdq2Xx7t7-AqjnjhL5r5rrWKzq7ixUK5vN3dTeCIkM3rZOGG8w7i-k7UaE5qZtWCeCHW-a1W4-npgIUd9SFmDUVxoW9r61XHuDBhTfxFJ5CO2Ksozw_O0kNLgObrsx2OyBFvzXTYlGOnx7wp3f_rVFTL0WgTrPA_NbKpTUFplBnqqnuONSR_3fY4aMEGWb7Il0qOc31LqZZUqlBA03gQbflF9iLVZkHBNrQXcMs6-idjdJhv1xW3pE4zXet1wg8mN0sj3bXuEKbjijrVA37_6e_7GABvgb9BWM0BfNOf9TC-Di-s5X71b0zikJz-aSAsnJ7wKZ9GCavdCawJ9Tt-5agHLgHJ0J9PJXakq89klj_H-OaMeEtmFquNurDjofnIxMMk0goWXgDwuScxC5vHY6quUCzAntBcEwOORcWoQoxIUfav8RdfkreXJYnQ4wU07pqKhvz603NOsdv9SCJAGq-up4Gt-kpc8Dl8DIui82kSeYlnsioaPI"}'
         headers:
             Content-Length:
-                - "2056"
+                - "2009"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:28:53 GMT
+                - Wed, 27 Aug 2025 15:06:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -589,10 +593,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - adca969e-bcbc-49b9-b21f-1503cdf50ae9
+                - 56abc993-9a9d-4b4a-a648-0bac15ee50b6
         status: 200 OK
         code: 200
-        duration: 140.990916ms
+        duration: 235.363197ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -608,8 +612,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/tokens/b32fb58d-ca08-435d-974e-3b1ae1ad02a4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/tokens/e345de0a-9a63-4a34-ad95-5a145ecb376e
         method: GET
       response:
         proto: HTTP/2.0
@@ -617,20 +621,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 213
+        content_length: 189
         uncompressed: false
-        body: '{"description":"","expires_at":"2025-01-28T14:28:16Z","id":"b32fb58d-ca08-435d-974e-3b1ae1ad02a4","namespace_id":"99e97ccb-1674-4512-be2f-49af20af694f","public_key":"","status":"creating","token":"\u003chidden\u003e"}'
+        body: '{"container_id":"12e72f95-3f8c-4b83-bc75-752f74cdfedc","description":"","expires_at":null,"id":"e345de0a-9a63-4a34-ad95-5a145ecb376e","public_key":"","status":"creating","token":"\u003chidden\u003e"}'
         headers:
             Content-Length:
-                - "213"
+                - "189"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:28:53 GMT
+                - Wed, 27 Aug 2025 15:06:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -638,50 +642,48 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e30f885d-ad59-4093-bd39-0e20fe3eb187
+                - 4c35d1b2-2694-451e-89c6-5c3917e98829
         status: 200 OK
         code: 200
-        duration: 64.013416ms
+        duration: 92.424374ms
     - id: 13
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 214
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"namespace_id":"99e97ccb-1674-4512-be2f-49af20af694f","name":"tf-co-suspicious-leakey","privacy":"public","protocol":"http1","secret_environment_variables":null,"http_option":"enabled","sandbox":"unknown_sandbox"}'
+        body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers
-        method: POST
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/tokens/e39d6f5e-edc4-488e-8121-101c6dfaa778
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 950
+        content_length: 204
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-27T14:28:53.359204470Z","description":"","domain_name":"testcontainertokennsiwvvoenn-tf-co-suspicious-leakey.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"6e8c4f40-1ae3-4009-991e-aa742e2f6578","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-suspicious-leakey","namespace_id":"99e97ccb-1674-4512-be2f-49af20af694f","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtestcontainertokennsiwvvoenn/tf-co-suspicious-leakey:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-27T14:28:53.359204470Z"}'
+        body: '{"description":"","expires_at":"2025-08-28T15:05:34Z","id":"e39d6f5e-edc4-488e-8121-101c6dfaa778","namespace_id":"bb0c03ad-4243-4a03-bbcb-83721935a599","public_key":"","status":"ready","token":"\u003chidden\u003e"}'
         headers:
             Content-Length:
-                - "950"
+                - "204"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:28:53 GMT
+                - Wed, 27 Aug 2025 15:06:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -689,10 +691,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e2e59411-8437-4b2a-be21-00ae7aadfb91
+                - 60ff3189-4dba-4913-a48e-6f6276ee2edb
         status: 200 OK
         code: 200
-        duration: 256.131083ms
+        duration: 83.350987ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -708,8 +710,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/6e8c4f40-1ae3-4009-991e-aa742e2f6578
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/tokens/e345de0a-9a63-4a34-ad95-5a145ecb376e
         method: GET
       response:
         proto: HTTP/2.0
@@ -717,20 +719,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 944
+        content_length: 186
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-27T14:28:53.359204Z","description":"","domain_name":"testcontainertokennsiwvvoenn-tf-co-suspicious-leakey.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"6e8c4f40-1ae3-4009-991e-aa742e2f6578","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-suspicious-leakey","namespace_id":"99e97ccb-1674-4512-be2f-49af20af694f","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtestcontainertokennsiwvvoenn/tf-co-suspicious-leakey:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-27T14:28:53.359204Z"}'
+        body: '{"container_id":"12e72f95-3f8c-4b83-bc75-752f74cdfedc","description":"","expires_at":null,"id":"e345de0a-9a63-4a34-ad95-5a145ecb376e","public_key":"","status":"ready","token":"\u003chidden\u003e"}'
         headers:
             Content-Length:
-                - "944"
+                - "186"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:28:53 GMT
+                - Wed, 27 Aug 2025 15:06:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -738,50 +740,48 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 17cfe45c-89bf-424e-85c7-b7c1c94d7237
+                - 07221963-0792-4f02-9b23-1f653d3cc014
         status: 200 OK
         code: 200
-        duration: 81.766ms
+        duration: 101.459799ms
     - id: 15
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 55
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"container_id":"6e8c4f40-1ae3-4009-991e-aa742e2f6578"}'
+        body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/tokens
-        method: POST
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/bb0c03ad-4243-4a03-bbcb-83721935a599
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2015
+        content_length: 591
         uncompressed: false
-        body: '{"container_id":"6e8c4f40-1ae3-4009-991e-aa742e2f6578","description":"","expires_at":null,"id":"0d5627d5-2e3d-41d9-b413-1866590f7bac","public_key":"-----BEGIN RSA PUBLIC KEY-----\nMIICCgKCAgEArst9TSyYxe7APQ5/oaaT547c/XNpZQgxuhjSUMlKWqZlh6EK+qdi\nmslJOGZnJ4yXorLQGLHAXMhU0B5lGFXGfLGjJE4RPa3B39CwYUkRN9p7vKJWCyMI\nuoFu+ayeHoGvWgyWypwAnIV+H8C9rjKOzByfXgWxQAjwPDnbOi6mt7lDuGjlVGHu\nBBC/gPVC1fvGwREgzls8H16XXj4QA5izY/lB5rKbS87kacWamGCWXOVeKLCX6Lfl\nBU/gtV5puq/8nZ5IHsWSOmn7jAuB3A9Jkx/5bd0DlY3yIbBmb/awvX/PVhQPhQhk\nEqgDj+N0ahtoaByI4SeQrHij73jcXxCPpZj92+OVao1DV+pPc8VHYpSVgcy60+iT\nDhGeQo6zTvDfvanzwmeESH2RN0XWA/0N3awyNNXk4y6zc+4OrKJ0A1gy8J7JBwuq\n72F0pv99t8TnRi9XlqCD4Q/6EM7zBQiv5axqieSUBC9IIGQVcPkjFrmy/lHOvedU\ngcGyFdUMZPJXZdK0iu2aghRFq88D47mEoP39k6eiTzmKZjTgK13fGYZFxVAgnuyW\nKsThygTsvyV66TQfg38pCw0sIYYE3pEXguEEMHQMOEqLc9RywCfgdsmQnjWOQ6/V\n2HsST12d9ude8I+IUh1WXSkXVzUE1nrYopsnTl792G6W6GN3juXoOOsCAwEAAQ==\n-----END RSA PUBLIC KEY-----\n","status":"creating","token":"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJhcHBsaWNhdGlvbl9jbGFpbSI6W3sibmFtZXNwYWNlX2lkIjoiIiwiYXBwbGljYXRpb25faWQiOiI2ZThjNGY0MC0xYWUzLTQwMDktOTkxZS1hYTc0MmUyZjY1NzgifV0sInZlcnNpb24iOjIsImF1ZCI6ImZ1bmN0aW9ucyIsImp0aSI6IjBkNTYyN2Q1LTJlM2QtNDFkOS1iNDEzLTE4NjY1OTBmN2JhYyIsImlhdCI6MTczNzk4ODEzMywiaXNzIjoiU0NBTEVXQVkiLCJuYmYiOjE3Mzc5ODgxMzMsInN1YiI6InRva2VuIn0.lgTVVCJDX13ayXV_rMui8nqSdFsh-xbkQkhbw70ET6kbULI4sv9DNzCEX2R3zfdGhzzZX1IvN72w_D2oK5HeUzqdJEM6Df3yGpmsIGICHsjZ3O8jvq-eKMo9KGmt3SIvD_7UKgL_rVkR8_kxESJN7gIckmW9YC-7JDKGPQlVGAS9lVIND26N6phEM8D5aJkk_kUJj1g_vK0eGHgw_9XlydMfhHo602ABHcXVQ4rj2QikiYQ4Y2xA4bXuKdATjtPT16uBVxbrpyF36qTz9-zyeZyRqubu0EWfXZZ1D3QmQ7WT9S54bKPb6i9k4giB_6ZZhXi951zXhsBV5k1bONYS74jPa1-clnYnRD2xWGkxletjCs2rNMvAKa6FIur08ackHJej3SZKNao1ez3sR6xyf3gZpDXTJ4OXVZ3EsFU-5-NcNATR0d_aY_ze5KBEPUnsSMnChka2ioUEe3Zf94CmEU-54yoqH5P_DKyz6zau85XpfTAascTcic0cxtZqAH2AlwIiECEsmB96W1EjmmcjoSniaspfbH7DPHYRBmmQSwQ2U_0L86PAw3dfhaOIzlRZovRHryWeR70YSMBso2vDDNip5Ilby7-xOP4UJdOPJe8ytJcyITph5iEB885l8NM3f-SisjLdjmngVaWub0PzRbSOrrtDXhhuNOTt1_8Vbes"}'
+        body: '{"created_at":"2025-08-27T15:05:50.219203Z","description":"","environment_variables":{},"error_message":null,"id":"bb0c03ad-4243-4a03-bbcb-83721935a599","name":"test-container-token-ns","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcontainertokenns4sheziip","registry_namespace_id":"325af02a-d343-4174-b32c-963f10295b52","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:04.519616Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "2015"
+                - "591"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:28:53 GMT
+                - Wed, 27 Aug 2025 15:06:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -789,10 +789,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3c2d9066-a048-4fe8-9fab-f3807db24064
+                - 9dcb34a4-fdc5-4e50-8aa8-e87b6b7aadf6
         status: 200 OK
         code: 200
-        duration: 147.649167ms
+        duration: 68.36696ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -808,8 +808,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/tokens/0d5627d5-2e3d-41d9-b413-1866590f7bac
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/tokens/e39d6f5e-edc4-488e-8121-101c6dfaa778
         method: GET
       response:
         proto: HTTP/2.0
@@ -817,20 +817,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 195
+        content_length: 204
         uncompressed: false
-        body: '{"container_id":"6e8c4f40-1ae3-4009-991e-aa742e2f6578","description":"","expires_at":null,"id":"0d5627d5-2e3d-41d9-b413-1866590f7bac","public_key":"","status":"creating","token":"\u003chidden\u003e"}'
+        body: '{"description":"","expires_at":"2025-08-28T15:05:34Z","id":"e39d6f5e-edc4-488e-8121-101c6dfaa778","namespace_id":"bb0c03ad-4243-4a03-bbcb-83721935a599","public_key":"","status":"ready","token":"\u003chidden\u003e"}'
         headers:
             Content-Length:
-                - "195"
+                - "204"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:28:53 GMT
+                - Wed, 27 Aug 2025 15:06:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -838,10 +838,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 616db5c2-7dac-47e8-9b4d-06f8c0a96fb1
+                - 83fb2a05-b36b-447a-8219-9bc698bf5b8a
         status: 200 OK
         code: 200
-        duration: 82.305916ms
+        duration: 98.164524ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -857,8 +857,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/tokens/b32fb58d-ca08-435d-974e-3b1ae1ad02a4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/12e72f95-3f8c-4b83-bc75-752f74cdfedc
         method: GET
       response:
         proto: HTTP/2.0
@@ -866,20 +866,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 213
+        content_length: 992
         uncompressed: false
-        body: '{"description":"","expires_at":"2025-01-28T14:28:16Z","id":"b32fb58d-ca08-435d-974e-3b1ae1ad02a4","namespace_id":"99e97ccb-1674-4512-be2f-49af20af694f","public_key":"","status":"creating","token":"\u003chidden\u003e"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:06.590067Z","description":"","domain_name":"testcontainertokenns4sheziip-tf-co-condescending-aryabhata.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"12e72f95-3f8c-4b83-bc75-752f74cdfedc","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-condescending-aryabhata","namespace_id":"bb0c03ad-4243-4a03-bbcb-83721935a599","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtestcontainertokenns4sheziip/tf-co-condescending-aryabhata:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:06.590067Z"}'
         headers:
             Content-Length:
-                - "213"
+                - "992"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:28:53 GMT
+                - Wed, 27 Aug 2025 15:06:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -887,10 +887,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7ff9d232-d655-4c4a-a2a1-115fe077f27c
+                - 503cde4c-9dc1-492c-9576-1a0a80f54ba9
         status: 200 OK
         code: 200
-        duration: 69.76725ms
+        duration: 121.588249ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -906,8 +906,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/tokens/0d5627d5-2e3d-41d9-b413-1866590f7bac
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/tokens/e345de0a-9a63-4a34-ad95-5a145ecb376e
         method: GET
       response:
         proto: HTTP/2.0
@@ -915,20 +915,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 195
+        content_length: 186
         uncompressed: false
-        body: '{"container_id":"6e8c4f40-1ae3-4009-991e-aa742e2f6578","description":"","expires_at":null,"id":"0d5627d5-2e3d-41d9-b413-1866590f7bac","public_key":"","status":"creating","token":"\u003chidden\u003e"}'
+        body: '{"container_id":"12e72f95-3f8c-4b83-bc75-752f74cdfedc","description":"","expires_at":null,"id":"e345de0a-9a63-4a34-ad95-5a145ecb376e","public_key":"","status":"ready","token":"\u003chidden\u003e"}'
         headers:
             Content-Length:
-                - "195"
+                - "186"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:28:53 GMT
+                - Wed, 27 Aug 2025 15:06:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -936,10 +936,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 693d3848-241f-4ac3-bcf2-e2473e42ed05
+                - 5c2e1d7e-7ca4-4134-bf86-ecf60693c46c
         status: 200 OK
         code: 200
-        duration: 77.901083ms
+        duration: 125.379213ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -955,29 +955,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/99e97ccb-1674-4512-be2f-49af20af694f
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/tokens/e39d6f5e-edc4-488e-8121-101c6dfaa778
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 572
+        content_length: 199
         uncompressed: false
-        body: '{"created_at":"2025-01-27T14:28:17.230570Z","description":"","environment_variables":{},"error_message":null,"id":"99e97ccb-1674-4512-be2f-49af20af694f","name":"test-container-token-ns","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcontainertokennsiwvvoenn","registry_namespace_id":"e5a96d6f-6d9d-4fe3-9e29-0ba82637aab0","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-27T14:28:50.388662Z"}'
+        body: '{"description":"","expires_at":"2025-08-28T15:05:34Z","id":"e39d6f5e-edc4-488e-8121-101c6dfaa778","namespace_id":"bb0c03ad-4243-4a03-bbcb-83721935a599","public_key":"","status":"deleting","token":""}'
         headers:
             Content-Length:
-                - "572"
+                - "199"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:28:54 GMT
+                - Wed, 27 Aug 2025 15:06:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -985,10 +985,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e849cd22-d0c4-4d17-ac51-3c6f4b703e92
+                - 43507a97-05cd-44d4-838e-4d49c9ffa31d
         status: 200 OK
         code: 200
-        duration: 72.017791ms
+        duration: 91.418206ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1004,29 +1004,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/tokens/b32fb58d-ca08-435d-974e-3b1ae1ad02a4
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/tokens/e345de0a-9a63-4a34-ad95-5a145ecb376e
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 213
+        content_length: 181
         uncompressed: false
-        body: '{"description":"","expires_at":"2025-01-28T14:28:16Z","id":"b32fb58d-ca08-435d-974e-3b1ae1ad02a4","namespace_id":"99e97ccb-1674-4512-be2f-49af20af694f","public_key":"","status":"creating","token":"\u003chidden\u003e"}'
+        body: '{"container_id":"12e72f95-3f8c-4b83-bc75-752f74cdfedc","description":"","expires_at":null,"id":"e345de0a-9a63-4a34-ad95-5a145ecb376e","public_key":"","status":"deleting","token":""}'
         headers:
             Content-Length:
-                - "213"
+                - "181"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:28:54 GMT
+                - Wed, 27 Aug 2025 15:06:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1034,10 +1034,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 62c1f386-4a36-4706-a107-9ed8086bdd03
+                - 39c8435d-fc41-45af-ab82-5fc4833e3cf4
         status: 200 OK
         code: 200
-        duration: 63.236875ms
+        duration: 105.5905ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1053,8 +1053,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/6e8c4f40-1ae3-4009-991e-aa742e2f6578
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/12e72f95-3f8c-4b83-bc75-752f74cdfedc
         method: GET
       response:
         proto: HTTP/2.0
@@ -1062,20 +1062,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 944
+        content_length: 992
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-27T14:28:53.359204Z","description":"","domain_name":"testcontainertokennsiwvvoenn-tf-co-suspicious-leakey.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"6e8c4f40-1ae3-4009-991e-aa742e2f6578","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-suspicious-leakey","namespace_id":"99e97ccb-1674-4512-be2f-49af20af694f","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtestcontainertokennsiwvvoenn/tf-co-suspicious-leakey:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-27T14:28:53.359204Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:06.590067Z","description":"","domain_name":"testcontainertokenns4sheziip-tf-co-condescending-aryabhata.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"12e72f95-3f8c-4b83-bc75-752f74cdfedc","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-condescending-aryabhata","namespace_id":"bb0c03ad-4243-4a03-bbcb-83721935a599","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtestcontainertokenns4sheziip/tf-co-condescending-aryabhata:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:06.590067Z"}'
         headers:
             Content-Length:
-                - "944"
+                - "992"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:28:54 GMT
+                - Wed, 27 Aug 2025 15:06:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1083,10 +1083,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ca979a62-99e4-4a68-ab29-ec84d589b153
+                - 5b089dfb-3049-4326-8b43-61647e48ac08
         status: 200 OK
         code: 200
-        duration: 66.057834ms
+        duration: 109.153215ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1102,29 +1102,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/tokens/0d5627d5-2e3d-41d9-b413-1866590f7bac
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/12e72f95-3f8c-4b83-bc75-752f74cdfedc
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 195
+        content_length: 996
         uncompressed: false
-        body: '{"container_id":"6e8c4f40-1ae3-4009-991e-aa742e2f6578","description":"","expires_at":null,"id":"0d5627d5-2e3d-41d9-b413-1866590f7bac","public_key":"","status":"creating","token":"\u003chidden\u003e"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:06.590067Z","description":"","domain_name":"testcontainertokenns4sheziip-tf-co-condescending-aryabhata.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"12e72f95-3f8c-4b83-bc75-752f74cdfedc","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-condescending-aryabhata","namespace_id":"bb0c03ad-4243-4a03-bbcb-83721935a599","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtestcontainertokenns4sheziip/tf-co-condescending-aryabhata:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:08.773685765Z"}'
         headers:
             Content-Length:
-                - "195"
+                - "996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:28:54 GMT
+                - Wed, 27 Aug 2025 15:06:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1132,10 +1132,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3f52c6c0-7710-4823-8e05-d7fc726a0645
+                - fa921106-7b4e-44fd-9f20-64d413f65a5b
         status: 200 OK
         code: 200
-        duration: 83.074375ms
+        duration: 357.37926ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1151,29 +1151,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/tokens/b32fb58d-ca08-435d-974e-3b1ae1ad02a4
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/bb0c03ad-4243-4a03-bbcb-83721935a599
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 205
+        content_length: 591
         uncompressed: false
-        body: '{"description":"","expires_at":"2025-01-28T14:28:16Z","id":"b32fb58d-ca08-435d-974e-3b1ae1ad02a4","namespace_id":"99e97ccb-1674-4512-be2f-49af20af694f","public_key":"","status":"deleting","token":""}'
+        body: '{"created_at":"2025-08-27T15:05:50.219203Z","description":"","environment_variables":{},"error_message":null,"id":"bb0c03ad-4243-4a03-bbcb-83721935a599","name":"test-container-token-ns","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcontainertokenns4sheziip","registry_namespace_id":"325af02a-d343-4174-b32c-963f10295b52","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:04.519616Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "205"
+                - "591"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:28:54 GMT
+                - Wed, 27 Aug 2025 15:06:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1181,10 +1181,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cf2e384c-c02a-4960-94ad-3e523d04f561
+                - 4d6e28a3-ab96-4af5-92ab-1f2a05ef3973
         status: 200 OK
         code: 200
-        duration: 83.142625ms
+        duration: 81.812942ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1200,8 +1200,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/tokens/0d5627d5-2e3d-41d9-b413-1866590f7bac
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/bb0c03ad-4243-4a03-bbcb-83721935a599
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1209,20 +1209,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 187
+        content_length: 597
         uncompressed: false
-        body: '{"container_id":"6e8c4f40-1ae3-4009-991e-aa742e2f6578","description":"","expires_at":null,"id":"0d5627d5-2e3d-41d9-b413-1866590f7bac","public_key":"","status":"deleting","token":""}'
+        body: '{"created_at":"2025-08-27T15:05:50.219203Z","description":"","environment_variables":{},"error_message":null,"id":"bb0c03ad-4243-4a03-bbcb-83721935a599","name":"test-container-token-ns","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcontainertokenns4sheziip","registry_namespace_id":"325af02a-d343-4174-b32c-963f10295b52","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:09.236973018Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "187"
+                - "597"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:28:54 GMT
+                - Wed, 27 Aug 2025 15:06:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1230,10 +1230,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 715d3f54-ded4-40de-a43d-dbc1383c66ef
+                - 36bba7a4-1e45-4012-9cad-49c5044fe06b
         status: 200 OK
         code: 200
-        duration: 106.258167ms
+        duration: 443.99294ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1249,8 +1249,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/6e8c4f40-1ae3-4009-991e-aa742e2f6578
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/bb0c03ad-4243-4a03-bbcb-83721935a599
         method: GET
       response:
         proto: HTTP/2.0
@@ -1258,20 +1258,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 944
+        content_length: 594
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-27T14:28:53.359204Z","description":"","domain_name":"testcontainertokennsiwvvoenn-tf-co-suspicious-leakey.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"6e8c4f40-1ae3-4009-991e-aa742e2f6578","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-suspicious-leakey","namespace_id":"99e97ccb-1674-4512-be2f-49af20af694f","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtestcontainertokennsiwvvoenn/tf-co-suspicious-leakey:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-27T14:28:53.359204Z"}'
+        body: '{"created_at":"2025-08-27T15:05:50.219203Z","description":"","environment_variables":{},"error_message":null,"id":"bb0c03ad-4243-4a03-bbcb-83721935a599","name":"test-container-token-ns","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcontainertokenns4sheziip","registry_namespace_id":"325af02a-d343-4174-b32c-963f10295b52","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:09.236973Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "944"
+                - "594"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:28:54 GMT
+                - Wed, 27 Aug 2025 15:06:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1279,10 +1279,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e568cc5a-00c2-4768-a734-e36787d15897
+                - 4cfa173f-2df9-420d-9390-7f9f7340493d
         status: 200 OK
         code: 200
-        duration: 82.566458ms
+        duration: 173.689247ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1298,645 +1298,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/6e8c4f40-1ae3-4009-991e-aa742e2f6578
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 948
-        uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-27T14:28:53.359204Z","description":"","domain_name":"testcontainertokennsiwvvoenn-tf-co-suspicious-leakey.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"6e8c4f40-1ae3-4009-991e-aa742e2f6578","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-suspicious-leakey","namespace_id":"99e97ccb-1674-4512-be2f-49af20af694f","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtestcontainertokennsiwvvoenn/tf-co-suspicious-leakey:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"deleting","timeout":"300s","updated_at":"2025-01-27T14:28:54.912739650Z"}'
-        headers:
-            Content-Length:
-                - "948"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 14:28:54 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 2a2291e5-33b2-49ef-81cb-8a88c22bea24
-        status: 200 OK
-        code: 200
-        duration: 151.279666ms
-    - id: 27
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/99e97ccb-1674-4512-be2f-49af20af694f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 572
-        uncompressed: false
-        body: '{"created_at":"2025-01-27T14:28:17.230570Z","description":"","environment_variables":{},"error_message":null,"id":"99e97ccb-1674-4512-be2f-49af20af694f","name":"test-container-token-ns","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcontainertokennsiwvvoenn","registry_namespace_id":"e5a96d6f-6d9d-4fe3-9e29-0ba82637aab0","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-27T14:28:50.388662Z"}'
-        headers:
-            Content-Length:
-                - "572"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 14:28:55 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 40e917f0-ca08-4973-b042-a4f3ecd339b0
-        status: 200 OK
-        code: 200
-        duration: 65.907417ms
-    - id: 28
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/99e97ccb-1674-4512-be2f-49af20af694f
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 578
-        uncompressed: false
-        body: '{"created_at":"2025-01-27T14:28:17.230570Z","description":"","environment_variables":{},"error_message":null,"id":"99e97ccb-1674-4512-be2f-49af20af694f","name":"test-container-token-ns","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcontainertokennsiwvvoenn","registry_namespace_id":"e5a96d6f-6d9d-4fe3-9e29-0ba82637aab0","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-27T14:28:55.109779618Z"}'
-        headers:
-            Content-Length:
-                - "578"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 14:28:55 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 6880698b-7be4-4d5d-96b7-896a4f5dcde8
-        status: 200 OK
-        code: 200
-        duration: 244.369375ms
-    - id: 29
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/99e97ccb-1674-4512-be2f-49af20af694f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 575
-        uncompressed: false
-        body: '{"created_at":"2025-01-27T14:28:17.230570Z","description":"","environment_variables":{},"error_message":null,"id":"99e97ccb-1674-4512-be2f-49af20af694f","name":"test-container-token-ns","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcontainertokennsiwvvoenn","registry_namespace_id":"e5a96d6f-6d9d-4fe3-9e29-0ba82637aab0","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-27T14:28:55.109780Z"}'
-        headers:
-            Content-Length:
-                - "575"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 14:28:55 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 777dc8f8-624f-45c7-94fe-04e9dc6a2d31
-        status: 200 OK
-        code: 200
-        duration: 66.381916ms
-    - id: 30
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/99e97ccb-1674-4512-be2f-49af20af694f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 575
-        uncompressed: false
-        body: '{"created_at":"2025-01-27T14:28:17.230570Z","description":"","environment_variables":{},"error_message":null,"id":"99e97ccb-1674-4512-be2f-49af20af694f","name":"test-container-token-ns","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcontainertokennsiwvvoenn","registry_namespace_id":"e5a96d6f-6d9d-4fe3-9e29-0ba82637aab0","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-27T14:28:55.109780Z"}'
-        headers:
-            Content-Length:
-                - "575"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 14:29:00 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 3cff2994-7c6e-4985-905e-d5c85cc468dc
-        status: 200 OK
-        code: 200
-        duration: 80.285292ms
-    - id: 31
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/99e97ccb-1674-4512-be2f-49af20af694f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 575
-        uncompressed: false
-        body: '{"created_at":"2025-01-27T14:28:17.230570Z","description":"","environment_variables":{},"error_message":null,"id":"99e97ccb-1674-4512-be2f-49af20af694f","name":"test-container-token-ns","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcontainertokennsiwvvoenn","registry_namespace_id":"e5a96d6f-6d9d-4fe3-9e29-0ba82637aab0","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-27T14:28:55.109780Z"}'
-        headers:
-            Content-Length:
-                - "575"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 14:29:05 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 9a5bc9d9-6537-41cd-aeaf-54d283125498
-        status: 200 OK
-        code: 200
-        duration: 74.938709ms
-    - id: 32
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/99e97ccb-1674-4512-be2f-49af20af694f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 575
-        uncompressed: false
-        body: '{"created_at":"2025-01-27T14:28:17.230570Z","description":"","environment_variables":{},"error_message":null,"id":"99e97ccb-1674-4512-be2f-49af20af694f","name":"test-container-token-ns","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcontainertokennsiwvvoenn","registry_namespace_id":"e5a96d6f-6d9d-4fe3-9e29-0ba82637aab0","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-27T14:28:55.109780Z"}'
-        headers:
-            Content-Length:
-                - "575"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 14:29:10 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 3708b84c-794e-4c46-bd98-dc4a8cb2da32
-        status: 200 OK
-        code: 200
-        duration: 73.608291ms
-    - id: 33
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/99e97ccb-1674-4512-be2f-49af20af694f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 575
-        uncompressed: false
-        body: '{"created_at":"2025-01-27T14:28:17.230570Z","description":"","environment_variables":{},"error_message":null,"id":"99e97ccb-1674-4512-be2f-49af20af694f","name":"test-container-token-ns","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcontainertokennsiwvvoenn","registry_namespace_id":"e5a96d6f-6d9d-4fe3-9e29-0ba82637aab0","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-27T14:28:55.109780Z"}'
-        headers:
-            Content-Length:
-                - "575"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 14:29:15 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - bf490d38-047e-4aa0-b63f-91cfdf03ab06
-        status: 200 OK
-        code: 200
-        duration: 68.34975ms
-    - id: 34
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/99e97ccb-1674-4512-be2f-49af20af694f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 575
-        uncompressed: false
-        body: '{"created_at":"2025-01-27T14:28:17.230570Z","description":"","environment_variables":{},"error_message":null,"id":"99e97ccb-1674-4512-be2f-49af20af694f","name":"test-container-token-ns","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcontainertokennsiwvvoenn","registry_namespace_id":"e5a96d6f-6d9d-4fe3-9e29-0ba82637aab0","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-27T14:28:55.109780Z"}'
-        headers:
-            Content-Length:
-                - "575"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 14:29:20 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 2bb39d0c-28b6-4523-b2d2-996a1e19970f
-        status: 200 OK
-        code: 200
-        duration: 82.487542ms
-    - id: 35
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/99e97ccb-1674-4512-be2f-49af20af694f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 575
-        uncompressed: false
-        body: '{"created_at":"2025-01-27T14:28:17.230570Z","description":"","environment_variables":{},"error_message":null,"id":"99e97ccb-1674-4512-be2f-49af20af694f","name":"test-container-token-ns","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcontainertokennsiwvvoenn","registry_namespace_id":"e5a96d6f-6d9d-4fe3-9e29-0ba82637aab0","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-27T14:28:55.109780Z"}'
-        headers:
-            Content-Length:
-                - "575"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 14:29:25 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 60cfaa9e-3ce9-4fff-9999-517c038c012b
-        status: 200 OK
-        code: 200
-        duration: 80.631708ms
-    - id: 36
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/99e97ccb-1674-4512-be2f-49af20af694f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 575
-        uncompressed: false
-        body: '{"created_at":"2025-01-27T14:28:17.230570Z","description":"","environment_variables":{},"error_message":null,"id":"99e97ccb-1674-4512-be2f-49af20af694f","name":"test-container-token-ns","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcontainertokennsiwvvoenn","registry_namespace_id":"e5a96d6f-6d9d-4fe3-9e29-0ba82637aab0","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-27T14:28:55.109780Z"}'
-        headers:
-            Content-Length:
-                - "575"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 14:29:30 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 11009764-9ae8-4655-aaf5-25433c02e22d
-        status: 200 OK
-        code: 200
-        duration: 83.009541ms
-    - id: 37
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/99e97ccb-1674-4512-be2f-49af20af694f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 575
-        uncompressed: false
-        body: '{"created_at":"2025-01-27T14:28:17.230570Z","description":"","environment_variables":{},"error_message":null,"id":"99e97ccb-1674-4512-be2f-49af20af694f","name":"test-container-token-ns","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcontainertokennsiwvvoenn","registry_namespace_id":"e5a96d6f-6d9d-4fe3-9e29-0ba82637aab0","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-27T14:28:55.109780Z"}'
-        headers:
-            Content-Length:
-                - "575"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 14:29:35 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 1081d06a-e308-4176-ba50-62b92209225a
-        status: 200 OK
-        code: 200
-        duration: 78.627583ms
-    - id: 38
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/99e97ccb-1674-4512-be2f-49af20af694f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 575
-        uncompressed: false
-        body: '{"created_at":"2025-01-27T14:28:17.230570Z","description":"","environment_variables":{},"error_message":null,"id":"99e97ccb-1674-4512-be2f-49af20af694f","name":"test-container-token-ns","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcontainertokennsiwvvoenn","registry_namespace_id":"e5a96d6f-6d9d-4fe3-9e29-0ba82637aab0","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-27T14:28:55.109780Z"}'
-        headers:
-            Content-Length:
-                - "575"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 14:29:41 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 172bfac8-4c18-4b17-9ce4-2146918e0bf2
-        status: 200 OK
-        code: 200
-        duration: 85.894542ms
-    - id: 39
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/99e97ccb-1674-4512-be2f-49af20af694f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/bb0c03ad-4243-4a03-bbcb-83721935a599
         method: GET
       response:
         proto: HTTP/2.0
@@ -1955,9 +1318,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:29:46 GMT
+                - Wed, 27 Aug 2025 15:06:14 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1965,11 +1328,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 947b45d3-35fc-4a84-af45-376db2e212bb
+                - 4e157c34-4e44-4d65-b12e-77144eed1aed
         status: 404 Not Found
         code: 404
-        duration: 36.6415ms
-    - id: 40
+        duration: 23.531407ms
+    - id: 27
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1984,8 +1347,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/tokens/0d5627d5-2e3d-41d9-b413-1866590f7bac
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/tokens/e345de0a-9a63-4a34-ad95-5a145ecb376e
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -2004,9 +1367,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:29:46 GMT
+                - Wed, 27 Aug 2025 15:06:14 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2014,11 +1377,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 80f6b008-7309-4a62-a8e1-6897d90ef99e
+                - 4e8b107e-8e37-427f-9a32-5c05282a52a5
         status: 404 Not Found
         code: 404
-        duration: 25.218167ms
-    - id: 41
+        duration: 23.353964ms
+    - id: 28
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2033,8 +1396,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/tokens/b32fb58d-ca08-435d-974e-3b1ae1ad02a4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/tokens/e39d6f5e-edc4-488e-8121-101c6dfaa778
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -2053,9 +1416,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:29:46 GMT
+                - Wed, 27 Aug 2025 15:06:14 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2063,7 +1426,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cc11e212-0111-4e68-ab82-dd2827d0241e
+                - fda3d6ab-6a34-48c4-a714-20b87fe9e30f
         status: 404 Not Found
         code: 404
-        duration: 30.113333ms
+        duration: 23.190317ms

--- a/internal/services/container/testdata/trigger-nats.cassette.yaml
+++ b/internal/services/container/testdata/trigger-nats.cassette.yaml
@@ -6,19 +6,19 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 89
+        content_length: 93
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-nats-account-keen-curie","project_id":"105bdce1-64c0-48ab-899d-868455867ecf"}'
+        body: '{"name":"tf-nats-account-vibrant-beaver","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778"}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/nats-accounts
         method: POST
       response:
@@ -27,20 +27,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 317
+        content_length: 321
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:48.531129261Z","endpoint":"nats://nats.mnq.fr-par.scaleway.com:4222","id":"AADGULIBDPUFWKRCVLGGIE5EEVIIOD2BSIQ3T3WAFOT4YC3TV6AN52VR","name":"tf-nats-account-keen-curie","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","updated_at":"2025-01-24T15:37:48.531129261Z"}'
+        body: '{"created_at":"2025-08-27T15:06:01.829958102Z","endpoint":"nats://nats.mnq.fr-par.scaleway.com:4222","id":"ABJMP6QEPGMC33K3SPDM6EKFDOCNUFH7FSUJGZCDGU5UNKOH2AFEMHFR","name":"tf-nats-account-vibrant-beaver","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","updated_at":"2025-08-27T15:06:01.829958102Z"}'
         headers:
             Content-Length:
-                - "317"
+                - "321"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:37:48 GMT
+                - Wed, 27 Aug 2025 15:06:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 455ec477-591c-4c59-b12d-f2953fd6434e
+                - 2764cf2b-104c-49c7-88ce-3d35f3e67b38
         status: 200 OK
         code: 200
-        duration: 239.99175ms
+        duration: 182.81685ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -67,8 +67,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/nats-accounts/AADGULIBDPUFWKRCVLGGIE5EEVIIOD2BSIQ3T3WAFOT4YC3TV6AN52VR
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/nats-accounts/ABJMP6QEPGMC33K3SPDM6EKFDOCNUFH7FSUJGZCDGU5UNKOH2AFEMHFR
         method: GET
       response:
         proto: HTTP/2.0
@@ -76,20 +76,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 311
+        content_length: 315
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:48.531129Z","endpoint":"nats://nats.mnq.fr-par.scaleway.com:4222","id":"AADGULIBDPUFWKRCVLGGIE5EEVIIOD2BSIQ3T3WAFOT4YC3TV6AN52VR","name":"tf-nats-account-keen-curie","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","updated_at":"2025-01-24T15:37:48.531129Z"}'
+        body: '{"created_at":"2025-08-27T15:06:01.829958Z","endpoint":"nats://nats.mnq.fr-par.scaleway.com:4222","id":"ABJMP6QEPGMC33K3SPDM6EKFDOCNUFH7FSUJGZCDGU5UNKOH2AFEMHFR","name":"tf-nats-account-vibrant-beaver","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","updated_at":"2025-08-27T15:06:01.829958Z"}'
         headers:
             Content-Length:
-                - "311"
+                - "315"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:37:48 GMT
+                - Wed, 27 Aug 2025 15:06:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,28 +97,28 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c2254cc0-6780-4ffb-aa70-aea373910a87
+                - 79c9aafc-99cc-4894-a64d-d74735e556c2
         status: 200 OK
         code: 200
-        duration: 88.924708ms
+        duration: 75.202205ms
     - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 156
+        content_length: 191
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-ns-peaceful-tesla","environment_variables":{},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","secret_environment_variables":[],"tags":null}'
+        body: '{"name":"tf-ns-reverent-hamilton","environment_variables":{},"project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","secret_environment_variables":[],"tags":null,"activate_vpc_integration":true}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces
         method: POST
       response:
@@ -127,20 +127,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 472
+        content_length: 508
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.310909455Z","description":"","environment_variables":{},"error_message":null,"id":"c3645d3e-a96e-4120-a453-4a3e19d1d3a9","name":"tf-ns-peaceful-tesla","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:37:49.310909455Z"}'
+        body: '{"created_at":"2025-08-27T15:06:03.177790196Z","description":"","environment_variables":{},"error_message":null,"id":"786e9702-5c8d-4eec-aaef-1407003b8ac8","name":"tf-ns-reverent-hamilton","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:06:03.177790196Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "472"
+                - "508"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:37:49 GMT
+                - Wed, 27 Aug 2025 15:06:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -148,10 +148,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - da49a12d-b5b2-46f1-9d53-64a57840e524
+                - 3831a032-e721-48c5-9199-249a86c698ac
         status: 200 OK
         code: 200
-        duration: 912.12325ms
+        duration: 1.492783616s
     - id: 3
       request:
         proto: HTTP/1.1
@@ -167,8 +167,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c3645d3e-a96e-4120-a453-4a3e19d1d3a9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/786e9702-5c8d-4eec-aaef-1407003b8ac8
         method: GET
       response:
         proto: HTTP/2.0
@@ -176,20 +176,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 466
+        content_length: 502
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.310909Z","description":"","environment_variables":{},"error_message":null,"id":"c3645d3e-a96e-4120-a453-4a3e19d1d3a9","name":"tf-ns-peaceful-tesla","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:37:49.310909Z"}'
+        body: '{"created_at":"2025-08-27T15:06:03.177790Z","description":"","environment_variables":{},"error_message":null,"id":"786e9702-5c8d-4eec-aaef-1407003b8ac8","name":"tf-ns-reverent-hamilton","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:06:03.177790Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "466"
+                - "502"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:37:49 GMT
+                - Wed, 27 Aug 2025 15:06:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -197,10 +197,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c76200c9-b08b-4a22-a27e-e691c8e15009
+                - 1050f4fe-45c1-44ff-bd15-2ff39335f072
         status: 200 OK
         code: 200
-        duration: 106.607208ms
+        duration: 75.811178ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -216,8 +216,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c3645d3e-a96e-4120-a453-4a3e19d1d3a9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/786e9702-5c8d-4eec-aaef-1407003b8ac8
         method: GET
       response:
         proto: HTTP/2.0
@@ -225,20 +225,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 466
+        content_length: 591
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.310909Z","description":"","environment_variables":{},"error_message":null,"id":"c3645d3e-a96e-4120-a453-4a3e19d1d3a9","name":"tf-ns-peaceful-tesla","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:37:51.605055Z"}'
+        body: '{"created_at":"2025-08-27T15:06:03.177790Z","description":"","environment_variables":{},"error_message":null,"id":"786e9702-5c8d-4eec-aaef-1407003b8ac8","name":"tf-ns-reverent-hamilton","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsreverenthamiltonttyhqt3d","registry_namespace_id":"4cb07919-5f2d-4a1d-9ed0-b210da739d9c","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:05.902593Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "466"
+                - "591"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:37:54 GMT
+                - Wed, 27 Aug 2025 15:06:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -246,10 +246,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9fe53335-6bb5-4906-a84d-05637646630c
+                - d00c7978-912b-48a3-9bb7-bca313b8e688
         status: 200 OK
         code: 200
-        duration: 68.716375ms
+        duration: 79.10513ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -265,8 +265,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c3645d3e-a96e-4120-a453-4a3e19d1d3a9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/786e9702-5c8d-4eec-aaef-1407003b8ac8
         method: GET
       response:
         proto: HTTP/2.0
@@ -274,20 +274,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 466
+        content_length: 591
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.310909Z","description":"","environment_variables":{},"error_message":null,"id":"c3645d3e-a96e-4120-a453-4a3e19d1d3a9","name":"tf-ns-peaceful-tesla","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:37:51.605055Z"}'
+        body: '{"created_at":"2025-08-27T15:06:03.177790Z","description":"","environment_variables":{},"error_message":null,"id":"786e9702-5c8d-4eec-aaef-1407003b8ac8","name":"tf-ns-reverent-hamilton","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsreverenthamiltonttyhqt3d","registry_namespace_id":"4cb07919-5f2d-4a1d-9ed0-b210da739d9c","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:05.902593Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "466"
+                - "591"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:37:59 GMT
+                - Wed, 27 Aug 2025 15:06:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -295,10 +295,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 37b68b76-8359-420f-865d-faf630fd3d96
+                - 68bea011-8214-46a8-aa7a-d98b6ef4f93d
         status: 200 OK
         code: 200
-        duration: 64.61875ms
+        duration: 66.94972ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -314,8 +314,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c3645d3e-a96e-4120-a453-4a3e19d1d3a9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/786e9702-5c8d-4eec-aaef-1407003b8ac8
         method: GET
       response:
         proto: HTTP/2.0
@@ -323,20 +323,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 466
+        content_length: 591
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.310909Z","description":"","environment_variables":{},"error_message":null,"id":"c3645d3e-a96e-4120-a453-4a3e19d1d3a9","name":"tf-ns-peaceful-tesla","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:37:51.605055Z"}'
+        body: '{"created_at":"2025-08-27T15:06:03.177790Z","description":"","environment_variables":{},"error_message":null,"id":"786e9702-5c8d-4eec-aaef-1407003b8ac8","name":"tf-ns-reverent-hamilton","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsreverenthamiltonttyhqt3d","registry_namespace_id":"4cb07919-5f2d-4a1d-9ed0-b210da739d9c","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:05.902593Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "466"
+                - "591"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:04 GMT
+                - Wed, 27 Aug 2025 15:06:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -344,48 +344,50 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3c0d9583-f254-4834-943e-b98d763da7e0
+                - 54367a66-64eb-436e-8bca-4fd345ec73e1
         status: 200 OK
         code: 200
-        duration: 64.394792ms
+        duration: 79.802649ms
     - id: 7
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 254
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"namespace_id":"786e9702-5c8d-4eec-aaef-1407003b8ac8","name":"tf-co-pensive-mirzakhani","privacy":"public","protocol":"http1","secret_environment_variables":null,"http_option":"enabled","sandbox":"unknown_sandbox","tags":null,"command":null,"args":null}'
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c3645d3e-a96e-4120-a453-4a3e19d1d3a9
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 466
+        content_length: 983
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.310909Z","description":"","environment_variables":{},"error_message":null,"id":"c3645d3e-a96e-4120-a453-4a3e19d1d3a9","name":"tf-ns-peaceful-tesla","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:37:51.605055Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:09.663036959Z","description":"","domain_name":"tfnsreverenthamiltonttyhqt3d-tf-co-pensive-mirzakhani.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"0ac2c960-6aed-4d4e-9bd3-79b08029f7ca","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-pensive-mirzakhani","namespace_id":"786e9702-5c8d-4eec-aaef-1407003b8ac8","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsreverenthamiltonttyhqt3d/tf-co-pensive-mirzakhani:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:09.663036959Z"}'
         headers:
             Content-Length:
-                - "466"
+                - "983"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:09 GMT
+                - Wed, 27 Aug 2025 15:06:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -393,10 +395,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - be389cb4-37c4-4559-80a7-8b52f2084654
+                - be5920af-622d-40ca-8eb9-e224bc966b22
         status: 200 OK
         code: 200
-        duration: 66.845041ms
+        duration: 1.26857962s
     - id: 8
       request:
         proto: HTTP/1.1
@@ -412,8 +414,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c3645d3e-a96e-4120-a453-4a3e19d1d3a9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/0ac2c960-6aed-4d4e-9bd3-79b08029f7ca
         method: GET
       response:
         proto: HTTP/2.0
@@ -421,20 +423,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 466
+        content_length: 977
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.310909Z","description":"","environment_variables":{},"error_message":null,"id":"c3645d3e-a96e-4120-a453-4a3e19d1d3a9","name":"tf-ns-peaceful-tesla","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:37:51.605055Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:09.663037Z","description":"","domain_name":"tfnsreverenthamiltonttyhqt3d-tf-co-pensive-mirzakhani.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"0ac2c960-6aed-4d4e-9bd3-79b08029f7ca","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-pensive-mirzakhani","namespace_id":"786e9702-5c8d-4eec-aaef-1407003b8ac8","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsreverenthamiltonttyhqt3d/tf-co-pensive-mirzakhani:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:09.663037Z"}'
         headers:
             Content-Length:
-                - "466"
+                - "977"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:14 GMT
+                - Wed, 27 Aug 2025 15:06:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -442,48 +444,50 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7a30a83b-dca3-48de-92b8-6e97e945bf28
+                - ea2c71be-057d-4ba6-9fef-2eaae4f9715d
         status: 200 OK
         code: 200
-        duration: 52.544541ms
+        duration: 98.114721ms
     - id: 9
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 295
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"name":"test-container-trigger-nats","container_id":"0ac2c960-6aed-4d4e-9bd3-79b08029f7ca","scw_nats_config":{"subject":"TestSubject","mnq_nats_account_id":"ABJMP6QEPGMC33K3SPDM6EKFDOCNUFH7FSUJGZCDGU5UNKOH2AFEMHFR","mnq_project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","mnq_region":"fr-par"}}'
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c3645d3e-a96e-4120-a453-4a3e19d1d3a9
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 552
+        content_length: 446
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.310909Z","description":"","environment_variables":{},"error_message":null,"id":"c3645d3e-a96e-4120-a453-4a3e19d1d3a9","name":"tf-ns-peaceful-tesla","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnspeacefultesla9odbwvna","registry_namespace_id":"a3471425-4285-431c-8605-a8c6948f60c4","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:38:19.400665Z"}'
+        body: '{"container_id":"0ac2c960-6aed-4d4e-9bd3-79b08029f7ca","description":"","error_message":null,"id":"e9b9d7b6-7df0-4431-ba74-87461bd71d38","input_type":"scw_nats","name":"test-container-trigger-nats","scw_nats_config":{"mnq_credential_id":null,"mnq_nats_account_id":"ABJMP6QEPGMC33K3SPDM6EKFDOCNUFH7FSUJGZCDGU5UNKOH2AFEMHFR","mnq_project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","mnq_region":"fr-par","subject":"TestSubject"},"status":"creating"}'
         headers:
             Content-Length:
-                - "552"
+                - "446"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:19 GMT
+                - Wed, 27 Aug 2025 15:06:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -491,10 +495,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 85601fbb-13c4-42ab-a04c-a3c82c1d06d8
+                - 7cfb482e-d0ad-499f-a902-032d9bedddd1
         status: 200 OK
         code: 200
-        duration: 55.870916ms
+        duration: 474.617459ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -510,8 +514,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c3645d3e-a96e-4120-a453-4a3e19d1d3a9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers/e9b9d7b6-7df0-4431-ba74-87461bd71d38
         method: GET
       response:
         proto: HTTP/2.0
@@ -519,20 +523,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 552
+        content_length: 446
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.310909Z","description":"","environment_variables":{},"error_message":null,"id":"c3645d3e-a96e-4120-a453-4a3e19d1d3a9","name":"tf-ns-peaceful-tesla","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnspeacefultesla9odbwvna","registry_namespace_id":"a3471425-4285-431c-8605-a8c6948f60c4","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:38:19.400665Z"}'
+        body: '{"container_id":"0ac2c960-6aed-4d4e-9bd3-79b08029f7ca","description":"","error_message":null,"id":"e9b9d7b6-7df0-4431-ba74-87461bd71d38","input_type":"scw_nats","name":"test-container-trigger-nats","scw_nats_config":{"mnq_credential_id":null,"mnq_nats_account_id":"ABJMP6QEPGMC33K3SPDM6EKFDOCNUFH7FSUJGZCDGU5UNKOH2AFEMHFR","mnq_project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","mnq_region":"fr-par","subject":"TestSubject"},"status":"creating"}'
         headers:
             Content-Length:
-                - "552"
+                - "446"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:19 GMT
+                - Wed, 27 Aug 2025 15:06:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -540,10 +544,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5d91d315-c7f1-4e81-b8b9-f8449dff06d8
+                - 2e440504-dc96-4b32-b606-988e520c9a50
         status: 200 OK
         code: 200
-        duration: 57.443125ms
+        duration: 100.505579ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -559,8 +563,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c3645d3e-a96e-4120-a453-4a3e19d1d3a9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers/e9b9d7b6-7df0-4431-ba74-87461bd71d38
         method: GET
       response:
         proto: HTTP/2.0
@@ -568,20 +572,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 552
+        content_length: 480
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.310909Z","description":"","environment_variables":{},"error_message":null,"id":"c3645d3e-a96e-4120-a453-4a3e19d1d3a9","name":"tf-ns-peaceful-tesla","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnspeacefultesla9odbwvna","registry_namespace_id":"a3471425-4285-431c-8605-a8c6948f60c4","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:38:19.400665Z"}'
+        body: '{"container_id":"0ac2c960-6aed-4d4e-9bd3-79b08029f7ca","description":"","error_message":null,"id":"e9b9d7b6-7df0-4431-ba74-87461bd71d38","input_type":"scw_nats","name":"test-container-trigger-nats","scw_nats_config":{"mnq_credential_id":"ff828cc8-b9e4-4c10-8eb7-a7004ae7f36a","mnq_nats_account_id":"ABJMP6QEPGMC33K3SPDM6EKFDOCNUFH7FSUJGZCDGU5UNKOH2AFEMHFR","mnq_project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","mnq_region":"fr-par","subject":"TestSubject"},"status":"creating"}'
         headers:
             Content-Length:
-                - "552"
+                - "480"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:19 GMT
+                - Wed, 27 Aug 2025 15:06:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -589,50 +593,48 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 607523fc-7810-4f13-8c81-0191cd4b3c3a
+                - 74e7c1c2-86fd-4f30-a87d-808158cd5593
         status: 200 OK
         code: 200
-        duration: 71.876875ms
+        duration: 110.21527ms
     - id: 12
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 213
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"namespace_id":"c3645d3e-a96e-4120-a453-4a3e19d1d3a9","name":"tf-co-admiring-swanson","privacy":"public","protocol":"http1","secret_environment_variables":null,"http_option":"enabled","sandbox":"unknown_sandbox"}'
+        body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers
-        method: POST
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers/e9b9d7b6-7df0-4431-ba74-87461bd71d38
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 912
+        content_length: 480
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:20.625765511Z","description":"","domain_name":"tfnspeacefultesla9odbwvna-tf-co-admiring-swanson.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"4d0677d4-ccbe-4abd-8665-bc5f9fd674fe","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-admiring-swanson","namespace_id":"c3645d3e-a96e-4120-a453-4a3e19d1d3a9","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnspeacefultesla9odbwvna/tf-co-admiring-swanson:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:38:20.625765511Z"}'
+        body: '{"container_id":"0ac2c960-6aed-4d4e-9bd3-79b08029f7ca","description":"","error_message":null,"id":"e9b9d7b6-7df0-4431-ba74-87461bd71d38","input_type":"scw_nats","name":"test-container-trigger-nats","scw_nats_config":{"mnq_credential_id":"ff828cc8-b9e4-4c10-8eb7-a7004ae7f36a","mnq_nats_account_id":"ABJMP6QEPGMC33K3SPDM6EKFDOCNUFH7FSUJGZCDGU5UNKOH2AFEMHFR","mnq_project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","mnq_region":"fr-par","subject":"TestSubject"},"status":"creating"}'
         headers:
             Content-Length:
-                - "912"
+                - "480"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:20 GMT
+                - Wed, 27 Aug 2025 15:06:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -640,10 +642,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2cdbf6d9-4f01-4d5f-a469-bb7182a142f6
+                - f5608bd0-8ab5-4059-a00a-4d99600266ea
         status: 200 OK
         code: 200
-        duration: 694.775666ms
+        duration: 89.364375ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -659,8 +661,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/4d0677d4-ccbe-4abd-8665-bc5f9fd674fe
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers/e9b9d7b6-7df0-4431-ba74-87461bd71d38
         method: GET
       response:
         proto: HTTP/2.0
@@ -668,20 +670,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 906
+        content_length: 477
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:20.625766Z","description":"","domain_name":"tfnspeacefultesla9odbwvna-tf-co-admiring-swanson.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"4d0677d4-ccbe-4abd-8665-bc5f9fd674fe","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-admiring-swanson","namespace_id":"c3645d3e-a96e-4120-a453-4a3e19d1d3a9","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnspeacefultesla9odbwvna/tf-co-admiring-swanson:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:38:20.625766Z"}'
+        body: '{"container_id":"0ac2c960-6aed-4d4e-9bd3-79b08029f7ca","description":"","error_message":null,"id":"e9b9d7b6-7df0-4431-ba74-87461bd71d38","input_type":"scw_nats","name":"test-container-trigger-nats","scw_nats_config":{"mnq_credential_id":"ff828cc8-b9e4-4c10-8eb7-a7004ae7f36a","mnq_nats_account_id":"ABJMP6QEPGMC33K3SPDM6EKFDOCNUFH7FSUJGZCDGU5UNKOH2AFEMHFR","mnq_project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","mnq_region":"fr-par","subject":"TestSubject"},"status":"ready"}'
         headers:
             Content-Length:
-                - "906"
+                - "477"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:20 GMT
+                - Wed, 27 Aug 2025 15:06:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -689,50 +691,48 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8f3d6452-b25b-48d7-81e3-3c918d5062fc
+                - 7bc00dc5-4aaf-49fc-8053-2eeffbba93c1
         status: 200 OK
         code: 200
-        duration: 93.154375ms
+        duration: 93.803947ms
     - id: 14
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 295
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"test-container-trigger-nats","container_id":"4d0677d4-ccbe-4abd-8665-bc5f9fd674fe","scw_nats_config":{"subject":"TestSubject","mnq_nats_account_id":"AADGULIBDPUFWKRCVLGGIE5EEVIIOD2BSIQ3T3WAFOT4YC3TV6AN52VR","mnq_project_id":"105bdce1-64c0-48ab-899d-868455867ecf","mnq_region":"fr-par"}}'
+        body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers
-        method: POST
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers/e9b9d7b6-7df0-4431-ba74-87461bd71d38
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 446
+        content_length: 477
         uncompressed: false
-        body: '{"container_id":"4d0677d4-ccbe-4abd-8665-bc5f9fd674fe","description":"","error_message":null,"id":"4d187890-6763-4b38-84b5-4cda753f9a89","input_type":"scw_nats","name":"test-container-trigger-nats","scw_nats_config":{"mnq_credential_id":null,"mnq_nats_account_id":"AADGULIBDPUFWKRCVLGGIE5EEVIIOD2BSIQ3T3WAFOT4YC3TV6AN52VR","mnq_project_id":"105bdce1-64c0-48ab-899d-868455867ecf","mnq_region":"fr-par","subject":"TestSubject"},"status":"creating"}'
+        body: '{"container_id":"0ac2c960-6aed-4d4e-9bd3-79b08029f7ca","description":"","error_message":null,"id":"e9b9d7b6-7df0-4431-ba74-87461bd71d38","input_type":"scw_nats","name":"test-container-trigger-nats","scw_nats_config":{"mnq_credential_id":"ff828cc8-b9e4-4c10-8eb7-a7004ae7f36a","mnq_nats_account_id":"ABJMP6QEPGMC33K3SPDM6EKFDOCNUFH7FSUJGZCDGU5UNKOH2AFEMHFR","mnq_project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","mnq_region":"fr-par","subject":"TestSubject"},"status":"ready"}'
         headers:
             Content-Length:
-                - "446"
+                - "477"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:20 GMT
+                - Wed, 27 Aug 2025 15:06:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -740,10 +740,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a77d70d1-b2e3-4d2f-b359-cd73ef5a4b8b
+                - 110e98f2-e29a-4d26-8261-c64d44957fd7
         status: 200 OK
         code: 200
-        duration: 150.491042ms
+        duration: 173.76129ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -759,8 +759,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers/4d187890-6763-4b38-84b5-4cda753f9a89
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers/e9b9d7b6-7df0-4431-ba74-87461bd71d38
         method: GET
       response:
         proto: HTTP/2.0
@@ -768,20 +768,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 446
+        content_length: 477
         uncompressed: false
-        body: '{"container_id":"4d0677d4-ccbe-4abd-8665-bc5f9fd674fe","description":"","error_message":null,"id":"4d187890-6763-4b38-84b5-4cda753f9a89","input_type":"scw_nats","name":"test-container-trigger-nats","scw_nats_config":{"mnq_credential_id":null,"mnq_nats_account_id":"AADGULIBDPUFWKRCVLGGIE5EEVIIOD2BSIQ3T3WAFOT4YC3TV6AN52VR","mnq_project_id":"105bdce1-64c0-48ab-899d-868455867ecf","mnq_region":"fr-par","subject":"TestSubject"},"status":"creating"}'
+        body: '{"container_id":"0ac2c960-6aed-4d4e-9bd3-79b08029f7ca","description":"","error_message":null,"id":"e9b9d7b6-7df0-4431-ba74-87461bd71d38","input_type":"scw_nats","name":"test-container-trigger-nats","scw_nats_config":{"mnq_credential_id":"ff828cc8-b9e4-4c10-8eb7-a7004ae7f36a","mnq_nats_account_id":"ABJMP6QEPGMC33K3SPDM6EKFDOCNUFH7FSUJGZCDGU5UNKOH2AFEMHFR","mnq_project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","mnq_region":"fr-par","subject":"TestSubject"},"status":"ready"}'
         headers:
             Content-Length:
-                - "446"
+                - "477"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:21 GMT
+                - Wed, 27 Aug 2025 15:06:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -789,10 +789,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 80abeb7f-27cc-46a0-8284-6e9f5017b7db
+                - 107a2b90-f3b9-4106-bd5b-0e0d48173e03
         status: 200 OK
         code: 200
-        duration: 132.514792ms
+        duration: 97.919791ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -808,8 +808,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers/4d187890-6763-4b38-84b5-4cda753f9a89
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers/e9b9d7b6-7df0-4431-ba74-87461bd71d38
         method: GET
       response:
         proto: HTTP/2.0
@@ -817,20 +817,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 480
+        content_length: 477
         uncompressed: false
-        body: '{"container_id":"4d0677d4-ccbe-4abd-8665-bc5f9fd674fe","description":"","error_message":null,"id":"4d187890-6763-4b38-84b5-4cda753f9a89","input_type":"scw_nats","name":"test-container-trigger-nats","scw_nats_config":{"mnq_credential_id":"7bab04a8-b61d-4c1b-b936-ea3ac1aa40c3","mnq_nats_account_id":"AADGULIBDPUFWKRCVLGGIE5EEVIIOD2BSIQ3T3WAFOT4YC3TV6AN52VR","mnq_project_id":"105bdce1-64c0-48ab-899d-868455867ecf","mnq_region":"fr-par","subject":"TestSubject"},"status":"creating"}'
+        body: '{"container_id":"0ac2c960-6aed-4d4e-9bd3-79b08029f7ca","description":"","error_message":null,"id":"e9b9d7b6-7df0-4431-ba74-87461bd71d38","input_type":"scw_nats","name":"test-container-trigger-nats","scw_nats_config":{"mnq_credential_id":"ff828cc8-b9e4-4c10-8eb7-a7004ae7f36a","mnq_nats_account_id":"ABJMP6QEPGMC33K3SPDM6EKFDOCNUFH7FSUJGZCDGU5UNKOH2AFEMHFR","mnq_project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","mnq_region":"fr-par","subject":"TestSubject"},"status":"ready"}'
         headers:
             Content-Length:
-                - "480"
+                - "477"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:26 GMT
+                - Wed, 27 Aug 2025 15:06:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -838,10 +838,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1fef597f-87c8-4ac6-9533-fdff0d65df36
+                - a12578fd-4531-4e94-b003-ad73267b0eb6
         status: 200 OK
         code: 200
-        duration: 77.122208ms
+        duration: 86.537482ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -857,8 +857,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers/4d187890-6763-4b38-84b5-4cda753f9a89
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/786e9702-5c8d-4eec-aaef-1407003b8ac8
         method: GET
       response:
         proto: HTTP/2.0
@@ -866,20 +866,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 480
+        content_length: 591
         uncompressed: false
-        body: '{"container_id":"4d0677d4-ccbe-4abd-8665-bc5f9fd674fe","description":"","error_message":null,"id":"4d187890-6763-4b38-84b5-4cda753f9a89","input_type":"scw_nats","name":"test-container-trigger-nats","scw_nats_config":{"mnq_credential_id":"7bab04a8-b61d-4c1b-b936-ea3ac1aa40c3","mnq_nats_account_id":"AADGULIBDPUFWKRCVLGGIE5EEVIIOD2BSIQ3T3WAFOT4YC3TV6AN52VR","mnq_project_id":"105bdce1-64c0-48ab-899d-868455867ecf","mnq_region":"fr-par","subject":"TestSubject"},"status":"creating"}'
+        body: '{"created_at":"2025-08-27T15:06:03.177790Z","description":"","environment_variables":{},"error_message":null,"id":"786e9702-5c8d-4eec-aaef-1407003b8ac8","name":"tf-ns-reverent-hamilton","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsreverenthamiltonttyhqt3d","registry_namespace_id":"4cb07919-5f2d-4a1d-9ed0-b210da739d9c","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:05.902593Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "480"
+                - "591"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:31 GMT
+                - Wed, 27 Aug 2025 15:06:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -887,10 +887,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bed39751-5cf1-4efd-b628-1638e53b08b6
+                - 9150f138-dcdd-4956-a3a8-70feeced6c21
         status: 200 OK
         code: 200
-        duration: 88.328167ms
+        duration: 75.400402ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -906,8 +906,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers/4d187890-6763-4b38-84b5-4cda753f9a89
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/nats-accounts/ABJMP6QEPGMC33K3SPDM6EKFDOCNUFH7FSUJGZCDGU5UNKOH2AFEMHFR
         method: GET
       response:
         proto: HTTP/2.0
@@ -915,20 +915,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 477
+        content_length: 315
         uncompressed: false
-        body: '{"container_id":"4d0677d4-ccbe-4abd-8665-bc5f9fd674fe","description":"","error_message":null,"id":"4d187890-6763-4b38-84b5-4cda753f9a89","input_type":"scw_nats","name":"test-container-trigger-nats","scw_nats_config":{"mnq_credential_id":"7bab04a8-b61d-4c1b-b936-ea3ac1aa40c3","mnq_nats_account_id":"AADGULIBDPUFWKRCVLGGIE5EEVIIOD2BSIQ3T3WAFOT4YC3TV6AN52VR","mnq_project_id":"105bdce1-64c0-48ab-899d-868455867ecf","mnq_region":"fr-par","subject":"TestSubject"},"status":"ready"}'
+        body: '{"created_at":"2025-08-27T15:06:01.829958Z","endpoint":"nats://nats.mnq.fr-par.scaleway.com:4222","id":"ABJMP6QEPGMC33K3SPDM6EKFDOCNUFH7FSUJGZCDGU5UNKOH2AFEMHFR","name":"tf-nats-account-vibrant-beaver","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","updated_at":"2025-08-27T15:06:01.829958Z"}'
         headers:
             Content-Length:
-                - "477"
+                - "315"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:36 GMT
+                - Wed, 27 Aug 2025 15:06:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -936,10 +936,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f4afc60d-0d3a-464a-bec7-15c6d5e4bcb5
+                - d0056da6-889a-44a0-8807-ea202316dce0
         status: 200 OK
         code: 200
-        duration: 77.950333ms
+        duration: 83.973009ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -955,8 +955,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers/4d187890-6763-4b38-84b5-4cda753f9a89
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/0ac2c960-6aed-4d4e-9bd3-79b08029f7ca
         method: GET
       response:
         proto: HTTP/2.0
@@ -964,20 +964,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 477
+        content_length: 977
         uncompressed: false
-        body: '{"container_id":"4d0677d4-ccbe-4abd-8665-bc5f9fd674fe","description":"","error_message":null,"id":"4d187890-6763-4b38-84b5-4cda753f9a89","input_type":"scw_nats","name":"test-container-trigger-nats","scw_nats_config":{"mnq_credential_id":"7bab04a8-b61d-4c1b-b936-ea3ac1aa40c3","mnq_nats_account_id":"AADGULIBDPUFWKRCVLGGIE5EEVIIOD2BSIQ3T3WAFOT4YC3TV6AN52VR","mnq_project_id":"105bdce1-64c0-48ab-899d-868455867ecf","mnq_region":"fr-par","subject":"TestSubject"},"status":"ready"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:09.663037Z","description":"","domain_name":"tfnsreverenthamiltonttyhqt3d-tf-co-pensive-mirzakhani.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"0ac2c960-6aed-4d4e-9bd3-79b08029f7ca","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-pensive-mirzakhani","namespace_id":"786e9702-5c8d-4eec-aaef-1407003b8ac8","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsreverenthamiltonttyhqt3d/tf-co-pensive-mirzakhani:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:09.663037Z"}'
         headers:
             Content-Length:
-                - "477"
+                - "977"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:36 GMT
+                - Wed, 27 Aug 2025 15:06:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -985,10 +985,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bc347c3c-444e-4bed-a514-1af442b82c31
+                - ea5a9050-57d6-45c5-b404-6c893a174818
         status: 200 OK
         code: 200
-        duration: 84.875208ms
+        duration: 93.112419ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1004,8 +1004,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers/4d187890-6763-4b38-84b5-4cda753f9a89
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers/e9b9d7b6-7df0-4431-ba74-87461bd71d38
         method: GET
       response:
         proto: HTTP/2.0
@@ -1015,7 +1015,7 @@ interactions:
         trailer: {}
         content_length: 477
         uncompressed: false
-        body: '{"container_id":"4d0677d4-ccbe-4abd-8665-bc5f9fd674fe","description":"","error_message":null,"id":"4d187890-6763-4b38-84b5-4cda753f9a89","input_type":"scw_nats","name":"test-container-trigger-nats","scw_nats_config":{"mnq_credential_id":"7bab04a8-b61d-4c1b-b936-ea3ac1aa40c3","mnq_nats_account_id":"AADGULIBDPUFWKRCVLGGIE5EEVIIOD2BSIQ3T3WAFOT4YC3TV6AN52VR","mnq_project_id":"105bdce1-64c0-48ab-899d-868455867ecf","mnq_region":"fr-par","subject":"TestSubject"},"status":"ready"}'
+        body: '{"container_id":"0ac2c960-6aed-4d4e-9bd3-79b08029f7ca","description":"","error_message":null,"id":"e9b9d7b6-7df0-4431-ba74-87461bd71d38","input_type":"scw_nats","name":"test-container-trigger-nats","scw_nats_config":{"mnq_credential_id":"ff828cc8-b9e4-4c10-8eb7-a7004ae7f36a","mnq_nats_account_id":"ABJMP6QEPGMC33K3SPDM6EKFDOCNUFH7FSUJGZCDGU5UNKOH2AFEMHFR","mnq_project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","mnq_region":"fr-par","subject":"TestSubject"},"status":"ready"}'
         headers:
             Content-Length:
                 - "477"
@@ -1024,9 +1024,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:36 GMT
+                - Wed, 27 Aug 2025 15:06:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1034,10 +1034,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7053ff4a-9bf6-43b7-8e2f-0be218423c60
+                - 2efe89f0-b4e1-4419-9613-438bda8fb6c0
         status: 200 OK
         code: 200
-        duration: 87.533375ms
+        duration: 92.924577ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1053,8 +1053,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers/4d187890-6763-4b38-84b5-4cda753f9a89
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/786e9702-5c8d-4eec-aaef-1407003b8ac8
         method: GET
       response:
         proto: HTTP/2.0
@@ -1062,20 +1062,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 477
+        content_length: 591
         uncompressed: false
-        body: '{"container_id":"4d0677d4-ccbe-4abd-8665-bc5f9fd674fe","description":"","error_message":null,"id":"4d187890-6763-4b38-84b5-4cda753f9a89","input_type":"scw_nats","name":"test-container-trigger-nats","scw_nats_config":{"mnq_credential_id":"7bab04a8-b61d-4c1b-b936-ea3ac1aa40c3","mnq_nats_account_id":"AADGULIBDPUFWKRCVLGGIE5EEVIIOD2BSIQ3T3WAFOT4YC3TV6AN52VR","mnq_project_id":"105bdce1-64c0-48ab-899d-868455867ecf","mnq_region":"fr-par","subject":"TestSubject"},"status":"ready"}'
+        body: '{"created_at":"2025-08-27T15:06:03.177790Z","description":"","environment_variables":{},"error_message":null,"id":"786e9702-5c8d-4eec-aaef-1407003b8ac8","name":"tf-ns-reverent-hamilton","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsreverenthamiltonttyhqt3d","registry_namespace_id":"4cb07919-5f2d-4a1d-9ed0-b210da739d9c","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:05.902593Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "477"
+                - "591"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:36 GMT
+                - Wed, 27 Aug 2025 15:06:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1083,10 +1083,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fc53b374-c2d5-4589-b942-099619eba92f
+                - a905a626-1a8a-4654-8a30-8d63a7e354f6
         status: 200 OK
         code: 200
-        duration: 83.382ms
+        duration: 95.699034ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1102,8 +1102,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/nats-accounts/AADGULIBDPUFWKRCVLGGIE5EEVIIOD2BSIQ3T3WAFOT4YC3TV6AN52VR
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/nats-accounts/ABJMP6QEPGMC33K3SPDM6EKFDOCNUFH7FSUJGZCDGU5UNKOH2AFEMHFR
         method: GET
       response:
         proto: HTTP/2.0
@@ -1111,20 +1111,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 311
+        content_length: 315
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:48.531129Z","endpoint":"nats://nats.mnq.fr-par.scaleway.com:4222","id":"AADGULIBDPUFWKRCVLGGIE5EEVIIOD2BSIQ3T3WAFOT4YC3TV6AN52VR","name":"tf-nats-account-keen-curie","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","updated_at":"2025-01-24T15:37:48.531129Z"}'
+        body: '{"created_at":"2025-08-27T15:06:01.829958Z","endpoint":"nats://nats.mnq.fr-par.scaleway.com:4222","id":"ABJMP6QEPGMC33K3SPDM6EKFDOCNUFH7FSUJGZCDGU5UNKOH2AFEMHFR","name":"tf-nats-account-vibrant-beaver","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","updated_at":"2025-08-27T15:06:01.829958Z"}'
         headers:
             Content-Length:
-                - "311"
+                - "315"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:37 GMT
+                - Wed, 27 Aug 2025 15:06:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1132,10 +1132,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a0f2ceb3-2916-4ed5-bb68-a953c2ce2814
+                - 50ce6a2b-4b58-4ef3-a43c-09b5c779d08b
         status: 200 OK
         code: 200
-        duration: 81.575208ms
+        duration: 102.709219ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1151,8 +1151,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c3645d3e-a96e-4120-a453-4a3e19d1d3a9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/0ac2c960-6aed-4d4e-9bd3-79b08029f7ca
         method: GET
       response:
         proto: HTTP/2.0
@@ -1160,20 +1160,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 552
+        content_length: 977
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.310909Z","description":"","environment_variables":{},"error_message":null,"id":"c3645d3e-a96e-4120-a453-4a3e19d1d3a9","name":"tf-ns-peaceful-tesla","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnspeacefultesla9odbwvna","registry_namespace_id":"a3471425-4285-431c-8605-a8c6948f60c4","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:38:19.400665Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:09.663037Z","description":"","domain_name":"tfnsreverenthamiltonttyhqt3d-tf-co-pensive-mirzakhani.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"0ac2c960-6aed-4d4e-9bd3-79b08029f7ca","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-pensive-mirzakhani","namespace_id":"786e9702-5c8d-4eec-aaef-1407003b8ac8","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsreverenthamiltonttyhqt3d/tf-co-pensive-mirzakhani:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:09.663037Z"}'
         headers:
             Content-Length:
-                - "552"
+                - "977"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:37 GMT
+                - Wed, 27 Aug 2025 15:06:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1181,10 +1181,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7eca53c4-547d-465f-b9e0-28588cd517db
+                - 313d7791-beb7-4d97-9502-332b61662836
         status: 200 OK
         code: 200
-        duration: 86.277042ms
+        duration: 89.843585ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1200,8 +1200,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/4d0677d4-ccbe-4abd-8665-bc5f9fd674fe
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers/e9b9d7b6-7df0-4431-ba74-87461bd71d38
         method: GET
       response:
         proto: HTTP/2.0
@@ -1209,20 +1209,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 906
+        content_length: 477
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:20.625766Z","description":"","domain_name":"tfnspeacefultesla9odbwvna-tf-co-admiring-swanson.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"4d0677d4-ccbe-4abd-8665-bc5f9fd674fe","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-admiring-swanson","namespace_id":"c3645d3e-a96e-4120-a453-4a3e19d1d3a9","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnspeacefultesla9odbwvna/tf-co-admiring-swanson:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:38:20.625766Z"}'
+        body: '{"container_id":"0ac2c960-6aed-4d4e-9bd3-79b08029f7ca","description":"","error_message":null,"id":"e9b9d7b6-7df0-4431-ba74-87461bd71d38","input_type":"scw_nats","name":"test-container-trigger-nats","scw_nats_config":{"mnq_credential_id":"ff828cc8-b9e4-4c10-8eb7-a7004ae7f36a","mnq_nats_account_id":"ABJMP6QEPGMC33K3SPDM6EKFDOCNUFH7FSUJGZCDGU5UNKOH2AFEMHFR","mnq_project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","mnq_region":"fr-par","subject":"TestSubject"},"status":"ready"}'
         headers:
             Content-Length:
-                - "906"
+                - "477"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:37 GMT
+                - Wed, 27 Aug 2025 15:06:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1230,10 +1230,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 22418d5d-1768-4176-8144-8e97448f50ef
+                - c78c2029-b306-4f30-8c78-28cce5830021
         status: 200 OK
         code: 200
-        duration: 76.260333ms
+        duration: 109.337448ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1249,8 +1249,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers/4d187890-6763-4b38-84b5-4cda753f9a89
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/nats-accounts/ABJMP6QEPGMC33K3SPDM6EKFDOCNUFH7FSUJGZCDGU5UNKOH2AFEMHFR
         method: GET
       response:
         proto: HTTP/2.0
@@ -1258,20 +1258,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 477
+        content_length: 315
         uncompressed: false
-        body: '{"container_id":"4d0677d4-ccbe-4abd-8665-bc5f9fd674fe","description":"","error_message":null,"id":"4d187890-6763-4b38-84b5-4cda753f9a89","input_type":"scw_nats","name":"test-container-trigger-nats","scw_nats_config":{"mnq_credential_id":"7bab04a8-b61d-4c1b-b936-ea3ac1aa40c3","mnq_nats_account_id":"AADGULIBDPUFWKRCVLGGIE5EEVIIOD2BSIQ3T3WAFOT4YC3TV6AN52VR","mnq_project_id":"105bdce1-64c0-48ab-899d-868455867ecf","mnq_region":"fr-par","subject":"TestSubject"},"status":"ready"}'
+        body: '{"created_at":"2025-08-27T15:06:01.829958Z","endpoint":"nats://nats.mnq.fr-par.scaleway.com:4222","id":"ABJMP6QEPGMC33K3SPDM6EKFDOCNUFH7FSUJGZCDGU5UNKOH2AFEMHFR","name":"tf-nats-account-vibrant-beaver","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","updated_at":"2025-08-27T15:06:01.829958Z"}'
         headers:
             Content-Length:
-                - "477"
+                - "315"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:37 GMT
+                - Wed, 27 Aug 2025 15:06:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1279,10 +1279,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bca52928-774a-40b8-b833-879611829e17
+                - fc8dda54-bca2-4a1e-9137-053ded78808d
         status: 200 OK
         code: 200
-        duration: 80.65825ms
+        duration: 87.185468ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1298,8 +1298,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c3645d3e-a96e-4120-a453-4a3e19d1d3a9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/786e9702-5c8d-4eec-aaef-1407003b8ac8
         method: GET
       response:
         proto: HTTP/2.0
@@ -1307,20 +1307,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 552
+        content_length: 591
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.310909Z","description":"","environment_variables":{},"error_message":null,"id":"c3645d3e-a96e-4120-a453-4a3e19d1d3a9","name":"tf-ns-peaceful-tesla","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnspeacefultesla9odbwvna","registry_namespace_id":"a3471425-4285-431c-8605-a8c6948f60c4","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:38:19.400665Z"}'
+        body: '{"created_at":"2025-08-27T15:06:03.177790Z","description":"","environment_variables":{},"error_message":null,"id":"786e9702-5c8d-4eec-aaef-1407003b8ac8","name":"tf-ns-reverent-hamilton","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsreverenthamiltonttyhqt3d","registry_namespace_id":"4cb07919-5f2d-4a1d-9ed0-b210da739d9c","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:05.902593Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "552"
+                - "591"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:38 GMT
+                - Wed, 27 Aug 2025 15:06:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1328,10 +1328,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1cce8498-33d9-406b-97b6-61329336574d
+                - 6244db54-22a5-4be6-a66b-47a32219f17a
         status: 200 OK
         code: 200
-        duration: 78.10225ms
+        duration: 89.097295ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1347,8 +1347,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/nats-accounts/AADGULIBDPUFWKRCVLGGIE5EEVIIOD2BSIQ3T3WAFOT4YC3TV6AN52VR
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/0ac2c960-6aed-4d4e-9bd3-79b08029f7ca
         method: GET
       response:
         proto: HTTP/2.0
@@ -1356,20 +1356,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 311
+        content_length: 977
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:48.531129Z","endpoint":"nats://nats.mnq.fr-par.scaleway.com:4222","id":"AADGULIBDPUFWKRCVLGGIE5EEVIIOD2BSIQ3T3WAFOT4YC3TV6AN52VR","name":"tf-nats-account-keen-curie","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","updated_at":"2025-01-24T15:37:48.531129Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:09.663037Z","description":"","domain_name":"tfnsreverenthamiltonttyhqt3d-tf-co-pensive-mirzakhani.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"0ac2c960-6aed-4d4e-9bd3-79b08029f7ca","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-pensive-mirzakhani","namespace_id":"786e9702-5c8d-4eec-aaef-1407003b8ac8","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsreverenthamiltonttyhqt3d/tf-co-pensive-mirzakhani:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:09.663037Z"}'
         headers:
             Content-Length:
-                - "311"
+                - "977"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:38 GMT
+                - Wed, 27 Aug 2025 15:06:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1377,10 +1377,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b76fcf54-93c6-438a-a12c-9fb9b419ac27
+                - f997511d-ee83-4d2a-9eae-e6fff908fd98
         status: 200 OK
         code: 200
-        duration: 87.68725ms
+        duration: 105.478366ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1396,8 +1396,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/4d0677d4-ccbe-4abd-8665-bc5f9fd674fe
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers/e9b9d7b6-7df0-4431-ba74-87461bd71d38
         method: GET
       response:
         proto: HTTP/2.0
@@ -1405,20 +1405,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 906
+        content_length: 477
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:20.625766Z","description":"","domain_name":"tfnspeacefultesla9odbwvna-tf-co-admiring-swanson.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"4d0677d4-ccbe-4abd-8665-bc5f9fd674fe","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-admiring-swanson","namespace_id":"c3645d3e-a96e-4120-a453-4a3e19d1d3a9","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnspeacefultesla9odbwvna/tf-co-admiring-swanson:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:38:20.625766Z"}'
+        body: '{"container_id":"0ac2c960-6aed-4d4e-9bd3-79b08029f7ca","description":"","error_message":null,"id":"e9b9d7b6-7df0-4431-ba74-87461bd71d38","input_type":"scw_nats","name":"test-container-trigger-nats","scw_nats_config":{"mnq_credential_id":"ff828cc8-b9e4-4c10-8eb7-a7004ae7f36a","mnq_nats_account_id":"ABJMP6QEPGMC33K3SPDM6EKFDOCNUFH7FSUJGZCDGU5UNKOH2AFEMHFR","mnq_project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","mnq_region":"fr-par","subject":"TestSubject"},"status":"ready"}'
         headers:
             Content-Length:
-                - "906"
+                - "477"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:38 GMT
+                - Wed, 27 Aug 2025 15:06:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1426,10 +1426,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 48724e17-4254-4e11-882f-704250832a42
+                - 384c6684-86ed-4299-9948-778e609952cb
         status: 200 OK
         code: 200
-        duration: 87.4785ms
+        duration: 80.190502ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1445,8 +1445,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers/4d187890-6763-4b38-84b5-4cda753f9a89
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers/e9b9d7b6-7df0-4431-ba74-87461bd71d38
         method: GET
       response:
         proto: HTTP/2.0
@@ -1456,7 +1456,7 @@ interactions:
         trailer: {}
         content_length: 477
         uncompressed: false
-        body: '{"container_id":"4d0677d4-ccbe-4abd-8665-bc5f9fd674fe","description":"","error_message":null,"id":"4d187890-6763-4b38-84b5-4cda753f9a89","input_type":"scw_nats","name":"test-container-trigger-nats","scw_nats_config":{"mnq_credential_id":"7bab04a8-b61d-4c1b-b936-ea3ac1aa40c3","mnq_nats_account_id":"AADGULIBDPUFWKRCVLGGIE5EEVIIOD2BSIQ3T3WAFOT4YC3TV6AN52VR","mnq_project_id":"105bdce1-64c0-48ab-899d-868455867ecf","mnq_region":"fr-par","subject":"TestSubject"},"status":"ready"}'
+        body: '{"container_id":"0ac2c960-6aed-4d4e-9bd3-79b08029f7ca","description":"","error_message":null,"id":"e9b9d7b6-7df0-4431-ba74-87461bd71d38","input_type":"scw_nats","name":"test-container-trigger-nats","scw_nats_config":{"mnq_credential_id":"ff828cc8-b9e4-4c10-8eb7-a7004ae7f36a","mnq_nats_account_id":"ABJMP6QEPGMC33K3SPDM6EKFDOCNUFH7FSUJGZCDGU5UNKOH2AFEMHFR","mnq_project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","mnq_region":"fr-par","subject":"TestSubject"},"status":"ready"}'
         headers:
             Content-Length:
                 - "477"
@@ -1465,9 +1465,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:38 GMT
+                - Wed, 27 Aug 2025 15:06:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1475,10 +1475,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 56fe24e8-9aa8-425b-83a9-cb82bce09bda
+                - 99c7faae-cf4c-428f-a41b-5213e54438be
         status: 200 OK
         code: 200
-        duration: 74.297875ms
+        duration: 104.693062ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1494,29 +1494,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/nats-accounts/AADGULIBDPUFWKRCVLGGIE5EEVIIOD2BSIQ3T3WAFOT4YC3TV6AN52VR
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers/e9b9d7b6-7df0-4431-ba74-87461bd71d38
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 311
+        content_length: 480
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:48.531129Z","endpoint":"nats://nats.mnq.fr-par.scaleway.com:4222","id":"AADGULIBDPUFWKRCVLGGIE5EEVIIOD2BSIQ3T3WAFOT4YC3TV6AN52VR","name":"tf-nats-account-keen-curie","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","updated_at":"2025-01-24T15:37:48.531129Z"}'
+        body: '{"container_id":"0ac2c960-6aed-4d4e-9bd3-79b08029f7ca","description":"","error_message":null,"id":"e9b9d7b6-7df0-4431-ba74-87461bd71d38","input_type":"scw_nats","name":"test-container-trigger-nats","scw_nats_config":{"mnq_credential_id":"ff828cc8-b9e4-4c10-8eb7-a7004ae7f36a","mnq_nats_account_id":"ABJMP6QEPGMC33K3SPDM6EKFDOCNUFH7FSUJGZCDGU5UNKOH2AFEMHFR","mnq_project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","mnq_region":"fr-par","subject":"TestSubject"},"status":"deleting"}'
         headers:
             Content-Length:
-                - "311"
+                - "480"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:39 GMT
+                - Wed, 27 Aug 2025 15:06:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1524,10 +1524,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 19134b13-6ed4-4df9-b7ef-fdb3568a29a2
+                - 5e94709d-607d-4c8c-a19d-abe58e952338
         status: 200 OK
         code: 200
-        duration: 62.011583ms
+        duration: 100.487651ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1543,8 +1543,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c3645d3e-a96e-4120-a453-4a3e19d1d3a9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers/e9b9d7b6-7df0-4431-ba74-87461bd71d38
         method: GET
       response:
         proto: HTTP/2.0
@@ -1552,20 +1552,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 552
+        content_length: 480
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.310909Z","description":"","environment_variables":{},"error_message":null,"id":"c3645d3e-a96e-4120-a453-4a3e19d1d3a9","name":"tf-ns-peaceful-tesla","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnspeacefultesla9odbwvna","registry_namespace_id":"a3471425-4285-431c-8605-a8c6948f60c4","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:38:19.400665Z"}'
+        body: '{"container_id":"0ac2c960-6aed-4d4e-9bd3-79b08029f7ca","description":"","error_message":null,"id":"e9b9d7b6-7df0-4431-ba74-87461bd71d38","input_type":"scw_nats","name":"test-container-trigger-nats","scw_nats_config":{"mnq_credential_id":"ff828cc8-b9e4-4c10-8eb7-a7004ae7f36a","mnq_nats_account_id":"ABJMP6QEPGMC33K3SPDM6EKFDOCNUFH7FSUJGZCDGU5UNKOH2AFEMHFR","mnq_project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","mnq_region":"fr-par","subject":"TestSubject"},"status":"deleting"}'
         headers:
             Content-Length:
-                - "552"
+                - "480"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:39 GMT
+                - Wed, 27 Aug 2025 15:06:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1573,10 +1573,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8b0dfa16-e12e-4b6e-867f-3d3afa6c8452
+                - 1407124a-afea-4442-842f-5e09e213cccb
         status: 200 OK
         code: 200
-        duration: 64.574416ms
+        duration: 172.474387ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1592,8 +1592,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/4d0677d4-ccbe-4abd-8665-bc5f9fd674fe
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers/e9b9d7b6-7df0-4431-ba74-87461bd71d38
         method: GET
       response:
         proto: HTTP/2.0
@@ -1601,20 +1601,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 906
+        content_length: 480
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:20.625766Z","description":"","domain_name":"tfnspeacefultesla9odbwvna-tf-co-admiring-swanson.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"4d0677d4-ccbe-4abd-8665-bc5f9fd674fe","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-admiring-swanson","namespace_id":"c3645d3e-a96e-4120-a453-4a3e19d1d3a9","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnspeacefultesla9odbwvna/tf-co-admiring-swanson:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:38:20.625766Z"}'
+        body: '{"container_id":"0ac2c960-6aed-4d4e-9bd3-79b08029f7ca","description":"","error_message":null,"id":"e9b9d7b6-7df0-4431-ba74-87461bd71d38","input_type":"scw_nats","name":"test-container-trigger-nats","scw_nats_config":{"mnq_credential_id":"ff828cc8-b9e4-4c10-8eb7-a7004ae7f36a","mnq_nats_account_id":"ABJMP6QEPGMC33K3SPDM6EKFDOCNUFH7FSUJGZCDGU5UNKOH2AFEMHFR","mnq_project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","mnq_region":"fr-par","subject":"TestSubject"},"status":"deleting"}'
         headers:
             Content-Length:
-                - "906"
+                - "480"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:39 GMT
+                - Wed, 27 Aug 2025 15:06:33 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1622,10 +1622,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 153d3438-6374-4679-839b-aa46b5bc4e5c
+                - b0dd705f-3b33-4926-9ff8-e1cf355925d5
         status: 200 OK
         code: 200
-        duration: 88.760875ms
+        duration: 103.924061ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1641,8 +1641,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers/4d187890-6763-4b38-84b5-4cda753f9a89
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers/e9b9d7b6-7df0-4431-ba74-87461bd71d38
         method: GET
       response:
         proto: HTTP/2.0
@@ -1650,20 +1650,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 477
+        content_length: 480
         uncompressed: false
-        body: '{"container_id":"4d0677d4-ccbe-4abd-8665-bc5f9fd674fe","description":"","error_message":null,"id":"4d187890-6763-4b38-84b5-4cda753f9a89","input_type":"scw_nats","name":"test-container-trigger-nats","scw_nats_config":{"mnq_credential_id":"7bab04a8-b61d-4c1b-b936-ea3ac1aa40c3","mnq_nats_account_id":"AADGULIBDPUFWKRCVLGGIE5EEVIIOD2BSIQ3T3WAFOT4YC3TV6AN52VR","mnq_project_id":"105bdce1-64c0-48ab-899d-868455867ecf","mnq_region":"fr-par","subject":"TestSubject"},"status":"ready"}'
+        body: '{"container_id":"0ac2c960-6aed-4d4e-9bd3-79b08029f7ca","description":"","error_message":null,"id":"e9b9d7b6-7df0-4431-ba74-87461bd71d38","input_type":"scw_nats","name":"test-container-trigger-nats","scw_nats_config":{"mnq_credential_id":"ff828cc8-b9e4-4c10-8eb7-a7004ae7f36a","mnq_nats_account_id":"ABJMP6QEPGMC33K3SPDM6EKFDOCNUFH7FSUJGZCDGU5UNKOH2AFEMHFR","mnq_project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","mnq_region":"fr-par","subject":"TestSubject"},"status":"deleting"}'
         headers:
             Content-Length:
-                - "477"
+                - "480"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:39 GMT
+                - Wed, 27 Aug 2025 15:06:38 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1671,10 +1671,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1589b56a-4a69-4dd8-9131-83222fff08b6
+                - ebc0bec5-efaa-4ead-a803-a3b98a9f2ef6
         status: 200 OK
         code: 200
-        duration: 85.942708ms
+        duration: 106.504645ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1690,8 +1690,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers/4d187890-6763-4b38-84b5-4cda753f9a89
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers/e9b9d7b6-7df0-4431-ba74-87461bd71d38
         method: GET
       response:
         proto: HTTP/2.0
@@ -1699,20 +1699,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 477
+        content_length: 480
         uncompressed: false
-        body: '{"container_id":"4d0677d4-ccbe-4abd-8665-bc5f9fd674fe","description":"","error_message":null,"id":"4d187890-6763-4b38-84b5-4cda753f9a89","input_type":"scw_nats","name":"test-container-trigger-nats","scw_nats_config":{"mnq_credential_id":"7bab04a8-b61d-4c1b-b936-ea3ac1aa40c3","mnq_nats_account_id":"AADGULIBDPUFWKRCVLGGIE5EEVIIOD2BSIQ3T3WAFOT4YC3TV6AN52VR","mnq_project_id":"105bdce1-64c0-48ab-899d-868455867ecf","mnq_region":"fr-par","subject":"TestSubject"},"status":"ready"}'
+        body: '{"container_id":"0ac2c960-6aed-4d4e-9bd3-79b08029f7ca","description":"","error_message":null,"id":"e9b9d7b6-7df0-4431-ba74-87461bd71d38","input_type":"scw_nats","name":"test-container-trigger-nats","scw_nats_config":{"mnq_credential_id":"ff828cc8-b9e4-4c10-8eb7-a7004ae7f36a","mnq_nats_account_id":"ABJMP6QEPGMC33K3SPDM6EKFDOCNUFH7FSUJGZCDGU5UNKOH2AFEMHFR","mnq_project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","mnq_region":"fr-par","subject":"TestSubject"},"status":"deleting"}'
         headers:
             Content-Length:
-                - "477"
+                - "480"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:40 GMT
+                - Wed, 27 Aug 2025 15:06:44 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1720,10 +1720,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6899a955-9b6a-41af-8ee7-894c22b40a4b
+                - 198d9695-7b53-4599-bbc8-9019c8e7340f
         status: 200 OK
         code: 200
-        duration: 79.423167ms
+        duration: 92.355073ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1739,9 +1739,9 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers/4d187890-6763-4b38-84b5-4cda753f9a89
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers/e9b9d7b6-7df0-4431-ba74-87461bd71d38
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
@@ -1750,7 +1750,7 @@ interactions:
         trailer: {}
         content_length: 480
         uncompressed: false
-        body: '{"container_id":"4d0677d4-ccbe-4abd-8665-bc5f9fd674fe","description":"","error_message":null,"id":"4d187890-6763-4b38-84b5-4cda753f9a89","input_type":"scw_nats","name":"test-container-trigger-nats","scw_nats_config":{"mnq_credential_id":"7bab04a8-b61d-4c1b-b936-ea3ac1aa40c3","mnq_nats_account_id":"AADGULIBDPUFWKRCVLGGIE5EEVIIOD2BSIQ3T3WAFOT4YC3TV6AN52VR","mnq_project_id":"105bdce1-64c0-48ab-899d-868455867ecf","mnq_region":"fr-par","subject":"TestSubject"},"status":"deleting"}'
+        body: '{"container_id":"0ac2c960-6aed-4d4e-9bd3-79b08029f7ca","description":"","error_message":null,"id":"e9b9d7b6-7df0-4431-ba74-87461bd71d38","input_type":"scw_nats","name":"test-container-trigger-nats","scw_nats_config":{"mnq_credential_id":"ff828cc8-b9e4-4c10-8eb7-a7004ae7f36a","mnq_nats_account_id":"ABJMP6QEPGMC33K3SPDM6EKFDOCNUFH7FSUJGZCDGU5UNKOH2AFEMHFR","mnq_project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","mnq_region":"fr-par","subject":"TestSubject"},"status":"deleting"}'
         headers:
             Content-Length:
                 - "480"
@@ -1759,9 +1759,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:40 GMT
+                - Wed, 27 Aug 2025 15:06:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1769,10 +1769,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c1878f03-63e3-43a7-9a88-111158bfaa1d
+                - ac7d632c-5c89-4d29-862a-e570aff7f6e8
         status: 200 OK
         code: 200
-        duration: 100.036792ms
+        duration: 98.307505ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1788,106 +1788,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers/4d187890-6763-4b38-84b5-4cda753f9a89
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 480
-        uncompressed: false
-        body: '{"container_id":"4d0677d4-ccbe-4abd-8665-bc5f9fd674fe","description":"","error_message":null,"id":"4d187890-6763-4b38-84b5-4cda753f9a89","input_type":"scw_nats","name":"test-container-trigger-nats","scw_nats_config":{"mnq_credential_id":"7bab04a8-b61d-4c1b-b936-ea3ac1aa40c3","mnq_nats_account_id":"AADGULIBDPUFWKRCVLGGIE5EEVIIOD2BSIQ3T3WAFOT4YC3TV6AN52VR","mnq_project_id":"105bdce1-64c0-48ab-899d-868455867ecf","mnq_region":"fr-par","subject":"TestSubject"},"status":"deleting"}'
-        headers:
-            Content-Length:
-                - "480"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:38:40 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - e9910cf1-85b1-4220-9d91-2a69eb411405
-        status: 200 OK
-        code: 200
-        duration: 78.624292ms
-    - id: 37
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers/4d187890-6763-4b38-84b5-4cda753f9a89
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 480
-        uncompressed: false
-        body: '{"container_id":"4d0677d4-ccbe-4abd-8665-bc5f9fd674fe","description":"","error_message":null,"id":"4d187890-6763-4b38-84b5-4cda753f9a89","input_type":"scw_nats","name":"test-container-trigger-nats","scw_nats_config":{"mnq_credential_id":"7bab04a8-b61d-4c1b-b936-ea3ac1aa40c3","mnq_nats_account_id":"AADGULIBDPUFWKRCVLGGIE5EEVIIOD2BSIQ3T3WAFOT4YC3TV6AN52VR","mnq_project_id":"105bdce1-64c0-48ab-899d-868455867ecf","mnq_region":"fr-par","subject":"TestSubject"},"status":"deleting"}'
-        headers:
-            Content-Length:
-                - "480"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:38:45 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 368eedd2-9757-4cc6-8b10-50caeb962aa5
-        status: 200 OK
-        code: 200
-        duration: 89.691375ms
-    - id: 38
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers/4d187890-6763-4b38-84b5-4cda753f9a89
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers/e9b9d7b6-7df0-4431-ba74-87461bd71d38
         method: GET
       response:
         proto: HTTP/2.0
@@ -1906,9 +1808,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:50 GMT
+                - Wed, 27 Aug 2025 15:06:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1916,10 +1818,106 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 77937a55-8ee7-4e64-98b3-ef2205196311
+                - 34e95c0f-34a4-412c-9c6a-bc61a48b78a0
         status: 404 Not Found
         code: 404
-        duration: 31.554541ms
+        duration: 34.672107ms
+    - id: 37
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/0ac2c960-6aed-4d4e-9bd3-79b08029f7ca
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 977
+        uncompressed: false
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:09.663037Z","description":"","domain_name":"tfnsreverenthamiltonttyhqt3d-tf-co-pensive-mirzakhani.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"0ac2c960-6aed-4d4e-9bd3-79b08029f7ca","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-pensive-mirzakhani","namespace_id":"786e9702-5c8d-4eec-aaef-1407003b8ac8","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsreverenthamiltonttyhqt3d/tf-co-pensive-mirzakhani:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:09.663037Z"}'
+        headers:
+            Content-Length:
+                - "977"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:54 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - bf4e5774-11d3-42eb-96d6-ba2ba73fce96
+        status: 200 OK
+        code: 200
+        duration: 87.873496ms
+    - id: 38
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/nats-accounts/ABJMP6QEPGMC33K3SPDM6EKFDOCNUFH7FSUJGZCDGU5UNKOH2AFEMHFR
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:54 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 81951947-8f0b-455c-8e95-feeb91674fd0
+        status: 204 No Content
+        code: 204
+        duration: 267.730611ms
     - id: 39
       request:
         proto: HTTP/1.1
@@ -1935,29 +1933,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/4d0677d4-ccbe-4abd-8665-bc5f9fd674fe
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/0ac2c960-6aed-4d4e-9bd3-79b08029f7ca
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 906
+        content_length: 981
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:20.625766Z","description":"","domain_name":"tfnspeacefultesla9odbwvna-tf-co-admiring-swanson.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"4d0677d4-ccbe-4abd-8665-bc5f9fd674fe","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-admiring-swanson","namespace_id":"c3645d3e-a96e-4120-a453-4a3e19d1d3a9","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnspeacefultesla9odbwvna/tf-co-admiring-swanson:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:38:20.625766Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:09.663037Z","description":"","domain_name":"tfnsreverenthamiltonttyhqt3d-tf-co-pensive-mirzakhani.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"0ac2c960-6aed-4d4e-9bd3-79b08029f7ca","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-pensive-mirzakhani","namespace_id":"786e9702-5c8d-4eec-aaef-1407003b8ac8","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsreverenthamiltonttyhqt3d/tf-co-pensive-mirzakhani:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:54.317165249Z"}'
         headers:
             Content-Length:
-                - "906"
+                - "981"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:50 GMT
+                - Wed, 27 Aug 2025 15:06:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1965,10 +1963,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ebf7fd85-ffcc-48b1-a152-b3c09768c318
+                - bf4752bb-afd0-40ac-a260-e2cd41abeb2d
         status: 200 OK
         code: 200
-        duration: 80.049125ms
+        duration: 209.430784ms
     - id: 40
       request:
         proto: HTTP/1.1
@@ -1984,29 +1982,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/4d0677d4-ccbe-4abd-8665-bc5f9fd674fe
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/786e9702-5c8d-4eec-aaef-1407003b8ac8
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 910
+        content_length: 591
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:20.625766Z","description":"","domain_name":"tfnspeacefultesla9odbwvna-tf-co-admiring-swanson.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"4d0677d4-ccbe-4abd-8665-bc5f9fd674fe","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-admiring-swanson","namespace_id":"c3645d3e-a96e-4120-a453-4a3e19d1d3a9","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnspeacefultesla9odbwvna/tf-co-admiring-swanson:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"deleting","timeout":"300s","updated_at":"2025-01-24T15:38:50.920330800Z"}'
+        body: '{"created_at":"2025-08-27T15:06:03.177790Z","description":"","environment_variables":{},"error_message":null,"id":"786e9702-5c8d-4eec-aaef-1407003b8ac8","name":"tf-ns-reverent-hamilton","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsreverenthamiltonttyhqt3d","registry_namespace_id":"4cb07919-5f2d-4a1d-9ed0-b210da739d9c","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:05.902593Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "910"
+                - "591"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:50 GMT
+                - Wed, 27 Aug 2025 15:06:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2014,10 +2012,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bd3be3b7-740d-4f51-b18f-60a3c75e2606
+                - a1f3c3bc-3c5b-4c35-816c-92877b765089
         status: 200 OK
         code: 200
-        duration: 141.67825ms
+        duration: 91.929348ms
     - id: 41
       request:
         proto: HTTP/1.1
@@ -2033,8 +2031,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/nats-accounts/AADGULIBDPUFWKRCVLGGIE5EEVIIOD2BSIQ3T3WAFOT4YC3TV6AN52VR
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/786e9702-5c8d-4eec-aaef-1407003b8ac8
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -2042,18 +2040,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 597
         uncompressed: false
-        body: ""
+        body: '{"created_at":"2025-08-27T15:06:03.177790Z","description":"","environment_variables":{},"error_message":null,"id":"786e9702-5c8d-4eec-aaef-1407003b8ac8","name":"tf-ns-reverent-hamilton","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsreverenthamiltonttyhqt3d","registry_namespace_id":"4cb07919-5f2d-4a1d-9ed0-b210da739d9c","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:54.597362108Z","vpc_integration_activated":true}'
         headers:
+            Content-Length:
+                - "597"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:51 GMT
+                - Wed, 27 Aug 2025 15:06:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2061,10 +2061,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2da5aa85-9749-475f-b860-3517674e62ff
-        status: 204 No Content
-        code: 204
-        duration: 267.371125ms
+                - 0b08409e-1590-456f-8087-deb73d7a980f
+        status: 200 OK
+        code: 200
+        duration: 279.542377ms
     - id: 42
       request:
         proto: HTTP/1.1
@@ -2080,8 +2080,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c3645d3e-a96e-4120-a453-4a3e19d1d3a9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/786e9702-5c8d-4eec-aaef-1407003b8ac8
         method: GET
       response:
         proto: HTTP/2.0
@@ -2089,20 +2089,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 552
+        content_length: 594
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.310909Z","description":"","environment_variables":{},"error_message":null,"id":"c3645d3e-a96e-4120-a453-4a3e19d1d3a9","name":"tf-ns-peaceful-tesla","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnspeacefultesla9odbwvna","registry_namespace_id":"a3471425-4285-431c-8605-a8c6948f60c4","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:38:19.400665Z"}'
+        body: '{"created_at":"2025-08-27T15:06:03.177790Z","description":"","environment_variables":{},"error_message":null,"id":"786e9702-5c8d-4eec-aaef-1407003b8ac8","name":"tf-ns-reverent-hamilton","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsreverenthamiltonttyhqt3d","registry_namespace_id":"4cb07919-5f2d-4a1d-9ed0-b210da739d9c","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:54.597362Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "552"
+                - "594"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:51 GMT
+                - Wed, 27 Aug 2025 15:06:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2110,10 +2110,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f2de2656-156e-479e-94cb-cad3786e34ca
+                - 37b312c2-59c2-4937-88fa-4e78c7692c9a
         status: 200 OK
         code: 200
-        duration: 104.310416ms
+        duration: 81.729116ms
     - id: 43
       request:
         proto: HTTP/1.1
@@ -2129,29 +2129,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c3645d3e-a96e-4120-a453-4a3e19d1d3a9
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/786e9702-5c8d-4eec-aaef-1407003b8ac8
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 558
+        content_length: 594
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.310909Z","description":"","environment_variables":{},"error_message":null,"id":"c3645d3e-a96e-4120-a453-4a3e19d1d3a9","name":"tf-ns-peaceful-tesla","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnspeacefultesla9odbwvna","registry_namespace_id":"a3471425-4285-431c-8605-a8c6948f60c4","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:38:51.157735732Z"}'
+        body: '{"created_at":"2025-08-27T15:06:03.177790Z","description":"","environment_variables":{},"error_message":null,"id":"786e9702-5c8d-4eec-aaef-1407003b8ac8","name":"tf-ns-reverent-hamilton","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsreverenthamiltonttyhqt3d","registry_namespace_id":"4cb07919-5f2d-4a1d-9ed0-b210da739d9c","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:54.597362Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "558"
+                - "594"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:51 GMT
+                - Wed, 27 Aug 2025 15:07:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2159,10 +2159,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ba130b14-b3dc-48db-a194-9b4df49a67f4
+                - b835b82e-ec75-437a-b638-ef1b704a49dc
         status: 200 OK
         code: 200
-        duration: 223.265ms
+        duration: 97.655855ms
     - id: 44
       request:
         proto: HTTP/1.1
@@ -2178,8 +2178,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c3645d3e-a96e-4120-a453-4a3e19d1d3a9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/786e9702-5c8d-4eec-aaef-1407003b8ac8
         method: GET
       response:
         proto: HTTP/2.0
@@ -2187,20 +2187,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 555
+        content_length: 594
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.310909Z","description":"","environment_variables":{},"error_message":null,"id":"c3645d3e-a96e-4120-a453-4a3e19d1d3a9","name":"tf-ns-peaceful-tesla","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnspeacefultesla9odbwvna","registry_namespace_id":"a3471425-4285-431c-8605-a8c6948f60c4","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:38:51.157736Z"}'
+        body: '{"created_at":"2025-08-27T15:06:03.177790Z","description":"","environment_variables":{},"error_message":null,"id":"786e9702-5c8d-4eec-aaef-1407003b8ac8","name":"tf-ns-reverent-hamilton","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsreverenthamiltonttyhqt3d","registry_namespace_id":"4cb07919-5f2d-4a1d-9ed0-b210da739d9c","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:54.597362Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "555"
+                - "594"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:51 GMT
+                - Wed, 27 Aug 2025 15:07:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2208,10 +2208,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 85b3b948-49a7-4b58-9b14-19b99983c702
+                - e45f461a-8d55-4142-8d27-cb88980d4735
         status: 200 OK
         code: 200
-        duration: 71.738417ms
+        duration: 89.762614ms
     - id: 45
       request:
         proto: HTTP/1.1
@@ -2227,8 +2227,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c3645d3e-a96e-4120-a453-4a3e19d1d3a9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/786e9702-5c8d-4eec-aaef-1407003b8ac8
         method: GET
       response:
         proto: HTTP/2.0
@@ -2236,20 +2236,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 555
+        content_length: 594
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.310909Z","description":"","environment_variables":{},"error_message":null,"id":"c3645d3e-a96e-4120-a453-4a3e19d1d3a9","name":"tf-ns-peaceful-tesla","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnspeacefultesla9odbwvna","registry_namespace_id":"a3471425-4285-431c-8605-a8c6948f60c4","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:38:51.157736Z"}'
+        body: '{"created_at":"2025-08-27T15:06:03.177790Z","description":"","environment_variables":{},"error_message":null,"id":"786e9702-5c8d-4eec-aaef-1407003b8ac8","name":"tf-ns-reverent-hamilton","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsreverenthamiltonttyhqt3d","registry_namespace_id":"4cb07919-5f2d-4a1d-9ed0-b210da739d9c","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:54.597362Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "555"
+                - "594"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:56 GMT
+                - Wed, 27 Aug 2025 15:07:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2257,10 +2257,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ccfb667f-f907-4096-8bbb-cdb1577cfa2f
+                - dbcc7825-87dc-4a30-bce9-d83f4af5aed9
         status: 200 OK
         code: 200
-        duration: 75.571625ms
+        duration: 94.783679ms
     - id: 46
       request:
         proto: HTTP/1.1
@@ -2276,8 +2276,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c3645d3e-a96e-4120-a453-4a3e19d1d3a9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/786e9702-5c8d-4eec-aaef-1407003b8ac8
         method: GET
       response:
         proto: HTTP/2.0
@@ -2285,20 +2285,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 555
+        content_length: 594
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.310909Z","description":"","environment_variables":{},"error_message":null,"id":"c3645d3e-a96e-4120-a453-4a3e19d1d3a9","name":"tf-ns-peaceful-tesla","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnspeacefultesla9odbwvna","registry_namespace_id":"a3471425-4285-431c-8605-a8c6948f60c4","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:38:51.157736Z"}'
+        body: '{"created_at":"2025-08-27T15:06:03.177790Z","description":"","environment_variables":{},"error_message":null,"id":"786e9702-5c8d-4eec-aaef-1407003b8ac8","name":"tf-ns-reverent-hamilton","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsreverenthamiltonttyhqt3d","registry_namespace_id":"4cb07919-5f2d-4a1d-9ed0-b210da739d9c","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:54.597362Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "555"
+                - "594"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:39:01 GMT
+                - Wed, 27 Aug 2025 15:07:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2306,10 +2306,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9baa14aa-64e8-4ebf-8c81-0128300737b0
+                - dfa812bd-88fa-474f-88fe-580fc20f07ba
         status: 200 OK
         code: 200
-        duration: 65.097541ms
+        duration: 81.725223ms
     - id: 47
       request:
         proto: HTTP/1.1
@@ -2325,155 +2325,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c3645d3e-a96e-4120-a453-4a3e19d1d3a9
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 555
-        uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.310909Z","description":"","environment_variables":{},"error_message":null,"id":"c3645d3e-a96e-4120-a453-4a3e19d1d3a9","name":"tf-ns-peaceful-tesla","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnspeacefultesla9odbwvna","registry_namespace_id":"a3471425-4285-431c-8605-a8c6948f60c4","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:38:51.157736Z"}'
-        headers:
-            Content-Length:
-                - "555"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:39:06 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - ff924922-5661-4ee2-97d1-7e03c03036a4
-        status: 200 OK
-        code: 200
-        duration: 151.48275ms
-    - id: 48
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c3645d3e-a96e-4120-a453-4a3e19d1d3a9
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 555
-        uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.310909Z","description":"","environment_variables":{},"error_message":null,"id":"c3645d3e-a96e-4120-a453-4a3e19d1d3a9","name":"tf-ns-peaceful-tesla","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnspeacefultesla9odbwvna","registry_namespace_id":"a3471425-4285-431c-8605-a8c6948f60c4","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:38:51.157736Z"}'
-        headers:
-            Content-Length:
-                - "555"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:39:11 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 2d56862a-5971-403c-98a8-7cd872a2e939
-        status: 200 OK
-        code: 200
-        duration: 155.738042ms
-    - id: 49
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c3645d3e-a96e-4120-a453-4a3e19d1d3a9
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 555
-        uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.310909Z","description":"","environment_variables":{},"error_message":null,"id":"c3645d3e-a96e-4120-a453-4a3e19d1d3a9","name":"tf-ns-peaceful-tesla","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnspeacefultesla9odbwvna","registry_namespace_id":"a3471425-4285-431c-8605-a8c6948f60c4","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:38:51.157736Z"}'
-        headers:
-            Content-Length:
-                - "555"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:39:16 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 184ec9ee-559d-4036-9cb6-fa5d20a154c7
-        status: 200 OK
-        code: 200
-        duration: 61.5205ms
-    - id: 50
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/c3645d3e-a96e-4120-a453-4a3e19d1d3a9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/786e9702-5c8d-4eec-aaef-1407003b8ac8
         method: GET
       response:
         proto: HTTP/2.0
@@ -2492,9 +2345,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:39:21 GMT
+                - Wed, 27 Aug 2025 15:07:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2502,11 +2355,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 502c2867-eec8-4a7a-93a3-2e5e87467289
+                - f43feedb-bc93-4342-85f6-f706e1b24e00
         status: 404 Not Found
         code: 404
-        duration: 26.148541ms
-    - id: 51
+        duration: 140.121316ms
+    - id: 48
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2521,8 +2374,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers/4d187890-6763-4b38-84b5-4cda753f9a89
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers/e9b9d7b6-7df0-4431-ba74-87461bd71d38
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -2532,7 +2385,7 @@ interactions:
         trailer: {}
         content_length: 105
         uncompressed: false
-        body: '{"message":"trigger does not exist: could not find trigger with id 4d187890-6763-4b38-84b5-4cda753f9a89"}'
+        body: '{"message":"trigger does not exist: could not find trigger with id e9b9d7b6-7df0-4431-ba74-87461bd71d38"}'
         headers:
             Content-Length:
                 - "105"
@@ -2541,9 +2394,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:39:21 GMT
+                - Wed, 27 Aug 2025 15:07:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2551,7 +2404,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 14b53634-4d58-46f6-9f71-b87639113927
+                - f60e3558-1572-495f-8600-0707c555b8ab
         status: 404 Not Found
         code: 404
-        duration: 33.350459ms
+        duration: 26.941151ms

--- a/internal/services/container/testdata/trigger-sqs.cassette.yaml
+++ b/internal/services/container/testdata/trigger-sqs.cassette.yaml
@@ -18,7 +18,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/account/v3/projects
         method: POST
       response:
@@ -27,20 +27,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 245
+        content_length: 266
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:48.585732Z","description":"","id":"f450679c-9a35-4b8e-a910-f2dd97e60f10","name":"tf_tests_container_trigger_sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","updated_at":"2025-01-24T15:37:48.585732Z"}'
+        body: '{"created_at":"2025-08-27T15:06:28.183860Z","description":"","id":"451a75ce-766a-43f9-9b0f-77a056b7e1ed","name":"tf_tests_container_trigger_sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","qualification":null,"updated_at":"2025-08-27T15:06:28.183860Z"}'
         headers:
             Content-Length:
-                - "245"
+                - "266"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:37:48 GMT
+                - Wed, 27 Aug 2025 15:06:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9283914c-7703-4a07-a777-17ae857669bb
+                - 9025af5e-5610-45aa-9519-b5586b23c8a6
         status: 200 OK
         code: 200
-        duration: 477.129083ms
+        duration: 394.900162ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -67,8 +67,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/account/v3/projects/f450679c-9a35-4b8e-a910-f2dd97e60f10
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/account/v3/projects/451a75ce-766a-43f9-9b0f-77a056b7e1ed
         method: GET
       response:
         proto: HTTP/2.0
@@ -76,20 +76,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 245
+        content_length: 311
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:48.585732Z","description":"","id":"f450679c-9a35-4b8e-a910-f2dd97e60f10","name":"tf_tests_container_trigger_sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","updated_at":"2025-01-24T15:37:48.585732Z"}'
+        body: '{"created_at":"2025-08-27T15:06:28.183860Z","description":"","id":"451a75ce-766a-43f9-9b0f-77a056b7e1ed","name":"tf_tests_container_trigger_sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","qualification":{"architecture_type":"unknown_architecture_type"},"updated_at":"2025-08-27T15:06:28.183860Z"}'
         headers:
             Content-Length:
-                - "245"
+                - "311"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:37:48 GMT
+                - Wed, 27 Aug 2025 15:06:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f0192458-d8b6-4ead-ba75-57323101a3d4
+                - 4935c6bb-958b-4196-a169-91ea5d2976fc
         status: 200 OK
         code: 200
-        duration: 141.119292ms
+        duration: 187.264822ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -112,13 +112,13 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"project_id":"f450679c-9a35-4b8e-a910-f2dd97e60f10"}'
+        body: '{"project_id":"451a75ce-766a-43f9-9b0f-77a056b7e1ed"}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/activate-sqs
         method: POST
       response:
@@ -129,7 +129,7 @@ interactions:
         trailer: {}
         content_length: 239
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.062843571Z","project_id":"f450679c-9a35-4b8e-a910-f2dd97e60f10","region":"fr-par","sqs_endpoint_url":"https://sqs.mnq.fr-par.scaleway.com","status":"enabled","updated_at":"2025-01-24T15:37:49.062843571Z"}'
+        body: '{"created_at":"2025-08-27T15:06:28.684881912Z","project_id":"451a75ce-766a-43f9-9b0f-77a056b7e1ed","region":"fr-par","sqs_endpoint_url":"https://sqs.mnq.fr-par.scaleway.com","status":"enabled","updated_at":"2025-08-27T15:06:28.684881912Z"}'
         headers:
             Content-Length:
                 - "239"
@@ -138,9 +138,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:37:49 GMT
+                - Wed, 27 Aug 2025 15:06:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -148,10 +148,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7db7c051-3ddf-4d83-8390-af7b7457446a
+                - 0fc6e5f0-143d-4cd4-8c2f-935e29bd22a4
         status: 200 OK
         code: 200
-        duration: 154.866958ms
+        duration: 184.432007ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -167,8 +167,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-info?project_id=f450679c-9a35-4b8e-a910-f2dd97e60f10
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-info?project_id=451a75ce-766a-43f9-9b0f-77a056b7e1ed
         method: GET
       response:
         proto: HTTP/2.0
@@ -178,7 +178,7 @@ interactions:
         trailer: {}
         content_length: 233
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.062843Z","project_id":"f450679c-9a35-4b8e-a910-f2dd97e60f10","region":"fr-par","sqs_endpoint_url":"https://sqs.mnq.fr-par.scaleway.com","status":"enabled","updated_at":"2025-01-24T15:37:49.062843Z"}'
+        body: '{"created_at":"2025-08-27T15:06:28.684881Z","project_id":"451a75ce-766a-43f9-9b0f-77a056b7e1ed","region":"fr-par","sqs_endpoint_url":"https://sqs.mnq.fr-par.scaleway.com","status":"enabled","updated_at":"2025-08-27T15:06:28.684881Z"}'
         headers:
             Content-Length:
                 - "233"
@@ -187,9 +187,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:37:49 GMT
+                - Wed, 27 Aug 2025 15:06:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -197,28 +197,28 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 32a8cb75-0df9-4e51-887c-28cfcbc7edc9
+                - 3f980fc3-6327-4857-adc8-636afbd21a24
         status: 200 OK
         code: 200
-        duration: 71.204875ms
+        duration: 75.417916ms
     - id: 4
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 163
+        content_length: 175
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"project_id":"f450679c-9a35-4b8e-a910-f2dd97e60f10","name":"tf-sqs-credentials-busy-cori","permissions":{"can_publish":true,"can_receive":true,"can_manage":true}}'
+        body: '{"project_id":"451a75ce-766a-43f9-9b0f-77a056b7e1ed","name":"tf-sqs-credentials-dazzling-visvesvaraya","permissions":{"can_publish":true,"can_receive":true,"can_manage":true}}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-credentials
         method: POST
       response:
@@ -227,20 +227,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 494
+        content_length: 506
         uncompressed: false
-        body: '{"access_key":"aPESevK1s7NaoiJKQZIF","created_at":"2025-01-24T15:37:49.341192860Z","id":"90077722-0c4a-4b09-b1d0-a3b1cdf2369e","name":"tf-sqs-credentials-busy-cori","permissions":{"can_manage":true,"can_publish":true,"can_receive":true},"project_id":"f450679c-9a35-4b8e-a910-f2dd97e60f10","region":"fr-par","secret_checksum":"9bdf90f793f77ea9b556728a7116d6dec89359ab","secret_key":"00000000-0000-0000-0000-000000000000","updated_at":"2025-01-24T15:37:49.341192860Z"}'
+        body: '{"access_key":"6q9lhzw6NRO0iF3k2A4d","created_at":"2025-08-27T15:06:28.976527189Z","id":"4637a1d0-51e8-4863-957f-ce050f8f97e8","name":"tf-sqs-credentials-dazzling-visvesvaraya","permissions":{"can_manage":true,"can_publish":true,"can_receive":true},"project_id":"451a75ce-766a-43f9-9b0f-77a056b7e1ed","region":"fr-par","secret_checksum":"571dc5b9999c5ba7a5e4d1a15402dd416b2a043d","secret_key":"00000000-0000-0000-0000-000000000000","updated_at":"2025-08-27T15:06:28.976527189Z"}'
         headers:
             Content-Length:
-                - "494"
+                - "506"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:37:49 GMT
+                - Wed, 27 Aug 2025 15:06:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -248,10 +248,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3c2909d8-a26e-418d-ba75-a84903ac0d8b
+                - 8dec5cb2-6271-4a0d-9d43-6a1a0468b211
         status: 200 OK
         code: 200
-        duration: 92.231708ms
+        duration: 181.681855ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -267,8 +267,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-credentials/90077722-0c4a-4b09-b1d0-a3b1cdf2369e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-credentials/4637a1d0-51e8-4863-957f-ce050f8f97e8
         method: GET
       response:
         proto: HTTP/2.0
@@ -276,20 +276,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 424
+        content_length: 436
         uncompressed: false
-        body: '{"access_key":"aPESevK1s7NaoiJKQZIF","created_at":"2025-01-24T15:37:49.341192Z","id":"90077722-0c4a-4b09-b1d0-a3b1cdf2369e","name":"tf-sqs-credentials-busy-cori","permissions":{"can_manage":true,"can_publish":true,"can_receive":true},"project_id":"f450679c-9a35-4b8e-a910-f2dd97e60f10","region":"fr-par","secret_checksum":"9bdf90f793f77ea9b556728a7116d6dec89359ab","secret_key":"00000000-0000-0000-0000-000000000000","updated_at":"2025-01-24T15:37:49.341192Z"}'
+        body: '{"access_key":"6q9lhzw6NRO0iF3k2A4d","created_at":"2025-08-27T15:06:28.976527Z","id":"4637a1d0-51e8-4863-957f-ce050f8f97e8","name":"tf-sqs-credentials-dazzling-visvesvaraya","permissions":{"can_manage":true,"can_publish":true,"can_receive":true},"project_id":"451a75ce-766a-43f9-9b0f-77a056b7e1ed","region":"fr-par","secret_checksum":"571dc5b9999c5ba7a5e4d1a15402dd416b2a043d","secret_key":"00000000-0000-0000-0000-000000000000","updated_at":"2025-08-27T15:06:28.976527Z"}'
         headers:
             Content-Length:
-                - "424"
+                - "436"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:37:49 GMT
+                - Wed, 27 Aug 2025 15:06:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -297,62 +297,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d6c63386-5546-4d13-84fe-536ae0ff1bca
+                - af93ee85-6c16-4e9f-8603-7051ae93ca43
         status: 200 OK
         code: 200
-        duration: 94.947ms
+        duration: 87.726464ms
     - id: 6
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 155
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"name":"tf-ns-funny-dewdney","environment_variables":{},"project_id":"f450679c-9a35-4b8e-a910-f2dd97e60f10","secret_environment_variables":[],"tags":null}'
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 471
-        uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.458163832Z","description":"","environment_variables":{},"error_message":null,"id":"5dd58b8d-e67f-481c-abf4-863baae060c4","name":"tf-ns-funny-dewdney","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"f450679c-9a35-4b8e-a910-f2dd97e60f10","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:37:49.458163832Z"}'
-        headers:
-            Content-Length:
-                - "471"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:37:49 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 9851f3be-1659-49e3-bd21-8c88817b8af5
-        status: 200 OK
-        code: 200
-        duration: 455.835042ms
-    - id: 7
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -367,8 +316,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-info?project_id=f450679c-9a35-4b8e-a910-f2dd97e60f10
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-info?project_id=451a75ce-766a-43f9-9b0f-77a056b7e1ed
         method: GET
       response:
         proto: HTTP/2.0
@@ -378,7 +327,7 @@ interactions:
         trailer: {}
         content_length: 233
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.062843Z","project_id":"f450679c-9a35-4b8e-a910-f2dd97e60f10","region":"fr-par","sqs_endpoint_url":"https://sqs.mnq.fr-par.scaleway.com","status":"enabled","updated_at":"2025-01-24T15:37:49.062843Z"}'
+        body: '{"created_at":"2025-08-27T15:06:28.684881Z","project_id":"451a75ce-766a-43f9-9b0f-77a056b7e1ed","region":"fr-par","sqs_endpoint_url":"https://sqs.mnq.fr-par.scaleway.com","status":"enabled","updated_at":"2025-08-27T15:06:28.684881Z"}'
         headers:
             Content-Length:
                 - "233"
@@ -387,9 +336,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:37:49 GMT
+                - Wed, 27 Aug 2025 15:06:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -397,60 +346,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 20febea8-192b-418c-936a-341fb743b342
+                - f24c6f76-fa48-4e48-9a0a-6f3a07856b9d
         status: 200 OK
         code: 200
-        duration: 70.381ms
-    - id: 8
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/5dd58b8d-e67f-481c-abf4-863baae060c4
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 465
-        uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.458164Z","description":"","environment_variables":{},"error_message":null,"id":"5dd58b8d-e67f-481c-abf4-863baae060c4","name":"tf-ns-funny-dewdney","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"f450679c-9a35-4b8e-a910-f2dd97e60f10","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:37:49.458164Z"}'
-        headers:
-            Content-Length:
-                - "465"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:37:49 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 46f77667-ba07-4c9a-83a7-4a05f657ffd0
-        status: 200 OK
-        code: 200
-        duration: 68.51025ms
-    - id: 9
+        duration: 75.413587ms
+    - id: 7
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -465,15 +365,15 @@ interactions:
         form: {}
         headers:
             Amz-Sdk-Invocation-Id:
-                - 75f3f843-3383-4fd1-aad1-a2cbeeb86fba
+                - ea3d6990-0439-4365-adb2-12374ffb6071
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
                 - application/x-amz-json-1.0
             User-Agent:
-                - aws-sdk-go-v2/1.32.7 ua/2.1 os/macos lang/go#1.23.3 md/GOOS#darwin md/GOARCH#arm64 api/sqs#1.37.3 m/E
+                - aws-sdk-go-v2/1.37.1 ua/2.1 os/linux lang/go#1.24.1 md/GOOS#linux md/GOARCH#amd64 api/sqs#1.38.6 m/E,e
             X-Amz-Date:
-                - 20250124T153749Z
+                - 20250827T150629Z
             X-Amz-Target:
                 - AmazonSQS.CreateQueue
             X-Amzn-Query-Mode:
@@ -488,20 +388,20 @@ interactions:
         trailer: {}
         content_length: 106
         uncompressed: false
-        body: '{"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-f450679c-9a35-4b8e-a910-f2dd97e60f10/TestQueue"}'
+        body: '{"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-451a75ce-766a-43f9-9b0f-77a056b7e1ed/TestQueue"}'
         headers:
             Content-Length:
                 - "106"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 24 Jan 2025 15:37:49 GMT
+                - Wed, 27 Aug 2025 15:06:29 GMT
             X-Amzn-Requestid:
-                - txcb6bd4df-f177-46b8-8a09-69cb2bb7ea02
+                - txb2b7de24-ee47-4c43-85f5-9ec6c0cbdaa0
         status: 200 OK
         code: 200
-        duration: 483.867209ms
-    - id: 10
+        duration: 186.306795ms
+    - id: 8
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -516,15 +416,15 @@ interactions:
         form: {}
         headers:
             Amz-Sdk-Invocation-Id:
-                - 76099b51-4feb-4890-abb8-c58662fabe4d
+                - 1c1e3db0-f9f0-4f61-99dd-f12c8f76cad4
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
                 - application/x-amz-json-1.0
             User-Agent:
-                - aws-sdk-go-v2/1.32.7 ua/2.1 os/macos lang/go#1.23.3 md/GOOS#darwin md/GOARCH#arm64 api/sqs#1.37.3 m/E
+                - aws-sdk-go-v2/1.37.1 ua/2.1 os/linux lang/go#1.24.1 md/GOOS#linux md/GOARCH#amd64 api/sqs#1.38.6 m/E,e
             X-Amz-Date:
-                - 20250124T153750Z
+                - 20250827T150629Z
             X-Amz-Target:
                 - AmazonSQS.GetQueueUrl
             X-Amzn-Query-Mode:
@@ -539,20 +439,20 @@ interactions:
         trailer: {}
         content_length: 106
         uncompressed: false
-        body: '{"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-f450679c-9a35-4b8e-a910-f2dd97e60f10/TestQueue"}'
+        body: '{"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-451a75ce-766a-43f9-9b0f-77a056b7e1ed/TestQueue"}'
         headers:
             Content-Length:
                 - "106"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 24 Jan 2025 15:37:50 GMT
+                - Wed, 27 Aug 2025 15:06:29 GMT
             X-Amzn-Requestid:
-                - tx226c6d46-fa2e-450d-8158-f347f5924af1
+                - txa493d8e8-4d69-425a-b130-bbffa2001e04
         status: 200 OK
         code: 200
-        duration: 21.541459ms
-    - id: 11
+        duration: 21.71037ms
+    - id: 9
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -563,19 +463,19 @@ interactions:
         host: sqs.mnq.fr-par.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"AttributeNames":["MaximumMessageSize","MessageRetentionPeriod","FifoQueue","ContentBasedDeduplication","ReceiveMessageWaitTimeSeconds","VisibilityTimeout"],"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-f450679c-9a35-4b8e-a910-f2dd97e60f10/TestQueue"}'
+        body: '{"AttributeNames":["MaximumMessageSize","MessageRetentionPeriod","FifoQueue","ContentBasedDeduplication","ReceiveMessageWaitTimeSeconds","VisibilityTimeout"],"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-451a75ce-766a-43f9-9b0f-77a056b7e1ed/TestQueue"}'
         form: {}
         headers:
             Amz-Sdk-Invocation-Id:
-                - 9a1a3dcf-94bf-42e5-a332-ea5e179a9a35
+                - 8093a29e-0992-4a67-b0a0-d65e81876373
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
                 - application/x-amz-json-1.0
             User-Agent:
-                - aws-sdk-go-v2/1.32.7 ua/2.1 os/macos lang/go#1.23.3 md/GOOS#darwin md/GOARCH#arm64 api/sqs#1.37.3 m/E
+                - aws-sdk-go-v2/1.37.1 ua/2.1 os/linux lang/go#1.24.1 md/GOOS#linux md/GOARCH#amd64 api/sqs#1.38.6 m/E,e
             X-Amz-Date:
-                - 20250124T153750Z
+                - 20250827T150629Z
             X-Amz-Target:
                 - AmazonSQS.GetQueueAttributes
             X-Amzn-Query-Mode:
@@ -597,12 +497,112 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 24 Jan 2025 15:37:50 GMT
+                - Wed, 27 Aug 2025 15:06:29 GMT
             X-Amzn-Requestid:
-                - tx7b534712-3565-435c-a1ab-739d327bc22e
+                - tx1ef795f8-700b-4ab7-85ef-d0934d0be3e3
         status: 200 OK
         code: 200
-        duration: 35.718833ms
+        duration: 30.859249ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 192
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"name":"tf-ns-vibrant-hofstadter","environment_variables":{},"project_id":"451a75ce-766a-43f9-9b0f-77a056b7e1ed","secret_environment_variables":[],"tags":null,"activate_vpc_integration":true}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 509
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:06:30.153439509Z","description":"","environment_variables":{},"error_message":null,"id":"e7e9218b-d951-4020-a0d5-1f0f613bd6cd","name":"tf-ns-vibrant-hofstadter","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"451a75ce-766a-43f9-9b0f-77a056b7e1ed","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:06:30.153439509Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "509"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:30 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 6c6fbff9-2a84-4872-994c-cc52d6ea9018
+        status: 200 OK
+        code: 200
+        duration: 1.624708466s
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/e7e9218b-d951-4020-a0d5-1f0f613bd6cd
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 503
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:06:30.153440Z","description":"","environment_variables":{},"error_message":null,"id":"e7e9218b-d951-4020-a0d5-1f0f613bd6cd","name":"tf-ns-vibrant-hofstadter","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"451a75ce-766a-43f9-9b0f-77a056b7e1ed","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:06:30.153440Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "503"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:30 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 1478dcd2-2110-4e87-9a28-fe9737026fc8
+        status: 200 OK
+        code: 200
+        duration: 78.800133ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -618,8 +618,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/5dd58b8d-e67f-481c-abf4-863baae060c4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/e7e9218b-d951-4020-a0d5-1f0f613bd6cd
         method: GET
       response:
         proto: HTTP/2.0
@@ -627,20 +627,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 552
+        content_length: 594
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.458164Z","description":"","environment_variables":{},"error_message":null,"id":"5dd58b8d-e67f-481c-abf4-863baae060c4","name":"tf-ns-funny-dewdney","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"f450679c-9a35-4b8e-a910-f2dd97e60f10","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsfunnydewdneym4jo1cgp","registry_namespace_id":"64595108-3c2d-4c3b-a85a-62dea2d5e80e","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:37:51.752424Z"}'
+        body: '{"created_at":"2025-08-27T15:06:30.153440Z","description":"","environment_variables":{},"error_message":null,"id":"e7e9218b-d951-4020-a0d5-1f0f613bd6cd","name":"tf-ns-vibrant-hofstadter","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"451a75ce-766a-43f9-9b0f-77a056b7e1ed","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsvibranthofstadtexf2vueoe","registry_namespace_id":"d2cecc96-e3f5-4aeb-bd79-4057c8b9816b","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:06:30.870647Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "552"
+                - "594"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:37:54 GMT
+                - Wed, 27 Aug 2025 15:06:35 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -648,10 +648,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d3e73932-4833-4253-962a-d1c72e630d42
+                - baa02180-6124-4388-8883-d54e9fd07852
         status: 200 OK
         code: 200
-        duration: 76.671917ms
+        duration: 74.668732ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -667,8 +667,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/5dd58b8d-e67f-481c-abf4-863baae060c4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/e7e9218b-d951-4020-a0d5-1f0f613bd6cd
         method: GET
       response:
         proto: HTTP/2.0
@@ -676,20 +676,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 552
+        content_length: 594
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.458164Z","description":"","environment_variables":{},"error_message":null,"id":"5dd58b8d-e67f-481c-abf4-863baae060c4","name":"tf-ns-funny-dewdney","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"f450679c-9a35-4b8e-a910-f2dd97e60f10","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsfunnydewdneym4jo1cgp","registry_namespace_id":"64595108-3c2d-4c3b-a85a-62dea2d5e80e","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:37:51.752424Z"}'
+        body: '{"created_at":"2025-08-27T15:06:30.153440Z","description":"","environment_variables":{},"error_message":null,"id":"e7e9218b-d951-4020-a0d5-1f0f613bd6cd","name":"tf-ns-vibrant-hofstadter","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"451a75ce-766a-43f9-9b0f-77a056b7e1ed","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsvibranthofstadtexf2vueoe","registry_namespace_id":"d2cecc96-e3f5-4aeb-bd79-4057c8b9816b","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:06:30.870647Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "552"
+                - "594"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:37:59 GMT
+                - Wed, 27 Aug 2025 15:06:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -697,10 +697,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e994148d-710e-4fc9-8921-d832cd03bb25
+                - 16dee1c9-21b6-4245-9b50-48b1e92824f4
         status: 200 OK
         code: 200
-        duration: 55.335292ms
+        duration: 101.184531ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -716,8 +716,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/5dd58b8d-e67f-481c-abf4-863baae060c4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/e7e9218b-d951-4020-a0d5-1f0f613bd6cd
         method: GET
       response:
         proto: HTTP/2.0
@@ -725,20 +725,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 552
+        content_length: 594
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.458164Z","description":"","environment_variables":{},"error_message":null,"id":"5dd58b8d-e67f-481c-abf4-863baae060c4","name":"tf-ns-funny-dewdney","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"f450679c-9a35-4b8e-a910-f2dd97e60f10","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsfunnydewdneym4jo1cgp","registry_namespace_id":"64595108-3c2d-4c3b-a85a-62dea2d5e80e","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:37:51.752424Z"}'
+        body: '{"created_at":"2025-08-27T15:06:30.153440Z","description":"","environment_variables":{},"error_message":null,"id":"e7e9218b-d951-4020-a0d5-1f0f613bd6cd","name":"tf-ns-vibrant-hofstadter","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"451a75ce-766a-43f9-9b0f-77a056b7e1ed","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsvibranthofstadtexf2vueoe","registry_namespace_id":"d2cecc96-e3f5-4aeb-bd79-4057c8b9816b","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:06:30.870647Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "552"
+                - "594"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:04 GMT
+                - Wed, 27 Aug 2025 15:06:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -746,10 +746,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 079631d7-8402-4c94-b564-adecc8fd95ff
+                - f425a298-c7b3-414b-af9e-66832c7a9c60
         status: 200 OK
         code: 200
-        duration: 68.75425ms
+        duration: 96.62588ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -765,8 +765,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/5dd58b8d-e67f-481c-abf4-863baae060c4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/e7e9218b-d951-4020-a0d5-1f0f613bd6cd
         method: GET
       response:
         proto: HTTP/2.0
@@ -774,20 +774,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 552
+        content_length: 592
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.458164Z","description":"","environment_variables":{},"error_message":null,"id":"5dd58b8d-e67f-481c-abf4-863baae060c4","name":"tf-ns-funny-dewdney","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"f450679c-9a35-4b8e-a910-f2dd97e60f10","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsfunnydewdneym4jo1cgp","registry_namespace_id":"64595108-3c2d-4c3b-a85a-62dea2d5e80e","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:37:51.752424Z"}'
+        body: '{"created_at":"2025-08-27T15:06:30.153440Z","description":"","environment_variables":{},"error_message":null,"id":"e7e9218b-d951-4020-a0d5-1f0f613bd6cd","name":"tf-ns-vibrant-hofstadter","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"451a75ce-766a-43f9-9b0f-77a056b7e1ed","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsvibranthofstadtexf2vueoe","registry_namespace_id":"d2cecc96-e3f5-4aeb-bd79-4057c8b9816b","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:48.641793Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "552"
+                - "592"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:09 GMT
+                - Wed, 27 Aug 2025 15:06:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -795,10 +795,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ed7e5759-5be0-40d0-adda-3e4e39033908
+                - baf6eec5-babf-4e45-aafe-129df6217a09
         status: 200 OK
         code: 200
-        duration: 76.433125ms
+        duration: 82.849286ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -814,8 +814,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/5dd58b8d-e67f-481c-abf4-863baae060c4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/e7e9218b-d951-4020-a0d5-1f0f613bd6cd
         method: GET
       response:
         proto: HTTP/2.0
@@ -823,20 +823,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 552
+        content_length: 592
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.458164Z","description":"","environment_variables":{},"error_message":null,"id":"5dd58b8d-e67f-481c-abf4-863baae060c4","name":"tf-ns-funny-dewdney","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"f450679c-9a35-4b8e-a910-f2dd97e60f10","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsfunnydewdneym4jo1cgp","registry_namespace_id":"64595108-3c2d-4c3b-a85a-62dea2d5e80e","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:37:51.752424Z"}'
+        body: '{"created_at":"2025-08-27T15:06:30.153440Z","description":"","environment_variables":{},"error_message":null,"id":"e7e9218b-d951-4020-a0d5-1f0f613bd6cd","name":"tf-ns-vibrant-hofstadter","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"451a75ce-766a-43f9-9b0f-77a056b7e1ed","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsvibranthofstadtexf2vueoe","registry_namespace_id":"d2cecc96-e3f5-4aeb-bd79-4057c8b9816b","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:48.641793Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "552"
+                - "592"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:14 GMT
+                - Wed, 27 Aug 2025 15:06:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -844,10 +844,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 81d11c0a-72ed-4a12-b9d5-f020e21e4d84
+                - 8a376e2c-c32c-487e-9c31-76083a2368e5
         status: 200 OK
         code: 200
-        duration: 62.217708ms
+        duration: 77.557335ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -863,8 +863,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/5dd58b8d-e67f-481c-abf4-863baae060c4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/e7e9218b-d951-4020-a0d5-1f0f613bd6cd
         method: GET
       response:
         proto: HTTP/2.0
@@ -872,20 +872,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 550
+        content_length: 592
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.458164Z","description":"","environment_variables":{},"error_message":null,"id":"5dd58b8d-e67f-481c-abf4-863baae060c4","name":"tf-ns-funny-dewdney","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"f450679c-9a35-4b8e-a910-f2dd97e60f10","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsfunnydewdneym4jo1cgp","registry_namespace_id":"64595108-3c2d-4c3b-a85a-62dea2d5e80e","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:38:19.465180Z"}'
+        body: '{"created_at":"2025-08-27T15:06:30.153440Z","description":"","environment_variables":{},"error_message":null,"id":"e7e9218b-d951-4020-a0d5-1f0f613bd6cd","name":"tf-ns-vibrant-hofstadter","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"451a75ce-766a-43f9-9b0f-77a056b7e1ed","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsvibranthofstadtexf2vueoe","registry_namespace_id":"d2cecc96-e3f5-4aeb-bd79-4057c8b9816b","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:48.641793Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "550"
+                - "592"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:19 GMT
+                - Wed, 27 Aug 2025 15:06:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -893,48 +893,50 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 54516aa5-d0d6-4a03-a2a2-259923471946
+                - 6da58a84-f25a-42b7-96bb-20cb18bf119d
         status: 200 OK
         code: 200
-        duration: 70.740959ms
+        duration: 72.882172ms
     - id: 18
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 255
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"namespace_id":"e7e9218b-d951-4020-a0d5-1f0f613bd6cd","name":"tf-co-xenodochial-lumiere","privacy":"public","protocol":"http1","secret_environment_variables":null,"http_option":"enabled","sandbox":"unknown_sandbox","tags":null,"command":null,"args":null}'
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/5dd58b8d-e67f-481c-abf4-863baae060c4
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 550
+        content_length: 986
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.458164Z","description":"","environment_variables":{},"error_message":null,"id":"5dd58b8d-e67f-481c-abf4-863baae060c4","name":"tf-ns-funny-dewdney","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"f450679c-9a35-4b8e-a910-f2dd97e60f10","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsfunnydewdneym4jo1cgp","registry_namespace_id":"64595108-3c2d-4c3b-a85a-62dea2d5e80e","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:38:19.465180Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:51.253340464Z","description":"","domain_name":"tfnsvibranthofstadtexf2vueoe-tf-co-xenodochial-lumiere.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"58f5113a-2906-471f-87fe-727be3c9a3fa","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-xenodochial-lumiere","namespace_id":"e7e9218b-d951-4020-a0d5-1f0f613bd6cd","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsvibranthofstadtexf2vueoe/tf-co-xenodochial-lumiere:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:51.253340464Z"}'
         headers:
             Content-Length:
-                - "550"
+                - "986"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:20 GMT
+                - Wed, 27 Aug 2025 15:06:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -942,10 +944,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 87c76a07-26fa-4e8e-a666-cb240f3001e9
+                - 218a64c9-8fd4-4a92-a080-0255b3023775
         status: 200 OK
         code: 200
-        duration: 74.9865ms
+        duration: 599.036514ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -961,8 +963,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/5dd58b8d-e67f-481c-abf4-863baae060c4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/58f5113a-2906-471f-87fe-727be3c9a3fa
         method: GET
       response:
         proto: HTTP/2.0
@@ -970,20 +972,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 550
+        content_length: 980
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.458164Z","description":"","environment_variables":{},"error_message":null,"id":"5dd58b8d-e67f-481c-abf4-863baae060c4","name":"tf-ns-funny-dewdney","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"f450679c-9a35-4b8e-a910-f2dd97e60f10","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsfunnydewdneym4jo1cgp","registry_namespace_id":"64595108-3c2d-4c3b-a85a-62dea2d5e80e","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:38:19.465180Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:51.253340Z","description":"","domain_name":"tfnsvibranthofstadtexf2vueoe-tf-co-xenodochial-lumiere.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"58f5113a-2906-471f-87fe-727be3c9a3fa","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-xenodochial-lumiere","namespace_id":"e7e9218b-d951-4020-a0d5-1f0f613bd6cd","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsvibranthofstadtexf2vueoe/tf-co-xenodochial-lumiere:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:51.253340Z"}'
         headers:
             Content-Length:
-                - "550"
+                - "980"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:20 GMT
+                - Wed, 27 Aug 2025 15:06:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -991,29 +993,29 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7069ce08-915e-4de7-ba3f-74d4d9f46eec
+                - 10bd88bc-915c-42b4-84f2-66662ddfded2
         status: 200 OK
         code: 200
-        duration: 195.574916ms
+        duration: 173.283728ms
     - id: 20
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 218
+        content_length: 208
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"namespace_id":"5dd58b8d-e67f-481c-abf4-863baae060c4","name":"tf-co-ecstatic-grothendieck","privacy":"public","protocol":"http1","secret_environment_variables":null,"http_option":"enabled","sandbox":"unknown_sandbox"}'
+        body: '{"name":"test-container-trigger-sqs","container_id":"58f5113a-2906-471f-87fe-727be3c9a3fa","scw_sqs_config":{"queue":"TestQueue","mnq_project_id":"451a75ce-766a-43f9-9b0f-77a056b7e1ed","mnq_region":"fr-par"}}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers
         method: POST
       response:
         proto: HTTP/2.0
@@ -1021,20 +1023,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 925
+        content_length: 358
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:20.757753029Z","description":"","domain_name":"tfnsfunnydewdneym4jo1cgp-tf-co-ecstatic-grothendieck.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"0ed78a5a-133b-4a7f-a1a1-48de372de485","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-ecstatic-grothendieck","namespace_id":"5dd58b8d-e67f-481c-abf4-863baae060c4","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsfunnydewdneym4jo1cgp/tf-co-ecstatic-grothendieck:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:38:20.757753029Z"}'
+        body: '{"container_id":"58f5113a-2906-471f-87fe-727be3c9a3fa","description":"","error_message":null,"id":"145cc115-791d-479c-bd32-19e29f05916b","input_type":"scw_sqs","name":"test-container-trigger-sqs","scw_sqs_config":{"mnq_credential_id":null,"mnq_project_id":"451a75ce-766a-43f9-9b0f-77a056b7e1ed","mnq_region":"fr-par","queue":"TestQueue"},"status":"creating"}'
         headers:
             Content-Length:
-                - "925"
+                - "358"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:20 GMT
+                - Wed, 27 Aug 2025 15:06:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1042,10 +1044,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 942745ec-73a5-4e83-ab1e-e7bdba421907
+                - 6e9ff202-def8-4f15-8047-bdb87bf6a776
         status: 200 OK
         code: 200
-        duration: 555.521041ms
+        duration: 295.294245ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1061,60 +1063,9 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/0ed78a5a-133b-4a7f-a1a1-48de372de485
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers/145cc115-791d-479c-bd32-19e29f05916b
         method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 919
-        uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:20.757753Z","description":"","domain_name":"tfnsfunnydewdneym4jo1cgp-tf-co-ecstatic-grothendieck.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"0ed78a5a-133b-4a7f-a1a1-48de372de485","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-ecstatic-grothendieck","namespace_id":"5dd58b8d-e67f-481c-abf4-863baae060c4","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsfunnydewdneym4jo1cgp/tf-co-ecstatic-grothendieck:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:38:20.757753Z"}'
-        headers:
-            Content-Length:
-                - "919"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:38:20 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 62f26f7a-d0cf-4ac5-9e1f-8129482830f8
-        status: 200 OK
-        code: 200
-        duration: 87.701667ms
-    - id: 22
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 208
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"name":"test-container-trigger-sqs","container_id":"0ed78a5a-133b-4a7f-a1a1-48de372de485","scw_sqs_config":{"queue":"TestQueue","mnq_project_id":"f450679c-9a35-4b8e-a910-f2dd97e60f10","mnq_region":"fr-par"}}'
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers
-        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
@@ -1123,7 +1074,7 @@ interactions:
         trailer: {}
         content_length: 358
         uncompressed: false
-        body: '{"container_id":"0ed78a5a-133b-4a7f-a1a1-48de372de485","description":"","error_message":null,"id":"8f59c57b-e90c-49bc-9572-bc08ad70b6a2","input_type":"scw_sqs","name":"test-container-trigger-sqs","scw_sqs_config":{"mnq_credential_id":null,"mnq_project_id":"f450679c-9a35-4b8e-a910-f2dd97e60f10","mnq_region":"fr-par","queue":"TestQueue"},"status":"creating"}'
+        body: '{"container_id":"58f5113a-2906-471f-87fe-727be3c9a3fa","description":"","error_message":null,"id":"145cc115-791d-479c-bd32-19e29f05916b","input_type":"scw_sqs","name":"test-container-trigger-sqs","scw_sqs_config":{"mnq_credential_id":null,"mnq_project_id":"451a75ce-766a-43f9-9b0f-77a056b7e1ed","mnq_region":"fr-par","queue":"TestQueue"},"status":"creating"}'
         headers:
             Content-Length:
                 - "358"
@@ -1132,9 +1083,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:21 GMT
+                - Wed, 27 Aug 2025 15:06:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1142,10 +1093,59 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fc541f94-3b76-4e73-b9ef-75e93bbe012c
+                - 5b63aff9-7e4e-4f88-9487-3fd13035f492
         status: 200 OK
         code: 200
-        duration: 147.60725ms
+        duration: 96.143294ms
+    - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers/145cc115-791d-479c-bd32-19e29f05916b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 392
+        uncompressed: false
+        body: '{"container_id":"58f5113a-2906-471f-87fe-727be3c9a3fa","description":"","error_message":null,"id":"145cc115-791d-479c-bd32-19e29f05916b","input_type":"scw_sqs","name":"test-container-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"acb5e3a2-8cb7-485d-a6ad-fd7c848d1888","mnq_project_id":"451a75ce-766a-43f9-9b0f-77a056b7e1ed","mnq_region":"fr-par","queue":"TestQueue"},"status":"creating"}'
+        headers:
+            Content-Length:
+                - "392"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:57 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 99fcc5d3-50f8-4430-9791-5ad27c206d9c
+        status: 200 OK
+        code: 200
+        duration: 117.738282ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1161,8 +1161,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers/8f59c57b-e90c-49bc-9572-bc08ad70b6a2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers/145cc115-791d-479c-bd32-19e29f05916b
         method: GET
       response:
         proto: HTTP/2.0
@@ -1170,20 +1170,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 358
+        content_length: 392
         uncompressed: false
-        body: '{"container_id":"0ed78a5a-133b-4a7f-a1a1-48de372de485","description":"","error_message":null,"id":"8f59c57b-e90c-49bc-9572-bc08ad70b6a2","input_type":"scw_sqs","name":"test-container-trigger-sqs","scw_sqs_config":{"mnq_credential_id":null,"mnq_project_id":"f450679c-9a35-4b8e-a910-f2dd97e60f10","mnq_region":"fr-par","queue":"TestQueue"},"status":"creating"}'
+        body: '{"container_id":"58f5113a-2906-471f-87fe-727be3c9a3fa","description":"","error_message":null,"id":"145cc115-791d-479c-bd32-19e29f05916b","input_type":"scw_sqs","name":"test-container-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"acb5e3a2-8cb7-485d-a6ad-fd7c848d1888","mnq_project_id":"451a75ce-766a-43f9-9b0f-77a056b7e1ed","mnq_region":"fr-par","queue":"TestQueue"},"status":"creating"}'
         headers:
             Content-Length:
-                - "358"
+                - "392"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:21 GMT
+                - Wed, 27 Aug 2025 15:07:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1191,10 +1191,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7363d82a-807e-4b3b-bce6-5c150e5181e0
+                - 71f0c877-79e8-44db-b915-ab55832f0813
         status: 200 OK
         code: 200
-        duration: 89.118125ms
+        duration: 113.877118ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1210,8 +1210,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers/8f59c57b-e90c-49bc-9572-bc08ad70b6a2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers/145cc115-791d-479c-bd32-19e29f05916b
         method: GET
       response:
         proto: HTTP/2.0
@@ -1221,7 +1221,7 @@ interactions:
         trailer: {}
         content_length: 392
         uncompressed: false
-        body: '{"container_id":"0ed78a5a-133b-4a7f-a1a1-48de372de485","description":"","error_message":null,"id":"8f59c57b-e90c-49bc-9572-bc08ad70b6a2","input_type":"scw_sqs","name":"test-container-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"d31016b4-2319-4f07-a16b-92f017cb7b58","mnq_project_id":"f450679c-9a35-4b8e-a910-f2dd97e60f10","mnq_region":"fr-par","queue":"TestQueue"},"status":"creating"}'
+        body: '{"container_id":"58f5113a-2906-471f-87fe-727be3c9a3fa","description":"","error_message":null,"id":"145cc115-791d-479c-bd32-19e29f05916b","input_type":"scw_sqs","name":"test-container-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"acb5e3a2-8cb7-485d-a6ad-fd7c848d1888","mnq_project_id":"451a75ce-766a-43f9-9b0f-77a056b7e1ed","mnq_region":"fr-par","queue":"TestQueue"},"status":"creating"}'
         headers:
             Content-Length:
                 - "392"
@@ -1230,9 +1230,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:26 GMT
+                - Wed, 27 Aug 2025 15:07:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1240,10 +1240,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5acbfb8c-d997-4f36-a432-9e432cb077ea
+                - a3a9c7c4-5fdd-4007-af85-619ce718f8f7
         status: 200 OK
         code: 200
-        duration: 81.797291ms
+        duration: 95.730674ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1259,8 +1259,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers/8f59c57b-e90c-49bc-9572-bc08ad70b6a2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers/145cc115-791d-479c-bd32-19e29f05916b
         method: GET
       response:
         proto: HTTP/2.0
@@ -1270,7 +1270,7 @@ interactions:
         trailer: {}
         content_length: 392
         uncompressed: false
-        body: '{"container_id":"0ed78a5a-133b-4a7f-a1a1-48de372de485","description":"","error_message":null,"id":"8f59c57b-e90c-49bc-9572-bc08ad70b6a2","input_type":"scw_sqs","name":"test-container-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"d31016b4-2319-4f07-a16b-92f017cb7b58","mnq_project_id":"f450679c-9a35-4b8e-a910-f2dd97e60f10","mnq_region":"fr-par","queue":"TestQueue"},"status":"creating"}'
+        body: '{"container_id":"58f5113a-2906-471f-87fe-727be3c9a3fa","description":"","error_message":null,"id":"145cc115-791d-479c-bd32-19e29f05916b","input_type":"scw_sqs","name":"test-container-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"acb5e3a2-8cb7-485d-a6ad-fd7c848d1888","mnq_project_id":"451a75ce-766a-43f9-9b0f-77a056b7e1ed","mnq_region":"fr-par","queue":"TestQueue"},"status":"creating"}'
         headers:
             Content-Length:
                 - "392"
@@ -1279,9 +1279,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:31 GMT
+                - Wed, 27 Aug 2025 15:07:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1289,10 +1289,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0a986d72-e0df-4780-8405-03a0e1b3b3a1
+                - b3e09f46-a323-4b0d-ba0c-76e5d81a4eb5
         status: 200 OK
         code: 200
-        duration: 140.36875ms
+        duration: 86.697694ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1308,8 +1308,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers/8f59c57b-e90c-49bc-9572-bc08ad70b6a2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers/145cc115-791d-479c-bd32-19e29f05916b
         method: GET
       response:
         proto: HTTP/2.0
@@ -1317,20 +1317,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 389
+        content_length: 392
         uncompressed: false
-        body: '{"container_id":"0ed78a5a-133b-4a7f-a1a1-48de372de485","description":"","error_message":null,"id":"8f59c57b-e90c-49bc-9572-bc08ad70b6a2","input_type":"scw_sqs","name":"test-container-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"d31016b4-2319-4f07-a16b-92f017cb7b58","mnq_project_id":"f450679c-9a35-4b8e-a910-f2dd97e60f10","mnq_region":"fr-par","queue":"TestQueue"},"status":"ready"}'
+        body: '{"container_id":"58f5113a-2906-471f-87fe-727be3c9a3fa","description":"","error_message":null,"id":"145cc115-791d-479c-bd32-19e29f05916b","input_type":"scw_sqs","name":"test-container-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"acb5e3a2-8cb7-485d-a6ad-fd7c848d1888","mnq_project_id":"451a75ce-766a-43f9-9b0f-77a056b7e1ed","mnq_region":"fr-par","queue":"TestQueue"},"status":"creating"}'
         headers:
             Content-Length:
-                - "389"
+                - "392"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:36 GMT
+                - Wed, 27 Aug 2025 15:07:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1338,10 +1338,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4f15f0e4-7352-4692-aed0-3913f365d22c
+                - a7bc70eb-c3a2-4a2c-b06d-e08b9f2423b6
         status: 200 OK
         code: 200
-        duration: 78.738458ms
+        duration: 103.624852ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1357,8 +1357,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers/8f59c57b-e90c-49bc-9572-bc08ad70b6a2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers/145cc115-791d-479c-bd32-19e29f05916b
         method: GET
       response:
         proto: HTTP/2.0
@@ -1368,7 +1368,7 @@ interactions:
         trailer: {}
         content_length: 389
         uncompressed: false
-        body: '{"container_id":"0ed78a5a-133b-4a7f-a1a1-48de372de485","description":"","error_message":null,"id":"8f59c57b-e90c-49bc-9572-bc08ad70b6a2","input_type":"scw_sqs","name":"test-container-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"d31016b4-2319-4f07-a16b-92f017cb7b58","mnq_project_id":"f450679c-9a35-4b8e-a910-f2dd97e60f10","mnq_region":"fr-par","queue":"TestQueue"},"status":"ready"}'
+        body: '{"container_id":"58f5113a-2906-471f-87fe-727be3c9a3fa","description":"","error_message":null,"id":"145cc115-791d-479c-bd32-19e29f05916b","input_type":"scw_sqs","name":"test-container-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"acb5e3a2-8cb7-485d-a6ad-fd7c848d1888","mnq_project_id":"451a75ce-766a-43f9-9b0f-77a056b7e1ed","mnq_region":"fr-par","queue":"TestQueue"},"status":"ready"}'
         headers:
             Content-Length:
                 - "389"
@@ -1377,9 +1377,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:36 GMT
+                - Wed, 27 Aug 2025 15:07:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1387,10 +1387,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f10638f6-75ee-41bd-a18e-aaa6d7499f90
+                - 8576743f-8f54-4e48-b6ff-d25b114a8559
         status: 200 OK
         code: 200
-        duration: 80.837792ms
+        duration: 107.137435ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1406,8 +1406,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers/8f59c57b-e90c-49bc-9572-bc08ad70b6a2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers/145cc115-791d-479c-bd32-19e29f05916b
         method: GET
       response:
         proto: HTTP/2.0
@@ -1417,7 +1417,7 @@ interactions:
         trailer: {}
         content_length: 389
         uncompressed: false
-        body: '{"container_id":"0ed78a5a-133b-4a7f-a1a1-48de372de485","description":"","error_message":null,"id":"8f59c57b-e90c-49bc-9572-bc08ad70b6a2","input_type":"scw_sqs","name":"test-container-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"d31016b4-2319-4f07-a16b-92f017cb7b58","mnq_project_id":"f450679c-9a35-4b8e-a910-f2dd97e60f10","mnq_region":"fr-par","queue":"TestQueue"},"status":"ready"}'
+        body: '{"container_id":"58f5113a-2906-471f-87fe-727be3c9a3fa","description":"","error_message":null,"id":"145cc115-791d-479c-bd32-19e29f05916b","input_type":"scw_sqs","name":"test-container-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"acb5e3a2-8cb7-485d-a6ad-fd7c848d1888","mnq_project_id":"451a75ce-766a-43f9-9b0f-77a056b7e1ed","mnq_region":"fr-par","queue":"TestQueue"},"status":"ready"}'
         headers:
             Content-Length:
                 - "389"
@@ -1426,9 +1426,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:36 GMT
+                - Wed, 27 Aug 2025 15:07:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1436,10 +1436,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 78778459-3315-48ee-8dac-74fb35251591
+                - 8d5d3cf0-0d39-4ffc-a5a5-46c18a1be2dc
         status: 200 OK
         code: 200
-        duration: 71.988417ms
+        duration: 103.771609ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1455,8 +1455,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers/8f59c57b-e90c-49bc-9572-bc08ad70b6a2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers/145cc115-791d-479c-bd32-19e29f05916b
         method: GET
       response:
         proto: HTTP/2.0
@@ -1466,7 +1466,7 @@ interactions:
         trailer: {}
         content_length: 389
         uncompressed: false
-        body: '{"container_id":"0ed78a5a-133b-4a7f-a1a1-48de372de485","description":"","error_message":null,"id":"8f59c57b-e90c-49bc-9572-bc08ad70b6a2","input_type":"scw_sqs","name":"test-container-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"d31016b4-2319-4f07-a16b-92f017cb7b58","mnq_project_id":"f450679c-9a35-4b8e-a910-f2dd97e60f10","mnq_region":"fr-par","queue":"TestQueue"},"status":"ready"}'
+        body: '{"container_id":"58f5113a-2906-471f-87fe-727be3c9a3fa","description":"","error_message":null,"id":"145cc115-791d-479c-bd32-19e29f05916b","input_type":"scw_sqs","name":"test-container-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"acb5e3a2-8cb7-485d-a6ad-fd7c848d1888","mnq_project_id":"451a75ce-766a-43f9-9b0f-77a056b7e1ed","mnq_region":"fr-par","queue":"TestQueue"},"status":"ready"}'
         headers:
             Content-Length:
                 - "389"
@@ -1475,9 +1475,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:36 GMT
+                - Wed, 27 Aug 2025 15:07:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1485,10 +1485,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 06f5e688-b033-4ccd-91e2-cfb1b3373a57
+                - 82b118a8-04a2-4fa7-b3f5-f4d8ae3d3c20
         status: 200 OK
         code: 200
-        duration: 113.537875ms
+        duration: 76.625494ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1504,8 +1504,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/account/v3/projects/f450679c-9a35-4b8e-a910-f2dd97e60f10
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers/145cc115-791d-479c-bd32-19e29f05916b
         method: GET
       response:
         proto: HTTP/2.0
@@ -1513,20 +1513,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 245
+        content_length: 389
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:48.585732Z","description":"","id":"f450679c-9a35-4b8e-a910-f2dd97e60f10","name":"tf_tests_container_trigger_sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","updated_at":"2025-01-24T15:37:48.585732Z"}'
+        body: '{"container_id":"58f5113a-2906-471f-87fe-727be3c9a3fa","description":"","error_message":null,"id":"145cc115-791d-479c-bd32-19e29f05916b","input_type":"scw_sqs","name":"test-container-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"acb5e3a2-8cb7-485d-a6ad-fd7c848d1888","mnq_project_id":"451a75ce-766a-43f9-9b0f-77a056b7e1ed","mnq_region":"fr-par","queue":"TestQueue"},"status":"ready"}'
         headers:
             Content-Length:
-                - "245"
+                - "389"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:37 GMT
+                - Wed, 27 Aug 2025 15:07:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1534,10 +1534,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 460b5422-ad23-4422-8940-9223fce8cb06
+                - 8039823f-4e12-4149-acfb-99a0778385ec
         status: 200 OK
         code: 200
-        duration: 128.352459ms
+        duration: 103.21215ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1553,8 +1553,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-info?project_id=f450679c-9a35-4b8e-a910-f2dd97e60f10
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/account/v3/projects/451a75ce-766a-43f9-9b0f-77a056b7e1ed
         method: GET
       response:
         proto: HTTP/2.0
@@ -1562,20 +1562,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 233
+        content_length: 311
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.062843Z","project_id":"f450679c-9a35-4b8e-a910-f2dd97e60f10","region":"fr-par","sqs_endpoint_url":"https://sqs.mnq.fr-par.scaleway.com","status":"enabled","updated_at":"2025-01-24T15:37:49.062843Z"}'
+        body: '{"created_at":"2025-08-27T15:06:28.183860Z","description":"","id":"451a75ce-766a-43f9-9b0f-77a056b7e1ed","name":"tf_tests_container_trigger_sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","qualification":{"architecture_type":"unknown_architecture_type"},"updated_at":"2025-08-27T15:06:28.183860Z"}'
         headers:
             Content-Length:
-                - "233"
+                - "311"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:37 GMT
+                - Wed, 27 Aug 2025 15:07:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1583,10 +1583,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9453f3b7-ffdc-4841-a7ff-2aa2f7b25b3d
+                - 3d417d2f-1420-4e6d-a5fe-ced7d2f7d2b0
         status: 200 OK
         code: 200
-        duration: 59.170167ms
+        duration: 228.23442ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1602,8 +1602,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/5dd58b8d-e67f-481c-abf4-863baae060c4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/e7e9218b-d951-4020-a0d5-1f0f613bd6cd
         method: GET
       response:
         proto: HTTP/2.0
@@ -1611,20 +1611,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 550
+        content_length: 592
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.458164Z","description":"","environment_variables":{},"error_message":null,"id":"5dd58b8d-e67f-481c-abf4-863baae060c4","name":"tf-ns-funny-dewdney","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"f450679c-9a35-4b8e-a910-f2dd97e60f10","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsfunnydewdneym4jo1cgp","registry_namespace_id":"64595108-3c2d-4c3b-a85a-62dea2d5e80e","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:38:19.465180Z"}'
+        body: '{"created_at":"2025-08-27T15:06:30.153440Z","description":"","environment_variables":{},"error_message":null,"id":"e7e9218b-d951-4020-a0d5-1f0f613bd6cd","name":"tf-ns-vibrant-hofstadter","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"451a75ce-766a-43f9-9b0f-77a056b7e1ed","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsvibranthofstadtexf2vueoe","registry_namespace_id":"d2cecc96-e3f5-4aeb-bd79-4057c8b9816b","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:48.641793Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "550"
+                - "592"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:37 GMT
+                - Wed, 27 Aug 2025 15:07:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1632,10 +1632,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 60bc0dc5-376e-4531-b4b1-476868287c2a
+                - d21aeddc-d10e-4804-891f-d0103b36ccc3
         status: 200 OK
         code: 200
-        duration: 67.787042ms
+        duration: 76.050064ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1651,8 +1651,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-credentials/90077722-0c4a-4b09-b1d0-a3b1cdf2369e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-info?project_id=451a75ce-766a-43f9-9b0f-77a056b7e1ed
         method: GET
       response:
         proto: HTTP/2.0
@@ -1660,20 +1660,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 424
+        content_length: 233
         uncompressed: false
-        body: '{"access_key":"aPESevK1s7NaoiJKQZIF","created_at":"2025-01-24T15:37:49.341192Z","id":"90077722-0c4a-4b09-b1d0-a3b1cdf2369e","name":"tf-sqs-credentials-busy-cori","permissions":{"can_manage":true,"can_publish":true,"can_receive":true},"project_id":"f450679c-9a35-4b8e-a910-f2dd97e60f10","region":"fr-par","secret_checksum":"9bdf90f793f77ea9b556728a7116d6dec89359ab","secret_key":"00000000-0000-0000-0000-000000000000","updated_at":"2025-01-24T15:37:49.341192Z"}'
+        body: '{"created_at":"2025-08-27T15:06:28.684881Z","project_id":"451a75ce-766a-43f9-9b0f-77a056b7e1ed","region":"fr-par","sqs_endpoint_url":"https://sqs.mnq.fr-par.scaleway.com","status":"enabled","updated_at":"2025-08-27T15:06:28.684881Z"}'
         headers:
             Content-Length:
-                - "424"
+                - "233"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:37 GMT
+                - Wed, 27 Aug 2025 15:07:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1681,10 +1681,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4b820247-4c4f-4c69-a645-8fb51a7b6e07
+                - eba6f7e8-6490-4cb9-9d8a-302b077ae132
         status: 200 OK
         code: 200
-        duration: 66.680333ms
+        duration: 79.492815ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1700,8 +1700,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/0ed78a5a-133b-4a7f-a1a1-48de372de485
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/58f5113a-2906-471f-87fe-727be3c9a3fa
         method: GET
       response:
         proto: HTTP/2.0
@@ -1709,20 +1709,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 919
+        content_length: 980
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:20.757753Z","description":"","domain_name":"tfnsfunnydewdneym4jo1cgp-tf-co-ecstatic-grothendieck.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"0ed78a5a-133b-4a7f-a1a1-48de372de485","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-ecstatic-grothendieck","namespace_id":"5dd58b8d-e67f-481c-abf4-863baae060c4","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsfunnydewdneym4jo1cgp/tf-co-ecstatic-grothendieck:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:38:20.757753Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:51.253340Z","description":"","domain_name":"tfnsvibranthofstadtexf2vueoe-tf-co-xenodochial-lumiere.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"58f5113a-2906-471f-87fe-727be3c9a3fa","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-xenodochial-lumiere","namespace_id":"e7e9218b-d951-4020-a0d5-1f0f613bd6cd","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsvibranthofstadtexf2vueoe/tf-co-xenodochial-lumiere:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:51.253340Z"}'
         headers:
             Content-Length:
-                - "919"
+                - "980"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:37 GMT
+                - Wed, 27 Aug 2025 15:07:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1730,11 +1730,60 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 456054e4-62c3-449f-ab35-987dda46473e
+                - f508c575-9c11-4e67-b1fb-fb80eec33306
         status: 200 OK
         code: 200
-        duration: 76.660834ms
+        duration: 92.356206ms
     - id: 35
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-credentials/4637a1d0-51e8-4863-957f-ce050f8f97e8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 436
+        uncompressed: false
+        body: '{"access_key":"6q9lhzw6NRO0iF3k2A4d","created_at":"2025-08-27T15:06:28.976527Z","id":"4637a1d0-51e8-4863-957f-ce050f8f97e8","name":"tf-sqs-credentials-dazzling-visvesvaraya","permissions":{"can_manage":true,"can_publish":true,"can_receive":true},"project_id":"451a75ce-766a-43f9-9b0f-77a056b7e1ed","region":"fr-par","secret_checksum":"571dc5b9999c5ba7a5e4d1a15402dd416b2a043d","secret_key":"00000000-0000-0000-0000-000000000000","updated_at":"2025-08-27T15:06:28.976527Z"}'
+        headers:
+            Content-Length:
+                - "436"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:07:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 31e1b7be-5d1a-4491-92b4-6255c8140aaa
+        status: 200 OK
+        code: 200
+        duration: 99.894864ms
+    - id: 36
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1749,15 +1798,15 @@ interactions:
         form: {}
         headers:
             Amz-Sdk-Invocation-Id:
-                - 496bc665-588e-4011-9321-2714c2205272
+                - 51fa401b-d103-4dea-b913-de41f907155b
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
                 - application/x-amz-json-1.0
             User-Agent:
-                - aws-sdk-go-v2/1.32.7 ua/2.1 os/macos lang/go#1.23.3 md/GOOS#darwin md/GOARCH#arm64 api/sqs#1.37.3 m/E
+                - aws-sdk-go-v2/1.37.1 ua/2.1 os/linux lang/go#1.24.1 md/GOOS#linux md/GOARCH#amd64 api/sqs#1.38.6 m/E,e
             X-Amz-Date:
-                - 20250124T153837Z
+                - 20250827T150723Z
             X-Amz-Target:
                 - AmazonSQS.GetQueueUrl
             X-Amzn-Query-Mode:
@@ -1772,20 +1821,20 @@ interactions:
         trailer: {}
         content_length: 106
         uncompressed: false
-        body: '{"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-f450679c-9a35-4b8e-a910-f2dd97e60f10/TestQueue"}'
+        body: '{"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-451a75ce-766a-43f9-9b0f-77a056b7e1ed/TestQueue"}'
         headers:
             Content-Length:
                 - "106"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 24 Jan 2025 15:38:37 GMT
+                - Wed, 27 Aug 2025 15:07:23 GMT
             X-Amzn-Requestid:
-                - tx52f24343-a99f-49ba-9177-537382b540f1
+                - tx0a96c078-83ba-4565-bdf1-66a8e4bb282a
         status: 200 OK
         code: 200
-        duration: 24.319625ms
-    - id: 36
+        duration: 29.531331ms
+    - id: 37
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1796,19 +1845,19 @@ interactions:
         host: sqs.mnq.fr-par.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"AttributeNames":["VisibilityTimeout","MaximumMessageSize","MessageRetentionPeriod","FifoQueue","ContentBasedDeduplication","ReceiveMessageWaitTimeSeconds"],"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-f450679c-9a35-4b8e-a910-f2dd97e60f10/TestQueue"}'
+        body: '{"AttributeNames":["FifoQueue","ContentBasedDeduplication","ReceiveMessageWaitTimeSeconds","VisibilityTimeout","MaximumMessageSize","MessageRetentionPeriod"],"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-451a75ce-766a-43f9-9b0f-77a056b7e1ed/TestQueue"}'
         form: {}
         headers:
             Amz-Sdk-Invocation-Id:
-                - b6200ea6-7170-43cb-9413-db059a6fdbba
+                - 4c0e4958-5aa0-4c7f-9870-549e913f418f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
                 - application/x-amz-json-1.0
             User-Agent:
-                - aws-sdk-go-v2/1.32.7 ua/2.1 os/macos lang/go#1.23.3 md/GOOS#darwin md/GOARCH#arm64 api/sqs#1.37.3 m/E
+                - aws-sdk-go-v2/1.37.1 ua/2.1 os/linux lang/go#1.24.1 md/GOOS#linux md/GOARCH#amd64 api/sqs#1.38.6 m/E,e
             X-Amz-Date:
-                - 20250124T153837Z
+                - 20250827T150723Z
             X-Amz-Target:
                 - AmazonSQS.GetQueueAttributes
             X-Amzn-Query-Mode:
@@ -1830,61 +1879,12 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 24 Jan 2025 15:38:37 GMT
+                - Wed, 27 Aug 2025 15:07:23 GMT
             X-Amzn-Requestid:
-                - txfc9f37d6-e4eb-4c23-8b0a-2e68c7e29a42
+                - txec0340b2-0e8b-4851-bf23-12d6c287a927
         status: 200 OK
         code: 200
-        duration: 40.652333ms
-    - id: 37
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers/8f59c57b-e90c-49bc-9572-bc08ad70b6a2
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 389
-        uncompressed: false
-        body: '{"container_id":"0ed78a5a-133b-4a7f-a1a1-48de372de485","description":"","error_message":null,"id":"8f59c57b-e90c-49bc-9572-bc08ad70b6a2","input_type":"scw_sqs","name":"test-container-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"d31016b4-2319-4f07-a16b-92f017cb7b58","mnq_project_id":"f450679c-9a35-4b8e-a910-f2dd97e60f10","mnq_region":"fr-par","queue":"TestQueue"},"status":"ready"}'
-        headers:
-            Content-Length:
-                - "389"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:38:37 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 2b984e32-2fe5-4a89-b578-5e2d1b0c493a
-        status: 200 OK
-        code: 200
-        duration: 97.022167ms
+        duration: 30.430991ms
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1900,8 +1900,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/account/v3/projects/f450679c-9a35-4b8e-a910-f2dd97e60f10
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers/145cc115-791d-479c-bd32-19e29f05916b
         method: GET
       response:
         proto: HTTP/2.0
@@ -1909,20 +1909,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 245
+        content_length: 389
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:48.585732Z","description":"","id":"f450679c-9a35-4b8e-a910-f2dd97e60f10","name":"tf_tests_container_trigger_sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","updated_at":"2025-01-24T15:37:48.585732Z"}'
+        body: '{"container_id":"58f5113a-2906-471f-87fe-727be3c9a3fa","description":"","error_message":null,"id":"145cc115-791d-479c-bd32-19e29f05916b","input_type":"scw_sqs","name":"test-container-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"acb5e3a2-8cb7-485d-a6ad-fd7c848d1888","mnq_project_id":"451a75ce-766a-43f9-9b0f-77a056b7e1ed","mnq_region":"fr-par","queue":"TestQueue"},"status":"ready"}'
         headers:
             Content-Length:
-                - "245"
+                - "389"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:38 GMT
+                - Wed, 27 Aug 2025 15:07:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1930,10 +1930,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 28b7e0ca-58a6-45a2-a94f-cf7bf5cbea7d
+                - 1f08e074-b343-4cb6-9548-0c3d47b2f466
         status: 200 OK
         code: 200
-        duration: 99.85325ms
+        duration: 103.416743ms
     - id: 39
       request:
         proto: HTTP/1.1
@@ -1949,8 +1949,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-info?project_id=f450679c-9a35-4b8e-a910-f2dd97e60f10
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/account/v3/projects/451a75ce-766a-43f9-9b0f-77a056b7e1ed
         method: GET
       response:
         proto: HTTP/2.0
@@ -1958,20 +1958,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 233
+        content_length: 311
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.062843Z","project_id":"f450679c-9a35-4b8e-a910-f2dd97e60f10","region":"fr-par","sqs_endpoint_url":"https://sqs.mnq.fr-par.scaleway.com","status":"enabled","updated_at":"2025-01-24T15:37:49.062843Z"}'
+        body: '{"created_at":"2025-08-27T15:06:28.183860Z","description":"","id":"451a75ce-766a-43f9-9b0f-77a056b7e1ed","name":"tf_tests_container_trigger_sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","qualification":{"architecture_type":"unknown_architecture_type"},"updated_at":"2025-08-27T15:06:28.183860Z"}'
         headers:
             Content-Length:
-                - "233"
+                - "311"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:38 GMT
+                - Wed, 27 Aug 2025 15:07:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1979,10 +1979,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 35280872-4aba-42eb-afac-8aefe092baee
+                - e782d362-f8c1-42f5-b136-e0059371cf71
         status: 200 OK
         code: 200
-        duration: 60.4365ms
+        duration: 184.145538ms
     - id: 40
       request:
         proto: HTTP/1.1
@@ -1998,8 +1998,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/5dd58b8d-e67f-481c-abf4-863baae060c4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/e7e9218b-d951-4020-a0d5-1f0f613bd6cd
         method: GET
       response:
         proto: HTTP/2.0
@@ -2007,20 +2007,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 550
+        content_length: 592
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.458164Z","description":"","environment_variables":{},"error_message":null,"id":"5dd58b8d-e67f-481c-abf4-863baae060c4","name":"tf-ns-funny-dewdney","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"f450679c-9a35-4b8e-a910-f2dd97e60f10","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsfunnydewdneym4jo1cgp","registry_namespace_id":"64595108-3c2d-4c3b-a85a-62dea2d5e80e","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:38:19.465180Z"}'
+        body: '{"created_at":"2025-08-27T15:06:30.153440Z","description":"","environment_variables":{},"error_message":null,"id":"e7e9218b-d951-4020-a0d5-1f0f613bd6cd","name":"tf-ns-vibrant-hofstadter","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"451a75ce-766a-43f9-9b0f-77a056b7e1ed","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsvibranthofstadtexf2vueoe","registry_namespace_id":"d2cecc96-e3f5-4aeb-bd79-4057c8b9816b","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:48.641793Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "550"
+                - "592"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:38 GMT
+                - Wed, 27 Aug 2025 15:07:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2028,10 +2028,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c39f338d-b28f-4e2b-b425-fdf63ff960ee
+                - b8bbac7d-417c-4898-ade5-c30d31098124
         status: 200 OK
         code: 200
-        duration: 60.520333ms
+        duration: 80.311492ms
     - id: 41
       request:
         proto: HTTP/1.1
@@ -2047,8 +2047,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-credentials/90077722-0c4a-4b09-b1d0-a3b1cdf2369e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-info?project_id=451a75ce-766a-43f9-9b0f-77a056b7e1ed
         method: GET
       response:
         proto: HTTP/2.0
@@ -2056,20 +2056,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 424
+        content_length: 233
         uncompressed: false
-        body: '{"access_key":"aPESevK1s7NaoiJKQZIF","created_at":"2025-01-24T15:37:49.341192Z","id":"90077722-0c4a-4b09-b1d0-a3b1cdf2369e","name":"tf-sqs-credentials-busy-cori","permissions":{"can_manage":true,"can_publish":true,"can_receive":true},"project_id":"f450679c-9a35-4b8e-a910-f2dd97e60f10","region":"fr-par","secret_checksum":"9bdf90f793f77ea9b556728a7116d6dec89359ab","secret_key":"00000000-0000-0000-0000-000000000000","updated_at":"2025-01-24T15:37:49.341192Z"}'
+        body: '{"created_at":"2025-08-27T15:06:28.684881Z","project_id":"451a75ce-766a-43f9-9b0f-77a056b7e1ed","region":"fr-par","sqs_endpoint_url":"https://sqs.mnq.fr-par.scaleway.com","status":"enabled","updated_at":"2025-08-27T15:06:28.684881Z"}'
         headers:
             Content-Length:
-                - "424"
+                - "233"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:38 GMT
+                - Wed, 27 Aug 2025 15:07:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2077,10 +2077,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c287398c-b669-4500-a5b0-b06aa34752f9
+                - cdfe1a46-c6f7-4daa-957e-a9c20f12cdd7
         status: 200 OK
         code: 200
-        duration: 61.098917ms
+        duration: 101.859111ms
     - id: 42
       request:
         proto: HTTP/1.1
@@ -2096,8 +2096,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/0ed78a5a-133b-4a7f-a1a1-48de372de485
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-credentials/4637a1d0-51e8-4863-957f-ce050f8f97e8
         method: GET
       response:
         proto: HTTP/2.0
@@ -2105,20 +2105,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 919
+        content_length: 436
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:20.757753Z","description":"","domain_name":"tfnsfunnydewdneym4jo1cgp-tf-co-ecstatic-grothendieck.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"0ed78a5a-133b-4a7f-a1a1-48de372de485","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-ecstatic-grothendieck","namespace_id":"5dd58b8d-e67f-481c-abf4-863baae060c4","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsfunnydewdneym4jo1cgp/tf-co-ecstatic-grothendieck:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:38:20.757753Z"}'
+        body: '{"access_key":"6q9lhzw6NRO0iF3k2A4d","created_at":"2025-08-27T15:06:28.976527Z","id":"4637a1d0-51e8-4863-957f-ce050f8f97e8","name":"tf-sqs-credentials-dazzling-visvesvaraya","permissions":{"can_manage":true,"can_publish":true,"can_receive":true},"project_id":"451a75ce-766a-43f9-9b0f-77a056b7e1ed","region":"fr-par","secret_checksum":"571dc5b9999c5ba7a5e4d1a15402dd416b2a043d","secret_key":"00000000-0000-0000-0000-000000000000","updated_at":"2025-08-27T15:06:28.976527Z"}'
         headers:
             Content-Length:
-                - "919"
+                - "436"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:38 GMT
+                - Wed, 27 Aug 2025 15:07:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2126,11 +2126,60 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c60c3118-ca47-4309-aade-4d113d4576ac
+                - 48ae5d3e-588c-4c96-9600-0451341a91df
         status: 200 OK
         code: 200
-        duration: 77.161125ms
+        duration: 75.755802ms
     - id: 43
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/58f5113a-2906-471f-87fe-727be3c9a3fa
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 980
+        uncompressed: false
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:51.253340Z","description":"","domain_name":"tfnsvibranthofstadtexf2vueoe-tf-co-xenodochial-lumiere.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"58f5113a-2906-471f-87fe-727be3c9a3fa","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-xenodochial-lumiere","namespace_id":"e7e9218b-d951-4020-a0d5-1f0f613bd6cd","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsvibranthofstadtexf2vueoe/tf-co-xenodochial-lumiere:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:51.253340Z"}'
+        headers:
+            Content-Length:
+                - "980"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:07:24 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 0c76ff55-e9d3-43d2-82eb-465e95dfba49
+        status: 200 OK
+        code: 200
+        duration: 101.854471ms
+    - id: 44
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2145,15 +2194,15 @@ interactions:
         form: {}
         headers:
             Amz-Sdk-Invocation-Id:
-                - fd87fd09-8d2f-4632-9688-0392bfb82afe
+                - 52b3c643-6cfe-44b9-b066-ec1bbce04440
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
                 - application/x-amz-json-1.0
             User-Agent:
-                - aws-sdk-go-v2/1.32.7 ua/2.1 os/macos lang/go#1.23.3 md/GOOS#darwin md/GOARCH#arm64 api/sqs#1.37.3 m/E
+                - aws-sdk-go-v2/1.37.1 ua/2.1 os/linux lang/go#1.24.1 md/GOOS#linux md/GOARCH#amd64 api/sqs#1.38.6 m/E,e
             X-Amz-Date:
-                - 20250124T153838Z
+                - 20250827T150724Z
             X-Amz-Target:
                 - AmazonSQS.GetQueueUrl
             X-Amzn-Query-Mode:
@@ -2168,20 +2217,20 @@ interactions:
         trailer: {}
         content_length: 106
         uncompressed: false
-        body: '{"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-f450679c-9a35-4b8e-a910-f2dd97e60f10/TestQueue"}'
+        body: '{"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-451a75ce-766a-43f9-9b0f-77a056b7e1ed/TestQueue"}'
         headers:
             Content-Length:
                 - "106"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 24 Jan 2025 15:38:38 GMT
+                - Wed, 27 Aug 2025 15:07:24 GMT
             X-Amzn-Requestid:
-                - tx9be5857f-4d43-4e64-8d24-f971fa5196f3
+                - txe8651a4b-a379-4cc1-ac22-8d4f32735731
         status: 200 OK
         code: 200
-        duration: 37.132459ms
-    - id: 44
+        duration: 24.961866ms
+    - id: 45
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2192,19 +2241,19 @@ interactions:
         host: sqs.mnq.fr-par.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"AttributeNames":["MessageRetentionPeriod","FifoQueue","ContentBasedDeduplication","ReceiveMessageWaitTimeSeconds","VisibilityTimeout","MaximumMessageSize"],"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-f450679c-9a35-4b8e-a910-f2dd97e60f10/TestQueue"}'
+        body: '{"AttributeNames":["MaximumMessageSize","MessageRetentionPeriod","FifoQueue","ContentBasedDeduplication","ReceiveMessageWaitTimeSeconds","VisibilityTimeout"],"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-451a75ce-766a-43f9-9b0f-77a056b7e1ed/TestQueue"}'
         form: {}
         headers:
             Amz-Sdk-Invocation-Id:
-                - 749df3c0-dbb4-4d4f-9ff1-78f952974100
+                - 9768ac50-0231-44a9-aa0d-63058e07a633
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
                 - application/x-amz-json-1.0
             User-Agent:
-                - aws-sdk-go-v2/1.32.7 ua/2.1 os/macos lang/go#1.23.3 md/GOOS#darwin md/GOARCH#arm64 api/sqs#1.37.3 m/E
+                - aws-sdk-go-v2/1.37.1 ua/2.1 os/linux lang/go#1.24.1 md/GOOS#linux md/GOARCH#amd64 api/sqs#1.38.6 m/E,e
             X-Amz-Date:
-                - 20250124T153838Z
+                - 20250827T150724Z
             X-Amz-Target:
                 - AmazonSQS.GetQueueAttributes
             X-Amzn-Query-Mode:
@@ -2226,61 +2275,12 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 24 Jan 2025 15:38:38 GMT
+                - Wed, 27 Aug 2025 15:07:24 GMT
             X-Amzn-Requestid:
-                - tx8828bf56-ea45-4d62-befb-4c4f19a5bb5f
+                - tx6febcb9d-5d49-4627-bcfe-5df7692a4eb4
         status: 200 OK
         code: 200
-        duration: 38.9065ms
-    - id: 45
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers/8f59c57b-e90c-49bc-9572-bc08ad70b6a2
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 389
-        uncompressed: false
-        body: '{"container_id":"0ed78a5a-133b-4a7f-a1a1-48de372de485","description":"","error_message":null,"id":"8f59c57b-e90c-49bc-9572-bc08ad70b6a2","input_type":"scw_sqs","name":"test-container-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"d31016b4-2319-4f07-a16b-92f017cb7b58","mnq_project_id":"f450679c-9a35-4b8e-a910-f2dd97e60f10","mnq_region":"fr-par","queue":"TestQueue"},"status":"ready"}'
-        headers:
-            Content-Length:
-                - "389"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:38:38 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 69771a08-2591-4a32-86cc-5c65f3d20673
-        status: 200 OK
-        code: 200
-        duration: 74.6385ms
+        duration: 25.681016ms
     - id: 46
       request:
         proto: HTTP/1.1
@@ -2296,8 +2296,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/account/v3/projects/f450679c-9a35-4b8e-a910-f2dd97e60f10
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers/145cc115-791d-479c-bd32-19e29f05916b
         method: GET
       response:
         proto: HTTP/2.0
@@ -2305,20 +2305,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 245
+        content_length: 389
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:48.585732Z","description":"","id":"f450679c-9a35-4b8e-a910-f2dd97e60f10","name":"tf_tests_container_trigger_sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","updated_at":"2025-01-24T15:37:48.585732Z"}'
+        body: '{"container_id":"58f5113a-2906-471f-87fe-727be3c9a3fa","description":"","error_message":null,"id":"145cc115-791d-479c-bd32-19e29f05916b","input_type":"scw_sqs","name":"test-container-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"acb5e3a2-8cb7-485d-a6ad-fd7c848d1888","mnq_project_id":"451a75ce-766a-43f9-9b0f-77a056b7e1ed","mnq_region":"fr-par","queue":"TestQueue"},"status":"ready"}'
         headers:
             Content-Length:
-                - "245"
+                - "389"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:39 GMT
+                - Wed, 27 Aug 2025 15:07:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2326,10 +2326,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - efd1473e-c12e-4df1-ab11-1de6205d2fc2
+                - 5ee49654-e920-40e1-9f48-d4dcdc183177
         status: 200 OK
         code: 200
-        duration: 96.678833ms
+        duration: 91.875273ms
     - id: 47
       request:
         proto: HTTP/1.1
@@ -2345,8 +2345,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-info?project_id=f450679c-9a35-4b8e-a910-f2dd97e60f10
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/account/v3/projects/451a75ce-766a-43f9-9b0f-77a056b7e1ed
         method: GET
       response:
         proto: HTTP/2.0
@@ -2354,20 +2354,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 233
+        content_length: 311
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.062843Z","project_id":"f450679c-9a35-4b8e-a910-f2dd97e60f10","region":"fr-par","sqs_endpoint_url":"https://sqs.mnq.fr-par.scaleway.com","status":"enabled","updated_at":"2025-01-24T15:37:49.062843Z"}'
+        body: '{"created_at":"2025-08-27T15:06:28.183860Z","description":"","id":"451a75ce-766a-43f9-9b0f-77a056b7e1ed","name":"tf_tests_container_trigger_sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","qualification":{"architecture_type":"unknown_architecture_type"},"updated_at":"2025-08-27T15:06:28.183860Z"}'
         headers:
             Content-Length:
-                - "233"
+                - "311"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:39 GMT
+                - Wed, 27 Aug 2025 15:07:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2375,10 +2375,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4aac501b-3a73-40a7-9a4e-0a4eb469dd98
+                - b2c7d719-2ebc-437b-92d0-589ffac5314e
         status: 200 OK
         code: 200
-        duration: 61.881292ms
+        duration: 177.73081ms
     - id: 48
       request:
         proto: HTTP/1.1
@@ -2394,8 +2394,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/5dd58b8d-e67f-481c-abf4-863baae060c4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-info?project_id=451a75ce-766a-43f9-9b0f-77a056b7e1ed
         method: GET
       response:
         proto: HTTP/2.0
@@ -2403,20 +2403,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 550
+        content_length: 233
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.458164Z","description":"","environment_variables":{},"error_message":null,"id":"5dd58b8d-e67f-481c-abf4-863baae060c4","name":"tf-ns-funny-dewdney","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"f450679c-9a35-4b8e-a910-f2dd97e60f10","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsfunnydewdneym4jo1cgp","registry_namespace_id":"64595108-3c2d-4c3b-a85a-62dea2d5e80e","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:38:19.465180Z"}'
+        body: '{"created_at":"2025-08-27T15:06:28.684881Z","project_id":"451a75ce-766a-43f9-9b0f-77a056b7e1ed","region":"fr-par","sqs_endpoint_url":"https://sqs.mnq.fr-par.scaleway.com","status":"enabled","updated_at":"2025-08-27T15:06:28.684881Z"}'
         headers:
             Content-Length:
-                - "550"
+                - "233"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:39 GMT
+                - Wed, 27 Aug 2025 15:07:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2424,10 +2424,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bd770d4f-c5c1-46a0-9eca-bb415352ab20
+                - d70779af-f556-4d61-bb91-a21fd476d3a3
         status: 200 OK
         code: 200
-        duration: 66.578875ms
+        duration: 72.86665ms
     - id: 49
       request:
         proto: HTTP/1.1
@@ -2443,8 +2443,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-credentials/90077722-0c4a-4b09-b1d0-a3b1cdf2369e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/e7e9218b-d951-4020-a0d5-1f0f613bd6cd
         method: GET
       response:
         proto: HTTP/2.0
@@ -2452,20 +2452,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 424
+        content_length: 592
         uncompressed: false
-        body: '{"access_key":"aPESevK1s7NaoiJKQZIF","created_at":"2025-01-24T15:37:49.341192Z","id":"90077722-0c4a-4b09-b1d0-a3b1cdf2369e","name":"tf-sqs-credentials-busy-cori","permissions":{"can_manage":true,"can_publish":true,"can_receive":true},"project_id":"f450679c-9a35-4b8e-a910-f2dd97e60f10","region":"fr-par","secret_checksum":"9bdf90f793f77ea9b556728a7116d6dec89359ab","secret_key":"00000000-0000-0000-0000-000000000000","updated_at":"2025-01-24T15:37:49.341192Z"}'
+        body: '{"created_at":"2025-08-27T15:06:30.153440Z","description":"","environment_variables":{},"error_message":null,"id":"e7e9218b-d951-4020-a0d5-1f0f613bd6cd","name":"tf-ns-vibrant-hofstadter","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"451a75ce-766a-43f9-9b0f-77a056b7e1ed","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsvibranthofstadtexf2vueoe","registry_namespace_id":"d2cecc96-e3f5-4aeb-bd79-4057c8b9816b","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:48.641793Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "424"
+                - "592"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:39 GMT
+                - Wed, 27 Aug 2025 15:07:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2473,10 +2473,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e1ccc91a-2cc1-4c97-a604-e34c073aa471
+                - 2fd37adf-d2ee-45ae-8e1f-5fb1b27b6cce
         status: 200 OK
         code: 200
-        duration: 88.893958ms
+        duration: 82.078618ms
     - id: 50
       request:
         proto: HTTP/1.1
@@ -2492,8 +2492,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/0ed78a5a-133b-4a7f-a1a1-48de372de485
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-credentials/4637a1d0-51e8-4863-957f-ce050f8f97e8
         method: GET
       response:
         proto: HTTP/2.0
@@ -2501,20 +2501,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 919
+        content_length: 436
         uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:20.757753Z","description":"","domain_name":"tfnsfunnydewdneym4jo1cgp-tf-co-ecstatic-grothendieck.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"0ed78a5a-133b-4a7f-a1a1-48de372de485","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-ecstatic-grothendieck","namespace_id":"5dd58b8d-e67f-481c-abf4-863baae060c4","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsfunnydewdneym4jo1cgp/tf-co-ecstatic-grothendieck:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:38:20.757753Z"}'
+        body: '{"access_key":"6q9lhzw6NRO0iF3k2A4d","created_at":"2025-08-27T15:06:28.976527Z","id":"4637a1d0-51e8-4863-957f-ce050f8f97e8","name":"tf-sqs-credentials-dazzling-visvesvaraya","permissions":{"can_manage":true,"can_publish":true,"can_receive":true},"project_id":"451a75ce-766a-43f9-9b0f-77a056b7e1ed","region":"fr-par","secret_checksum":"571dc5b9999c5ba7a5e4d1a15402dd416b2a043d","secret_key":"00000000-0000-0000-0000-000000000000","updated_at":"2025-08-27T15:06:28.976527Z"}'
         headers:
             Content-Length:
-                - "919"
+                - "436"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:39 GMT
+                - Wed, 27 Aug 2025 15:07:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2522,11 +2522,60 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 47608f36-4204-430e-9058-4b2ea54fa094
+                - 2e852970-ee37-4396-a29b-cf610150791e
         status: 200 OK
         code: 200
-        duration: 84.66325ms
+        duration: 186.685425ms
     - id: 51
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/58f5113a-2906-471f-87fe-727be3c9a3fa
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 980
+        uncompressed: false
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:51.253340Z","description":"","domain_name":"tfnsvibranthofstadtexf2vueoe-tf-co-xenodochial-lumiere.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"58f5113a-2906-471f-87fe-727be3c9a3fa","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-xenodochial-lumiere","namespace_id":"e7e9218b-d951-4020-a0d5-1f0f613bd6cd","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsvibranthofstadtexf2vueoe/tf-co-xenodochial-lumiere:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:51.253340Z"}'
+        headers:
+            Content-Length:
+                - "980"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:07:25 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 6a1e40b5-fbd8-4c46-80c1-a8b73559d5ec
+        status: 200 OK
+        code: 200
+        duration: 173.054915ms
+    - id: 52
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2541,15 +2590,15 @@ interactions:
         form: {}
         headers:
             Amz-Sdk-Invocation-Id:
-                - ddddb91b-08da-4850-853a-8cec3a22a80b
+                - 804e95fa-0c5b-4887-8824-e743132677db
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
                 - application/x-amz-json-1.0
             User-Agent:
-                - aws-sdk-go-v2/1.32.7 ua/2.1 os/macos lang/go#1.23.3 md/GOOS#darwin md/GOARCH#arm64 api/sqs#1.37.3 m/E
+                - aws-sdk-go-v2/1.37.1 ua/2.1 os/linux lang/go#1.24.1 md/GOOS#linux md/GOARCH#amd64 api/sqs#1.38.6 m/E,e
             X-Amz-Date:
-                - 20250124T153839Z
+                - 20250827T150725Z
             X-Amz-Target:
                 - AmazonSQS.GetQueueUrl
             X-Amzn-Query-Mode:
@@ -2564,20 +2613,20 @@ interactions:
         trailer: {}
         content_length: 106
         uncompressed: false
-        body: '{"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-f450679c-9a35-4b8e-a910-f2dd97e60f10/TestQueue"}'
+        body: '{"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-451a75ce-766a-43f9-9b0f-77a056b7e1ed/TestQueue"}'
         headers:
             Content-Length:
                 - "106"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 24 Jan 2025 15:38:39 GMT
+                - Wed, 27 Aug 2025 15:07:25 GMT
             X-Amzn-Requestid:
-                - tx9cb3e15f-7556-440d-9a8a-58275bd81577
+                - tx1e097780-b1bb-4c1a-8c72-ec07422e46a6
         status: 200 OK
         code: 200
-        duration: 23.03175ms
-    - id: 52
+        duration: 26.766343ms
+    - id: 53
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2588,19 +2637,19 @@ interactions:
         host: sqs.mnq.fr-par.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"AttributeNames":["VisibilityTimeout","MaximumMessageSize","MessageRetentionPeriod","FifoQueue","ContentBasedDeduplication","ReceiveMessageWaitTimeSeconds"],"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-f450679c-9a35-4b8e-a910-f2dd97e60f10/TestQueue"}'
+        body: '{"AttributeNames":["FifoQueue","ContentBasedDeduplication","ReceiveMessageWaitTimeSeconds","VisibilityTimeout","MaximumMessageSize","MessageRetentionPeriod"],"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-451a75ce-766a-43f9-9b0f-77a056b7e1ed/TestQueue"}'
         form: {}
         headers:
             Amz-Sdk-Invocation-Id:
-                - e70b010d-7137-4f9a-9e2f-08543dbafc6d
+                - ffb7b905-22ac-4ab6-88a3-abd976f8dee4
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
                 - application/x-amz-json-1.0
             User-Agent:
-                - aws-sdk-go-v2/1.32.7 ua/2.1 os/macos lang/go#1.23.3 md/GOOS#darwin md/GOARCH#arm64 api/sqs#1.37.3 m/E
+                - aws-sdk-go-v2/1.37.1 ua/2.1 os/linux lang/go#1.24.1 md/GOOS#linux md/GOARCH#amd64 api/sqs#1.38.6 m/E,e
             X-Amz-Date:
-                - 20250124T153839Z
+                - 20250827T150725Z
             X-Amz-Target:
                 - AmazonSQS.GetQueueAttributes
             X-Amzn-Query-Mode:
@@ -2622,13 +2671,13 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 24 Jan 2025 15:38:39 GMT
+                - Wed, 27 Aug 2025 15:07:25 GMT
             X-Amzn-Requestid:
-                - txb66aa229-4ff7-4a10-a1d6-6cd1604f0fae
+                - tx79fb9000-f24c-49dc-a4ff-24a6bf8b741c
         status: 200 OK
         code: 200
-        duration: 35.896292ms
-    - id: 53
+        duration: 25.202118ms
+    - id: 54
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2643,8 +2692,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers/8f59c57b-e90c-49bc-9572-bc08ad70b6a2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers/145cc115-791d-479c-bd32-19e29f05916b
         method: GET
       response:
         proto: HTTP/2.0
@@ -2654,7 +2703,7 @@ interactions:
         trailer: {}
         content_length: 389
         uncompressed: false
-        body: '{"container_id":"0ed78a5a-133b-4a7f-a1a1-48de372de485","description":"","error_message":null,"id":"8f59c57b-e90c-49bc-9572-bc08ad70b6a2","input_type":"scw_sqs","name":"test-container-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"d31016b4-2319-4f07-a16b-92f017cb7b58","mnq_project_id":"f450679c-9a35-4b8e-a910-f2dd97e60f10","mnq_region":"fr-par","queue":"TestQueue"},"status":"ready"}'
+        body: '{"container_id":"58f5113a-2906-471f-87fe-727be3c9a3fa","description":"","error_message":null,"id":"145cc115-791d-479c-bd32-19e29f05916b","input_type":"scw_sqs","name":"test-container-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"acb5e3a2-8cb7-485d-a6ad-fd7c848d1888","mnq_project_id":"451a75ce-766a-43f9-9b0f-77a056b7e1ed","mnq_region":"fr-par","queue":"TestQueue"},"status":"ready"}'
         headers:
             Content-Length:
                 - "389"
@@ -2663,9 +2712,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:39 GMT
+                - Wed, 27 Aug 2025 15:07:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2673,11 +2722,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 37109456-d6a7-4545-914c-704b2e1aceb9
+                - 8e797de6-ed50-4b01-bd73-7c9de57c2384
         status: 200 OK
         code: 200
-        duration: 81.307375ms
-    - id: 54
+        duration: 94.923485ms
+    - id: 55
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2692,15 +2741,15 @@ interactions:
         form: {}
         headers:
             Amz-Sdk-Invocation-Id:
-                - e0b3fc96-1404-4823-b378-7466ec2469b7
+                - 067e96c7-835a-41da-b569-90e518e97600
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
                 - application/x-amz-json-1.0
             User-Agent:
-                - aws-sdk-go-v2/1.32.7 ua/2.1 os/macos lang/go#1.23.3 md/GOOS#darwin md/GOARCH#arm64 api/sqs#1.37.3 m/E
+                - aws-sdk-go-v2/1.37.1 ua/2.1 os/linux lang/go#1.24.1 md/GOOS#linux md/GOARCH#amd64 api/sqs#1.38.6 m/E,e
             X-Amz-Date:
-                - 20250124T153840Z
+                - 20250827T150725Z
             X-Amz-Target:
                 - AmazonSQS.GetQueueUrl
             X-Amzn-Query-Mode:
@@ -2715,20 +2764,20 @@ interactions:
         trailer: {}
         content_length: 106
         uncompressed: false
-        body: '{"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-f450679c-9a35-4b8e-a910-f2dd97e60f10/TestQueue"}'
+        body: '{"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-451a75ce-766a-43f9-9b0f-77a056b7e1ed/TestQueue"}'
         headers:
             Content-Length:
                 - "106"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 24 Jan 2025 15:38:40 GMT
+                - Wed, 27 Aug 2025 15:07:25 GMT
             X-Amzn-Requestid:
-                - tx2bfcb6c8-cb26-4d50-8173-2c2e7de47735
+                - tx99c94f4b-2562-4b97-bbe9-f1ce53f681ce
         status: 200 OK
         code: 200
-        duration: 27.097125ms
-    - id: 55
+        duration: 30.827494ms
+    - id: 56
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2739,19 +2788,19 @@ interactions:
         host: sqs.mnq.fr-par.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-f450679c-9a35-4b8e-a910-f2dd97e60f10/TestQueue"}'
+        body: '{"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-451a75ce-766a-43f9-9b0f-77a056b7e1ed/TestQueue"}'
         form: {}
         headers:
             Amz-Sdk-Invocation-Id:
-                - dacdea98-12b0-44cc-9fe9-8dc1f5c6ec68
+                - 8b9c3c09-f403-4316-977c-dbd8d778522a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
                 - application/x-amz-json-1.0
             User-Agent:
-                - aws-sdk-go-v2/1.32.7 ua/2.1 os/macos lang/go#1.23.3 md/GOOS#darwin md/GOARCH#arm64 api/sqs#1.37.3 m/E
+                - aws-sdk-go-v2/1.37.1 ua/2.1 os/linux lang/go#1.24.1 md/GOOS#linux md/GOARCH#amd64 api/sqs#1.38.6 m/E,e
             X-Amz-Date:
-                - 20250124T153840Z
+                - 20250827T150725Z
             X-Amz-Target:
                 - AmazonSQS.DeleteQueue
             X-Amzn-Query-Mode:
@@ -2773,13 +2822,13 @@ interactions:
             Content-Type:
                 - application/x-amz-json-1.0; charset=utf-8
             Date:
-                - Fri, 24 Jan 2025 15:38:40 GMT
+                - Wed, 27 Aug 2025 15:07:26 GMT
             X-Amzn-Requestid:
-                - tx9a9269e1-37ec-4dd9-9029-0636594fdc4f
+                - txb4a55e39-3581-458d-a56e-5f0bef32d44a
         status: 200 OK
         code: 200
-        duration: 31.816125ms
-    - id: 56
+        duration: 39.550225ms
+    - id: 57
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2794,15 +2843,15 @@ interactions:
         form: {}
         headers:
             Amz-Sdk-Invocation-Id:
-                - 0263e024-655f-47f6-8f84-a36c35ee9351
+                - d781c4c3-12e0-4724-8850-4d524d6154a1
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
                 - application/x-amz-json-1.0
             User-Agent:
-                - aws-sdk-go-v2/1.32.7 ua/2.1 os/macos lang/go#1.23.3 md/GOOS#darwin md/GOARCH#arm64 api/sqs#1.37.3 m/E
+                - aws-sdk-go-v2/1.37.1 ua/2.1 os/linux lang/go#1.24.1 md/GOOS#linux md/GOARCH#amd64 api/sqs#1.38.6 m/E,e
             X-Amz-Date:
-                - 20250124T153840Z
+                - 20250827T150726Z
             X-Amz-Target:
                 - AmazonSQS.GetQueueUrl
             X-Amzn-Query-Mode:
@@ -2824,63 +2873,14 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 24 Jan 2025 15:38:40 GMT
+                - Wed, 27 Aug 2025 15:07:26 GMT
             X-Amzn-Query-Error:
                 - AWS.SimpleQueueService.NonExistentQueue;Sender
             X-Amzn-Requestid:
-                - txf220a68b-3ef3-40dc-ac81-32880fbde649
+                - tx795a86c4-13b0-471d-9b2a-d37d904c0eeb
         status: 404 Not Found
         code: 404
-        duration: 19.484625ms
-    - id: 57
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers/8f59c57b-e90c-49bc-9572-bc08ad70b6a2
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 389
-        uncompressed: false
-        body: '{"container_id":"0ed78a5a-133b-4a7f-a1a1-48de372de485","description":"","error_message":null,"id":"8f59c57b-e90c-49bc-9572-bc08ad70b6a2","input_type":"scw_sqs","name":"test-container-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"d31016b4-2319-4f07-a16b-92f017cb7b58","mnq_project_id":"f450679c-9a35-4b8e-a910-f2dd97e60f10","mnq_region":"fr-par","queue":"TestQueue"},"status":"ready"}'
-        headers:
-            Content-Length:
-                - "389"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:38:40 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - d0ef219a-3802-415c-a01a-0b1b5e2d93a7
-        status: 200 OK
-        code: 200
-        duration: 89.558834ms
+        duration: 23.38679ms
     - id: 58
       request:
         proto: HTTP/1.1
@@ -2896,27 +2896,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-credentials/90077722-0c4a-4b09-b1d0-a3b1cdf2369e
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers/145cc115-791d-479c-bd32-19e29f05916b
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 389
         uncompressed: false
-        body: ""
+        body: '{"container_id":"58f5113a-2906-471f-87fe-727be3c9a3fa","description":"","error_message":null,"id":"145cc115-791d-479c-bd32-19e29f05916b","input_type":"scw_sqs","name":"test-container-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"acb5e3a2-8cb7-485d-a6ad-fd7c848d1888","mnq_project_id":"451a75ce-766a-43f9-9b0f-77a056b7e1ed","mnq_region":"fr-par","queue":"TestQueue"},"status":"ready"}'
         headers:
+            Content-Length:
+                - "389"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:40 GMT
+                - Wed, 27 Aug 2025 15:07:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2924,10 +2926,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5030aeb7-c0d2-4f5f-b2b7-8348cef8242a
-        status: 204 No Content
-        code: 204
-        duration: 89.4285ms
+                - fcaf0ca6-4ef6-40f2-b69e-883cbae89fb9
+        status: 200 OK
+        code: 200
+        duration: 97.646545ms
     - id: 59
       request:
         proto: HTTP/1.1
@@ -2943,8 +2945,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers/8f59c57b-e90c-49bc-9572-bc08ad70b6a2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-credentials/4637a1d0-51e8-4863-957f-ce050f8f97e8
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -2952,20 +2954,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 392
+        content_length: 0
         uncompressed: false
-        body: '{"container_id":"0ed78a5a-133b-4a7f-a1a1-48de372de485","description":"","error_message":null,"id":"8f59c57b-e90c-49bc-9572-bc08ad70b6a2","input_type":"scw_sqs","name":"test-container-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"d31016b4-2319-4f07-a16b-92f017cb7b58","mnq_project_id":"f450679c-9a35-4b8e-a910-f2dd97e60f10","mnq_region":"fr-par","queue":"TestQueue"},"status":"deleting"}'
+        body: ""
         headers:
-            Content-Length:
-                - "392"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:40 GMT
+                - Wed, 27 Aug 2025 15:07:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2973,10 +2973,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a28a9ac4-0803-45c2-ab20-84893c0b330e
-        status: 200 OK
-        code: 200
-        duration: 115.244625ms
+                - 0dc8c98b-9a6b-4ec5-9476-b52a6a8d9215
+        status: 204 No Content
+        code: 204
+        duration: 126.127967ms
     - id: 60
       request:
         proto: HTTP/1.1
@@ -2992,9 +2992,9 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers/8f59c57b-e90c-49bc-9572-bc08ad70b6a2
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers/145cc115-791d-479c-bd32-19e29f05916b
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
@@ -3003,7 +3003,7 @@ interactions:
         trailer: {}
         content_length: 392
         uncompressed: false
-        body: '{"container_id":"0ed78a5a-133b-4a7f-a1a1-48de372de485","description":"","error_message":null,"id":"8f59c57b-e90c-49bc-9572-bc08ad70b6a2","input_type":"scw_sqs","name":"test-container-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"d31016b4-2319-4f07-a16b-92f017cb7b58","mnq_project_id":"f450679c-9a35-4b8e-a910-f2dd97e60f10","mnq_region":"fr-par","queue":"TestQueue"},"status":"deleting"}'
+        body: '{"container_id":"58f5113a-2906-471f-87fe-727be3c9a3fa","description":"","error_message":null,"id":"145cc115-791d-479c-bd32-19e29f05916b","input_type":"scw_sqs","name":"test-container-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"acb5e3a2-8cb7-485d-a6ad-fd7c848d1888","mnq_project_id":"451a75ce-766a-43f9-9b0f-77a056b7e1ed","mnq_region":"fr-par","queue":"TestQueue"},"status":"deleting"}'
         headers:
             Content-Length:
                 - "392"
@@ -3012,9 +3012,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:40 GMT
+                - Wed, 27 Aug 2025 15:07:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3022,10 +3022,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 394b4f3e-4b10-48e9-8e9a-afd32d0f43df
+                - fb582123-48dc-4dbc-928e-ad5204926c23
         status: 200 OK
         code: 200
-        duration: 89.48075ms
+        duration: 128.055545ms
     - id: 61
       request:
         proto: HTTP/1.1
@@ -3041,8 +3041,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers/8f59c57b-e90c-49bc-9572-bc08ad70b6a2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers/145cc115-791d-479c-bd32-19e29f05916b
         method: GET
       response:
         proto: HTTP/2.0
@@ -3052,7 +3052,7 @@ interactions:
         trailer: {}
         content_length: 392
         uncompressed: false
-        body: '{"container_id":"0ed78a5a-133b-4a7f-a1a1-48de372de485","description":"","error_message":null,"id":"8f59c57b-e90c-49bc-9572-bc08ad70b6a2","input_type":"scw_sqs","name":"test-container-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"d31016b4-2319-4f07-a16b-92f017cb7b58","mnq_project_id":"f450679c-9a35-4b8e-a910-f2dd97e60f10","mnq_region":"fr-par","queue":"TestQueue"},"status":"deleting"}'
+        body: '{"container_id":"58f5113a-2906-471f-87fe-727be3c9a3fa","description":"","error_message":null,"id":"145cc115-791d-479c-bd32-19e29f05916b","input_type":"scw_sqs","name":"test-container-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"acb5e3a2-8cb7-485d-a6ad-fd7c848d1888","mnq_project_id":"451a75ce-766a-43f9-9b0f-77a056b7e1ed","mnq_region":"fr-par","queue":"TestQueue"},"status":"deleting"}'
         headers:
             Content-Length:
                 - "392"
@@ -3061,9 +3061,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:46 GMT
+                - Wed, 27 Aug 2025 15:07:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3071,10 +3071,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8233f803-7262-4724-9a7b-f425d2f5035e
+                - 46c441cc-4ffa-4ff7-a616-550f0c98222b
         status: 200 OK
         code: 200
-        duration: 138.592167ms
+        duration: 91.705946ms
     - id: 62
       request:
         proto: HTTP/1.1
@@ -3090,8 +3090,204 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers/8f59c57b-e90c-49bc-9572-bc08ad70b6a2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers/145cc115-791d-479c-bd32-19e29f05916b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 392
+        uncompressed: false
+        body: '{"container_id":"58f5113a-2906-471f-87fe-727be3c9a3fa","description":"","error_message":null,"id":"145cc115-791d-479c-bd32-19e29f05916b","input_type":"scw_sqs","name":"test-container-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"acb5e3a2-8cb7-485d-a6ad-fd7c848d1888","mnq_project_id":"451a75ce-766a-43f9-9b0f-77a056b7e1ed","mnq_region":"fr-par","queue":"TestQueue"},"status":"deleting"}'
+        headers:
+            Content-Length:
+                - "392"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:07:31 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 0d8b7fb9-3fc9-4e19-beaf-eebd02e94d13
+        status: 200 OK
+        code: 200
+        duration: 110.945936ms
+    - id: 63
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers/145cc115-791d-479c-bd32-19e29f05916b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 392
+        uncompressed: false
+        body: '{"container_id":"58f5113a-2906-471f-87fe-727be3c9a3fa","description":"","error_message":null,"id":"145cc115-791d-479c-bd32-19e29f05916b","input_type":"scw_sqs","name":"test-container-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"acb5e3a2-8cb7-485d-a6ad-fd7c848d1888","mnq_project_id":"451a75ce-766a-43f9-9b0f-77a056b7e1ed","mnq_region":"fr-par","queue":"TestQueue"},"status":"deleting"}'
+        headers:
+            Content-Length:
+                - "392"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:07:36 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 6cf1aa0b-16ab-43b5-8053-1493fd2f7d2b
+        status: 200 OK
+        code: 200
+        duration: 109.395016ms
+    - id: 64
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers/145cc115-791d-479c-bd32-19e29f05916b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 392
+        uncompressed: false
+        body: '{"container_id":"58f5113a-2906-471f-87fe-727be3c9a3fa","description":"","error_message":null,"id":"145cc115-791d-479c-bd32-19e29f05916b","input_type":"scw_sqs","name":"test-container-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"acb5e3a2-8cb7-485d-a6ad-fd7c848d1888","mnq_project_id":"451a75ce-766a-43f9-9b0f-77a056b7e1ed","mnq_region":"fr-par","queue":"TestQueue"},"status":"deleting"}'
+        headers:
+            Content-Length:
+                - "392"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:07:41 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 56dfd224-7889-47b2-aa48-7e0b531aa043
+        status: 200 OK
+        code: 200
+        duration: 91.746947ms
+    - id: 65
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers/145cc115-791d-479c-bd32-19e29f05916b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 392
+        uncompressed: false
+        body: '{"container_id":"58f5113a-2906-471f-87fe-727be3c9a3fa","description":"","error_message":null,"id":"145cc115-791d-479c-bd32-19e29f05916b","input_type":"scw_sqs","name":"test-container-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"acb5e3a2-8cb7-485d-a6ad-fd7c848d1888","mnq_project_id":"451a75ce-766a-43f9-9b0f-77a056b7e1ed","mnq_region":"fr-par","queue":"TestQueue"},"status":"deleting"}'
+        headers:
+            Content-Length:
+                - "392"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:07:46 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - afe3161d-257b-4dde-956e-466c7b1a26e3
+        status: 200 OK
+        code: 200
+        duration: 94.370471ms
+    - id: 66
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers/145cc115-791d-479c-bd32-19e29f05916b
         method: GET
       response:
         proto: HTTP/2.0
@@ -3110,9 +3306,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:51 GMT
+                - Wed, 27 Aug 2025 15:07:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3120,11 +3316,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1ee16e6b-3d44-4568-9063-0e5f585d06a2
+                - c185a4bf-31c2-43b7-8dab-34623777929f
         status: 404 Not Found
         code: 404
-        duration: 33.109583ms
-    - id: 63
+        duration: 25.686187ms
+    - id: 67
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3139,8 +3335,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-info?project_id=f450679c-9a35-4b8e-a910-f2dd97e60f10
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-info?project_id=451a75ce-766a-43f9-9b0f-77a056b7e1ed
         method: GET
       response:
         proto: HTTP/2.0
@@ -3150,7 +3346,7 @@ interactions:
         trailer: {}
         content_length: 233
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.062843Z","project_id":"f450679c-9a35-4b8e-a910-f2dd97e60f10","region":"fr-par","sqs_endpoint_url":"https://sqs.mnq.fr-par.scaleway.com","status":"enabled","updated_at":"2025-01-24T15:37:49.062843Z"}'
+        body: '{"created_at":"2025-08-27T15:06:28.684881Z","project_id":"451a75ce-766a-43f9-9b0f-77a056b7e1ed","region":"fr-par","sqs_endpoint_url":"https://sqs.mnq.fr-par.scaleway.com","status":"enabled","updated_at":"2025-08-27T15:06:28.684881Z"}'
         headers:
             Content-Length:
                 - "233"
@@ -3159,9 +3355,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:51 GMT
+                - Wed, 27 Aug 2025 15:07:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3169,208 +3365,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 912708ac-6ae0-4c6c-85e6-993b0742e172
+                - 76153c58-9d03-4911-9c23-0734f814572c
         status: 200 OK
         code: 200
-        duration: 64.693542ms
-    - id: 64
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/0ed78a5a-133b-4a7f-a1a1-48de372de485
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 919
-        uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:20.757753Z","description":"","domain_name":"tfnsfunnydewdneym4jo1cgp-tf-co-ecstatic-grothendieck.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"0ed78a5a-133b-4a7f-a1a1-48de372de485","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-ecstatic-grothendieck","namespace_id":"5dd58b8d-e67f-481c-abf4-863baae060c4","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsfunnydewdneym4jo1cgp/tf-co-ecstatic-grothendieck:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:38:20.757753Z"}'
-        headers:
-            Content-Length:
-                - "919"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:38:51 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 809ee5c3-03c3-47ae-9f53-6545a5c4e2a0
-        status: 200 OK
-        code: 200
-        duration: 77.022875ms
-    - id: 65
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/0ed78a5a-133b-4a7f-a1a1-48de372de485
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 923
-        uncompressed: false
-        body: '{"cpu_limit":1000,"created_at":"2025-01-24T15:38:20.757753Z","description":"","domain_name":"tfnsfunnydewdneym4jo1cgp-tf-co-ecstatic-grothendieck.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"0ed78a5a-133b-4a7f-a1a1-48de372de485","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-ecstatic-grothendieck","namespace_id":"5dd58b8d-e67f-481c-abf4-863baae060c4","port":8080,"privacy":"public","protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsfunnydewdneym4jo1cgp/tf-co-ecstatic-grothendieck:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"deleting","timeout":"300s","updated_at":"2025-01-24T15:38:51.338672416Z"}'
-        headers:
-            Content-Length:
-                - "923"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:38:51 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 8d15d4fd-6021-4f84-b3ae-dabf5d420b37
-        status: 200 OK
-        code: 200
-        duration: 135.357542ms
-    - id: 66
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/5dd58b8d-e67f-481c-abf4-863baae060c4
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 550
-        uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.458164Z","description":"","environment_variables":{},"error_message":null,"id":"5dd58b8d-e67f-481c-abf4-863baae060c4","name":"tf-ns-funny-dewdney","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"f450679c-9a35-4b8e-a910-f2dd97e60f10","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsfunnydewdneym4jo1cgp","registry_namespace_id":"64595108-3c2d-4c3b-a85a-62dea2d5e80e","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:38:19.465180Z"}'
-        headers:
-            Content-Length:
-                - "550"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:38:51 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - e1d056ce-387c-4289-8120-0184b1b0d053
-        status: 200 OK
-        code: 200
-        duration: 64.138833ms
-    - id: 67
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 53
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"project_id":"f450679c-9a35-4b8e-a910-f2dd97e60f10"}'
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/deactivate-sqs
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 184
-        uncompressed: false
-        body: '{"created_at":null,"project_id":"f450679c-9a35-4b8e-a910-f2dd97e60f10","region":"fr-par","sqs_endpoint_url":"https://sqs.mnq.fr-par.scaleway.com","status":"disabled","updated_at":null}'
-        headers:
-            Content-Length:
-                - "184"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:38:51 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - e78345a9-bc41-47b3-b9f1-fe24f8f93511
-        status: 200 OK
-        code: 200
-        duration: 226.921ms
+        duration: 100.727744ms
     - id: 68
       request:
         proto: HTTP/1.1
@@ -3386,29 +3384,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/5dd58b8d-e67f-481c-abf4-863baae060c4
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/58f5113a-2906-471f-87fe-727be3c9a3fa
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 556
+        content_length: 980
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.458164Z","description":"","environment_variables":{},"error_message":null,"id":"5dd58b8d-e67f-481c-abf4-863baae060c4","name":"tf-ns-funny-dewdney","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"f450679c-9a35-4b8e-a910-f2dd97e60f10","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsfunnydewdneym4jo1cgp","registry_namespace_id":"64595108-3c2d-4c3b-a85a-62dea2d5e80e","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:38:51.535412866Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:51.253340Z","description":"","domain_name":"tfnsvibranthofstadtexf2vueoe-tf-co-xenodochial-lumiere.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"58f5113a-2906-471f-87fe-727be3c9a3fa","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-xenodochial-lumiere","namespace_id":"e7e9218b-d951-4020-a0d5-1f0f613bd6cd","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsvibranthofstadtexf2vueoe/tf-co-xenodochial-lumiere:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:51.253340Z"}'
         headers:
             Content-Length:
-                - "556"
+                - "980"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:51 GMT
+                - Wed, 27 Aug 2025 15:07:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3416,10 +3414,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c6e0c9ae-a91f-4e02-97df-e722f5d1db7f
+                - f45966ed-f1e4-49a6-bc50-1d1a0924ec7f
         status: 200 OK
         code: 200
-        duration: 169.961417ms
+        duration: 107.466ms
     - id: 69
       request:
         proto: HTTP/1.1
@@ -3435,29 +3433,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/5dd58b8d-e67f-481c-abf4-863baae060c4
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/58f5113a-2906-471f-87fe-727be3c9a3fa
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 553
+        content_length: 984
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:37:49.458164Z","description":"","environment_variables":{},"error_message":null,"id":"5dd58b8d-e67f-481c-abf4-863baae060c4","name":"tf-ns-funny-dewdney","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"f450679c-9a35-4b8e-a910-f2dd97e60f10","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsfunnydewdneym4jo1cgp","registry_namespace_id":"64595108-3c2d-4c3b-a85a-62dea2d5e80e","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:38:51.535413Z"}'
+        body: '{"args":[],"command":[],"cpu_limit":1000,"created_at":"2025-08-27T15:06:51.253340Z","description":"","domain_name":"tfnsvibranthofstadtexf2vueoe-tf-co-xenodochial-lumiere.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"health_check":{"failure_threshold":30,"interval":"10s","tcp":{}},"http_option":"enabled","id":"58f5113a-2906-471f-87fe-727be3c9a3fa","local_storage_limit":1000,"max_concurrency":50,"max_scale":5,"memory_limit":2048,"min_scale":0,"name":"tf-co-xenodochial-lumiere","namespace_id":"e7e9218b-d951-4020-a0d5-1f0f613bd6cd","port":8080,"privacy":"public","private_network_id":null,"protocol":"http1","ready_at":null,"region":"fr-par","registry_image":"rg.fr-par.scw.cloud/funcscwtfnsvibranthofstadtexf2vueoe/tf-co-xenodochial-lumiere:latest","sandbox":"v2","scaling_option":{"concurrent_requests_threshold":50},"secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:07:51.901887806Z"}'
         headers:
             Content-Length:
-                - "553"
+                - "984"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:51 GMT
+                - Wed, 27 Aug 2025 15:07:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3465,10 +3463,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4d1eeb0a-a54e-448b-bf03-aef0257c195d
+                - b558691c-28f6-4203-8f9c-e54ced2b401c
         status: 200 OK
         code: 200
-        duration: 67.598208ms
+        duration: 141.896479ms
     - id: 70
       request:
         proto: HTTP/1.1
@@ -3484,8 +3482,206 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/5dd58b8d-e67f-481c-abf4-863baae060c4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/e7e9218b-d951-4020-a0d5-1f0f613bd6cd
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 592
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:06:30.153440Z","description":"","environment_variables":{},"error_message":null,"id":"e7e9218b-d951-4020-a0d5-1f0f613bd6cd","name":"tf-ns-vibrant-hofstadter","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"451a75ce-766a-43f9-9b0f-77a056b7e1ed","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsvibranthofstadtexf2vueoe","registry_namespace_id":"d2cecc96-e3f5-4aeb-bd79-4057c8b9816b","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:48.641793Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "592"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:07:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - c90ab709-fb3b-4ff8-9a0d-55dca42d9832
+        status: 200 OK
+        code: 200
+        duration: 88.7046ms
+    - id: 71
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 53
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"project_id":"451a75ce-766a-43f9-9b0f-77a056b7e1ed"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/deactivate-sqs
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 184
+        uncompressed: false
+        body: '{"created_at":null,"project_id":"451a75ce-766a-43f9-9b0f-77a056b7e1ed","region":"fr-par","sqs_endpoint_url":"https://sqs.mnq.fr-par.scaleway.com","status":"disabled","updated_at":null}'
+        headers:
+            Content-Length:
+                - "184"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:07:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 487679a6-eda5-4f3b-9b02-95f0ab7ba83e
+        status: 200 OK
+        code: 200
+        duration: 264.306116ms
+    - id: 72
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/e7e9218b-d951-4020-a0d5-1f0f613bd6cd
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 598
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:06:30.153440Z","description":"","environment_variables":{},"error_message":null,"id":"e7e9218b-d951-4020-a0d5-1f0f613bd6cd","name":"tf-ns-vibrant-hofstadter","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"451a75ce-766a-43f9-9b0f-77a056b7e1ed","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsvibranthofstadtexf2vueoe","registry_namespace_id":"d2cecc96-e3f5-4aeb-bd79-4057c8b9816b","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:07:52.089740322Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "598"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:07:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - fecc87a7-e13b-4b2c-98b9-819da02391a0
+        status: 200 OK
+        code: 200
+        duration: 261.241415ms
+    - id: 73
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/e7e9218b-d951-4020-a0d5-1f0f613bd6cd
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 595
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:06:30.153440Z","description":"","environment_variables":{},"error_message":null,"id":"e7e9218b-d951-4020-a0d5-1f0f613bd6cd","name":"tf-ns-vibrant-hofstadter","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"451a75ce-766a-43f9-9b0f-77a056b7e1ed","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfnsvibranthofstadtexf2vueoe","registry_namespace_id":"d2cecc96-e3f5-4aeb-bd79-4057c8b9816b","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:07:52.089740Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "595"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:07:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 1f8e2090-daa4-4b40-ac6f-3667bb2a906d
+        status: 200 OK
+        code: 200
+        duration: 90.449305ms
+    - id: 74
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/e7e9218b-d951-4020-a0d5-1f0f613bd6cd
         method: GET
       response:
         proto: HTTP/2.0
@@ -3504,9 +3700,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:56 GMT
+                - Wed, 27 Aug 2025 15:07:57 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3514,11 +3710,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ca952eae-8747-43c2-86d9-8dbb59b431b7
+                - 1698dca0-c0fc-4db5-a7c6-08a30d41618f
         status: 404 Not Found
         code: 404
-        duration: 29.270833ms
-    - id: 71
+        duration: 34.791737ms
+    - id: 75
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3533,8 +3729,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/account/v3/projects/f450679c-9a35-4b8e-a910-f2dd97e60f10
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/account/v3/projects/451a75ce-766a-43f9-9b0f-77a056b7e1ed
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -3551,9 +3747,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:58 GMT
+                - Wed, 27 Aug 2025 15:07:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3561,11 +3757,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 67559abc-0dfc-4167-990b-5557dcad9210
+                - bb7645cc-1425-4c1a-a861-5904cdfaab7d
         status: 204 No Content
         code: 204
-        duration: 1.373411375s
-    - id: 72
+        duration: 1.362618525s
+    - id: 76
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3580,8 +3776,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers/8f59c57b-e90c-49bc-9572-bc08ad70b6a2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/triggers/145cc115-791d-479c-bd32-19e29f05916b
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -3591,7 +3787,7 @@ interactions:
         trailer: {}
         content_length: 105
         uncompressed: false
-        body: '{"message":"trigger does not exist: could not find trigger with id 8f59c57b-e90c-49bc-9572-bc08ad70b6a2"}'
+        body: '{"message":"trigger does not exist: could not find trigger with id 145cc115-791d-479c-bd32-19e29f05916b"}'
         headers:
             Content-Length:
                 - "105"
@@ -3600,9 +3796,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:38:58 GMT
+                - Wed, 27 Aug 2025 15:07:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3610,7 +3806,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 31a94333-8f70-435d-9f64-ba77104adf47
+                - 0af51cf6-3061-4fc7-8b15-4627642cb4e6
         status: 404 Not Found
         code: 404
-        duration: 33.696208ms
+        duration: 29.589594ms

--- a/internal/services/container/token_test.go
+++ b/internal/services/container/token_test.go
@@ -21,7 +21,7 @@ func TestAccToken_Basic(t *testing.T) {
 	if !*acctest.UpdateCassettes {
 		// This hardcoded value has to be replaced with the expiration in cassettes.
 		// Should be in the first "POST /tokens" request.
-		expiresAt = "2025-01-28T15:28:16+01:00"
+		expiresAt = "2025-08-28T17:05:34+02:00"
 	}
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/internal/services/function/namespace.go
+++ b/internal/services/function/namespace.go
@@ -88,9 +88,9 @@ func ResourceNamespace() *schema.Resource {
 			},
 			"activate_vpc_integration": {
 				Type:        schema.TypeBool,
-				ForceNew:    true,
+				Deprecated:  "VPC integration is now available on all namespaces, so this field is not configurable anymore and its value will always be \"true\".",
 				Optional:    true,
-				Default:     false,
+				Default:     true,
 				Description: "Activate VPC integration for the namespace",
 			},
 			"region":          regional.Schema(),
@@ -118,10 +118,6 @@ func ResourceFunctionNamespaceCreate(ctx context.Context, d *schema.ResourceData
 	rawTag, tagExist := d.GetOk("tags")
 	if tagExist {
 		createReq.Tags = types.ExpandStrings(rawTag)
-	}
-
-	if activateVPC, ok := d.GetOk("activate_vpc_integration"); ok {
-		createReq.ActivateVpcIntegration = activateVPC.(bool)
 	}
 
 	ns, err := api.CreateNamespace(createReq, scw.WithContext(ctx))

--- a/internal/services/function/namespace.go
+++ b/internal/services/function/namespace.go
@@ -113,6 +113,7 @@ func ResourceFunctionNamespaceCreate(ctx context.Context, d *schema.ResourceData
 		Name:                       types.ExpandOrGenerateString(d.Get("name").(string), "func"),
 		ProjectID:                  d.Get("project_id").(string),
 		Region:                     region,
+		ActivateVpcIntegration:     true,
 	}
 
 	rawTag, tagExist := d.GetOk("tags")

--- a/internal/services/function/namespace_test.go
+++ b/internal/services/function/namespace_test.go
@@ -2,7 +2,6 @@ package function_test
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -212,26 +211,9 @@ func TestAccFunctionNamespace_VPCIntegration(t *testing.T) {
 				`,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFunctionNamespaceExists(tt, "scaleway_function_namespace.main"),
-					resource.TestCheckResourceAttr("scaleway_function_namespace.main", "activate_vpc_integration", "false"),
+					resource.TestCheckResourceAttr("scaleway_function_namespace.main", "activate_vpc_integration", "true"),
 					acctest.CheckResourceIDPersisted("scaleway_function_namespace.main", &namespaceID),
 				),
-			},
-			{
-				Config: `
-					resource scaleway_vpc_private_network main {}
-			
-					resource scaleway_function_namespace main {}
-			
-					resource scaleway_function main {
-						namespace_id = scaleway_function_namespace.main.id
-						privacy = "private"
-						sandbox = "v1"
-						runtime = "go123"
-						handler = "Handle"
-						private_network_id = scaleway_vpc_private_network.main.id
-					}
-				`,
-				ExpectError: regexp.MustCompile("Application can't be attached to private network, vpc integration must be activated on its parent namespace"),
 			},
 			{
 				Config: `
@@ -255,7 +237,7 @@ func TestAccFunctionNamespace_VPCIntegration(t *testing.T) {
 					testAccCheckFunctionExists(tt, "scaleway_function.main"),
 					resource.TestCheckResourceAttr("scaleway_function_namespace.main", "activate_vpc_integration", "true"),
 					resource.TestCheckResourceAttrPair("scaleway_function.main", "private_network_id", "scaleway_vpc_private_network.main", "id"),
-					acctest.CheckResourceIDChanged("scaleway_function_namespace.main", &namespaceID),
+					acctest.CheckResourceIDPersisted("scaleway_function_namespace.main", &namespaceID),
 				),
 			},
 		},

--- a/internal/services/function/testdata/data-source-function-basic.cassette.yaml
+++ b/internal/services/function/testdata/data-source-function-basic.cassette.yaml
@@ -6,19 +6,19 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 150
+        content_length: 182
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-ds-function","environment_variables":{},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","secret_environment_variables":[],"tags":null}'
+        body: '{"name":"tf-ds-function","environment_variables":{},"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","secret_environment_variables":[],"tags":null,"activate_vpc_integration":true}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces
         method: POST
       response:
@@ -27,20 +27,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 466
+        content_length: 499
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.397210609Z","description":"","environment_variables":{},"error_message":null,"id":"1aafcc97-4ee6-40a2-89d1-7e2313e17224","name":"tf-ds-function","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:44:07.397210609Z"}'
+        body: '{"created_at":"2025-08-27T15:05:14.035883448Z","description":"","environment_variables":{},"error_message":null,"id":"552fb3b3-7bd9-499f-8e11-e1e9db5dece0","name":"tf-ds-function","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:14.035883448Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "466"
+                - "499"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:07 GMT
+                - Wed, 27 Aug 2025 15:05:14 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fa74b7e0-b1e3-480a-86f0-13830ecc80a0
+                - 4009671b-760a-4ce0-9b17-684c864f17f5
         status: 200 OK
         code: 200
-        duration: 752.600083ms
+        duration: 5.824041583s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -67,8 +67,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/1aafcc97-4ee6-40a2-89d1-7e2313e17224
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/552fb3b3-7bd9-499f-8e11-e1e9db5dece0
         method: GET
       response:
         proto: HTTP/2.0
@@ -76,20 +76,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 460
+        content_length: 493
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.397211Z","description":"","environment_variables":{},"error_message":null,"id":"1aafcc97-4ee6-40a2-89d1-7e2313e17224","name":"tf-ds-function","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:44:07.397211Z"}'
+        body: '{"created_at":"2025-08-27T15:05:14.035883Z","description":"","environment_variables":{},"error_message":null,"id":"552fb3b3-7bd9-499f-8e11-e1e9db5dece0","name":"tf-ds-function","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:14.035883Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "460"
+                - "493"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:07 GMT
+                - Wed, 27 Aug 2025 15:05:14 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5b08bdb6-a290-4785-bd23-fced83eb85dd
+                - 8a84e607-017f-451a-8f35-97dcabb825d2
         status: 200 OK
         code: 200
-        duration: 78.901458ms
+        duration: 53.016596ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -116,8 +116,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/1aafcc97-4ee6-40a2-89d1-7e2313e17224
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/552fb3b3-7bd9-499f-8e11-e1e9db5dece0
         method: GET
       response:
         proto: HTTP/2.0
@@ -125,20 +125,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 541
+        content_length: 576
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.397211Z","description":"","environment_variables":{},"error_message":null,"id":"1aafcc97-4ee6-40a2-89d1-7e2313e17224","name":"tf-ds-function","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfdsfunctionzrbseofv","registry_namespace_id":"d0a94938-de65-4c53-a802-1447ef27c0c7","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:44:11.495699Z"}'
+        body: '{"created_at":"2025-08-27T15:05:14.035883Z","description":"","environment_variables":{},"error_message":null,"id":"552fb3b3-7bd9-499f-8e11-e1e9db5dece0","name":"tf-ds-function","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfdsfunctionut3yjoav","registry_namespace_id":"6a374333-96da-491a-957c-9631f2715aa0","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:18.686782Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "541"
+                - "576"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:12 GMT
+                - Wed, 27 Aug 2025 15:05:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -146,10 +146,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 552a85e3-4f0f-4ea8-80e6-04c4b04b5fdf
+                - fa1b8b30-4845-40e0-9445-1717bc5b461a
         status: 200 OK
         code: 200
-        duration: 61.06925ms
+        duration: 168.460718ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -165,8 +165,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/1aafcc97-4ee6-40a2-89d1-7e2313e17224
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/552fb3b3-7bd9-499f-8e11-e1e9db5dece0
         method: GET
       response:
         proto: HTTP/2.0
@@ -174,20 +174,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 541
+        content_length: 574
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.397211Z","description":"","environment_variables":{},"error_message":null,"id":"1aafcc97-4ee6-40a2-89d1-7e2313e17224","name":"tf-ds-function","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfdsfunctionzrbseofv","registry_namespace_id":"d0a94938-de65-4c53-a802-1447ef27c0c7","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:44:11.495699Z"}'
+        body: '{"created_at":"2025-08-27T15:05:14.035883Z","description":"","environment_variables":{},"error_message":null,"id":"552fb3b3-7bd9-499f-8e11-e1e9db5dece0","name":"tf-ds-function","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfdsfunctionut3yjoav","registry_namespace_id":"6a374333-96da-491a-957c-9631f2715aa0","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:21.815754Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "541"
+                - "574"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:12 GMT
+                - Wed, 27 Aug 2025 15:05:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -195,62 +195,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 25670f64-3a21-4a74-9cc0-f731fe98f414
+                - bbfcfb6f-fc54-4172-b257-0969eb5cd445
         status: 200 OK
         code: 200
-        duration: 60.376041ms
+        duration: 51.327648ms
     - id: 4
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 306
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"name":"tf-ds-function","namespace_id":"1aafcc97-4ee6-40a2-89d1-7e2313e17224","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"node22","memory_limit":256,"handler":"handler.handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox"}'
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 678
-        uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:13.012959565Z","description":"","domain_name":"tfdsfunctionzrbseofv-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"10160653-f828-464f-986a-6ae95e7676f6","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"1aafcc97-4ee6-40a2-89d1-7e2313e17224","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:13.012959565Z"}'
-        headers:
-            Content-Length:
-                - "678"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:44:13 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 1d3dee6e-c408-4fe6-8d57-978fb736ee40
-        status: 200 OK
-        code: 200
-        duration: 387.100042ms
-    - id: 5
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -265,8 +214,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/10160653-f828-464f-986a-6ae95e7676f6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/552fb3b3-7bd9-499f-8e11-e1e9db5dece0
         method: GET
       response:
         proto: HTTP/2.0
@@ -274,20 +223,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 672
+        content_length: 574
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:13.012960Z","description":"","domain_name":"tfdsfunctionzrbseofv-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"10160653-f828-464f-986a-6ae95e7676f6","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"1aafcc97-4ee6-40a2-89d1-7e2313e17224","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:13.012960Z"}'
+        body: '{"created_at":"2025-08-27T15:05:14.035883Z","description":"","environment_variables":{},"error_message":null,"id":"552fb3b3-7bd9-499f-8e11-e1e9db5dece0","name":"tf-ds-function","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfdsfunctionut3yjoav","registry_namespace_id":"6a374333-96da-491a-957c-9631f2715aa0","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:21.815754Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "672"
+                - "574"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:13 GMT
+                - Wed, 27 Aug 2025 15:05:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -295,10 +244,61 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7db30287-252a-41ae-8ace-b2ec6bde0eff
+                - 7baae387-649a-441a-b9f2-49c0ed748547
         status: 200 OK
         code: 200
-        duration: 94.227542ms
+        duration: 47.315991ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 318
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"name":"tf-ds-function","namespace_id":"552fb3b3-7bd9-499f-8e11-e1e9db5dece0","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"node22","memory_limit":256,"handler":"handler.handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox","tags":null}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 714
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:25.465397886Z","description":"","domain_name":"tfdsfunctionut3yjoav-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"e27c4778-a4a8-4e1c-bdeb-03b3416add00","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"552fb3b3-7bd9-499f-8e11-e1e9db5dece0","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:25.465397886Z"}'
+        headers:
+            Content-Length:
+                - "714"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:05:25 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 5cb31870-43bb-46c4-bc7c-47a21b311adc
+        status: 200 OK
+        code: 200
+        duration: 1.128577235s
     - id: 6
       request:
         proto: HTTP/1.1
@@ -314,8 +314,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/10160653-f828-464f-986a-6ae95e7676f6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e27c4778-a4a8-4e1c-bdeb-03b3416add00
         method: GET
       response:
         proto: HTTP/2.0
@@ -323,20 +323,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 672
+        content_length: 708
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:13.012960Z","description":"","domain_name":"tfdsfunctionzrbseofv-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"10160653-f828-464f-986a-6ae95e7676f6","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"1aafcc97-4ee6-40a2-89d1-7e2313e17224","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:13.012960Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:25.465398Z","description":"","domain_name":"tfdsfunctionut3yjoav-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"e27c4778-a4a8-4e1c-bdeb-03b3416add00","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"552fb3b3-7bd9-499f-8e11-e1e9db5dece0","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:25.465398Z"}'
         headers:
             Content-Length:
-                - "672"
+                - "708"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:13 GMT
+                - Wed, 27 Aug 2025 15:05:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -344,10 +344,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c58d363f-c10d-461d-8acb-63beb7fc3856
+                - d447987c-3cb9-4080-897b-cda37cb84ecf
         status: 200 OK
         code: 200
-        duration: 67.173625ms
+        duration: 47.687208ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -363,8 +363,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/10160653-f828-464f-986a-6ae95e7676f6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e27c4778-a4a8-4e1c-bdeb-03b3416add00
         method: GET
       response:
         proto: HTTP/2.0
@@ -372,20 +372,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 672
+        content_length: 708
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:13.012960Z","description":"","domain_name":"tfdsfunctionzrbseofv-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"10160653-f828-464f-986a-6ae95e7676f6","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"1aafcc97-4ee6-40a2-89d1-7e2313e17224","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:13.012960Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:25.465398Z","description":"","domain_name":"tfdsfunctionut3yjoav-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"e27c4778-a4a8-4e1c-bdeb-03b3416add00","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"552fb3b3-7bd9-499f-8e11-e1e9db5dece0","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:25.465398Z"}'
         headers:
             Content-Length:
-                - "672"
+                - "708"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:13 GMT
+                - Wed, 27 Aug 2025 15:05:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -393,10 +393,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 35fe1da1-44af-4872-9546-78ae3157ca16
+                - eacc36ae-844e-44da-b6e8-21df06388c62
         status: 200 OK
         code: 200
-        duration: 113.149833ms
+        duration: 61.51858ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -412,8 +412,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/1aafcc97-4ee6-40a2-89d1-7e2313e17224
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e27c4778-a4a8-4e1c-bdeb-03b3416add00
         method: GET
       response:
         proto: HTTP/2.0
@@ -421,20 +421,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 541
+        content_length: 708
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.397211Z","description":"","environment_variables":{},"error_message":null,"id":"1aafcc97-4ee6-40a2-89d1-7e2313e17224","name":"tf-ds-function","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfdsfunctionzrbseofv","registry_namespace_id":"d0a94938-de65-4c53-a802-1447ef27c0c7","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:44:11.495699Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:25.465398Z","description":"","domain_name":"tfdsfunctionut3yjoav-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"e27c4778-a4a8-4e1c-bdeb-03b3416add00","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"552fb3b3-7bd9-499f-8e11-e1e9db5dece0","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:25.465398Z"}'
         headers:
             Content-Length:
-                - "541"
+                - "708"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:14 GMT
+                - Wed, 27 Aug 2025 15:05:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -442,10 +442,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3cca5a2e-485a-4cfb-97e9-59fdbc4b1589
+                - 2af7f2cc-8c50-4bb7-83d5-983f09f937fa
         status: 200 OK
         code: 200
-        duration: 75.100333ms
+        duration: 46.578137ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -461,8 +461,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/10160653-f828-464f-986a-6ae95e7676f6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/552fb3b3-7bd9-499f-8e11-e1e9db5dece0
         method: GET
       response:
         proto: HTTP/2.0
@@ -470,20 +470,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 672
+        content_length: 574
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:13.012960Z","description":"","domain_name":"tfdsfunctionzrbseofv-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"10160653-f828-464f-986a-6ae95e7676f6","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"1aafcc97-4ee6-40a2-89d1-7e2313e17224","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:13.012960Z"}'
+        body: '{"created_at":"2025-08-27T15:05:14.035883Z","description":"","environment_variables":{},"error_message":null,"id":"552fb3b3-7bd9-499f-8e11-e1e9db5dece0","name":"tf-ds-function","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfdsfunctionut3yjoav","registry_namespace_id":"6a374333-96da-491a-957c-9631f2715aa0","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:21.815754Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "672"
+                - "574"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:14 GMT
+                - Wed, 27 Aug 2025 15:05:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -491,10 +491,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8e251236-36d9-4058-bc42-4f088109b479
+                - bd2562de-2f39-449f-83de-95fa105b1826
         status: 200 OK
         code: 200
-        duration: 76.6465ms
+        duration: 43.209687ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -510,8 +510,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/1aafcc97-4ee6-40a2-89d1-7e2313e17224
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e27c4778-a4a8-4e1c-bdeb-03b3416add00
         method: GET
       response:
         proto: HTTP/2.0
@@ -519,20 +519,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 541
+        content_length: 708
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.397211Z","description":"","environment_variables":{},"error_message":null,"id":"1aafcc97-4ee6-40a2-89d1-7e2313e17224","name":"tf-ds-function","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfdsfunctionzrbseofv","registry_namespace_id":"d0a94938-de65-4c53-a802-1447ef27c0c7","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:44:11.495699Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:25.465398Z","description":"","domain_name":"tfdsfunctionut3yjoav-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"e27c4778-a4a8-4e1c-bdeb-03b3416add00","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"552fb3b3-7bd9-499f-8e11-e1e9db5dece0","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:25.465398Z"}'
         headers:
             Content-Length:
-                - "541"
+                - "708"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:15 GMT
+                - Wed, 27 Aug 2025 15:05:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -540,10 +540,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d6e34818-b1eb-4c06-b3e0-672af42a046a
+                - 98146d0e-86a5-4e5e-b038-e7b788c18bfa
         status: 200 OK
         code: 200
-        duration: 230.895334ms
+        duration: 87.402388ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -559,8 +559,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/10160653-f828-464f-986a-6ae95e7676f6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/552fb3b3-7bd9-499f-8e11-e1e9db5dece0
         method: GET
       response:
         proto: HTTP/2.0
@@ -568,20 +568,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 672
+        content_length: 574
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:13.012960Z","description":"","domain_name":"tfdsfunctionzrbseofv-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"10160653-f828-464f-986a-6ae95e7676f6","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"1aafcc97-4ee6-40a2-89d1-7e2313e17224","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:13.012960Z"}'
+        body: '{"created_at":"2025-08-27T15:05:14.035883Z","description":"","environment_variables":{},"error_message":null,"id":"552fb3b3-7bd9-499f-8e11-e1e9db5dece0","name":"tf-ds-function","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfdsfunctionut3yjoav","registry_namespace_id":"6a374333-96da-491a-957c-9631f2715aa0","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:21.815754Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "672"
+                - "574"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:15 GMT
+                - Wed, 27 Aug 2025 15:05:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -589,10 +589,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 21fd587e-7f39-462a-8035-df6aa4f1a990
+                - 9e69d9ea-9e2b-4da1-b7d7-44eb3dd80a14
         status: 200 OK
         code: 200
-        duration: 120.420333ms
+        duration: 49.717608ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -608,8 +608,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions?name=tf-ds-function&namespace_id=1aafcc97-4ee6-40a2-89d1-7e2313e17224&order_by=created_at_asc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e27c4778-a4a8-4e1c-bdeb-03b3416add00
         method: GET
       response:
         proto: HTTP/2.0
@@ -617,20 +617,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 704
+        content_length: 708
         uncompressed: false
-        body: '{"functions":[{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:13.012960Z","description":"","domain_name":"tfdsfunctionzrbseofv-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"10160653-f828-464f-986a-6ae95e7676f6","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"1aafcc97-4ee6-40a2-89d1-7e2313e17224","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:13.012960Z"}],"total_count":1}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:25.465398Z","description":"","domain_name":"tfdsfunctionut3yjoav-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"e27c4778-a4a8-4e1c-bdeb-03b3416add00","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"552fb3b3-7bd9-499f-8e11-e1e9db5dece0","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:25.465398Z"}'
         headers:
             Content-Length:
-                - "704"
+                - "708"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:15 GMT
+                - Wed, 27 Aug 2025 15:05:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -638,10 +638,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 251bbabd-9768-44bd-bbc3-0d5b73c930bb
+                - 6d8499a3-e351-4dc8-9e97-c0132461b671
         status: 200 OK
         code: 200
-        duration: 286.556625ms
+        duration: 40.33348ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -657,8 +657,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/10160653-f828-464f-986a-6ae95e7676f6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions?name=tf-ds-function&namespace_id=552fb3b3-7bd9-499f-8e11-e1e9db5dece0&order_by=created_at_asc
         method: GET
       response:
         proto: HTTP/2.0
@@ -666,20 +666,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 672
+        content_length: 740
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:13.012960Z","description":"","domain_name":"tfdsfunctionzrbseofv-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"10160653-f828-464f-986a-6ae95e7676f6","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"1aafcc97-4ee6-40a2-89d1-7e2313e17224","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:13.012960Z"}'
+        body: '{"functions":[{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:25.465398Z","description":"","domain_name":"tfdsfunctionut3yjoav-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"e27c4778-a4a8-4e1c-bdeb-03b3416add00","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"552fb3b3-7bd9-499f-8e11-e1e9db5dece0","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:25.465398Z"}],"total_count":1}'
         headers:
             Content-Length:
-                - "672"
+                - "740"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:15 GMT
+                - Wed, 27 Aug 2025 15:05:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -687,10 +687,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ee89fbd9-5bb4-495e-ac8b-886bf80afeda
+                - cbd030f1-0d40-4f9c-93e2-3097ac9c7178
         status: 200 OK
         code: 200
-        duration: 286.297541ms
+        duration: 41.675758ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -706,8 +706,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/10160653-f828-464f-986a-6ae95e7676f6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e27c4778-a4a8-4e1c-bdeb-03b3416add00
         method: GET
       response:
         proto: HTTP/2.0
@@ -715,20 +715,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 672
+        content_length: 708
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:13.012960Z","description":"","domain_name":"tfdsfunctionzrbseofv-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"10160653-f828-464f-986a-6ae95e7676f6","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"1aafcc97-4ee6-40a2-89d1-7e2313e17224","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:13.012960Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:25.465398Z","description":"","domain_name":"tfdsfunctionut3yjoav-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"e27c4778-a4a8-4e1c-bdeb-03b3416add00","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"552fb3b3-7bd9-499f-8e11-e1e9db5dece0","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:25.465398Z"}'
         headers:
             Content-Length:
-                - "672"
+                - "708"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:15 GMT
+                - Wed, 27 Aug 2025 15:05:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -736,10 +736,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d72bdaa5-5de5-4089-a507-f6499427c4ab
+                - ccc20569-b698-44fb-8005-42e2cc08dfe2
         status: 200 OK
         code: 200
-        duration: 85.80175ms
+        duration: 58.371105ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -755,8 +755,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions?name=tf-ds-function&namespace_id=1aafcc97-4ee6-40a2-89d1-7e2313e17224&order_by=created_at_asc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e27c4778-a4a8-4e1c-bdeb-03b3416add00
         method: GET
       response:
         proto: HTTP/2.0
@@ -764,20 +764,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 704
+        content_length: 708
         uncompressed: false
-        body: '{"functions":[{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:13.012960Z","description":"","domain_name":"tfdsfunctionzrbseofv-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"10160653-f828-464f-986a-6ae95e7676f6","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"1aafcc97-4ee6-40a2-89d1-7e2313e17224","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:13.012960Z"}],"total_count":1}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:25.465398Z","description":"","domain_name":"tfdsfunctionut3yjoav-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"e27c4778-a4a8-4e1c-bdeb-03b3416add00","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"552fb3b3-7bd9-499f-8e11-e1e9db5dece0","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:25.465398Z"}'
         headers:
             Content-Length:
-                - "704"
+                - "708"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:16 GMT
+                - Wed, 27 Aug 2025 15:05:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -785,10 +785,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8dcf7be3-96a2-4d90-8e4f-0d748cf36ba3
+                - 1c8b2d96-4d15-45a9-8208-a02ac85e2b5c
         status: 200 OK
         code: 200
-        duration: 76.538666ms
+        duration: 46.273215ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -804,8 +804,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/10160653-f828-464f-986a-6ae95e7676f6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e27c4778-a4a8-4e1c-bdeb-03b3416add00
         method: GET
       response:
         proto: HTTP/2.0
@@ -813,20 +813,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 672
+        content_length: 708
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:13.012960Z","description":"","domain_name":"tfdsfunctionzrbseofv-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"10160653-f828-464f-986a-6ae95e7676f6","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"1aafcc97-4ee6-40a2-89d1-7e2313e17224","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:13.012960Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:25.465398Z","description":"","domain_name":"tfdsfunctionut3yjoav-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"e27c4778-a4a8-4e1c-bdeb-03b3416add00","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"552fb3b3-7bd9-499f-8e11-e1e9db5dece0","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:25.465398Z"}'
         headers:
             Content-Length:
-                - "672"
+                - "708"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:16 GMT
+                - Wed, 27 Aug 2025 15:05:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -834,10 +834,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c16b53f9-e292-410f-9de6-180cbf846a81
+                - 9a442a8d-85cf-4edb-8eba-4d46a942d8c0
         status: 200 OK
         code: 200
-        duration: 106.469958ms
+        duration: 53.023902ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -853,8 +853,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/10160653-f828-464f-986a-6ae95e7676f6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions?name=tf-ds-function&namespace_id=552fb3b3-7bd9-499f-8e11-e1e9db5dece0&order_by=created_at_asc
         method: GET
       response:
         proto: HTTP/2.0
@@ -862,20 +862,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 672
+        content_length: 740
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:13.012960Z","description":"","domain_name":"tfdsfunctionzrbseofv-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"10160653-f828-464f-986a-6ae95e7676f6","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"1aafcc97-4ee6-40a2-89d1-7e2313e17224","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:13.012960Z"}'
+        body: '{"functions":[{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:25.465398Z","description":"","domain_name":"tfdsfunctionut3yjoav-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"e27c4778-a4a8-4e1c-bdeb-03b3416add00","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"552fb3b3-7bd9-499f-8e11-e1e9db5dece0","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:25.465398Z"}],"total_count":1}'
         headers:
             Content-Length:
-                - "672"
+                - "740"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:16 GMT
+                - Wed, 27 Aug 2025 15:05:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -883,10 +883,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4cd3208c-1c98-4503-8d79-6179350193f7
+                - 1fb796c6-89d0-4a6c-8b25-f4967186998e
         status: 200 OK
         code: 200
-        duration: 77.417667ms
+        duration: 129.361939ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -902,8 +902,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/10160653-f828-464f-986a-6ae95e7676f6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e27c4778-a4a8-4e1c-bdeb-03b3416add00
         method: GET
       response:
         proto: HTTP/2.0
@@ -911,20 +911,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 672
+        content_length: 708
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:13.012960Z","description":"","domain_name":"tfdsfunctionzrbseofv-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"10160653-f828-464f-986a-6ae95e7676f6","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"1aafcc97-4ee6-40a2-89d1-7e2313e17224","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:13.012960Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:25.465398Z","description":"","domain_name":"tfdsfunctionut3yjoav-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"e27c4778-a4a8-4e1c-bdeb-03b3416add00","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"552fb3b3-7bd9-499f-8e11-e1e9db5dece0","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:25.465398Z"}'
         headers:
             Content-Length:
-                - "672"
+                - "708"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:16 GMT
+                - Wed, 27 Aug 2025 15:05:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -932,10 +932,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c350e342-dd3f-4e31-b5a2-4dfbb194a16c
+                - 9fa6cde4-8871-44f3-8a53-9b595351ec8f
         status: 200 OK
         code: 200
-        duration: 80.328292ms
+        duration: 50.375703ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -951,8 +951,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/10160653-f828-464f-986a-6ae95e7676f6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e27c4778-a4a8-4e1c-bdeb-03b3416add00
         method: GET
       response:
         proto: HTTP/2.0
@@ -960,20 +960,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 672
+        content_length: 708
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:13.012960Z","description":"","domain_name":"tfdsfunctionzrbseofv-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"10160653-f828-464f-986a-6ae95e7676f6","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"1aafcc97-4ee6-40a2-89d1-7e2313e17224","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:13.012960Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:25.465398Z","description":"","domain_name":"tfdsfunctionut3yjoav-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"e27c4778-a4a8-4e1c-bdeb-03b3416add00","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"552fb3b3-7bd9-499f-8e11-e1e9db5dece0","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:25.465398Z"}'
         headers:
             Content-Length:
-                - "672"
+                - "708"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:17 GMT
+                - Wed, 27 Aug 2025 15:05:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -981,10 +981,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cc9448c3-3b3a-40fc-8364-2da241e60844
+                - bccd20f4-6f25-4efd-a0f9-e1fb629bdc4f
         status: 200 OK
         code: 200
-        duration: 75.30225ms
+        duration: 61.493033ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1000,8 +1000,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions?name=tf-ds-function&namespace_id=1aafcc97-4ee6-40a2-89d1-7e2313e17224&order_by=created_at_asc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions?name=tf-ds-function&namespace_id=552fb3b3-7bd9-499f-8e11-e1e9db5dece0&order_by=created_at_asc
         method: GET
       response:
         proto: HTTP/2.0
@@ -1009,20 +1009,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 704
+        content_length: 740
         uncompressed: false
-        body: '{"functions":[{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:13.012960Z","description":"","domain_name":"tfdsfunctionzrbseofv-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"10160653-f828-464f-986a-6ae95e7676f6","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"1aafcc97-4ee6-40a2-89d1-7e2313e17224","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:13.012960Z"}],"total_count":1}'
+        body: '{"functions":[{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:25.465398Z","description":"","domain_name":"tfdsfunctionut3yjoav-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"e27c4778-a4a8-4e1c-bdeb-03b3416add00","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"552fb3b3-7bd9-499f-8e11-e1e9db5dece0","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:25.465398Z"}],"total_count":1}'
         headers:
             Content-Length:
-                - "704"
+                - "740"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:17 GMT
+                - Wed, 27 Aug 2025 15:05:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1030,10 +1030,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ec3cbe86-ad05-47b7-b6fa-f11a78c09fab
+                - f8e92050-00ae-40f9-8130-128454c730c6
         status: 200 OK
         code: 200
-        duration: 80.227959ms
+        duration: 59.881619ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1049,8 +1049,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/10160653-f828-464f-986a-6ae95e7676f6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e27c4778-a4a8-4e1c-bdeb-03b3416add00
         method: GET
       response:
         proto: HTTP/2.0
@@ -1058,20 +1058,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 672
+        content_length: 708
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:13.012960Z","description":"","domain_name":"tfdsfunctionzrbseofv-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"10160653-f828-464f-986a-6ae95e7676f6","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"1aafcc97-4ee6-40a2-89d1-7e2313e17224","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:13.012960Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:25.465398Z","description":"","domain_name":"tfdsfunctionut3yjoav-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"e27c4778-a4a8-4e1c-bdeb-03b3416add00","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"552fb3b3-7bd9-499f-8e11-e1e9db5dece0","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:25.465398Z"}'
         headers:
             Content-Length:
-                - "672"
+                - "708"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:17 GMT
+                - Wed, 27 Aug 2025 15:05:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1079,10 +1079,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6aa9e0ae-629a-460e-9764-a19d12cf24d5
+                - 857b1cf2-2aac-46f5-8087-9ac7b745abae
         status: 200 OK
         code: 200
-        duration: 91.67975ms
+        duration: 64.60903ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1098,8 +1098,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/1aafcc97-4ee6-40a2-89d1-7e2313e17224
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e27c4778-a4a8-4e1c-bdeb-03b3416add00
         method: GET
       response:
         proto: HTTP/2.0
@@ -1107,20 +1107,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 541
+        content_length: 708
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.397211Z","description":"","environment_variables":{},"error_message":null,"id":"1aafcc97-4ee6-40a2-89d1-7e2313e17224","name":"tf-ds-function","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfdsfunctionzrbseofv","registry_namespace_id":"d0a94938-de65-4c53-a802-1447ef27c0c7","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:44:11.495699Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:25.465398Z","description":"","domain_name":"tfdsfunctionut3yjoav-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"e27c4778-a4a8-4e1c-bdeb-03b3416add00","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"552fb3b3-7bd9-499f-8e11-e1e9db5dece0","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:25.465398Z"}'
         headers:
             Content-Length:
-                - "541"
+                - "708"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:17 GMT
+                - Wed, 27 Aug 2025 15:05:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1128,10 +1128,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e3a5001d-16c8-4f5f-bdeb-bebff7b93b0d
+                - 508c4825-438f-4fb0-9e4e-29bd37d57bf6
         status: 200 OK
         code: 200
-        duration: 63.141333ms
+        duration: 49.915509ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1147,8 +1147,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/10160653-f828-464f-986a-6ae95e7676f6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/552fb3b3-7bd9-499f-8e11-e1e9db5dece0
         method: GET
       response:
         proto: HTTP/2.0
@@ -1156,20 +1156,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 672
+        content_length: 574
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:13.012960Z","description":"","domain_name":"tfdsfunctionzrbseofv-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"10160653-f828-464f-986a-6ae95e7676f6","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"1aafcc97-4ee6-40a2-89d1-7e2313e17224","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:13.012960Z"}'
+        body: '{"created_at":"2025-08-27T15:05:14.035883Z","description":"","environment_variables":{},"error_message":null,"id":"552fb3b3-7bd9-499f-8e11-e1e9db5dece0","name":"tf-ds-function","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfdsfunctionut3yjoav","registry_namespace_id":"6a374333-96da-491a-957c-9631f2715aa0","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:21.815754Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "672"
+                - "574"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:17 GMT
+                - Wed, 27 Aug 2025 15:05:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1177,10 +1177,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 638a846e-889f-4c84-af3d-bbe96a514a6c
+                - add4534e-a7d1-4817-aa65-908ba2e64286
         status: 200 OK
         code: 200
-        duration: 89.109917ms
+        duration: 37.933156ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1196,8 +1196,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions?name=tf-ds-function&namespace_id=1aafcc97-4ee6-40a2-89d1-7e2313e17224&order_by=created_at_asc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e27c4778-a4a8-4e1c-bdeb-03b3416add00
         method: GET
       response:
         proto: HTTP/2.0
@@ -1205,20 +1205,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 704
+        content_length: 708
         uncompressed: false
-        body: '{"functions":[{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:13.012960Z","description":"","domain_name":"tfdsfunctionzrbseofv-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"10160653-f828-464f-986a-6ae95e7676f6","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"1aafcc97-4ee6-40a2-89d1-7e2313e17224","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:13.012960Z"}],"total_count":1}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:25.465398Z","description":"","domain_name":"tfdsfunctionut3yjoav-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"e27c4778-a4a8-4e1c-bdeb-03b3416add00","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"552fb3b3-7bd9-499f-8e11-e1e9db5dece0","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:25.465398Z"}'
         headers:
             Content-Length:
-                - "704"
+                - "708"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:17 GMT
+                - Wed, 27 Aug 2025 15:05:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1226,10 +1226,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0d6de215-537a-4a54-8013-72de4646f04d
+                - 62df5ac3-f646-4165-b938-28c98499547f
         status: 200 OK
         code: 200
-        duration: 85.057875ms
+        duration: 51.633102ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1245,8 +1245,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/10160653-f828-464f-986a-6ae95e7676f6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions?name=tf-ds-function&namespace_id=552fb3b3-7bd9-499f-8e11-e1e9db5dece0&order_by=created_at_asc
         method: GET
       response:
         proto: HTTP/2.0
@@ -1254,20 +1254,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 672
+        content_length: 740
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:13.012960Z","description":"","domain_name":"tfdsfunctionzrbseofv-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"10160653-f828-464f-986a-6ae95e7676f6","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"1aafcc97-4ee6-40a2-89d1-7e2313e17224","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:13.012960Z"}'
+        body: '{"functions":[{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:25.465398Z","description":"","domain_name":"tfdsfunctionut3yjoav-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"e27c4778-a4a8-4e1c-bdeb-03b3416add00","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"552fb3b3-7bd9-499f-8e11-e1e9db5dece0","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:25.465398Z"}],"total_count":1}'
         headers:
             Content-Length:
-                - "672"
+                - "740"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:17 GMT
+                - Wed, 27 Aug 2025 15:05:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1275,10 +1275,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2e9716f3-eabd-4469-8b8c-8574152e7602
+                - b356f710-7f0e-481c-bfeb-7d8833b1c4bc
         status: 200 OK
         code: 200
-        duration: 153.690958ms
+        duration: 52.236554ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1294,8 +1294,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/10160653-f828-464f-986a-6ae95e7676f6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e27c4778-a4a8-4e1c-bdeb-03b3416add00
         method: GET
       response:
         proto: HTTP/2.0
@@ -1303,20 +1303,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 672
+        content_length: 708
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:13.012960Z","description":"","domain_name":"tfdsfunctionzrbseofv-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"10160653-f828-464f-986a-6ae95e7676f6","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"1aafcc97-4ee6-40a2-89d1-7e2313e17224","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:13.012960Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:25.465398Z","description":"","domain_name":"tfdsfunctionut3yjoav-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"e27c4778-a4a8-4e1c-bdeb-03b3416add00","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"552fb3b3-7bd9-499f-8e11-e1e9db5dece0","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:25.465398Z"}'
         headers:
             Content-Length:
-                - "672"
+                - "708"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:18 GMT
+                - Wed, 27 Aug 2025 15:05:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1324,10 +1324,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 34b97c44-efad-48e3-a769-b7b3f1824077
+                - 897cd403-a3b5-45b7-b27f-70fb8b57948f
         status: 200 OK
         code: 200
-        duration: 83.581ms
+        duration: 47.646251ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1343,8 +1343,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/10160653-f828-464f-986a-6ae95e7676f6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e27c4778-a4a8-4e1c-bdeb-03b3416add00
         method: GET
       response:
         proto: HTTP/2.0
@@ -1352,20 +1352,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 672
+        content_length: 708
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:13.012960Z","description":"","domain_name":"tfdsfunctionzrbseofv-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"10160653-f828-464f-986a-6ae95e7676f6","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"1aafcc97-4ee6-40a2-89d1-7e2313e17224","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:13.012960Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:25.465398Z","description":"","domain_name":"tfdsfunctionut3yjoav-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"e27c4778-a4a8-4e1c-bdeb-03b3416add00","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"552fb3b3-7bd9-499f-8e11-e1e9db5dece0","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:25.465398Z"}'
         headers:
             Content-Length:
-                - "672"
+                - "708"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:18 GMT
+                - Wed, 27 Aug 2025 15:05:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1373,10 +1373,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2ddbd379-5604-47f4-b3fa-b12d9184d1a3
+                - 5ddeacc3-6834-41ea-91ce-9c12380c86e0
         status: 200 OK
         code: 200
-        duration: 70.919459ms
+        duration: 110.499055ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1392,8 +1392,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions?name=tf-ds-function&namespace_id=1aafcc97-4ee6-40a2-89d1-7e2313e17224&order_by=created_at_asc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e27c4778-a4a8-4e1c-bdeb-03b3416add00
         method: GET
       response:
         proto: HTTP/2.0
@@ -1401,20 +1401,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 704
+        content_length: 708
         uncompressed: false
-        body: '{"functions":[{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:13.012960Z","description":"","domain_name":"tfdsfunctionzrbseofv-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"10160653-f828-464f-986a-6ae95e7676f6","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"1aafcc97-4ee6-40a2-89d1-7e2313e17224","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:13.012960Z"}],"total_count":1}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:25.465398Z","description":"","domain_name":"tfdsfunctionut3yjoav-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"e27c4778-a4a8-4e1c-bdeb-03b3416add00","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"552fb3b3-7bd9-499f-8e11-e1e9db5dece0","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:25.465398Z"}'
         headers:
             Content-Length:
-                - "704"
+                - "708"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:18 GMT
+                - Wed, 27 Aug 2025 15:05:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1422,10 +1422,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7ae449d3-ba44-4182-a483-03e6f34ada9c
+                - 82facb43-b23e-4219-9962-9d3a64374963
         status: 200 OK
         code: 200
-        duration: 80.575208ms
+        duration: 140.77232ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1441,8 +1441,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/10160653-f828-464f-986a-6ae95e7676f6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions?name=tf-ds-function&namespace_id=552fb3b3-7bd9-499f-8e11-e1e9db5dece0&order_by=created_at_asc
         method: GET
       response:
         proto: HTTP/2.0
@@ -1450,20 +1450,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 672
+        content_length: 740
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:13.012960Z","description":"","domain_name":"tfdsfunctionzrbseofv-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"10160653-f828-464f-986a-6ae95e7676f6","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"1aafcc97-4ee6-40a2-89d1-7e2313e17224","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:13.012960Z"}'
+        body: '{"functions":[{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:25.465398Z","description":"","domain_name":"tfdsfunctionut3yjoav-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"e27c4778-a4a8-4e1c-bdeb-03b3416add00","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"552fb3b3-7bd9-499f-8e11-e1e9db5dece0","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:25.465398Z"}],"total_count":1}'
         headers:
             Content-Length:
-                - "672"
+                - "740"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:18 GMT
+                - Wed, 27 Aug 2025 15:05:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1471,10 +1471,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4203e65a-25f4-42f1-a9eb-7056752a6071
+                - 7bac69a3-d200-4842-a6a9-dcf8705cf016
         status: 200 OK
         code: 200
-        duration: 88.093417ms
+        duration: 143.726563ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1490,8 +1490,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/10160653-f828-464f-986a-6ae95e7676f6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e27c4778-a4a8-4e1c-bdeb-03b3416add00
         method: GET
       response:
         proto: HTTP/2.0
@@ -1499,20 +1499,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 672
+        content_length: 708
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:13.012960Z","description":"","domain_name":"tfdsfunctionzrbseofv-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"10160653-f828-464f-986a-6ae95e7676f6","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"1aafcc97-4ee6-40a2-89d1-7e2313e17224","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:13.012960Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:25.465398Z","description":"","domain_name":"tfdsfunctionut3yjoav-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"e27c4778-a4a8-4e1c-bdeb-03b3416add00","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"552fb3b3-7bd9-499f-8e11-e1e9db5dece0","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:25.465398Z"}'
         headers:
             Content-Length:
-                - "672"
+                - "708"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:19 GMT
+                - Wed, 27 Aug 2025 15:05:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1520,10 +1520,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5c34636b-9168-48ce-a503-c1dc08439bdb
+                - a8c92ae4-f12c-4b69-aee0-1680d0bcffbc
         status: 200 OK
         code: 200
-        duration: 88.352375ms
+        duration: 58.958057ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1539,29 +1539,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/10160653-f828-464f-986a-6ae95e7676f6
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e27c4778-a4a8-4e1c-bdeb-03b3416add00
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 676
+        content_length: 708
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:13.012960Z","description":"","domain_name":"tfdsfunctionzrbseofv-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"10160653-f828-464f-986a-6ae95e7676f6","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"1aafcc97-4ee6-40a2-89d1-7e2313e17224","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"deleting","timeout":"300s","updated_at":"2025-01-24T15:44:19.261187949Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:25.465398Z","description":"","domain_name":"tfdsfunctionut3yjoav-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"e27c4778-a4a8-4e1c-bdeb-03b3416add00","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"552fb3b3-7bd9-499f-8e11-e1e9db5dece0","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:25.465398Z"}'
         headers:
             Content-Length:
-                - "676"
+                - "708"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:19 GMT
+                - Wed, 27 Aug 2025 15:05:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1569,10 +1569,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3e65bec8-68d7-4b65-b36b-09ca2beba8a4
+                - ecd04002-2663-49ce-98b1-3bc476052540
         status: 200 OK
         code: 200
-        duration: 146.390916ms
+        duration: 57.842173ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1588,29 +1588,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/1aafcc97-4ee6-40a2-89d1-7e2313e17224
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e27c4778-a4a8-4e1c-bdeb-03b3416add00
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 541
+        content_length: 712
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.397211Z","description":"","environment_variables":{},"error_message":null,"id":"1aafcc97-4ee6-40a2-89d1-7e2313e17224","name":"tf-ds-function","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfdsfunctionzrbseofv","registry_namespace_id":"d0a94938-de65-4c53-a802-1447ef27c0c7","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:44:11.495699Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:25.465398Z","description":"","domain_name":"tfdsfunctionut3yjoav-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"e27c4778-a4a8-4e1c-bdeb-03b3416add00","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"552fb3b3-7bd9-499f-8e11-e1e9db5dece0","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:28.695471856Z"}'
         headers:
             Content-Length:
-                - "541"
+                - "712"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:19 GMT
+                - Wed, 27 Aug 2025 15:05:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1618,10 +1618,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a09f0960-4acd-4f31-9500-be1211918416
+                - 2e4350cb-fe9f-41c6-b844-46ee6c4ccb03
         status: 200 OK
         code: 200
-        duration: 69.721166ms
+        duration: 338.361538ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1637,29 +1637,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/1aafcc97-4ee6-40a2-89d1-7e2313e17224
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/552fb3b3-7bd9-499f-8e11-e1e9db5dece0
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 547
+        content_length: 574
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.397211Z","description":"","environment_variables":{},"error_message":null,"id":"1aafcc97-4ee6-40a2-89d1-7e2313e17224","name":"tf-ds-function","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfdsfunctionzrbseofv","registry_namespace_id":"d0a94938-de65-4c53-a802-1447ef27c0c7","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:44:19.478379705Z"}'
+        body: '{"created_at":"2025-08-27T15:05:14.035883Z","description":"","environment_variables":{},"error_message":null,"id":"552fb3b3-7bd9-499f-8e11-e1e9db5dece0","name":"tf-ds-function","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfdsfunctionut3yjoav","registry_namespace_id":"6a374333-96da-491a-957c-9631f2715aa0","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:21.815754Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "547"
+                - "574"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:19 GMT
+                - Wed, 27 Aug 2025 15:05:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1667,10 +1667,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 383d9fb4-f489-4887-8b42-b717b6fc1257
+                - 28fe4dc6-2e56-4484-bac4-dbd4b764b005
         status: 200 OK
         code: 200
-        duration: 246.473167ms
+        duration: 53.048549ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1686,29 +1686,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/1aafcc97-4ee6-40a2-89d1-7e2313e17224
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/552fb3b3-7bd9-499f-8e11-e1e9db5dece0
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 544
+        content_length: 580
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.397211Z","description":"","environment_variables":{},"error_message":null,"id":"1aafcc97-4ee6-40a2-89d1-7e2313e17224","name":"tf-ds-function","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfdsfunctionzrbseofv","registry_namespace_id":"d0a94938-de65-4c53-a802-1447ef27c0c7","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:44:19.478380Z"}'
+        body: '{"created_at":"2025-08-27T15:05:14.035883Z","description":"","environment_variables":{},"error_message":null,"id":"552fb3b3-7bd9-499f-8e11-e1e9db5dece0","name":"tf-ds-function","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfdsfunctionut3yjoav","registry_namespace_id":"6a374333-96da-491a-957c-9631f2715aa0","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:29.100295288Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "544"
+                - "580"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:19 GMT
+                - Wed, 27 Aug 2025 15:05:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1716,10 +1716,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 04a209ad-0b02-4710-a3a4-4af4c164edf9
+                - d0c94b04-f8b7-4d9f-8104-51faf99a15fd
         status: 200 OK
         code: 200
-        duration: 74.101459ms
+        duration: 741.978131ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1735,8 +1735,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/1aafcc97-4ee6-40a2-89d1-7e2313e17224
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/552fb3b3-7bd9-499f-8e11-e1e9db5dece0
         method: GET
       response:
         proto: HTTP/2.0
@@ -1744,20 +1744,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 544
+        content_length: 577
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.397211Z","description":"","environment_variables":{},"error_message":null,"id":"1aafcc97-4ee6-40a2-89d1-7e2313e17224","name":"tf-ds-function","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfdsfunctionzrbseofv","registry_namespace_id":"d0a94938-de65-4c53-a802-1447ef27c0c7","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:44:19.478380Z"}'
+        body: '{"created_at":"2025-08-27T15:05:14.035883Z","description":"","environment_variables":{},"error_message":null,"id":"552fb3b3-7bd9-499f-8e11-e1e9db5dece0","name":"tf-ds-function","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfdsfunctionut3yjoav","registry_namespace_id":"6a374333-96da-491a-957c-9631f2715aa0","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:29.100295Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "544"
+                - "577"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:24 GMT
+                - Wed, 27 Aug 2025 15:05:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1765,10 +1765,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 187b1bc5-9780-43bd-98b8-057c005d269c
+                - 9eba0c3c-f0af-415e-8214-dd46580e5593
         status: 200 OK
         code: 200
-        duration: 69.394125ms
+        duration: 44.17583ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1784,8 +1784,302 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/1aafcc97-4ee6-40a2-89d1-7e2313e17224
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/552fb3b3-7bd9-499f-8e11-e1e9db5dece0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 577
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:14.035883Z","description":"","environment_variables":{},"error_message":null,"id":"552fb3b3-7bd9-499f-8e11-e1e9db5dece0","name":"tf-ds-function","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfdsfunctionut3yjoav","registry_namespace_id":"6a374333-96da-491a-957c-9631f2715aa0","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:29.100295Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "577"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:05:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - be85d1d3-46cc-4206-b2d2-9c96765b59e5
+        status: 200 OK
+        code: 200
+        duration: 53.211184ms
+    - id: 37
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/552fb3b3-7bd9-499f-8e11-e1e9db5dece0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 577
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:14.035883Z","description":"","environment_variables":{},"error_message":null,"id":"552fb3b3-7bd9-499f-8e11-e1e9db5dece0","name":"tf-ds-function","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfdsfunctionut3yjoav","registry_namespace_id":"6a374333-96da-491a-957c-9631f2715aa0","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:29.100295Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "577"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:05:39 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 48e96161-60f0-4a68-afad-c987fa88b09f
+        status: 200 OK
+        code: 200
+        duration: 50.331072ms
+    - id: 38
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/552fb3b3-7bd9-499f-8e11-e1e9db5dece0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 577
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:14.035883Z","description":"","environment_variables":{},"error_message":null,"id":"552fb3b3-7bd9-499f-8e11-e1e9db5dece0","name":"tf-ds-function","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfdsfunctionut3yjoav","registry_namespace_id":"6a374333-96da-491a-957c-9631f2715aa0","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:29.100295Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "577"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:05:44 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 26ed594f-4b25-4373-a7c9-09e677b7ff85
+        status: 200 OK
+        code: 200
+        duration: 50.000873ms
+    - id: 39
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/552fb3b3-7bd9-499f-8e11-e1e9db5dece0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 577
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:14.035883Z","description":"","environment_variables":{},"error_message":null,"id":"552fb3b3-7bd9-499f-8e11-e1e9db5dece0","name":"tf-ds-function","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfdsfunctionut3yjoav","registry_namespace_id":"6a374333-96da-491a-957c-9631f2715aa0","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:29.100295Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "577"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:05:50 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 8ae98680-123c-4858-a1fe-212893e1f106
+        status: 200 OK
+        code: 200
+        duration: 45.495149ms
+    - id: 40
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/552fb3b3-7bd9-499f-8e11-e1e9db5dece0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 577
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:14.035883Z","description":"","environment_variables":{},"error_message":null,"id":"552fb3b3-7bd9-499f-8e11-e1e9db5dece0","name":"tf-ds-function","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfdsfunctionut3yjoav","registry_namespace_id":"6a374333-96da-491a-957c-9631f2715aa0","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:29.100295Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "577"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:05:55 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 9d055332-49c3-4cba-b22b-a98e3d64532c
+        status: 200 OK
+        code: 200
+        duration: 62.163046ms
+    - id: 41
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/552fb3b3-7bd9-499f-8e11-e1e9db5dece0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 577
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:14.035883Z","description":"","environment_variables":{},"error_message":null,"id":"552fb3b3-7bd9-499f-8e11-e1e9db5dece0","name":"tf-ds-function","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfdsfunctionut3yjoav","registry_namespace_id":"6a374333-96da-491a-957c-9631f2715aa0","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:29.100295Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "577"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:00 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 03f9ee21-1787-4c0d-8b2c-93757aca9398
+        status: 200 OK
+        code: 200
+        duration: 41.679731ms
+    - id: 42
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/552fb3b3-7bd9-499f-8e11-e1e9db5dece0
         method: GET
       response:
         proto: HTTP/2.0
@@ -1804,9 +2098,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:29 GMT
+                - Wed, 27 Aug 2025 15:06:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1814,11 +2108,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d5e2c616-0a3b-4978-90e1-c8e160d7a1f3
+                - 8385b701-6d83-4803-a750-cbafdb80e3bc
         status: 404 Not Found
         code: 404
-        duration: 31.475584ms
-    - id: 37
+        duration: 26.657562ms
+    - id: 43
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1833,8 +2127,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/10160653-f828-464f-986a-6ae95e7676f6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e27c4778-a4a8-4e1c-bdeb-03b3416add00
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1853,9 +2147,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:29 GMT
+                - Wed, 27 Aug 2025 15:06:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1863,11 +2157,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b6fe8f08-1b13-44d0-809a-05cb25bb6037
+                - 1bd86688-d3f1-4d39-a5ef-03e9a87a7023
         status: 404 Not Found
         code: 404
-        duration: 23.396208ms
-    - id: 38
+        duration: 101.357295ms
+    - id: 44
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1882,8 +2176,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/10160653-f828-464f-986a-6ae95e7676f6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e27c4778-a4a8-4e1c-bdeb-03b3416add00
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1902,9 +2196,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:29 GMT
+                - Wed, 27 Aug 2025 15:06:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1912,11 +2206,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 01028d8e-9053-4efb-9d11-d452a5b77b92
+                - 170f92a3-0759-430e-acad-a49d4261a251
         status: 404 Not Found
         code: 404
-        duration: 22.163458ms
-    - id: 39
+        duration: 28.337755ms
+    - id: 45
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1931,8 +2225,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/10160653-f828-464f-986a-6ae95e7676f6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e27c4778-a4a8-4e1c-bdeb-03b3416add00
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1951,9 +2245,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:29 GMT
+                - Wed, 27 Aug 2025 15:06:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1961,7 +2255,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c2e2b6d5-6ead-419f-a78f-e95494df90e0
+                - 3bf9f8ce-fe92-4891-a969-78d92a8e2f9b
         status: 404 Not Found
         code: 404
-        duration: 26.395959ms
+        duration: 24.155337ms

--- a/internal/services/function/testdata/data-source-function-namespace-basic.cassette.yaml
+++ b/internal/services/function/testdata/data-source-function-namespace-basic.cassette.yaml
@@ -6,19 +6,19 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 148
+        content_length: 180
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"test-cr-data","environment_variables":{},"project_id":"6867048b-fe12-4e96-835e-41c79a39604b","secret_environment_variables":[],"tags":null}'
+        body: '{"name":"test-cr-data","environment_variables":{},"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","secret_environment_variables":[],"tags":null,"activate_vpc_integration":true}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces
         method: POST
       response:
@@ -27,20 +27,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 478
+        content_length: 497
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:22:39.302376057Z","description":"","environment_variables":{},"error_message":null,"id":"9521908a-b95d-413b-9159-661736d82a0e","name":"test-cr-data","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-04-28T09:22:39.302376057Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.648621537Z","description":"","environment_variables":{},"error_message":null,"id":"a83b7871-6f6f-4a89-a6c6-9704bfcef310","name":"test-cr-data","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:13.648621537Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "478"
+                - "497"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:39 GMT
+                - Wed, 27 Aug 2025 15:05:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d063f5ac-b721-413c-a073-1fe1bf574408
+                - 4ae129e0-f6d3-4b0b-a9fb-31a40c66d907
         status: 200 OK
         code: 200
-        duration: 1.326693916s
+        duration: 5.495898195s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -67,8 +67,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/9521908a-b95d-413b-9159-661736d82a0e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a83b7871-6f6f-4a89-a6c6-9704bfcef310
         method: GET
       response:
         proto: HTTP/2.0
@@ -76,20 +76,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 472
+        content_length: 491
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:22:39.302376Z","description":"","environment_variables":{},"error_message":null,"id":"9521908a-b95d-413b-9159-661736d82a0e","name":"test-cr-data","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-04-28T09:22:39.302376Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.648622Z","description":"","environment_variables":{},"error_message":null,"id":"a83b7871-6f6f-4a89-a6c6-9704bfcef310","name":"test-cr-data","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:13.648622Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "472"
+                - "491"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:39 GMT
+                - Wed, 27 Aug 2025 15:05:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1db0c314-486f-40de-bbb6-4a9c73bbfc2d
+                - 439ac38f-8da0-4094-b449-29ade2ae6240
         status: 200 OK
         code: 200
-        duration: 38.736916ms
+        duration: 46.534984ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -116,8 +116,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/9521908a-b95d-413b-9159-661736d82a0e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a83b7871-6f6f-4a89-a6c6-9704bfcef310
         method: GET
       response:
         proto: HTTP/2.0
@@ -125,20 +125,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 551
+        content_length: 570
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:22:39.302376Z","description":"","environment_variables":{},"error_message":null,"id":"9521908a-b95d-413b-9159-661736d82a0e","name":"test-cr-data","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdatae3yrt7gv","registry_namespace_id":"7a2721ff-5ffe-48f2-b1f6-0c3a0973a967","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-28T09:22:41.881988Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.648622Z","description":"","environment_variables":{},"error_message":null,"id":"a83b7871-6f6f-4a89-a6c6-9704bfcef310","name":"test-cr-data","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdata5mkmvktf","registry_namespace_id":"29434bb6-05be-4f4a-bea6-da2548f1dd42","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:19.044658Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "551"
+                - "570"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:44 GMT
+                - Wed, 27 Aug 2025 15:05:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -146,10 +146,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ee11e567-24bc-4c75-adcc-4e5ffe04a555
+                - ef5c8599-1fc3-40e4-87b8-03e34312416e
         status: 200 OK
         code: 200
-        duration: 52.046125ms
+        duration: 460.425509ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -165,8 +165,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/9521908a-b95d-413b-9159-661736d82a0e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a83b7871-6f6f-4a89-a6c6-9704bfcef310
         method: GET
       response:
         proto: HTTP/2.0
@@ -174,20 +174,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 551
+        content_length: 570
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:22:39.302376Z","description":"","environment_variables":{},"error_message":null,"id":"9521908a-b95d-413b-9159-661736d82a0e","name":"test-cr-data","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdatae3yrt7gv","registry_namespace_id":"7a2721ff-5ffe-48f2-b1f6-0c3a0973a967","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-28T09:22:41.881988Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.648622Z","description":"","environment_variables":{},"error_message":null,"id":"a83b7871-6f6f-4a89-a6c6-9704bfcef310","name":"test-cr-data","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdata5mkmvktf","registry_namespace_id":"29434bb6-05be-4f4a-bea6-da2548f1dd42","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:19.044658Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "551"
+                - "570"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:44 GMT
+                - Wed, 27 Aug 2025 15:05:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -195,10 +195,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 38ce9b6e-fb99-414d-a10f-960c47fe8c25
+                - 9365cd1c-f8a1-4191-a3df-17d88db3b11b
         status: 200 OK
         code: 200
-        duration: 41.229209ms
+        duration: 164.389429ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -214,8 +214,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/9521908a-b95d-413b-9159-661736d82a0e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a83b7871-6f6f-4a89-a6c6-9704bfcef310
         method: GET
       response:
         proto: HTTP/2.0
@@ -223,20 +223,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 551
+        content_length: 570
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:22:39.302376Z","description":"","environment_variables":{},"error_message":null,"id":"9521908a-b95d-413b-9159-661736d82a0e","name":"test-cr-data","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdatae3yrt7gv","registry_namespace_id":"7a2721ff-5ffe-48f2-b1f6-0c3a0973a967","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-28T09:22:41.881988Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.648622Z","description":"","environment_variables":{},"error_message":null,"id":"a83b7871-6f6f-4a89-a6c6-9704bfcef310","name":"test-cr-data","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdata5mkmvktf","registry_namespace_id":"29434bb6-05be-4f4a-bea6-da2548f1dd42","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:19.044658Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "551"
+                - "570"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:44 GMT
+                - Wed, 27 Aug 2025 15:05:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -244,10 +244,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1c80bdbb-9a32-4018-8f97-7f42b9c242a4
+                - 1eed964e-058c-4555-8f87-bb2b2fd94cbe
         status: 200 OK
         code: 200
-        duration: 45.032041ms
+        duration: 46.429477ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -263,7 +263,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces?name=test-cr-data&order_by=created_at_asc
         method: GET
       response:
@@ -272,20 +272,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 585
+        content_length: 603
         uncompressed: false
-        body: '{"namespaces":[{"created_at":"2025-04-28T09:22:39.302376Z","description":"","environment_variables":{},"error_message":null,"id":"9521908a-b95d-413b-9159-661736d82a0e","name":"test-cr-data","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdatae3yrt7gv","registry_namespace_id":"7a2721ff-5ffe-48f2-b1f6-0c3a0973a967","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-28T09:22:41.881988Z"}],"total_count":1}'
+        body: '{"namespaces":[{"created_at":"2025-08-27T15:05:13.648622Z","description":"","environment_variables":{},"error_message":null,"id":"a83b7871-6f6f-4a89-a6c6-9704bfcef310","name":"test-cr-data","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdata5mkmvktf","registry_namespace_id":"29434bb6-05be-4f4a-bea6-da2548f1dd42","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:19.044658Z","vpc_integration_activated":true}],"total_count":1}'
         headers:
             Content-Length:
-                - "585"
+                - "603"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:44 GMT
+                - Wed, 27 Aug 2025 15:05:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -293,10 +293,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 391daac0-8746-43b2-aa1a-6420806be690
+                - 80210671-0fe7-4a96-81cd-4b2195dddee0
         status: 200 OK
         code: 200
-        duration: 49.57025ms
+        duration: 48.09349ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -312,8 +312,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/9521908a-b95d-413b-9159-661736d82a0e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a83b7871-6f6f-4a89-a6c6-9704bfcef310
         method: GET
       response:
         proto: HTTP/2.0
@@ -321,20 +321,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 551
+        content_length: 570
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:22:39.302376Z","description":"","environment_variables":{},"error_message":null,"id":"9521908a-b95d-413b-9159-661736d82a0e","name":"test-cr-data","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdatae3yrt7gv","registry_namespace_id":"7a2721ff-5ffe-48f2-b1f6-0c3a0973a967","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-28T09:22:41.881988Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.648622Z","description":"","environment_variables":{},"error_message":null,"id":"a83b7871-6f6f-4a89-a6c6-9704bfcef310","name":"test-cr-data","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdata5mkmvktf","registry_namespace_id":"29434bb6-05be-4f4a-bea6-da2548f1dd42","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:19.044658Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "551"
+                - "570"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:44 GMT
+                - Wed, 27 Aug 2025 15:05:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -342,10 +342,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - df159f70-4d03-4ed5-a52d-96157ee49f80
+                - 14659941-ac60-4f58-90b5-d9afcf4b7c7d
         status: 200 OK
         code: 200
-        duration: 41.125292ms
+        duration: 123.282769ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -361,8 +361,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/9521908a-b95d-413b-9159-661736d82a0e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a83b7871-6f6f-4a89-a6c6-9704bfcef310
         method: GET
       response:
         proto: HTTP/2.0
@@ -370,20 +370,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 551
+        content_length: 570
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:22:39.302376Z","description":"","environment_variables":{},"error_message":null,"id":"9521908a-b95d-413b-9159-661736d82a0e","name":"test-cr-data","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdatae3yrt7gv","registry_namespace_id":"7a2721ff-5ffe-48f2-b1f6-0c3a0973a967","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-28T09:22:41.881988Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.648622Z","description":"","environment_variables":{},"error_message":null,"id":"a83b7871-6f6f-4a89-a6c6-9704bfcef310","name":"test-cr-data","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdata5mkmvktf","registry_namespace_id":"29434bb6-05be-4f4a-bea6-da2548f1dd42","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:19.044658Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "551"
+                - "570"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:44 GMT
+                - Wed, 27 Aug 2025 15:05:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -391,10 +391,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 39f2ef4c-97e7-427f-93d0-b5482a809a44
+                - 73344ad2-cc05-4aa1-bf59-44be40b2f0c9
         status: 200 OK
         code: 200
-        duration: 41.935459ms
+        duration: 57.647636ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -410,7 +410,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces?name=test-cr-data&order_by=created_at_asc
         method: GET
       response:
@@ -419,20 +419,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 585
+        content_length: 603
         uncompressed: false
-        body: '{"namespaces":[{"created_at":"2025-04-28T09:22:39.302376Z","description":"","environment_variables":{},"error_message":null,"id":"9521908a-b95d-413b-9159-661736d82a0e","name":"test-cr-data","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdatae3yrt7gv","registry_namespace_id":"7a2721ff-5ffe-48f2-b1f6-0c3a0973a967","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-28T09:22:41.881988Z"}],"total_count":1}'
+        body: '{"namespaces":[{"created_at":"2025-08-27T15:05:13.648622Z","description":"","environment_variables":{},"error_message":null,"id":"a83b7871-6f6f-4a89-a6c6-9704bfcef310","name":"test-cr-data","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdata5mkmvktf","registry_namespace_id":"29434bb6-05be-4f4a-bea6-da2548f1dd42","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:19.044658Z","vpc_integration_activated":true}],"total_count":1}'
         headers:
             Content-Length:
-                - "585"
+                - "603"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:44 GMT
+                - Wed, 27 Aug 2025 15:05:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -440,10 +440,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 324f23cd-2028-4678-a05d-c2e6a61e3daf
+                - 13ea2362-b282-4e55-8d8d-646f63195171
         status: 200 OK
         code: 200
-        duration: 55.754125ms
+        duration: 46.043453ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -459,8 +459,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/9521908a-b95d-413b-9159-661736d82a0e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a83b7871-6f6f-4a89-a6c6-9704bfcef310
         method: GET
       response:
         proto: HTTP/2.0
@@ -468,20 +468,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 551
+        content_length: 570
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:22:39.302376Z","description":"","environment_variables":{},"error_message":null,"id":"9521908a-b95d-413b-9159-661736d82a0e","name":"test-cr-data","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdatae3yrt7gv","registry_namespace_id":"7a2721ff-5ffe-48f2-b1f6-0c3a0973a967","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-28T09:22:41.881988Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.648622Z","description":"","environment_variables":{},"error_message":null,"id":"a83b7871-6f6f-4a89-a6c6-9704bfcef310","name":"test-cr-data","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdata5mkmvktf","registry_namespace_id":"29434bb6-05be-4f4a-bea6-da2548f1dd42","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:19.044658Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "551"
+                - "570"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:44 GMT
+                - Wed, 27 Aug 2025 15:05:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -489,10 +489,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f61abfbe-32e4-4cf8-92c1-eb779f510fe1
+                - 5e2bf491-c272-45e4-8d2b-fb6335d3b044
         status: 200 OK
         code: 200
-        duration: 38.911084ms
+        duration: 52.33092ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -508,8 +508,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/9521908a-b95d-413b-9159-661736d82a0e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a83b7871-6f6f-4a89-a6c6-9704bfcef310
         method: GET
       response:
         proto: HTTP/2.0
@@ -517,20 +517,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 551
+        content_length: 570
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:22:39.302376Z","description":"","environment_variables":{},"error_message":null,"id":"9521908a-b95d-413b-9159-661736d82a0e","name":"test-cr-data","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdatae3yrt7gv","registry_namespace_id":"7a2721ff-5ffe-48f2-b1f6-0c3a0973a967","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-28T09:22:41.881988Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.648622Z","description":"","environment_variables":{},"error_message":null,"id":"a83b7871-6f6f-4a89-a6c6-9704bfcef310","name":"test-cr-data","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdata5mkmvktf","registry_namespace_id":"29434bb6-05be-4f4a-bea6-da2548f1dd42","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:19.044658Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "551"
+                - "570"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:44 GMT
+                - Wed, 27 Aug 2025 15:05:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -538,10 +538,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 98430efe-dd31-411b-8526-c96c59e8d145
+                - 02889354-28bd-401e-8f97-bedef61449f4
         status: 200 OK
         code: 200
-        duration: 94.840333ms
+        duration: 48.987086ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -557,8 +557,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/9521908a-b95d-413b-9159-661736d82a0e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a83b7871-6f6f-4a89-a6c6-9704bfcef310
         method: GET
       response:
         proto: HTTP/2.0
@@ -566,20 +566,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 551
+        content_length: 570
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:22:39.302376Z","description":"","environment_variables":{},"error_message":null,"id":"9521908a-b95d-413b-9159-661736d82a0e","name":"test-cr-data","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdatae3yrt7gv","registry_namespace_id":"7a2721ff-5ffe-48f2-b1f6-0c3a0973a967","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-28T09:22:41.881988Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.648622Z","description":"","environment_variables":{},"error_message":null,"id":"a83b7871-6f6f-4a89-a6c6-9704bfcef310","name":"test-cr-data","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdata5mkmvktf","registry_namespace_id":"29434bb6-05be-4f4a-bea6-da2548f1dd42","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:19.044658Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "551"
+                - "570"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:44 GMT
+                - Wed, 27 Aug 2025 15:05:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -587,10 +587,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f343d4d7-dcf9-4bc0-a930-b12571fdb965
+                - 23aa88f9-aee7-4639-8988-6d052a1d1a64
         status: 200 OK
         code: 200
-        duration: 45.082125ms
+        duration: 215.175641ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -606,8 +606,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/9521908a-b95d-413b-9159-661736d82a0e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a83b7871-6f6f-4a89-a6c6-9704bfcef310
         method: GET
       response:
         proto: HTTP/2.0
@@ -615,20 +615,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 551
+        content_length: 570
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:22:39.302376Z","description":"","environment_variables":{},"error_message":null,"id":"9521908a-b95d-413b-9159-661736d82a0e","name":"test-cr-data","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdatae3yrt7gv","registry_namespace_id":"7a2721ff-5ffe-48f2-b1f6-0c3a0973a967","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-28T09:22:41.881988Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.648622Z","description":"","environment_variables":{},"error_message":null,"id":"a83b7871-6f6f-4a89-a6c6-9704bfcef310","name":"test-cr-data","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdata5mkmvktf","registry_namespace_id":"29434bb6-05be-4f4a-bea6-da2548f1dd42","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:19.044658Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "551"
+                - "570"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:45 GMT
+                - Wed, 27 Aug 2025 15:05:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -636,10 +636,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d143709d-881e-4614-9248-d8d54934fb54
+                - a85157c9-71d0-4087-9259-0d926566062d
         status: 200 OK
         code: 200
-        duration: 37.555584ms
+        duration: 53.294639ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -655,7 +655,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces?name=test-cr-data&order_by=created_at_asc
         method: GET
       response:
@@ -664,20 +664,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 585
+        content_length: 603
         uncompressed: false
-        body: '{"namespaces":[{"created_at":"2025-04-28T09:22:39.302376Z","description":"","environment_variables":{},"error_message":null,"id":"9521908a-b95d-413b-9159-661736d82a0e","name":"test-cr-data","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdatae3yrt7gv","registry_namespace_id":"7a2721ff-5ffe-48f2-b1f6-0c3a0973a967","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-28T09:22:41.881988Z"}],"total_count":1}'
+        body: '{"namespaces":[{"created_at":"2025-08-27T15:05:13.648622Z","description":"","environment_variables":{},"error_message":null,"id":"a83b7871-6f6f-4a89-a6c6-9704bfcef310","name":"test-cr-data","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdata5mkmvktf","registry_namespace_id":"29434bb6-05be-4f4a-bea6-da2548f1dd42","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:19.044658Z","vpc_integration_activated":true}],"total_count":1}'
         headers:
             Content-Length:
-                - "585"
+                - "603"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:45 GMT
+                - Wed, 27 Aug 2025 15:05:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -685,10 +685,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a89b0707-dda1-4c02-b9d6-e5d15710c73a
+                - f739bbf7-f393-4f8a-b094-0a222f6f5fb1
         status: 200 OK
         code: 200
-        duration: 37.598ms
+        duration: 53.481079ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -704,8 +704,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/9521908a-b95d-413b-9159-661736d82a0e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a83b7871-6f6f-4a89-a6c6-9704bfcef310
         method: GET
       response:
         proto: HTTP/2.0
@@ -713,20 +713,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 551
+        content_length: 570
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:22:39.302376Z","description":"","environment_variables":{},"error_message":null,"id":"9521908a-b95d-413b-9159-661736d82a0e","name":"test-cr-data","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdatae3yrt7gv","registry_namespace_id":"7a2721ff-5ffe-48f2-b1f6-0c3a0973a967","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-28T09:22:41.881988Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.648622Z","description":"","environment_variables":{},"error_message":null,"id":"a83b7871-6f6f-4a89-a6c6-9704bfcef310","name":"test-cr-data","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdata5mkmvktf","registry_namespace_id":"29434bb6-05be-4f4a-bea6-da2548f1dd42","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:19.044658Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "551"
+                - "570"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:45 GMT
+                - Wed, 27 Aug 2025 15:05:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -734,10 +734,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 937f6bf8-1810-4bda-8061-064494e5dbbd
+                - 37abb2f2-cc4b-4cce-9b05-fee973445115
         status: 200 OK
         code: 200
-        duration: 83.181792ms
+        duration: 46.269007ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -753,8 +753,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/9521908a-b95d-413b-9159-661736d82a0e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a83b7871-6f6f-4a89-a6c6-9704bfcef310
         method: GET
       response:
         proto: HTTP/2.0
@@ -762,20 +762,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 551
+        content_length: 570
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:22:39.302376Z","description":"","environment_variables":{},"error_message":null,"id":"9521908a-b95d-413b-9159-661736d82a0e","name":"test-cr-data","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdatae3yrt7gv","registry_namespace_id":"7a2721ff-5ffe-48f2-b1f6-0c3a0973a967","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-28T09:22:41.881988Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.648622Z","description":"","environment_variables":{},"error_message":null,"id":"a83b7871-6f6f-4a89-a6c6-9704bfcef310","name":"test-cr-data","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdata5mkmvktf","registry_namespace_id":"29434bb6-05be-4f4a-bea6-da2548f1dd42","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:19.044658Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "551"
+                - "570"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:45 GMT
+                - Wed, 27 Aug 2025 15:05:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -783,10 +783,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7d43abe1-22f0-4dd0-848d-cc6be01f8fbc
+                - 59cbae54-f07c-48d7-bae9-fcb0d7c5c279
         status: 200 OK
         code: 200
-        duration: 40.613958ms
+        duration: 47.468937ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -802,7 +802,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces?name=test-cr-data&order_by=created_at_asc
         method: GET
       response:
@@ -811,20 +811,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 585
+        content_length: 603
         uncompressed: false
-        body: '{"namespaces":[{"created_at":"2025-04-28T09:22:39.302376Z","description":"","environment_variables":{},"error_message":null,"id":"9521908a-b95d-413b-9159-661736d82a0e","name":"test-cr-data","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdatae3yrt7gv","registry_namespace_id":"7a2721ff-5ffe-48f2-b1f6-0c3a0973a967","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-28T09:22:41.881988Z"}],"total_count":1}'
+        body: '{"namespaces":[{"created_at":"2025-08-27T15:05:13.648622Z","description":"","environment_variables":{},"error_message":null,"id":"a83b7871-6f6f-4a89-a6c6-9704bfcef310","name":"test-cr-data","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdata5mkmvktf","registry_namespace_id":"29434bb6-05be-4f4a-bea6-da2548f1dd42","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:19.044658Z","vpc_integration_activated":true}],"total_count":1}'
         headers:
             Content-Length:
-                - "585"
+                - "603"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:45 GMT
+                - Wed, 27 Aug 2025 15:05:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -832,10 +832,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e87cf683-32bd-4677-91dd-08d646cbbccd
+                - 8d0565a2-dd1b-49be-b9a5-e69f8ea8fd41
         status: 200 OK
         code: 200
-        duration: 48.606542ms
+        duration: 54.148671ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -851,8 +851,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/9521908a-b95d-413b-9159-661736d82a0e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a83b7871-6f6f-4a89-a6c6-9704bfcef310
         method: GET
       response:
         proto: HTTP/2.0
@@ -860,20 +860,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 551
+        content_length: 570
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:22:39.302376Z","description":"","environment_variables":{},"error_message":null,"id":"9521908a-b95d-413b-9159-661736d82a0e","name":"test-cr-data","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdatae3yrt7gv","registry_namespace_id":"7a2721ff-5ffe-48f2-b1f6-0c3a0973a967","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-28T09:22:41.881988Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.648622Z","description":"","environment_variables":{},"error_message":null,"id":"a83b7871-6f6f-4a89-a6c6-9704bfcef310","name":"test-cr-data","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdata5mkmvktf","registry_namespace_id":"29434bb6-05be-4f4a-bea6-da2548f1dd42","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:19.044658Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "551"
+                - "570"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:45 GMT
+                - Wed, 27 Aug 2025 15:05:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -881,10 +881,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 24fc8944-7584-48ce-b5e6-fbd538ec91c4
+                - c781158a-9e61-4aab-bc3b-b6296d2befb6
         status: 200 OK
         code: 200
-        duration: 97.327084ms
+        duration: 41.483216ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -900,8 +900,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/9521908a-b95d-413b-9159-661736d82a0e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a83b7871-6f6f-4a89-a6c6-9704bfcef310
         method: GET
       response:
         proto: HTTP/2.0
@@ -909,20 +909,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 551
+        content_length: 570
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:22:39.302376Z","description":"","environment_variables":{},"error_message":null,"id":"9521908a-b95d-413b-9159-661736d82a0e","name":"test-cr-data","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdatae3yrt7gv","registry_namespace_id":"7a2721ff-5ffe-48f2-b1f6-0c3a0973a967","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-28T09:22:41.881988Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.648622Z","description":"","environment_variables":{},"error_message":null,"id":"a83b7871-6f6f-4a89-a6c6-9704bfcef310","name":"test-cr-data","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdata5mkmvktf","registry_namespace_id":"29434bb6-05be-4f4a-bea6-da2548f1dd42","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:19.044658Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "551"
+                - "570"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:45 GMT
+                - Wed, 27 Aug 2025 15:05:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -930,10 +930,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b1ee4c11-bb17-4c60-8b44-18d3ae467b7b
+                - df2d1477-b2f7-4ff0-94d2-3960917d0aad
         status: 200 OK
         code: 200
-        duration: 81.595792ms
+        duration: 35.187614ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -949,8 +949,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/9521908a-b95d-413b-9159-661736d82a0e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a83b7871-6f6f-4a89-a6c6-9704bfcef310
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -958,20 +958,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 557
+        content_length: 576
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:22:39.302376Z","description":"","environment_variables":{},"error_message":null,"id":"9521908a-b95d-413b-9159-661736d82a0e","name":"test-cr-data","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdatae3yrt7gv","registry_namespace_id":"7a2721ff-5ffe-48f2-b1f6-0c3a0973a967","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-04-28T09:22:45.610589696Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.648622Z","description":"","environment_variables":{},"error_message":null,"id":"a83b7871-6f6f-4a89-a6c6-9704bfcef310","name":"test-cr-data","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdata5mkmvktf","registry_namespace_id":"29434bb6-05be-4f4a-bea6-da2548f1dd42","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:21.025338873Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "557"
+                - "576"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:45 GMT
+                - Wed, 27 Aug 2025 15:05:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -979,10 +979,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 510b2ed7-1062-461d-9846-a19c97c4447f
+                - 4dbadd4a-24fe-493c-ac7f-ecbcedc5e0c4
         status: 200 OK
         code: 200
-        duration: 191.018583ms
+        duration: 208.50745ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -998,8 +998,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/9521908a-b95d-413b-9159-661736d82a0e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a83b7871-6f6f-4a89-a6c6-9704bfcef310
         method: GET
       response:
         proto: HTTP/2.0
@@ -1007,20 +1007,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 554
+        content_length: 573
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:22:39.302376Z","description":"","environment_variables":{},"error_message":null,"id":"9521908a-b95d-413b-9159-661736d82a0e","name":"test-cr-data","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdatae3yrt7gv","registry_namespace_id":"7a2721ff-5ffe-48f2-b1f6-0c3a0973a967","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-04-28T09:22:45.610590Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.648622Z","description":"","environment_variables":{},"error_message":null,"id":"a83b7871-6f6f-4a89-a6c6-9704bfcef310","name":"test-cr-data","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdata5mkmvktf","registry_namespace_id":"29434bb6-05be-4f4a-bea6-da2548f1dd42","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:21.025339Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "554"
+                - "573"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:45 GMT
+                - Wed, 27 Aug 2025 15:05:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1028,10 +1028,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b9b26873-240b-4c29-9196-9f76a5ee10d8
+                - 0eae7bb5-c7aa-43ac-83c7-8a597a7adbb1
         status: 200 OK
         code: 200
-        duration: 38.900792ms
+        duration: 45.285992ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1047,8 +1047,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/9521908a-b95d-413b-9159-661736d82a0e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a83b7871-6f6f-4a89-a6c6-9704bfcef310
         method: GET
       response:
         proto: HTTP/2.0
@@ -1067,9 +1067,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:50 GMT
+                - Wed, 27 Aug 2025 15:05:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1077,10 +1077,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 997197ab-8990-4831-9ad1-4461738ae6d3
+                - 6bcaea10-967d-4560-a9a0-7c90c8640766
         status: 404 Not Found
         code: 404
-        duration: 21.568417ms
+        duration: 20.05524ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1096,8 +1096,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/9521908a-b95d-413b-9159-661736d82a0e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a83b7871-6f6f-4a89-a6c6-9704bfcef310
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1116,9 +1116,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:50 GMT
+                - Wed, 27 Aug 2025 15:05:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1126,10 +1126,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4dc6b8f4-91c7-444c-a027-c4b9eaa3bb3e
+                - 43bfef40-1228-4154-98b2-2833b079ff25
         status: 404 Not Found
         code: 404
-        duration: 65.899292ms
+        duration: 26.101746ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1145,8 +1145,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/9521908a-b95d-413b-9159-661736d82a0e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a83b7871-6f6f-4a89-a6c6-9704bfcef310
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1165,9 +1165,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:50 GMT
+                - Wed, 27 Aug 2025 15:05:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1175,10 +1175,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 93594db6-bc29-4e60-bed4-a77f810091b7
+                - 1824c7ba-d579-4e75-b6a0-340549257c37
         status: 404 Not Found
         code: 404
-        duration: 25.278291ms
+        duration: 22.912943ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1194,8 +1194,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/9521908a-b95d-413b-9159-661736d82a0e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a83b7871-6f6f-4a89-a6c6-9704bfcef310
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1214,9 +1214,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:50 GMT
+                - Wed, 27 Aug 2025 15:05:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1224,7 +1224,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6e820359-efff-4c2c-b5d8-19029e9eb2b3
+                - 8fe934af-e907-49c7-8e66-e62e031d49dd
         status: 404 Not Found
         code: 404
-        duration: 32.661583ms
+        duration: 28.212266ms

--- a/internal/services/function/testdata/function-basic.cassette.yaml
+++ b/internal/services/function/testdata/function-basic.cassette.yaml
@@ -6,13 +6,13 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 160
+        content_length: 194
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-func-vibrant-dijkstra","environment_variables":{},"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","secret_environment_variables":[],"tags":null}'
+        body: '{"name":"tf-func-pensive-hofstadter","environment_variables":{},"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","secret_environment_variables":[],"tags":null,"activate_vpc_integration":true}'
         form: {}
         headers:
             Content-Type:
@@ -27,20 +27,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 490
+        content_length: 511
         uncompressed: false
-        body: '{"created_at":"2025-05-27T18:18:38.563437566Z","description":"","environment_variables":{},"error_message":null,"id":"7022bdf8-596f-4a9f-9248-bf63dc19ce0f","name":"tf-func-vibrant-dijkstra","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-05-27T18:18:38.563437566Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.606946532Z","description":"","environment_variables":{},"error_message":null,"id":"fc2566b4-a2ad-468b-bef6-88d6d3fbaea2","name":"tf-func-pensive-hofstadter","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:13.606946532Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "490"
+                - "511"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 27 May 2025 18:18:38 GMT
+                - Wed, 27 Aug 2025 15:05:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6dd2fa6a-5e03-4158-ace2-9b4042090043
+                - 4891c834-3967-4ea2-b7bf-623f5e0d6b2d
         status: 200 OK
         code: 200
-        duration: 498.885318ms
+        duration: 5.467165614s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -68,7 +68,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7022bdf8-596f-4a9f-9248-bf63dc19ce0f
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/fc2566b4-a2ad-468b-bef6-88d6d3fbaea2
         method: GET
       response:
         proto: HTTP/2.0
@@ -76,20 +76,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 484
+        content_length: 505
         uncompressed: false
-        body: '{"created_at":"2025-05-27T18:18:38.563438Z","description":"","environment_variables":{},"error_message":null,"id":"7022bdf8-596f-4a9f-9248-bf63dc19ce0f","name":"tf-func-vibrant-dijkstra","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-05-27T18:18:38.563438Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.606947Z","description":"","environment_variables":{},"error_message":null,"id":"fc2566b4-a2ad-468b-bef6-88d6d3fbaea2","name":"tf-func-pensive-hofstadter","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:13.606947Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "484"
+                - "505"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 27 May 2025 18:18:38 GMT
+                - Wed, 27 Aug 2025 15:05:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b8c6d043-c176-4317-a60e-eceb753a2202
+                - f223eca3-387a-4f93-9a43-adc077d415ce
         status: 200 OK
         code: 200
-        duration: 51.660956ms
+        duration: 42.593278ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -117,7 +117,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7022bdf8-596f-4a9f-9248-bf63dc19ce0f
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/fc2566b4-a2ad-468b-bef6-88d6d3fbaea2
         method: GET
       response:
         proto: HTTP/2.0
@@ -125,20 +125,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 573
+        content_length: 594
         uncompressed: false
-        body: '{"created_at":"2025-05-27T18:18:38.563438Z","description":"","environment_variables":{},"error_message":null,"id":"7022bdf8-596f-4a9f-9248-bf63dc19ce0f","name":"tf-func-vibrant-dijkstra","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncvibrantdijkstrgofatooh","registry_namespace_id":"bc07a5db-ad1f-4cf1-b57d-afb65d30fdc7","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-05-27T18:18:41.005092Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.606947Z","description":"","environment_variables":{},"error_message":null,"id":"fc2566b4-a2ad-468b-bef6-88d6d3fbaea2","name":"tf-func-pensive-hofstadter","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncpensivehofstadccfx5m9t","registry_namespace_id":"8fcf36f8-a4ff-4a69-a22f-2825c092a535","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:18.187722Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "573"
+                - "594"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 27 May 2025 18:18:43 GMT
+                - Wed, 27 Aug 2025 15:05:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -146,10 +146,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4aa848e6-43ec-46b3-bfeb-0c71d3065e82
+                - 2ed1f604-9cae-4f5a-9d77-4c6908f4e00f
         status: 200 OK
         code: 200
-        duration: 57.112806ms
+        duration: 514.493418ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -166,7 +166,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7022bdf8-596f-4a9f-9248-bf63dc19ce0f
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/fc2566b4-a2ad-468b-bef6-88d6d3fbaea2
         method: GET
       response:
         proto: HTTP/2.0
@@ -174,20 +174,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 573
+        content_length: 594
         uncompressed: false
-        body: '{"created_at":"2025-05-27T18:18:38.563438Z","description":"","environment_variables":{},"error_message":null,"id":"7022bdf8-596f-4a9f-9248-bf63dc19ce0f","name":"tf-func-vibrant-dijkstra","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncvibrantdijkstrgofatooh","registry_namespace_id":"bc07a5db-ad1f-4cf1-b57d-afb65d30fdc7","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-05-27T18:18:41.005092Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.606947Z","description":"","environment_variables":{},"error_message":null,"id":"fc2566b4-a2ad-468b-bef6-88d6d3fbaea2","name":"tf-func-pensive-hofstadter","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncpensivehofstadccfx5m9t","registry_namespace_id":"8fcf36f8-a4ff-4a69-a22f-2825c092a535","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:18.187722Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "573"
+                - "594"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 27 May 2025 18:18:43 GMT
+                - Wed, 27 Aug 2025 15:05:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -195,10 +195,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 01a4e461-ca88-4287-bffe-60b7025c7899
+                - 7f058d4d-de09-4200-ab22-67b4f8a34f08
         status: 200 OK
         code: 200
-        duration: 43.712452ms
+        duration: 49.441769ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -210,7 +210,7 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"foobar","namespace_id":"7022bdf8-596f-4a9f-9248-bf63dc19ce0f","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"node22","memory_limit":256,"handler":"handler.handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox","tags":["tag1","tag2"]}'
+        body: '{"name":"foobar","namespace_id":"fc2566b4-a2ad-468b-bef6-88d6d3fbaea2","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"node22","memory_limit":256,"handler":"handler.handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox","tags":["tag1","tag2"]}'
         form: {}
         headers:
             Content-Type:
@@ -227,7 +227,7 @@ interactions:
         trailer: {}
         content_length: 719
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-05-27T18:18:44.010304019Z","description":"","domain_name":"tffuncvibrantdijkstrgofatooh-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"0cfe1223-c337-4271-96a9-5386f206e0ba","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"7022bdf8-596f-4a9f-9248-bf63dc19ce0f","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":["tag1","tag2"],"timeout":"300s","updated_at":"2025-05-27T18:18:44.010304019Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:19.848447455Z","description":"","domain_name":"tffuncpensivehofstadccfx5m9t-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"e3266862-2844-471a-a0d0-39e9739833f4","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"fc2566b4-a2ad-468b-bef6-88d6d3fbaea2","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":["tag1","tag2"],"timeout":"300s","updated_at":"2025-08-27T15:05:19.848447455Z"}'
         headers:
             Content-Length:
                 - "719"
@@ -236,9 +236,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 27 May 2025 18:18:44 GMT
+                - Wed, 27 Aug 2025 15:05:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -246,10 +246,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 38e27e74-5948-4e0a-a9dd-e5fc877232da
+                - 55338e7e-279f-4bc9-8ba6-fe3be33621e3
         status: 200 OK
         code: 200
-        duration: 289.860437ms
+        duration: 645.616119ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -266,7 +266,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0cfe1223-c337-4271-96a9-5386f206e0ba
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e3266862-2844-471a-a0d0-39e9739833f4
         method: GET
       response:
         proto: HTTP/2.0
@@ -276,7 +276,7 @@ interactions:
         trailer: {}
         content_length: 713
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-05-27T18:18:44.010304Z","description":"","domain_name":"tffuncvibrantdijkstrgofatooh-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"0cfe1223-c337-4271-96a9-5386f206e0ba","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"7022bdf8-596f-4a9f-9248-bf63dc19ce0f","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":["tag1","tag2"],"timeout":"300s","updated_at":"2025-05-27T18:18:44.010304Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:19.848447Z","description":"","domain_name":"tffuncpensivehofstadccfx5m9t-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"e3266862-2844-471a-a0d0-39e9739833f4","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"fc2566b4-a2ad-468b-bef6-88d6d3fbaea2","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":["tag1","tag2"],"timeout":"300s","updated_at":"2025-08-27T15:05:19.848447Z"}'
         headers:
             Content-Length:
                 - "713"
@@ -285,9 +285,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 27 May 2025 18:18:44 GMT
+                - Wed, 27 Aug 2025 15:05:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -295,10 +295,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 21f36981-04a4-4c66-aa0b-3c833a3a4d6e
+                - a3ec3270-201d-4bff-bb98-3567f1ffa61d
         status: 200 OK
         code: 200
-        duration: 56.372939ms
+        duration: 44.475491ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -315,7 +315,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0cfe1223-c337-4271-96a9-5386f206e0ba
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e3266862-2844-471a-a0d0-39e9739833f4
         method: GET
       response:
         proto: HTTP/2.0
@@ -325,7 +325,7 @@ interactions:
         trailer: {}
         content_length: 713
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-05-27T18:18:44.010304Z","description":"","domain_name":"tffuncvibrantdijkstrgofatooh-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"0cfe1223-c337-4271-96a9-5386f206e0ba","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"7022bdf8-596f-4a9f-9248-bf63dc19ce0f","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":["tag1","tag2"],"timeout":"300s","updated_at":"2025-05-27T18:18:44.010304Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:19.848447Z","description":"","domain_name":"tffuncpensivehofstadccfx5m9t-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"e3266862-2844-471a-a0d0-39e9739833f4","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"fc2566b4-a2ad-468b-bef6-88d6d3fbaea2","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":["tag1","tag2"],"timeout":"300s","updated_at":"2025-08-27T15:05:19.848447Z"}'
         headers:
             Content-Length:
                 - "713"
@@ -334,9 +334,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 27 May 2025 18:18:44 GMT
+                - Wed, 27 Aug 2025 15:05:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -344,10 +344,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4d090b03-219a-4995-8062-2b26735abe81
+                - b7c5dfc5-fa37-4a9f-829a-62a78431ef31
         status: 200 OK
         code: 200
-        duration: 62.313574ms
+        duration: 48.778154ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -364,7 +364,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0cfe1223-c337-4271-96a9-5386f206e0ba
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e3266862-2844-471a-a0d0-39e9739833f4
         method: GET
       response:
         proto: HTTP/2.0
@@ -374,7 +374,7 @@ interactions:
         trailer: {}
         content_length: 713
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-05-27T18:18:44.010304Z","description":"","domain_name":"tffuncvibrantdijkstrgofatooh-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"0cfe1223-c337-4271-96a9-5386f206e0ba","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"7022bdf8-596f-4a9f-9248-bf63dc19ce0f","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":["tag1","tag2"],"timeout":"300s","updated_at":"2025-05-27T18:18:44.010304Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:19.848447Z","description":"","domain_name":"tffuncpensivehofstadccfx5m9t-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"e3266862-2844-471a-a0d0-39e9739833f4","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"fc2566b4-a2ad-468b-bef6-88d6d3fbaea2","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":["tag1","tag2"],"timeout":"300s","updated_at":"2025-08-27T15:05:19.848447Z"}'
         headers:
             Content-Length:
                 - "713"
@@ -383,9 +383,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 27 May 2025 18:18:44 GMT
+                - Wed, 27 Aug 2025 15:05:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -393,10 +393,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 438f3753-3d7f-4248-8470-f52ad28c3d70
+                - 2e6d1e4c-c6bd-4605-ac81-8ebbca4e0bc7
         status: 200 OK
         code: 200
-        duration: 65.138938ms
+        duration: 52.564809ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -413,7 +413,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7022bdf8-596f-4a9f-9248-bf63dc19ce0f
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/fc2566b4-a2ad-468b-bef6-88d6d3fbaea2
         method: GET
       response:
         proto: HTTP/2.0
@@ -421,20 +421,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 573
+        content_length: 594
         uncompressed: false
-        body: '{"created_at":"2025-05-27T18:18:38.563438Z","description":"","environment_variables":{},"error_message":null,"id":"7022bdf8-596f-4a9f-9248-bf63dc19ce0f","name":"tf-func-vibrant-dijkstra","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncvibrantdijkstrgofatooh","registry_namespace_id":"bc07a5db-ad1f-4cf1-b57d-afb65d30fdc7","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-05-27T18:18:41.005092Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.606947Z","description":"","environment_variables":{},"error_message":null,"id":"fc2566b4-a2ad-468b-bef6-88d6d3fbaea2","name":"tf-func-pensive-hofstadter","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncpensivehofstadccfx5m9t","registry_namespace_id":"8fcf36f8-a4ff-4a69-a22f-2825c092a535","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:18.187722Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "573"
+                - "594"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 27 May 2025 18:18:45 GMT
+                - Wed, 27 Aug 2025 15:05:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -442,10 +442,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7745372c-c3a5-48b6-97a8-3afaf13912b8
+                - ddbcd6d1-24a4-4c2e-8f35-4a7a4211b141
         status: 200 OK
         code: 200
-        duration: 50.039255ms
+        duration: 46.245722ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -462,7 +462,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0cfe1223-c337-4271-96a9-5386f206e0ba
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e3266862-2844-471a-a0d0-39e9739833f4
         method: GET
       response:
         proto: HTTP/2.0
@@ -472,7 +472,7 @@ interactions:
         trailer: {}
         content_length: 713
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-05-27T18:18:44.010304Z","description":"","domain_name":"tffuncvibrantdijkstrgofatooh-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"0cfe1223-c337-4271-96a9-5386f206e0ba","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"7022bdf8-596f-4a9f-9248-bf63dc19ce0f","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":["tag1","tag2"],"timeout":"300s","updated_at":"2025-05-27T18:18:44.010304Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:19.848447Z","description":"","domain_name":"tffuncpensivehofstadccfx5m9t-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"e3266862-2844-471a-a0d0-39e9739833f4","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"fc2566b4-a2ad-468b-bef6-88d6d3fbaea2","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":["tag1","tag2"],"timeout":"300s","updated_at":"2025-08-27T15:05:19.848447Z"}'
         headers:
             Content-Length:
                 - "713"
@@ -481,9 +481,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 27 May 2025 18:18:45 GMT
+                - Wed, 27 Aug 2025 15:05:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -491,10 +491,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a948e6ec-fdd3-4ee6-812c-fa36b99c39e7
+                - 76abd487-2c09-45f4-8700-912e0d45f35a
         status: 200 OK
         code: 200
-        duration: 66.91538ms
+        duration: 46.994688ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -511,7 +511,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0cfe1223-c337-4271-96a9-5386f206e0ba
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e3266862-2844-471a-a0d0-39e9739833f4
         method: GET
       response:
         proto: HTTP/2.0
@@ -521,7 +521,7 @@ interactions:
         trailer: {}
         content_length: 713
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-05-27T18:18:44.010304Z","description":"","domain_name":"tffuncvibrantdijkstrgofatooh-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"0cfe1223-c337-4271-96a9-5386f206e0ba","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"7022bdf8-596f-4a9f-9248-bf63dc19ce0f","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":["tag1","tag2"],"timeout":"300s","updated_at":"2025-05-27T18:18:44.010304Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:19.848447Z","description":"","domain_name":"tffuncpensivehofstadccfx5m9t-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"e3266862-2844-471a-a0d0-39e9739833f4","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"fc2566b4-a2ad-468b-bef6-88d6d3fbaea2","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":["tag1","tag2"],"timeout":"300s","updated_at":"2025-08-27T15:05:19.848447Z"}'
         headers:
             Content-Length:
                 - "713"
@@ -530,9 +530,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 27 May 2025 18:18:47 GMT
+                - Wed, 27 Aug 2025 15:05:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -540,10 +540,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cde2e8ed-5724-4add-b541-6432bac777e1
+                - 216196d6-a35c-4198-b2e8-a033f0b5cc19
         status: 200 OK
         code: 200
-        duration: 62.06188ms
+        duration: 53.589492ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -560,7 +560,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0cfe1223-c337-4271-96a9-5386f206e0ba
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e3266862-2844-471a-a0d0-39e9739833f4
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -570,7 +570,7 @@ interactions:
         trailer: {}
         content_length: 717
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-05-27T18:18:44.010304Z","description":"","domain_name":"tffuncvibrantdijkstrgofatooh-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"0cfe1223-c337-4271-96a9-5386f206e0ba","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"7022bdf8-596f-4a9f-9248-bf63dc19ce0f","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"deleting","tags":["tag1","tag2"],"timeout":"300s","updated_at":"2025-05-27T18:18:47.101834685Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:19.848447Z","description":"","domain_name":"tffuncpensivehofstadccfx5m9t-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"e3266862-2844-471a-a0d0-39e9739833f4","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"fc2566b4-a2ad-468b-bef6-88d6d3fbaea2","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"deleting","tags":["tag1","tag2"],"timeout":"300s","updated_at":"2025-08-27T15:05:21.041489465Z"}'
         headers:
             Content-Length:
                 - "717"
@@ -579,9 +579,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 27 May 2025 18:18:47 GMT
+                - Wed, 27 Aug 2025 15:05:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -589,10 +589,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fb52e846-0aa3-4a63-b9a5-8317199896b8
+                - 5e6d8447-d2f8-4b6e-bf66-7220b23ce040
         status: 200 OK
         code: 200
-        duration: 126.531198ms
+        duration: 189.292146ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -609,7 +609,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7022bdf8-596f-4a9f-9248-bf63dc19ce0f
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/fc2566b4-a2ad-468b-bef6-88d6d3fbaea2
         method: GET
       response:
         proto: HTTP/2.0
@@ -617,20 +617,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 573
+        content_length: 594
         uncompressed: false
-        body: '{"created_at":"2025-05-27T18:18:38.563438Z","description":"","environment_variables":{},"error_message":null,"id":"7022bdf8-596f-4a9f-9248-bf63dc19ce0f","name":"tf-func-vibrant-dijkstra","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncvibrantdijkstrgofatooh","registry_namespace_id":"bc07a5db-ad1f-4cf1-b57d-afb65d30fdc7","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-05-27T18:18:41.005092Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.606947Z","description":"","environment_variables":{},"error_message":null,"id":"fc2566b4-a2ad-468b-bef6-88d6d3fbaea2","name":"tf-func-pensive-hofstadter","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncpensivehofstadccfx5m9t","registry_namespace_id":"8fcf36f8-a4ff-4a69-a22f-2825c092a535","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:18.187722Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "573"
+                - "594"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 27 May 2025 18:18:47 GMT
+                - Wed, 27 Aug 2025 15:05:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -638,10 +638,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ad0570c9-cb03-4cf4-abb8-70fd7bac932a
+                - 751ca343-d5fb-4919-9855-c78de7b35d20
         status: 200 OK
         code: 200
-        duration: 42.911382ms
+        duration: 46.057649ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -658,7 +658,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7022bdf8-596f-4a9f-9248-bf63dc19ce0f
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/fc2566b4-a2ad-468b-bef6-88d6d3fbaea2
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -666,20 +666,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 579
+        content_length: 600
         uncompressed: false
-        body: '{"created_at":"2025-05-27T18:18:38.563438Z","description":"","environment_variables":{},"error_message":null,"id":"7022bdf8-596f-4a9f-9248-bf63dc19ce0f","name":"tf-func-vibrant-dijkstra","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncvibrantdijkstrgofatooh","registry_namespace_id":"bc07a5db-ad1f-4cf1-b57d-afb65d30fdc7","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-05-27T18:18:47.261932288Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.606947Z","description":"","environment_variables":{},"error_message":null,"id":"fc2566b4-a2ad-468b-bef6-88d6d3fbaea2","name":"tf-func-pensive-hofstadter","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncpensivehofstadccfx5m9t","registry_namespace_id":"8fcf36f8-a4ff-4a69-a22f-2825c092a535","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:21.239146724Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "579"
+                - "600"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 27 May 2025 18:18:47 GMT
+                - Wed, 27 Aug 2025 15:05:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -687,10 +687,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8c9786ef-002f-4567-8c4d-7106506c2cdc
+                - ba65cca7-1c88-4afb-ab28-608240d13a21
         status: 200 OK
         code: 200
-        duration: 223.47639ms
+        duration: 250.283616ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -707,7 +707,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7022bdf8-596f-4a9f-9248-bf63dc19ce0f
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/fc2566b4-a2ad-468b-bef6-88d6d3fbaea2
         method: GET
       response:
         proto: HTTP/2.0
@@ -715,20 +715,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 576
+        content_length: 597
         uncompressed: false
-        body: '{"created_at":"2025-05-27T18:18:38.563438Z","description":"","environment_variables":{},"error_message":null,"id":"7022bdf8-596f-4a9f-9248-bf63dc19ce0f","name":"tf-func-vibrant-dijkstra","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncvibrantdijkstrgofatooh","registry_namespace_id":"bc07a5db-ad1f-4cf1-b57d-afb65d30fdc7","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-05-27T18:18:47.261932Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.606947Z","description":"","environment_variables":{},"error_message":null,"id":"fc2566b4-a2ad-468b-bef6-88d6d3fbaea2","name":"tf-func-pensive-hofstadter","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncpensivehofstadccfx5m9t","registry_namespace_id":"8fcf36f8-a4ff-4a69-a22f-2825c092a535","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:21.239147Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "576"
+                - "597"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 27 May 2025 18:18:47 GMT
+                - Wed, 27 Aug 2025 15:05:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -736,10 +736,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - be2ae9bf-1ab0-453f-8d2f-5555659beed4
+                - 9734d9c0-37f5-453e-b6f0-96981e1a1621
         status: 200 OK
         code: 200
-        duration: 51.390267ms
+        duration: 65.875565ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -756,7 +756,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7022bdf8-596f-4a9f-9248-bf63dc19ce0f
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/fc2566b4-a2ad-468b-bef6-88d6d3fbaea2
         method: GET
       response:
         proto: HTTP/2.0
@@ -764,20 +764,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 576
+        content_length: 597
         uncompressed: false
-        body: '{"created_at":"2025-05-27T18:18:38.563438Z","description":"","environment_variables":{},"error_message":null,"id":"7022bdf8-596f-4a9f-9248-bf63dc19ce0f","name":"tf-func-vibrant-dijkstra","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncvibrantdijkstrgofatooh","registry_namespace_id":"bc07a5db-ad1f-4cf1-b57d-afb65d30fdc7","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-05-27T18:18:47.261932Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.606947Z","description":"","environment_variables":{},"error_message":null,"id":"fc2566b4-a2ad-468b-bef6-88d6d3fbaea2","name":"tf-func-pensive-hofstadter","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncpensivehofstadccfx5m9t","registry_namespace_id":"8fcf36f8-a4ff-4a69-a22f-2825c092a535","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:21.239147Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "576"
+                - "597"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 27 May 2025 18:18:52 GMT
+                - Wed, 27 Aug 2025 15:05:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -785,10 +785,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - dadd6f5b-a668-49c7-af90-c60c0458a13c
+                - ad84ac70-cc46-4f76-b7bd-31c73624a75b
         status: 200 OK
         code: 200
-        duration: 172.313359ms
+        duration: 50.739105ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -805,7 +805,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7022bdf8-596f-4a9f-9248-bf63dc19ce0f
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/fc2566b4-a2ad-468b-bef6-88d6d3fbaea2
         method: GET
       response:
         proto: HTTP/2.0
@@ -813,20 +813,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 576
+        content_length: 597
         uncompressed: false
-        body: '{"created_at":"2025-05-27T18:18:38.563438Z","description":"","environment_variables":{},"error_message":null,"id":"7022bdf8-596f-4a9f-9248-bf63dc19ce0f","name":"tf-func-vibrant-dijkstra","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncvibrantdijkstrgofatooh","registry_namespace_id":"bc07a5db-ad1f-4cf1-b57d-afb65d30fdc7","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-05-27T18:18:47.261932Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.606947Z","description":"","environment_variables":{},"error_message":null,"id":"fc2566b4-a2ad-468b-bef6-88d6d3fbaea2","name":"tf-func-pensive-hofstadter","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncpensivehofstadccfx5m9t","registry_namespace_id":"8fcf36f8-a4ff-4a69-a22f-2825c092a535","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:21.239147Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "576"
+                - "597"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 27 May 2025 18:18:57 GMT
+                - Wed, 27 Aug 2025 15:05:31 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -834,10 +834,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6bee5b05-00bb-4193-9260-02961e0d13bd
+                - 97e1bce5-5cb5-479e-b6ab-d70aa10df6f5
         status: 200 OK
         code: 200
-        duration: 54.285593ms
+        duration: 44.176622ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -854,7 +854,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7022bdf8-596f-4a9f-9248-bf63dc19ce0f
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/fc2566b4-a2ad-468b-bef6-88d6d3fbaea2
         method: GET
       response:
         proto: HTTP/2.0
@@ -862,20 +862,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 576
+        content_length: 597
         uncompressed: false
-        body: '{"created_at":"2025-05-27T18:18:38.563438Z","description":"","environment_variables":{},"error_message":null,"id":"7022bdf8-596f-4a9f-9248-bf63dc19ce0f","name":"tf-func-vibrant-dijkstra","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncvibrantdijkstrgofatooh","registry_namespace_id":"bc07a5db-ad1f-4cf1-b57d-afb65d30fdc7","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-05-27T18:18:47.261932Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.606947Z","description":"","environment_variables":{},"error_message":null,"id":"fc2566b4-a2ad-468b-bef6-88d6d3fbaea2","name":"tf-func-pensive-hofstadter","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncpensivehofstadccfx5m9t","registry_namespace_id":"8fcf36f8-a4ff-4a69-a22f-2825c092a535","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:21.239147Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "576"
+                - "597"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 27 May 2025 18:19:02 GMT
+                - Wed, 27 Aug 2025 15:05:36 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -883,10 +883,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b5432e04-dee0-4ea6-9b62-edfa478366a6
+                - d15a5cfc-7a96-4a98-9381-7d3a2036855e
         status: 200 OK
         code: 200
-        duration: 90.024845ms
+        duration: 166.54866ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -903,7 +903,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7022bdf8-596f-4a9f-9248-bf63dc19ce0f
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/fc2566b4-a2ad-468b-bef6-88d6d3fbaea2
         method: GET
       response:
         proto: HTTP/2.0
@@ -911,20 +911,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 576
+        content_length: 597
         uncompressed: false
-        body: '{"created_at":"2025-05-27T18:18:38.563438Z","description":"","environment_variables":{},"error_message":null,"id":"7022bdf8-596f-4a9f-9248-bf63dc19ce0f","name":"tf-func-vibrant-dijkstra","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncvibrantdijkstrgofatooh","registry_namespace_id":"bc07a5db-ad1f-4cf1-b57d-afb65d30fdc7","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-05-27T18:18:47.261932Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.606947Z","description":"","environment_variables":{},"error_message":null,"id":"fc2566b4-a2ad-468b-bef6-88d6d3fbaea2","name":"tf-func-pensive-hofstadter","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncpensivehofstadccfx5m9t","registry_namespace_id":"8fcf36f8-a4ff-4a69-a22f-2825c092a535","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:21.239147Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "576"
+                - "597"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 27 May 2025 18:19:07 GMT
+                - Wed, 27 Aug 2025 15:05:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -932,10 +932,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0b0341ba-5998-4d86-8f7f-efd63cc2c4b2
+                - 46159b9a-4990-4ac4-8e02-70844800d356
         status: 200 OK
         code: 200
-        duration: 47.097888ms
+        duration: 42.731441ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -952,7 +952,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7022bdf8-596f-4a9f-9248-bf63dc19ce0f
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/fc2566b4-a2ad-468b-bef6-88d6d3fbaea2
         method: GET
       response:
         proto: HTTP/2.0
@@ -960,20 +960,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 576
+        content_length: 597
         uncompressed: false
-        body: '{"created_at":"2025-05-27T18:18:38.563438Z","description":"","environment_variables":{},"error_message":null,"id":"7022bdf8-596f-4a9f-9248-bf63dc19ce0f","name":"tf-func-vibrant-dijkstra","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncvibrantdijkstrgofatooh","registry_namespace_id":"bc07a5db-ad1f-4cf1-b57d-afb65d30fdc7","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-05-27T18:18:47.261932Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.606947Z","description":"","environment_variables":{},"error_message":null,"id":"fc2566b4-a2ad-468b-bef6-88d6d3fbaea2","name":"tf-func-pensive-hofstadter","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncpensivehofstadccfx5m9t","registry_namespace_id":"8fcf36f8-a4ff-4a69-a22f-2825c092a535","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:21.239147Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "576"
+                - "597"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 27 May 2025 18:19:12 GMT
+                - Wed, 27 Aug 2025 15:05:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -981,10 +981,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e34519dc-ce9a-4e15-8583-8a01835c7df0
+                - b70a1b5a-c1ce-4d70-977c-0c62104c067b
         status: 200 OK
         code: 200
-        duration: 41.415545ms
+        duration: 47.502655ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1001,7 +1001,56 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7022bdf8-596f-4a9f-9248-bf63dc19ce0f
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/fc2566b4-a2ad-468b-bef6-88d6d3fbaea2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 597
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:13.606947Z","description":"","environment_variables":{},"error_message":null,"id":"fc2566b4-a2ad-468b-bef6-88d6d3fbaea2","name":"tf-func-pensive-hofstadter","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncpensivehofstadccfx5m9t","registry_namespace_id":"8fcf36f8-a4ff-4a69-a22f-2825c092a535","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:21.239147Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "597"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:05:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 4411f336-af2d-4214-a769-bdddda203d6e
+        status: 200 OK
+        code: 200
+        duration: 66.492539ms
+    - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/fc2566b4-a2ad-468b-bef6-88d6d3fbaea2
         method: GET
       response:
         proto: HTTP/2.0
@@ -1020,9 +1069,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 27 May 2025 18:19:17 GMT
+                - Wed, 27 Aug 2025 15:05:57 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1030,11 +1079,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ae6e262f-f765-4527-baeb-696c572c2a7d
+                - fc776712-6355-4352-a383-5e78a940730e
         status: 404 Not Found
         code: 404
-        duration: 32.006366ms
-    - id: 21
+        duration: 186.592603ms
+    - id: 22
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1050,7 +1099,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0cfe1223-c337-4271-96a9-5386f206e0ba
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e3266862-2844-471a-a0d0-39e9739833f4
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1069,9 +1118,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 27 May 2025 18:19:17 GMT
+                - Wed, 27 Aug 2025 15:05:57 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1079,7 +1128,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 20159565-2ae5-4b52-8686-de56d54b8f3c
+                - b58103fd-af53-43ac-a485-65f6685807e8
         status: 404 Not Found
         code: 404
-        duration: 23.42112ms
+        duration: 27.948113ms

--- a/internal/services/function/testdata/function-cron-basic.cassette.yaml
+++ b/internal/services/function/testdata/function-cron-basic.cassette.yaml
@@ -6,19 +6,19 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 164
+        content_length: 196
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-tests-function-cron-basic","environment_variables":{},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","secret_environment_variables":[],"tags":null}'
+        body: '{"name":"tf-tests-function-cron-basic","environment_variables":{},"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","secret_environment_variables":[],"tags":null,"activate_vpc_integration":true}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces
         method: POST
       response:
@@ -27,20 +27,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 480
+        content_length: 513
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.603440658Z","description":"","environment_variables":{},"error_message":null,"id":"7304eff4-899d-4a14-8a42-ce165f51cd99","name":"tf-tests-function-cron-basic","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:44:07.603440658Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.801141162Z","description":"","environment_variables":{},"error_message":null,"id":"64ec6f01-f20f-4ab3-8705-16e0234e141c","name":"tf-tests-function-cron-basic","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:13.801141162Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "480"
+                - "513"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:07 GMT
+                - Wed, 27 Aug 2025 15:05:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 464dc4a9-c3e1-4682-903b-6c8de84240b1
+                - 8c6dcfa4-f790-455b-aa1e-8fac7648b258
         status: 200 OK
         code: 200
-        duration: 849.684375ms
+        duration: 5.608723901s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -67,8 +67,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7304eff4-899d-4a14-8a42-ce165f51cd99
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/64ec6f01-f20f-4ab3-8705-16e0234e141c
         method: GET
       response:
         proto: HTTP/2.0
@@ -76,20 +76,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 474
+        content_length: 507
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.603441Z","description":"","environment_variables":{},"error_message":null,"id":"7304eff4-899d-4a14-8a42-ce165f51cd99","name":"tf-tests-function-cron-basic","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:44:07.603441Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.801141Z","description":"","environment_variables":{},"error_message":null,"id":"64ec6f01-f20f-4ab3-8705-16e0234e141c","name":"tf-tests-function-cron-basic","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:13.801141Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "474"
+                - "507"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:07 GMT
+                - Wed, 27 Aug 2025 15:05:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ecafaa19-62cf-4e18-b01a-894ed9c1aaf8
+                - 6b383041-4465-46b0-a70f-73130f25e608
         status: 200 OK
         code: 200
-        duration: 69.624083ms
+        duration: 43.343175ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -116,8 +116,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7304eff4-899d-4a14-8a42-ce165f51cd99
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/64ec6f01-f20f-4ab3-8705-16e0234e141c
         method: GET
       response:
         proto: HTTP/2.0
@@ -125,20 +125,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 563
+        content_length: 598
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.603441Z","description":"","environment_variables":{},"error_message":null,"id":"7304eff4-899d-4a14-8a42-ce165f51cd99","name":"tf-tests-function-cron-basic","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronb1rnx9gkw","registry_namespace_id":"ade24a3a-fbce-4062-a3b2-e742d90716a3","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:44:11.264472Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.801141Z","description":"","environment_variables":{},"error_message":null,"id":"64ec6f01-f20f-4ab3-8705-16e0234e141c","name":"tf-tests-function-cron-basic","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronb6qkxfjuo","registry_namespace_id":"cf657630-a360-497c-b39a-951081fd2523","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:17.034932Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "563"
+                - "598"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:12 GMT
+                - Wed, 27 Aug 2025 15:05:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -146,10 +146,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e9d10506-c390-4b57-ad46-e7209cbd1744
+                - 17f9055c-d049-44eb-8f9e-f1420ac423a5
         status: 200 OK
         code: 200
-        duration: 56.368709ms
+        duration: 441.822107ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -165,8 +165,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7304eff4-899d-4a14-8a42-ce165f51cd99
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/64ec6f01-f20f-4ab3-8705-16e0234e141c
         method: GET
       response:
         proto: HTTP/2.0
@@ -174,20 +174,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 563
+        content_length: 596
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.603441Z","description":"","environment_variables":{},"error_message":null,"id":"7304eff4-899d-4a14-8a42-ce165f51cd99","name":"tf-tests-function-cron-basic","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronb1rnx9gkw","registry_namespace_id":"ade24a3a-fbce-4062-a3b2-e742d90716a3","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:44:11.264472Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.801141Z","description":"","environment_variables":{},"error_message":null,"id":"64ec6f01-f20f-4ab3-8705-16e0234e141c","name":"tf-tests-function-cron-basic","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronb6qkxfjuo","registry_namespace_id":"cf657630-a360-497c-b39a-951081fd2523","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:21.370431Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "563"
+                - "596"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:12 GMT
+                - Wed, 27 Aug 2025 15:05:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -195,62 +195,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fc02825b-1a7b-421f-9113-d27c5b36acec
+                - af284923-6aee-408d-9986-a1c4f1750af9
         status: 200 OK
         code: 200
-        duration: 71.322833ms
+        duration: 45.265844ms
     - id: 4
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 311
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"name":"tf-tests-cron-basic","namespace_id":"7304eff4-899d-4a14-8a42-ce165f51cd99","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"node20","memory_limit":256,"handler":"handler.handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox"}'
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 696
-        uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:13.149581204Z","description":"","domain_name":"tftestsfunctioncronb1rnx9gkw-tf-tests-cron-basic.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"c30df728-66dc-4b9c-a243-88cd3ca231f3","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-cron-basic","namespace_id":"7304eff4-899d-4a14-8a42-ce165f51cd99","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:13.149581204Z"}'
-        headers:
-            Content-Length:
-                - "696"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:44:13 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 280afbac-052f-4745-b354-204b124adec0
-        status: 200 OK
-        code: 200
-        duration: 341.61075ms
-    - id: 5
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -265,8 +214,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/c30df728-66dc-4b9c-a243-88cd3ca231f3
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/64ec6f01-f20f-4ab3-8705-16e0234e141c
         method: GET
       response:
         proto: HTTP/2.0
@@ -274,20 +223,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 690
+        content_length: 596
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:13.149581Z","description":"","domain_name":"tftestsfunctioncronb1rnx9gkw-tf-tests-cron-basic.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"c30df728-66dc-4b9c-a243-88cd3ca231f3","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-cron-basic","namespace_id":"7304eff4-899d-4a14-8a42-ce165f51cd99","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:13.149581Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.801141Z","description":"","environment_variables":{},"error_message":null,"id":"64ec6f01-f20f-4ab3-8705-16e0234e141c","name":"tf-tests-function-cron-basic","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronb6qkxfjuo","registry_namespace_id":"cf657630-a360-497c-b39a-951081fd2523","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:21.370431Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "690"
+                - "596"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:13 GMT
+                - Wed, 27 Aug 2025 15:05:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -295,10 +244,61 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b505caf1-6d5f-4523-9290-e63f83af7548
+                - 2f9cbfa4-dfe3-4f52-b3a6-27ff08b5409c
         status: 200 OK
         code: 200
-        duration: 63.696083ms
+        duration: 42.586768ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 323
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"name":"tf-tests-cron-basic","namespace_id":"64ec6f01-f20f-4ab3-8705-16e0234e141c","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"node20","memory_limit":256,"handler":"handler.handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox","tags":null}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 732
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:25.589081179Z","description":"","domain_name":"tftestsfunctioncronb6qkxfjuo-tf-tests-cron-basic.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"0e97b4fe-bec9-46cd-960e-bc1fd46ed330","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-cron-basic","namespace_id":"64ec6f01-f20f-4ab3-8705-16e0234e141c","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:25.589081179Z"}'
+        headers:
+            Content-Length:
+                - "732"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:05:25 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 7a29bede-2a2f-4961-b6f6-5f3de7f2b10e
+        status: 200 OK
+        code: 200
+        duration: 1.205888969s
     - id: 6
       request:
         proto: HTTP/1.1
@@ -314,8 +314,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/c30df728-66dc-4b9c-a243-88cd3ca231f3
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0e97b4fe-bec9-46cd-960e-bc1fd46ed330
         method: GET
       response:
         proto: HTTP/2.0
@@ -323,20 +323,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 690
+        content_length: 726
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:13.149581Z","description":"","domain_name":"tftestsfunctioncronb1rnx9gkw-tf-tests-cron-basic.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"c30df728-66dc-4b9c-a243-88cd3ca231f3","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-cron-basic","namespace_id":"7304eff4-899d-4a14-8a42-ce165f51cd99","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:13.149581Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:25.589081Z","description":"","domain_name":"tftestsfunctioncronb6qkxfjuo-tf-tests-cron-basic.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"0e97b4fe-bec9-46cd-960e-bc1fd46ed330","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-cron-basic","namespace_id":"64ec6f01-f20f-4ab3-8705-16e0234e141c","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:25.589081Z"}'
         headers:
             Content-Length:
-                - "690"
+                - "726"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:13 GMT
+                - Wed, 27 Aug 2025 15:05:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -344,10 +344,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7f9d4060-7b8d-43d6-99bf-73e01606bc1b
+                - 6a374b8b-422c-4003-90ce-13acf8820b60
         status: 200 OK
         code: 200
-        duration: 75.727791ms
+        duration: 53.72665ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -363,8 +363,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/c30df728-66dc-4b9c-a243-88cd3ca231f3
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0e97b4fe-bec9-46cd-960e-bc1fd46ed330
         method: GET
       response:
         proto: HTTP/2.0
@@ -372,20 +372,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 690
+        content_length: 726
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:13.149581Z","description":"","domain_name":"tftestsfunctioncronb1rnx9gkw-tf-tests-cron-basic.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"c30df728-66dc-4b9c-a243-88cd3ca231f3","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-cron-basic","namespace_id":"7304eff4-899d-4a14-8a42-ce165f51cd99","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:13.149581Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:25.589081Z","description":"","domain_name":"tftestsfunctioncronb6qkxfjuo-tf-tests-cron-basic.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"0e97b4fe-bec9-46cd-960e-bc1fd46ed330","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-cron-basic","namespace_id":"64ec6f01-f20f-4ab3-8705-16e0234e141c","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:25.589081Z"}'
         headers:
             Content-Length:
-                - "690"
+                - "726"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:13 GMT
+                - Wed, 27 Aug 2025 15:05:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -393,62 +393,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ebef5979-afa1-4433-8863-ce3eedad1542
+                - f33f34f4-bc77-4c2d-9ccc-52abb9d7cf84
         status: 200 OK
         code: 200
-        duration: 80.065375ms
+        duration: 46.836241ms
     - id: 8
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 116
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"function_id":"c30df728-66dc-4b9c-a243-88cd3ca231f3","schedule":"0 0 * * *","args":{},"name":"tf-tests-cron-basic"}'
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 179
-        uncompressed: false
-        body: '{"args":{},"function_id":"c30df728-66dc-4b9c-a243-88cd3ca231f3","id":"0f255603-2d6b-4e69-9369-32370e4eb77c","name":"tf-tests-cron-basic","schedule":"0 0 * * *","status":"pending"}'
-        headers:
-            Content-Length:
-                - "179"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:44:13 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 1c86d945-6054-4c9f-82f7-c4b05d9c155f
-        status: 200 OK
-        code: 200
-        duration: 92.12275ms
-    - id: 9
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -463,8 +412,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/0f255603-2d6b-4e69-9369-32370e4eb77c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0e97b4fe-bec9-46cd-960e-bc1fd46ed330
         method: GET
       response:
         proto: HTTP/2.0
@@ -472,20 +421,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 177
+        content_length: 726
         uncompressed: false
-        body: '{"args":{},"function_id":"c30df728-66dc-4b9c-a243-88cd3ca231f3","id":"0f255603-2d6b-4e69-9369-32370e4eb77c","name":"tf-tests-cron-basic","schedule":"0 0 * * *","status":"ready"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:25.589081Z","description":"","domain_name":"tftestsfunctioncronb6qkxfjuo-tf-tests-cron-basic.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"0e97b4fe-bec9-46cd-960e-bc1fd46ed330","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-cron-basic","namespace_id":"64ec6f01-f20f-4ab3-8705-16e0234e141c","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:25.589081Z"}'
         headers:
             Content-Length:
-                - "177"
+                - "726"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:13 GMT
+                - Wed, 27 Aug 2025 15:05:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -493,10 +442,61 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1fe210ff-9fce-4797-9e4e-c5990ebc347a
+                - 2a0e5662-939b-4a71-b793-d2ebea0e47ac
         status: 200 OK
         code: 200
-        duration: 95.277375ms
+        duration: 55.755466ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 116
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"function_id":"0e97b4fe-bec9-46cd-960e-bc1fd46ed330","schedule":"0 0 * * *","args":{},"name":"tf-tests-cron-basic"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 179
+        uncompressed: false
+        body: '{"args":{},"function_id":"0e97b4fe-bec9-46cd-960e-bc1fd46ed330","id":"9a7ef699-9cc1-4d4d-94f9-1321df360e7f","name":"tf-tests-cron-basic","schedule":"0 0 * * *","status":"pending"}'
+        headers:
+            Content-Length:
+                - "179"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:05:25 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 7bf40e5c-80e8-4805-a381-82a7af581ec3
+        status: 200 OK
+        code: 200
+        duration: 104.186611ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -512,8 +512,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/0f255603-2d6b-4e69-9369-32370e4eb77c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/9a7ef699-9cc1-4d4d-94f9-1321df360e7f
         method: GET
       response:
         proto: HTTP/2.0
@@ -521,20 +521,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 177
+        content_length: 179
         uncompressed: false
-        body: '{"args":{},"function_id":"c30df728-66dc-4b9c-a243-88cd3ca231f3","id":"0f255603-2d6b-4e69-9369-32370e4eb77c","name":"tf-tests-cron-basic","schedule":"0 0 * * *","status":"ready"}'
+        body: '{"args":{},"function_id":"0e97b4fe-bec9-46cd-960e-bc1fd46ed330","id":"9a7ef699-9cc1-4d4d-94f9-1321df360e7f","name":"tf-tests-cron-basic","schedule":"0 0 * * *","status":"pending"}'
         headers:
             Content-Length:
-                - "177"
+                - "179"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:13 GMT
+                - Wed, 27 Aug 2025 15:05:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -542,10 +542,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a9996866-70a5-4d34-96bb-3a0472f63cae
+                - 2d5a02c9-2764-4e9e-9607-9a683ac2b156
         status: 200 OK
         code: 200
-        duration: 78.568542ms
+        duration: 50.322363ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -561,8 +561,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/0f255603-2d6b-4e69-9369-32370e4eb77c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/9a7ef699-9cc1-4d4d-94f9-1321df360e7f
         method: GET
       response:
         proto: HTTP/2.0
@@ -572,7 +572,7 @@ interactions:
         trailer: {}
         content_length: 177
         uncompressed: false
-        body: '{"args":{},"function_id":"c30df728-66dc-4b9c-a243-88cd3ca231f3","id":"0f255603-2d6b-4e69-9369-32370e4eb77c","name":"tf-tests-cron-basic","schedule":"0 0 * * *","status":"ready"}'
+        body: '{"args":{},"function_id":"0e97b4fe-bec9-46cd-960e-bc1fd46ed330","id":"9a7ef699-9cc1-4d4d-94f9-1321df360e7f","name":"tf-tests-cron-basic","schedule":"0 0 * * *","status":"ready"}'
         headers:
             Content-Length:
                 - "177"
@@ -581,9 +581,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:13 GMT
+                - Wed, 27 Aug 2025 15:05:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -591,10 +591,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e839c6c7-2a6e-4ab4-bdea-7924136368aa
+                - 2ccf8c92-db2d-422b-95cc-068dcc0be831
         status: 200 OK
         code: 200
-        duration: 79.954ms
+        duration: 52.570071ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -610,8 +610,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7304eff4-899d-4a14-8a42-ce165f51cd99
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/9a7ef699-9cc1-4d4d-94f9-1321df360e7f
         method: GET
       response:
         proto: HTTP/2.0
@@ -619,20 +619,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 563
+        content_length: 177
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.603441Z","description":"","environment_variables":{},"error_message":null,"id":"7304eff4-899d-4a14-8a42-ce165f51cd99","name":"tf-tests-function-cron-basic","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronb1rnx9gkw","registry_namespace_id":"ade24a3a-fbce-4062-a3b2-e742d90716a3","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:44:11.264472Z"}'
+        body: '{"args":{},"function_id":"0e97b4fe-bec9-46cd-960e-bc1fd46ed330","id":"9a7ef699-9cc1-4d4d-94f9-1321df360e7f","name":"tf-tests-cron-basic","schedule":"0 0 * * *","status":"ready"}'
         headers:
             Content-Length:
-                - "563"
+                - "177"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:14 GMT
+                - Wed, 27 Aug 2025 15:05:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -640,10 +640,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5acddc27-119a-4aca-b402-de507dfd36b0
+                - 8f168d67-185f-41d6-90fb-4a3915bfec01
         status: 200 OK
         code: 200
-        duration: 65.546292ms
+        duration: 52.810742ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -659,8 +659,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/c30df728-66dc-4b9c-a243-88cd3ca231f3
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/9a7ef699-9cc1-4d4d-94f9-1321df360e7f
         method: GET
       response:
         proto: HTTP/2.0
@@ -668,20 +668,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 690
+        content_length: 177
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:13.149581Z","description":"","domain_name":"tftestsfunctioncronb1rnx9gkw-tf-tests-cron-basic.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"c30df728-66dc-4b9c-a243-88cd3ca231f3","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-cron-basic","namespace_id":"7304eff4-899d-4a14-8a42-ce165f51cd99","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:13.149581Z"}'
+        body: '{"args":{},"function_id":"0e97b4fe-bec9-46cd-960e-bc1fd46ed330","id":"9a7ef699-9cc1-4d4d-94f9-1321df360e7f","name":"tf-tests-cron-basic","schedule":"0 0 * * *","status":"ready"}'
         headers:
             Content-Length:
-                - "690"
+                - "177"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:14 GMT
+                - Wed, 27 Aug 2025 15:05:31 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -689,10 +689,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c9740557-735d-47ff-b569-04fff68c0ad0
+                - 885ad8a8-5f8a-4c69-ac62-38c1bdda8db1
         status: 200 OK
         code: 200
-        duration: 125.860292ms
+        duration: 60.455006ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -708,8 +708,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/0f255603-2d6b-4e69-9369-32370e4eb77c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/64ec6f01-f20f-4ab3-8705-16e0234e141c
         method: GET
       response:
         proto: HTTP/2.0
@@ -717,20 +717,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 177
+        content_length: 596
         uncompressed: false
-        body: '{"args":{},"function_id":"c30df728-66dc-4b9c-a243-88cd3ca231f3","id":"0f255603-2d6b-4e69-9369-32370e4eb77c","name":"tf-tests-cron-basic","schedule":"0 0 * * *","status":"ready"}'
+        body: '{"created_at":"2025-08-27T15:05:13.801141Z","description":"","environment_variables":{},"error_message":null,"id":"64ec6f01-f20f-4ab3-8705-16e0234e141c","name":"tf-tests-function-cron-basic","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronb6qkxfjuo","registry_namespace_id":"cf657630-a360-497c-b39a-951081fd2523","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:21.370431Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "177"
+                - "596"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:14 GMT
+                - Wed, 27 Aug 2025 15:05:31 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -738,10 +738,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 06d2ce7f-1b06-40c4-a6eb-ffaa5274e538
+                - a6cc06fd-18bb-4b40-b73e-f72393ffcf42
         status: 200 OK
         code: 200
-        duration: 244.21625ms
+        duration: 37.976258ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -757,8 +757,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/0f255603-2d6b-4e69-9369-32370e4eb77c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0e97b4fe-bec9-46cd-960e-bc1fd46ed330
         method: GET
       response:
         proto: HTTP/2.0
@@ -766,20 +766,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 177
+        content_length: 726
         uncompressed: false
-        body: '{"args":{},"function_id":"c30df728-66dc-4b9c-a243-88cd3ca231f3","id":"0f255603-2d6b-4e69-9369-32370e4eb77c","name":"tf-tests-cron-basic","schedule":"0 0 * * *","status":"ready"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:25.589081Z","description":"","domain_name":"tftestsfunctioncronb6qkxfjuo-tf-tests-cron-basic.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"0e97b4fe-bec9-46cd-960e-bc1fd46ed330","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-cron-basic","namespace_id":"64ec6f01-f20f-4ab3-8705-16e0234e141c","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:25.589081Z"}'
         headers:
             Content-Length:
-                - "177"
+                - "726"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:16 GMT
+                - Wed, 27 Aug 2025 15:05:31 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -787,10 +787,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d5eeae06-4a03-4598-8d5b-820777fa15c4
+                - f39047ee-e264-4e8a-a302-1ff1aa5a116b
         status: 200 OK
         code: 200
-        duration: 83.645916ms
+        duration: 51.175334ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -806,29 +806,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/0f255603-2d6b-4e69-9369-32370e4eb77c
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/9a7ef699-9cc1-4d4d-94f9-1321df360e7f
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 180
+        content_length: 177
         uncompressed: false
-        body: '{"args":{},"function_id":"c30df728-66dc-4b9c-a243-88cd3ca231f3","id":"0f255603-2d6b-4e69-9369-32370e4eb77c","name":"tf-tests-cron-basic","schedule":"0 0 * * *","status":"deleting"}'
+        body: '{"args":{},"function_id":"0e97b4fe-bec9-46cd-960e-bc1fd46ed330","id":"9a7ef699-9cc1-4d4d-94f9-1321df360e7f","name":"tf-tests-cron-basic","schedule":"0 0 * * *","status":"ready"}'
         headers:
             Content-Length:
-                - "180"
+                - "177"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:16 GMT
+                - Wed, 27 Aug 2025 15:05:31 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -836,10 +836,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2843d39b-e7bd-4812-9c80-c921e19e2526
+                - 50380f0a-30a8-4b49-af33-1424f4d73847
         status: 200 OK
         code: 200
-        duration: 121.132167ms
+        duration: 60.35576ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -855,8 +855,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/c30df728-66dc-4b9c-a243-88cd3ca231f3
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/9a7ef699-9cc1-4d4d-94f9-1321df360e7f
         method: GET
       response:
         proto: HTTP/2.0
@@ -864,20 +864,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 690
+        content_length: 177
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:13.149581Z","description":"","domain_name":"tftestsfunctioncronb1rnx9gkw-tf-tests-cron-basic.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"c30df728-66dc-4b9c-a243-88cd3ca231f3","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-cron-basic","namespace_id":"7304eff4-899d-4a14-8a42-ce165f51cd99","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:13.149581Z"}'
+        body: '{"args":{},"function_id":"0e97b4fe-bec9-46cd-960e-bc1fd46ed330","id":"9a7ef699-9cc1-4d4d-94f9-1321df360e7f","name":"tf-tests-cron-basic","schedule":"0 0 * * *","status":"ready"}'
         headers:
             Content-Length:
-                - "690"
+                - "177"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:16 GMT
+                - Wed, 27 Aug 2025 15:05:31 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -885,10 +885,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d3ab1f4d-db81-436e-b14b-99d671b08991
+                - 646d3973-643d-4af2-906c-8dd91249a011
         status: 200 OK
         code: 200
-        duration: 77.69525ms
+        duration: 58.572825ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -904,8 +904,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/c30df728-66dc-4b9c-a243-88cd3ca231f3
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/9a7ef699-9cc1-4d4d-94f9-1321df360e7f
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -913,20 +913,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 694
+        content_length: 180
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:13.149581Z","description":"","domain_name":"tftestsfunctioncronb1rnx9gkw-tf-tests-cron-basic.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"c30df728-66dc-4b9c-a243-88cd3ca231f3","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-cron-basic","namespace_id":"7304eff4-899d-4a14-8a42-ce165f51cd99","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"deleting","timeout":"300s","updated_at":"2025-01-24T15:44:16.384856519Z"}'
+        body: '{"args":{},"function_id":"0e97b4fe-bec9-46cd-960e-bc1fd46ed330","id":"9a7ef699-9cc1-4d4d-94f9-1321df360e7f","name":"tf-tests-cron-basic","schedule":"0 0 * * *","status":"deleting"}'
         headers:
             Content-Length:
-                - "694"
+                - "180"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:16 GMT
+                - Wed, 27 Aug 2025 15:05:32 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -934,10 +934,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6878323c-2c4d-47ff-a66d-526682c004e7
+                - 2cd0d044-fec8-4005-b156-05d9f65115e6
         status: 200 OK
         code: 200
-        duration: 135.88125ms
+        duration: 98.490114ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -953,8 +953,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7304eff4-899d-4a14-8a42-ce165f51cd99
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0e97b4fe-bec9-46cd-960e-bc1fd46ed330
         method: GET
       response:
         proto: HTTP/2.0
@@ -962,20 +962,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 563
+        content_length: 726
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.603441Z","description":"","environment_variables":{},"error_message":null,"id":"7304eff4-899d-4a14-8a42-ce165f51cd99","name":"tf-tests-function-cron-basic","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronb1rnx9gkw","registry_namespace_id":"ade24a3a-fbce-4062-a3b2-e742d90716a3","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:44:11.264472Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:25.589081Z","description":"","domain_name":"tftestsfunctioncronb6qkxfjuo-tf-tests-cron-basic.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"0e97b4fe-bec9-46cd-960e-bc1fd46ed330","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-cron-basic","namespace_id":"64ec6f01-f20f-4ab3-8705-16e0234e141c","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:25.589081Z"}'
         headers:
             Content-Length:
-                - "563"
+                - "726"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:16 GMT
+                - Wed, 27 Aug 2025 15:05:32 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -983,10 +983,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1646414a-f1ba-4930-b369-c0f04cfdf167
+                - 6d0c330c-c6a3-4082-a85c-5bb834c1475a
         status: 200 OK
         code: 200
-        duration: 71.43275ms
+        duration: 48.861603ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1002,8 +1002,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7304eff4-899d-4a14-8a42-ce165f51cd99
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0e97b4fe-bec9-46cd-960e-bc1fd46ed330
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1011,20 +1011,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 569
+        content_length: 730
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.603441Z","description":"","environment_variables":{},"error_message":null,"id":"7304eff4-899d-4a14-8a42-ce165f51cd99","name":"tf-tests-function-cron-basic","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronb1rnx9gkw","registry_namespace_id":"ade24a3a-fbce-4062-a3b2-e742d90716a3","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:44:16.599843157Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:25.589081Z","description":"","domain_name":"tftestsfunctioncronb6qkxfjuo-tf-tests-cron-basic.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"0e97b4fe-bec9-46cd-960e-bc1fd46ed330","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-cron-basic","namespace_id":"64ec6f01-f20f-4ab3-8705-16e0234e141c","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:32.253501820Z"}'
         headers:
             Content-Length:
-                - "569"
+                - "730"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:16 GMT
+                - Wed, 27 Aug 2025 15:05:32 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1032,10 +1032,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 91d257d1-6c99-47a9-833c-76e09e89b3eb
+                - 9a42c7b5-f001-46ab-b1b6-accfcf90713e
         status: 200 OK
         code: 200
-        duration: 241.406417ms
+        duration: 147.348671ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1051,8 +1051,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7304eff4-899d-4a14-8a42-ce165f51cd99
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/64ec6f01-f20f-4ab3-8705-16e0234e141c
         method: GET
       response:
         proto: HTTP/2.0
@@ -1060,20 +1060,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 566
+        content_length: 596
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.603441Z","description":"","environment_variables":{},"error_message":null,"id":"7304eff4-899d-4a14-8a42-ce165f51cd99","name":"tf-tests-function-cron-basic","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronb1rnx9gkw","registry_namespace_id":"ade24a3a-fbce-4062-a3b2-e742d90716a3","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:44:16.599843Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.801141Z","description":"","environment_variables":{},"error_message":null,"id":"64ec6f01-f20f-4ab3-8705-16e0234e141c","name":"tf-tests-function-cron-basic","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronb6qkxfjuo","registry_namespace_id":"cf657630-a360-497c-b39a-951081fd2523","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:21.370431Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "566"
+                - "596"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:16 GMT
+                - Wed, 27 Aug 2025 15:05:32 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1081,10 +1081,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d163ce35-6897-4fbb-9488-00376059bc2d
+                - 3698ba37-4c50-4584-83f4-46e4353120b2
         status: 200 OK
         code: 200
-        duration: 60.9515ms
+        duration: 49.259679ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1100,8 +1100,351 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7304eff4-899d-4a14-8a42-ce165f51cd99
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/64ec6f01-f20f-4ab3-8705-16e0234e141c
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 602
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:13.801141Z","description":"","environment_variables":{},"error_message":null,"id":"64ec6f01-f20f-4ab3-8705-16e0234e141c","name":"tf-tests-function-cron-basic","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronb6qkxfjuo","registry_namespace_id":"cf657630-a360-497c-b39a-951081fd2523","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:32.394293349Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "602"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:05:32 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3b45511b-62db-4e48-91cd-4e067fdefd98
+        status: 200 OK
+        code: 200
+        duration: 223.660931ms
+    - id: 23
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/64ec6f01-f20f-4ab3-8705-16e0234e141c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 599
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:13.801141Z","description":"","environment_variables":{},"error_message":null,"id":"64ec6f01-f20f-4ab3-8705-16e0234e141c","name":"tf-tests-function-cron-basic","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronb6qkxfjuo","registry_namespace_id":"cf657630-a360-497c-b39a-951081fd2523","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:32.394293Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "599"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:05:32 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - bd8d927c-63ae-4615-92d4-cfca5b47e418
+        status: 200 OK
+        code: 200
+        duration: 70.585255ms
+    - id: 24
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/64ec6f01-f20f-4ab3-8705-16e0234e141c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 599
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:13.801141Z","description":"","environment_variables":{},"error_message":null,"id":"64ec6f01-f20f-4ab3-8705-16e0234e141c","name":"tf-tests-function-cron-basic","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronb6qkxfjuo","registry_namespace_id":"cf657630-a360-497c-b39a-951081fd2523","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:32.394293Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "599"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:05:37 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 460fabfb-446d-43ba-aba6-f49e0f95b025
+        status: 200 OK
+        code: 200
+        duration: 55.155012ms
+    - id: 25
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/64ec6f01-f20f-4ab3-8705-16e0234e141c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 599
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:13.801141Z","description":"","environment_variables":{},"error_message":null,"id":"64ec6f01-f20f-4ab3-8705-16e0234e141c","name":"tf-tests-function-cron-basic","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronb6qkxfjuo","registry_namespace_id":"cf657630-a360-497c-b39a-951081fd2523","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:32.394293Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "599"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:05:42 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 5bdc2b46-f0ea-4e87-8010-5ef8f6fa06f3
+        status: 200 OK
+        code: 200
+        duration: 49.709605ms
+    - id: 26
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/64ec6f01-f20f-4ab3-8705-16e0234e141c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 599
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:13.801141Z","description":"","environment_variables":{},"error_message":null,"id":"64ec6f01-f20f-4ab3-8705-16e0234e141c","name":"tf-tests-function-cron-basic","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronb6qkxfjuo","registry_namespace_id":"cf657630-a360-497c-b39a-951081fd2523","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:32.394293Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "599"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:05:47 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - cbfc99b0-7325-49b5-8018-7561d042de9a
+        status: 200 OK
+        code: 200
+        duration: 50.698302ms
+    - id: 27
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/64ec6f01-f20f-4ab3-8705-16e0234e141c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 599
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:13.801141Z","description":"","environment_variables":{},"error_message":null,"id":"64ec6f01-f20f-4ab3-8705-16e0234e141c","name":"tf-tests-function-cron-basic","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronb6qkxfjuo","registry_namespace_id":"cf657630-a360-497c-b39a-951081fd2523","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:32.394293Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "599"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:05:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 91f0bb99-ea94-43f8-8f6f-dfc08c01ab43
+        status: 200 OK
+        code: 200
+        duration: 116.00123ms
+    - id: 28
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/64ec6f01-f20f-4ab3-8705-16e0234e141c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 599
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:13.801141Z","description":"","environment_variables":{},"error_message":null,"id":"64ec6f01-f20f-4ab3-8705-16e0234e141c","name":"tf-tests-function-cron-basic","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronb6qkxfjuo","registry_namespace_id":"cf657630-a360-497c-b39a-951081fd2523","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:32.394293Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "599"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:05:57 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - de59aed9-5b73-4b79-a4a2-04276bed225b
+        status: 200 OK
+        code: 200
+        duration: 98.707931ms
+    - id: 29
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/64ec6f01-f20f-4ab3-8705-16e0234e141c
         method: GET
       response:
         proto: HTTP/2.0
@@ -1120,9 +1463,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:21 GMT
+                - Wed, 27 Aug 2025 15:06:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1130,11 +1473,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 79a314e3-bd15-4dca-950f-50c53f40ae4a
+                - 0786b525-5496-414d-962c-3ad614bf9adc
         status: 404 Not Found
         code: 404
-        duration: 33.744458ms
-    - id: 23
+        duration: 27.861121ms
+    - id: 30
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1149,8 +1492,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/0f255603-2d6b-4e69-9369-32370e4eb77c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/9a7ef699-9cc1-4d4d-94f9-1321df360e7f
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1169,9 +1512,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:21 GMT
+                - Wed, 27 Aug 2025 15:06:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1179,7 +1522,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 79c74a8e-9af6-43b3-8cee-3d1af23b915d
+                - 35c8c700-91a9-4f9d-9601-81c152d59c1d
         status: 404 Not Found
         code: 404
-        duration: 45.111ms
+        duration: 23.181038ms

--- a/internal/services/function/testdata/function-cron-name-update.cassette.yaml
+++ b/internal/services/function/testdata/function-cron-name-update.cassette.yaml
@@ -6,19 +6,19 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 170
+        content_length: 202
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-tests-function-cron-name-update","environment_variables":{},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","secret_environment_variables":[],"tags":null}'
+        body: '{"name":"tf-tests-function-cron-name-update","environment_variables":{},"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","secret_environment_variables":[],"tags":null,"activate_vpc_integration":true}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces
         method: POST
       response:
@@ -27,20 +27,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 486
+        content_length: 519
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.414748732Z","description":"","environment_variables":{},"error_message":null,"id":"509d2fdc-0136-4cce-8404-59da8fb7c7d8","name":"tf-tests-function-cron-name-update","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:44:07.414748732Z"}'
+        body: '{"created_at":"2025-08-27T15:05:29.821363271Z","description":"","environment_variables":{},"error_message":null,"id":"58014314-847b-496a-8dbf-0d08e44c4ca3","name":"tf-tests-function-cron-name-update","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:29.821363271Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "486"
+                - "519"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:07 GMT
+                - Wed, 27 Aug 2025 15:05:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 15a8eac2-06ce-4a20-8926-379010c4baa4
+                - 56c2410d-2b3f-49d9-ae1c-ba9fd4436d8e
         status: 200 OK
         code: 200
-        duration: 854.229916ms
+        duration: 2.852917152s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -67,8 +67,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/509d2fdc-0136-4cce-8404-59da8fb7c7d8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/58014314-847b-496a-8dbf-0d08e44c4ca3
         method: GET
       response:
         proto: HTTP/2.0
@@ -76,20 +76,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 480
+        content_length: 513
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.414749Z","description":"","environment_variables":{},"error_message":null,"id":"509d2fdc-0136-4cce-8404-59da8fb7c7d8","name":"tf-tests-function-cron-name-update","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:44:07.414749Z"}'
+        body: '{"created_at":"2025-08-27T15:05:29.821363Z","description":"","environment_variables":{},"error_message":null,"id":"58014314-847b-496a-8dbf-0d08e44c4ca3","name":"tf-tests-function-cron-name-update","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:29.821363Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "480"
+                - "513"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:07 GMT
+                - Wed, 27 Aug 2025 15:05:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 845c3375-34d5-4f2b-944d-8fe8baa02213
+                - f9d5e8a7-4086-40a5-b438-8e1fbc5b30a6
         status: 200 OK
         code: 200
-        duration: 64.200334ms
+        duration: 45.021967ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -116,8 +116,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/509d2fdc-0136-4cce-8404-59da8fb7c7d8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/58014314-847b-496a-8dbf-0d08e44c4ca3
         method: GET
       response:
         proto: HTTP/2.0
@@ -125,20 +125,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 569
+        content_length: 513
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.414749Z","description":"","environment_variables":{},"error_message":null,"id":"509d2fdc-0136-4cce-8404-59da8fb7c7d8","name":"tf-tests-function-cron-name-update","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronnn2li4w6o","registry_namespace_id":"6e2075a9-6b34-441e-841d-c04326a246f5","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:44:11.443788Z"}'
+        body: '{"created_at":"2025-08-27T15:05:29.821363Z","description":"","environment_variables":{},"error_message":null,"id":"58014314-847b-496a-8dbf-0d08e44c4ca3","name":"tf-tests-function-cron-name-update","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:31.922090Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "569"
+                - "513"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:12 GMT
+                - Wed, 27 Aug 2025 15:05:34 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -146,10 +146,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6a2a12e4-8315-453c-81a2-e47c9d57af67
+                - 4a3778d2-6183-49f0-8462-48c3e41935ec
         status: 200 OK
         code: 200
-        duration: 59.779833ms
+        duration: 47.330159ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -165,8 +165,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/509d2fdc-0136-4cce-8404-59da8fb7c7d8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/58014314-847b-496a-8dbf-0d08e44c4ca3
         method: GET
       response:
         proto: HTTP/2.0
@@ -174,20 +174,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 569
+        content_length: 513
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.414749Z","description":"","environment_variables":{},"error_message":null,"id":"509d2fdc-0136-4cce-8404-59da8fb7c7d8","name":"tf-tests-function-cron-name-update","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronnn2li4w6o","registry_namespace_id":"6e2075a9-6b34-441e-841d-c04326a246f5","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:44:11.443788Z"}'
+        body: '{"created_at":"2025-08-27T15:05:29.821363Z","description":"","environment_variables":{},"error_message":null,"id":"58014314-847b-496a-8dbf-0d08e44c4ca3","name":"tf-tests-function-cron-name-update","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:31.922090Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "569"
+                - "513"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:12 GMT
+                - Wed, 27 Aug 2025 15:05:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -195,50 +195,48 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7f496ed6-d05b-4444-a0df-19ff12e823c1
+                - 5a85aed1-28fe-47b9-99a8-76025f224b07
         status: 200 OK
         code: 200
-        duration: 60.368209ms
+        duration: 48.122687ms
     - id: 4
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 326
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-tests-function-cron-name-update","namespace_id":"509d2fdc-0136-4cce-8404-59da8fb7c7d8","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"node20","memory_limit":256,"handler":"handler.handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox"}'
+        body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions
-        method: POST
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/58014314-847b-496a-8dbf-0d08e44c4ca3
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 726
+        content_length: 604
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:13.021078828Z","description":"","domain_name":"tftestsfunctioncronnn2li4w6o-tf-tests-function-cron-name-update.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"547816d7-9352-46d4-863b-7113aeca29a3","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-function-cron-name-update","namespace_id":"509d2fdc-0136-4cce-8404-59da8fb7c7d8","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:13.021078828Z"}'
+        body: '{"created_at":"2025-08-27T15:05:29.821363Z","description":"","environment_variables":{},"error_message":null,"id":"58014314-847b-496a-8dbf-0d08e44c4ca3","name":"tf-tests-function-cron-name-update","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronn8orvlx9c","registry_namespace_id":"781421b7-bf25-4500-a95a-6695e130e698","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:43.747839Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "726"
+                - "604"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:13 GMT
+                - Wed, 27 Aug 2025 15:05:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -246,10 +244,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0c86e07d-e12b-4ba1-a8ee-f4c4369afa46
+                - c6cf0f06-09e5-463e-97c5-a63b5daba9a7
         status: 200 OK
         code: 200
-        duration: 397.749584ms
+        duration: 42.999855ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -265,8 +263,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/547816d7-9352-46d4-863b-7113aeca29a3
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/58014314-847b-496a-8dbf-0d08e44c4ca3
         method: GET
       response:
         proto: HTTP/2.0
@@ -274,20 +272,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 720
+        content_length: 604
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:13.021079Z","description":"","domain_name":"tftestsfunctioncronnn2li4w6o-tf-tests-function-cron-name-update.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"547816d7-9352-46d4-863b-7113aeca29a3","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-function-cron-name-update","namespace_id":"509d2fdc-0136-4cce-8404-59da8fb7c7d8","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:13.021079Z"}'
+        body: '{"created_at":"2025-08-27T15:05:29.821363Z","description":"","environment_variables":{},"error_message":null,"id":"58014314-847b-496a-8dbf-0d08e44c4ca3","name":"tf-tests-function-cron-name-update","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronn8orvlx9c","registry_namespace_id":"781421b7-bf25-4500-a95a-6695e130e698","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:43.747839Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "720"
+                - "604"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:13 GMT
+                - Wed, 27 Aug 2025 15:05:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -295,10 +293,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 13f8099a-ff20-4124-b722-df70a2f4036b
+                - ad62b350-fdf1-4eac-a192-d20c685f5de1
         status: 200 OK
         code: 200
-        duration: 142.244416ms
+        duration: 56.66611ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -314,8 +312,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/547816d7-9352-46d4-863b-7113aeca29a3
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/58014314-847b-496a-8dbf-0d08e44c4ca3
         method: GET
       response:
         proto: HTTP/2.0
@@ -323,20 +321,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 720
+        content_length: 602
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:13.021079Z","description":"","domain_name":"tftestsfunctioncronnn2li4w6o-tf-tests-function-cron-name-update.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"547816d7-9352-46d4-863b-7113aeca29a3","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-function-cron-name-update","namespace_id":"509d2fdc-0136-4cce-8404-59da8fb7c7d8","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:13.021079Z"}'
+        body: '{"created_at":"2025-08-27T15:05:29.821363Z","description":"","environment_variables":{},"error_message":null,"id":"58014314-847b-496a-8dbf-0d08e44c4ca3","name":"tf-tests-function-cron-name-update","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronn8orvlx9c","registry_namespace_id":"781421b7-bf25-4500-a95a-6695e130e698","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:52.126517Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "720"
+                - "602"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:13 GMT
+                - Wed, 27 Aug 2025 15:05:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -344,10 +342,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6189a64d-1dc5-432a-8585-c0b585b8eb8a
+                - aa6dc7eb-b312-424d-95e1-34ce3f4480a0
         status: 200 OK
         code: 200
-        duration: 72.876625ms
+        duration: 45.972195ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -363,8 +361,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/547816d7-9352-46d4-863b-7113aeca29a3
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/58014314-847b-496a-8dbf-0d08e44c4ca3
         method: GET
       response:
         proto: HTTP/2.0
@@ -372,20 +370,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 720
+        content_length: 602
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:13.021079Z","description":"","domain_name":"tftestsfunctioncronnn2li4w6o-tf-tests-function-cron-name-update.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"547816d7-9352-46d4-863b-7113aeca29a3","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-function-cron-name-update","namespace_id":"509d2fdc-0136-4cce-8404-59da8fb7c7d8","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:13.021079Z"}'
+        body: '{"created_at":"2025-08-27T15:05:29.821363Z","description":"","environment_variables":{},"error_message":null,"id":"58014314-847b-496a-8dbf-0d08e44c4ca3","name":"tf-tests-function-cron-name-update","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronn8orvlx9c","registry_namespace_id":"781421b7-bf25-4500-a95a-6695e130e698","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:52.126517Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "720"
+                - "602"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:13 GMT
+                - Wed, 27 Aug 2025 15:05:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -393,29 +391,29 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1ea6ee32-ec87-45de-a892-561d8170ed68
+                - 779f3531-26cc-4012-905d-ac8d9d06cb60
         status: 200 OK
         code: 200
-        duration: 79.175792ms
+        duration: 41.70605ms
     - id: 8
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 131
+        content_length: 338
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"function_id":"547816d7-9352-46d4-863b-7113aeca29a3","schedule":"0 0 * * *","args":{},"name":"tf-tests-function-cron-name-update"}'
+        body: '{"name":"tf-tests-function-cron-name-update","namespace_id":"58014314-847b-496a-8dbf-0d08e44c4ca3","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"node20","memory_limit":256,"handler":"handler.handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox","tags":null}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions
         method: POST
       response:
         proto: HTTP/2.0
@@ -423,20 +421,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 194
+        content_length: 762
         uncompressed: false
-        body: '{"args":{},"function_id":"547816d7-9352-46d4-863b-7113aeca29a3","id":"43d8dcd6-c01c-4fc8-a73b-6d1fa9f586ae","name":"tf-tests-function-cron-name-update","schedule":"0 0 * * *","status":"pending"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:55.734649676Z","description":"","domain_name":"tftestsfunctioncronn8orvlx9c-tf-tests-function-cron-name-update.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"ffbd1151-4c0c-4bc8-93b7-9eec8b9a84d6","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-function-cron-name-update","namespace_id":"58014314-847b-496a-8dbf-0d08e44c4ca3","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:55.734649676Z"}'
         headers:
             Content-Length:
-                - "194"
+                - "762"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:13 GMT
+                - Wed, 27 Aug 2025 15:05:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -444,10 +442,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fd66fd0e-6888-4f81-b87e-7acd26f89dbc
+                - 1a89cc50-8bb5-4ea8-9b1a-da1b025e6add
         status: 200 OK
         code: 200
-        duration: 115.976458ms
+        duration: 583.663095ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -463,8 +461,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/43d8dcd6-c01c-4fc8-a73b-6d1fa9f586ae
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/ffbd1151-4c0c-4bc8-93b7-9eec8b9a84d6
         method: GET
       response:
         proto: HTTP/2.0
@@ -472,20 +470,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 192
+        content_length: 756
         uncompressed: false
-        body: '{"args":{},"function_id":"547816d7-9352-46d4-863b-7113aeca29a3","id":"43d8dcd6-c01c-4fc8-a73b-6d1fa9f586ae","name":"tf-tests-function-cron-name-update","schedule":"0 0 * * *","status":"ready"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:55.734650Z","description":"","domain_name":"tftestsfunctioncronn8orvlx9c-tf-tests-function-cron-name-update.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"ffbd1151-4c0c-4bc8-93b7-9eec8b9a84d6","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-function-cron-name-update","namespace_id":"58014314-847b-496a-8dbf-0d08e44c4ca3","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:55.734650Z"}'
         headers:
             Content-Length:
-                - "192"
+                - "756"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:13 GMT
+                - Wed, 27 Aug 2025 15:05:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -493,10 +491,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e78262ba-ea29-4ddb-b6e5-95c6698029c0
+                - ad891f89-b1fa-4ef3-8b61-b671e23b562e
         status: 200 OK
         code: 200
-        duration: 91.085416ms
+        duration: 47.821274ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -512,8 +510,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/43d8dcd6-c01c-4fc8-a73b-6d1fa9f586ae
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/ffbd1151-4c0c-4bc8-93b7-9eec8b9a84d6
         method: GET
       response:
         proto: HTTP/2.0
@@ -521,20 +519,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 192
+        content_length: 756
         uncompressed: false
-        body: '{"args":{},"function_id":"547816d7-9352-46d4-863b-7113aeca29a3","id":"43d8dcd6-c01c-4fc8-a73b-6d1fa9f586ae","name":"tf-tests-function-cron-name-update","schedule":"0 0 * * *","status":"ready"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:55.734650Z","description":"","domain_name":"tftestsfunctioncronn8orvlx9c-tf-tests-function-cron-name-update.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"ffbd1151-4c0c-4bc8-93b7-9eec8b9a84d6","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-function-cron-name-update","namespace_id":"58014314-847b-496a-8dbf-0d08e44c4ca3","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:55.734650Z"}'
         headers:
             Content-Length:
-                - "192"
+                - "756"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:13 GMT
+                - Wed, 27 Aug 2025 15:05:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -542,10 +540,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5c0c0ecc-9f50-42b7-a0a9-82bacc131f80
+                - b674f557-79f4-4c09-a787-e11ed1ae95ba
         status: 200 OK
         code: 200
-        duration: 82.61975ms
+        duration: 94.529099ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -561,8 +559,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/43d8dcd6-c01c-4fc8-a73b-6d1fa9f586ae
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/ffbd1151-4c0c-4bc8-93b7-9eec8b9a84d6
         method: GET
       response:
         proto: HTTP/2.0
@@ -570,20 +568,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 192
+        content_length: 756
         uncompressed: false
-        body: '{"args":{},"function_id":"547816d7-9352-46d4-863b-7113aeca29a3","id":"43d8dcd6-c01c-4fc8-a73b-6d1fa9f586ae","name":"tf-tests-function-cron-name-update","schedule":"0 0 * * *","status":"ready"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:55.734650Z","description":"","domain_name":"tftestsfunctioncronn8orvlx9c-tf-tests-function-cron-name-update.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"ffbd1151-4c0c-4bc8-93b7-9eec8b9a84d6","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-function-cron-name-update","namespace_id":"58014314-847b-496a-8dbf-0d08e44c4ca3","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:55.734650Z"}'
         headers:
             Content-Length:
-                - "192"
+                - "756"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:13 GMT
+                - Wed, 27 Aug 2025 15:05:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -591,48 +589,50 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ca2e049b-4749-4140-be91-793d04b22b1d
+                - 1fb004d9-3afc-46a3-98f6-b9ca4537ed44
         status: 200 OK
         code: 200
-        duration: 78.656708ms
+        duration: 47.229694ms
     - id: 12
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 131
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"function_id":"ffbd1151-4c0c-4bc8-93b7-9eec8b9a84d6","schedule":"0 0 * * *","args":{},"name":"tf-tests-function-cron-name-update"}'
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/509d2fdc-0136-4cce-8404-59da8fb7c7d8
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 569
+        content_length: 194
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.414749Z","description":"","environment_variables":{},"error_message":null,"id":"509d2fdc-0136-4cce-8404-59da8fb7c7d8","name":"tf-tests-function-cron-name-update","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronnn2li4w6o","registry_namespace_id":"6e2075a9-6b34-441e-841d-c04326a246f5","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:44:11.443788Z"}'
+        body: '{"args":{},"function_id":"ffbd1151-4c0c-4bc8-93b7-9eec8b9a84d6","id":"d824667f-f96f-49be-b9b8-fced891a282b","name":"tf-tests-function-cron-name-update","schedule":"0 0 * * *","status":"pending"}'
         headers:
             Content-Length:
-                - "569"
+                - "194"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:14 GMT
+                - Wed, 27 Aug 2025 15:05:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -640,10 +640,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4c6bf652-c3fb-4c66-bfbe-ea24b80dfec3
+                - aad7baf4-0078-45aa-b0cc-bcf956403971
         status: 200 OK
         code: 200
-        duration: 73.388166ms
+        duration: 165.172568ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -659,8 +659,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/547816d7-9352-46d4-863b-7113aeca29a3
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/d824667f-f96f-49be-b9b8-fced891a282b
         method: GET
       response:
         proto: HTTP/2.0
@@ -668,20 +668,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 720
+        content_length: 192
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:13.021079Z","description":"","domain_name":"tftestsfunctioncronnn2li4w6o-tf-tests-function-cron-name-update.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"547816d7-9352-46d4-863b-7113aeca29a3","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-function-cron-name-update","namespace_id":"509d2fdc-0136-4cce-8404-59da8fb7c7d8","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:13.021079Z"}'
+        body: '{"args":{},"function_id":"ffbd1151-4c0c-4bc8-93b7-9eec8b9a84d6","id":"d824667f-f96f-49be-b9b8-fced891a282b","name":"tf-tests-function-cron-name-update","schedule":"0 0 * * *","status":"ready"}'
         headers:
             Content-Length:
-                - "720"
+                - "192"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:14 GMT
+                - Wed, 27 Aug 2025 15:05:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -689,10 +689,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8a2725bf-fef7-41a2-9b36-a40e47f26d05
+                - f2ff026d-86c8-4da9-9906-25dc02b34dfe
         status: 200 OK
         code: 200
-        duration: 140.733042ms
+        duration: 63.006559ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -708,8 +708,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/43d8dcd6-c01c-4fc8-a73b-6d1fa9f586ae
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/d824667f-f96f-49be-b9b8-fced891a282b
         method: GET
       response:
         proto: HTTP/2.0
@@ -719,7 +719,7 @@ interactions:
         trailer: {}
         content_length: 192
         uncompressed: false
-        body: '{"args":{},"function_id":"547816d7-9352-46d4-863b-7113aeca29a3","id":"43d8dcd6-c01c-4fc8-a73b-6d1fa9f586ae","name":"tf-tests-function-cron-name-update","schedule":"0 0 * * *","status":"ready"}'
+        body: '{"args":{},"function_id":"ffbd1151-4c0c-4bc8-93b7-9eec8b9a84d6","id":"d824667f-f96f-49be-b9b8-fced891a282b","name":"tf-tests-function-cron-name-update","schedule":"0 0 * * *","status":"ready"}'
         headers:
             Content-Length:
                 - "192"
@@ -728,9 +728,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:14 GMT
+                - Wed, 27 Aug 2025 15:05:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -738,10 +738,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e0bc7e3d-2834-41c1-ab03-21b54a60e6ed
+                - 3cad68c1-afcb-4870-b7a7-bbecfb9331a4
         status: 200 OK
         code: 200
-        duration: 244.467833ms
+        duration: 57.117459ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -757,8 +757,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/509d2fdc-0136-4cce-8404-59da8fb7c7d8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/d824667f-f96f-49be-b9b8-fced891a282b
         method: GET
       response:
         proto: HTTP/2.0
@@ -766,20 +766,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 569
+        content_length: 192
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.414749Z","description":"","environment_variables":{},"error_message":null,"id":"509d2fdc-0136-4cce-8404-59da8fb7c7d8","name":"tf-tests-function-cron-name-update","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronnn2li4w6o","registry_namespace_id":"6e2075a9-6b34-441e-841d-c04326a246f5","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:44:11.443788Z"}'
+        body: '{"args":{},"function_id":"ffbd1151-4c0c-4bc8-93b7-9eec8b9a84d6","id":"d824667f-f96f-49be-b9b8-fced891a282b","name":"tf-tests-function-cron-name-update","schedule":"0 0 * * *","status":"ready"}'
         headers:
             Content-Length:
-                - "569"
+                - "192"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:15 GMT
+                - Wed, 27 Aug 2025 15:05:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -787,10 +787,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2e1ea8a4-56c7-4e19-9801-41c3aa38c9d5
+                - 9e6aa603-3964-4f52-aea0-88fa33236283
         status: 200 OK
         code: 200
-        duration: 76.592959ms
+        duration: 61.649061ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -806,8 +806,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/547816d7-9352-46d4-863b-7113aeca29a3
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/58014314-847b-496a-8dbf-0d08e44c4ca3
         method: GET
       response:
         proto: HTTP/2.0
@@ -815,20 +815,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 720
+        content_length: 602
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:13.021079Z","description":"","domain_name":"tftestsfunctioncronnn2li4w6o-tf-tests-function-cron-name-update.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"547816d7-9352-46d4-863b-7113aeca29a3","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-function-cron-name-update","namespace_id":"509d2fdc-0136-4cce-8404-59da8fb7c7d8","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:13.021079Z"}'
+        body: '{"created_at":"2025-08-27T15:05:29.821363Z","description":"","environment_variables":{},"error_message":null,"id":"58014314-847b-496a-8dbf-0d08e44c4ca3","name":"tf-tests-function-cron-name-update","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronn8orvlx9c","registry_namespace_id":"781421b7-bf25-4500-a95a-6695e130e698","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:52.126517Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "720"
+                - "602"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:16 GMT
+                - Wed, 27 Aug 2025 15:05:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -836,10 +836,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 071a4e24-1c98-4fa8-b0f9-14b9223c136e
+                - 6f80f7a7-e93a-46d3-8c5d-6720bef661ec
         status: 200 OK
         code: 200
-        duration: 88.592833ms
+        duration: 55.471499ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -855,8 +855,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/43d8dcd6-c01c-4fc8-a73b-6d1fa9f586ae
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/ffbd1151-4c0c-4bc8-93b7-9eec8b9a84d6
         method: GET
       response:
         proto: HTTP/2.0
@@ -864,20 +864,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 192
+        content_length: 756
         uncompressed: false
-        body: '{"args":{},"function_id":"547816d7-9352-46d4-863b-7113aeca29a3","id":"43d8dcd6-c01c-4fc8-a73b-6d1fa9f586ae","name":"tf-tests-function-cron-name-update","schedule":"0 0 * * *","status":"ready"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:55.734650Z","description":"","domain_name":"tftestsfunctioncronn8orvlx9c-tf-tests-function-cron-name-update.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"ffbd1151-4c0c-4bc8-93b7-9eec8b9a84d6","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-function-cron-name-update","namespace_id":"58014314-847b-496a-8dbf-0d08e44c4ca3","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:55.734650Z"}'
         headers:
             Content-Length:
-                - "192"
+                - "756"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:16 GMT
+                - Wed, 27 Aug 2025 15:05:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -885,10 +885,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3cf27aab-ca3b-4db3-9d5b-f69dbe302bd0
+                - 30422b14-4854-4757-8d01-f7916270fe98
         status: 200 OK
         code: 200
-        duration: 85.595875ms
+        duration: 53.447502ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -904,8 +904,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/43d8dcd6-c01c-4fc8-a73b-6d1fa9f586ae
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/d824667f-f96f-49be-b9b8-fced891a282b
         method: GET
       response:
         proto: HTTP/2.0
@@ -915,7 +915,7 @@ interactions:
         trailer: {}
         content_length: 192
         uncompressed: false
-        body: '{"args":{},"function_id":"547816d7-9352-46d4-863b-7113aeca29a3","id":"43d8dcd6-c01c-4fc8-a73b-6d1fa9f586ae","name":"tf-tests-function-cron-name-update","schedule":"0 0 * * *","status":"ready"}'
+        body: '{"args":{},"function_id":"ffbd1151-4c0c-4bc8-93b7-9eec8b9a84d6","id":"d824667f-f96f-49be-b9b8-fced891a282b","name":"tf-tests-function-cron-name-update","schedule":"0 0 * * *","status":"ready"}'
         headers:
             Content-Length:
                 - "192"
@@ -924,9 +924,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:16 GMT
+                - Wed, 27 Aug 2025 15:05:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -934,11 +934,207 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - db0a6466-3706-403f-a7a2-618d473b4513
+                - 1c780861-fbf6-40f4-9486-d119b3aa5a47
         status: 200 OK
         code: 200
-        duration: 75.371542ms
+        duration: 42.803659ms
     - id: 19
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/58014314-847b-496a-8dbf-0d08e44c4ca3
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 602
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:29.821363Z","description":"","environment_variables":{},"error_message":null,"id":"58014314-847b-496a-8dbf-0d08e44c4ca3","name":"tf-tests-function-cron-name-update","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronn8orvlx9c","registry_namespace_id":"781421b7-bf25-4500-a95a-6695e130e698","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:52.126517Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "602"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:05:57 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - a5ec339e-39e5-44ca-be23-8ed0029117bb
+        status: 200 OK
+        code: 200
+        duration: 62.45785ms
+    - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/ffbd1151-4c0c-4bc8-93b7-9eec8b9a84d6
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 756
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:55.734650Z","description":"","domain_name":"tftestsfunctioncronn8orvlx9c-tf-tests-function-cron-name-update.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"ffbd1151-4c0c-4bc8-93b7-9eec8b9a84d6","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-function-cron-name-update","namespace_id":"58014314-847b-496a-8dbf-0d08e44c4ca3","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:55.734650Z"}'
+        headers:
+            Content-Length:
+                - "756"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:05:57 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - afa6adb3-2ef3-4987-8dc5-708197b5ac2b
+        status: 200 OK
+        code: 200
+        duration: 72.517325ms
+    - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/d824667f-f96f-49be-b9b8-fced891a282b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 192
+        uncompressed: false
+        body: '{"args":{},"function_id":"ffbd1151-4c0c-4bc8-93b7-9eec8b9a84d6","id":"d824667f-f96f-49be-b9b8-fced891a282b","name":"tf-tests-function-cron-name-update","schedule":"0 0 * * *","status":"ready"}'
+        headers:
+            Content-Length:
+                - "192"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:05:57 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3c31a26f-0a76-4807-86c9-5fce10a6e32c
+        status: 200 OK
+        code: 200
+        duration: 119.337742ms
+    - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/d824667f-f96f-49be-b9b8-fced891a282b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 192
+        uncompressed: false
+        body: '{"args":{},"function_id":"ffbd1151-4c0c-4bc8-93b7-9eec8b9a84d6","id":"d824667f-f96f-49be-b9b8-fced891a282b","name":"tf-tests-function-cron-name-update","schedule":"0 0 * * *","status":"ready"}'
+        headers:
+            Content-Length:
+                - "192"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:05:57 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 9ca2407d-7bb8-4a78-b5b6-b01802dbf6f5
+        status: 200 OK
+        code: 200
+        duration: 63.504814ms
+    - id: 23
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -955,8 +1151,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/43d8dcd6-c01c-4fc8-a73b-6d1fa9f586ae
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/d824667f-f96f-49be-b9b8-fced891a282b
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -966,7 +1162,7 @@ interactions:
         trailer: {}
         content_length: 184
         uncompressed: false
-        body: '{"args":{"test":"scw"},"function_id":"547816d7-9352-46d4-863b-7113aeca29a3","id":"43d8dcd6-c01c-4fc8-a73b-6d1fa9f586ae","name":"name-changed","schedule":"0 0 * * *","status":"pending"}'
+        body: '{"args":{"test":"scw"},"function_id":"ffbd1151-4c0c-4bc8-93b7-9eec8b9a84d6","id":"d824667f-f96f-49be-b9b8-fced891a282b","name":"name-changed","schedule":"0 0 * * *","status":"pending"}'
         headers:
             Content-Length:
                 - "184"
@@ -975,9 +1171,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:17 GMT
+                - Wed, 27 Aug 2025 15:05:57 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -985,206 +1181,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c6ef4cd8-7073-4682-9af5-354ba7a57d3e
+                - f5344831-ae53-4a9e-afbf-0d59c058f76e
         status: 200 OK
         code: 200
-        duration: 122.035833ms
-    - id: 20
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/43d8dcd6-c01c-4fc8-a73b-6d1fa9f586ae
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 182
-        uncompressed: false
-        body: '{"args":{"test":"scw"},"function_id":"547816d7-9352-46d4-863b-7113aeca29a3","id":"43d8dcd6-c01c-4fc8-a73b-6d1fa9f586ae","name":"name-changed","schedule":"0 0 * * *","status":"ready"}'
-        headers:
-            Content-Length:
-                - "182"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:44:17 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - b015349e-e6fc-4c19-96d7-da269d8884c7
-        status: 200 OK
-        code: 200
-        duration: 91.488459ms
-    - id: 21
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/43d8dcd6-c01c-4fc8-a73b-6d1fa9f586ae
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 182
-        uncompressed: false
-        body: '{"args":{"test":"scw"},"function_id":"547816d7-9352-46d4-863b-7113aeca29a3","id":"43d8dcd6-c01c-4fc8-a73b-6d1fa9f586ae","name":"name-changed","schedule":"0 0 * * *","status":"ready"}'
-        headers:
-            Content-Length:
-                - "182"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:44:17 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 236955d4-2abd-48cf-a664-251788235262
-        status: 200 OK
-        code: 200
-        duration: 81.922917ms
-    - id: 22
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/509d2fdc-0136-4cce-8404-59da8fb7c7d8
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 569
-        uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.414749Z","description":"","environment_variables":{},"error_message":null,"id":"509d2fdc-0136-4cce-8404-59da8fb7c7d8","name":"tf-tests-function-cron-name-update","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronnn2li4w6o","registry_namespace_id":"6e2075a9-6b34-441e-841d-c04326a246f5","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:44:11.443788Z"}'
-        headers:
-            Content-Length:
-                - "569"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:44:18 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - e2c22291-124c-4d3c-b520-68ef26b121e7
-        status: 200 OK
-        code: 200
-        duration: 54.960958ms
-    - id: 23
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/547816d7-9352-46d4-863b-7113aeca29a3
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 720
-        uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:13.021079Z","description":"","domain_name":"tftestsfunctioncronnn2li4w6o-tf-tests-function-cron-name-update.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"547816d7-9352-46d4-863b-7113aeca29a3","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-function-cron-name-update","namespace_id":"509d2fdc-0136-4cce-8404-59da8fb7c7d8","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:13.021079Z"}'
-        headers:
-            Content-Length:
-                - "720"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:44:18 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - dbfb1e01-efda-4acf-ad7d-d34d0ee6d62c
-        status: 200 OK
-        code: 200
-        duration: 76.029459ms
+        duration: 225.217782ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1200,8 +1200,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/43d8dcd6-c01c-4fc8-a73b-6d1fa9f586ae
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/d824667f-f96f-49be-b9b8-fced891a282b
         method: GET
       response:
         proto: HTTP/2.0
@@ -1211,7 +1211,7 @@ interactions:
         trailer: {}
         content_length: 182
         uncompressed: false
-        body: '{"args":{"test":"scw"},"function_id":"547816d7-9352-46d4-863b-7113aeca29a3","id":"43d8dcd6-c01c-4fc8-a73b-6d1fa9f586ae","name":"name-changed","schedule":"0 0 * * *","status":"ready"}'
+        body: '{"args":{"test":"scw"},"function_id":"ffbd1151-4c0c-4bc8-93b7-9eec8b9a84d6","id":"d824667f-f96f-49be-b9b8-fced891a282b","name":"name-changed","schedule":"0 0 * * *","status":"ready"}'
         headers:
             Content-Length:
                 - "182"
@@ -1220,9 +1220,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:18 GMT
+                - Wed, 27 Aug 2025 15:05:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1230,10 +1230,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4a8acaf0-97f6-49ad-9568-97d00a127b6a
+                - 37350442-8089-4b6c-957d-d10684742ffa
         status: 200 OK
         code: 200
-        duration: 71.01475ms
+        duration: 53.649801ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1249,8 +1249,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/43d8dcd6-c01c-4fc8-a73b-6d1fa9f586ae
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/d824667f-f96f-49be-b9b8-fced891a282b
         method: GET
       response:
         proto: HTTP/2.0
@@ -1260,7 +1260,7 @@ interactions:
         trailer: {}
         content_length: 182
         uncompressed: false
-        body: '{"args":{"test":"scw"},"function_id":"547816d7-9352-46d4-863b-7113aeca29a3","id":"43d8dcd6-c01c-4fc8-a73b-6d1fa9f586ae","name":"name-changed","schedule":"0 0 * * *","status":"ready"}'
+        body: '{"args":{"test":"scw"},"function_id":"ffbd1151-4c0c-4bc8-93b7-9eec8b9a84d6","id":"d824667f-f96f-49be-b9b8-fced891a282b","name":"name-changed","schedule":"0 0 * * *","status":"ready"}'
         headers:
             Content-Length:
                 - "182"
@@ -1269,9 +1269,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:19 GMT
+                - Wed, 27 Aug 2025 15:05:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1279,10 +1279,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2ab0bac0-fbd3-4199-b5be-565973764796
+                - 50141e61-f580-4ed2-9256-328a4602e8f9
         status: 200 OK
         code: 200
-        duration: 80.146375ms
+        duration: 58.028748ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1298,29 +1298,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/43d8dcd6-c01c-4fc8-a73b-6d1fa9f586ae
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/58014314-847b-496a-8dbf-0d08e44c4ca3
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 185
+        content_length: 602
         uncompressed: false
-        body: '{"args":{"test":"scw"},"function_id":"547816d7-9352-46d4-863b-7113aeca29a3","id":"43d8dcd6-c01c-4fc8-a73b-6d1fa9f586ae","name":"name-changed","schedule":"0 0 * * *","status":"deleting"}'
+        body: '{"created_at":"2025-08-27T15:05:29.821363Z","description":"","environment_variables":{},"error_message":null,"id":"58014314-847b-496a-8dbf-0d08e44c4ca3","name":"tf-tests-function-cron-name-update","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronn8orvlx9c","registry_namespace_id":"781421b7-bf25-4500-a95a-6695e130e698","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:52.126517Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "185"
+                - "602"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:19 GMT
+                - Wed, 27 Aug 2025 15:05:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1328,10 +1328,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2bc866e2-516c-461d-8dd2-d509e346ee02
+                - 2ebdb29c-47e7-47cf-b063-e17b48430c18
         status: 200 OK
         code: 200
-        duration: 111.229875ms
+        duration: 35.691834ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1347,8 +1347,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/547816d7-9352-46d4-863b-7113aeca29a3
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/ffbd1151-4c0c-4bc8-93b7-9eec8b9a84d6
         method: GET
       response:
         proto: HTTP/2.0
@@ -1356,20 +1356,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 720
+        content_length: 756
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:13.021079Z","description":"","domain_name":"tftestsfunctioncronnn2li4w6o-tf-tests-function-cron-name-update.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"547816d7-9352-46d4-863b-7113aeca29a3","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-function-cron-name-update","namespace_id":"509d2fdc-0136-4cce-8404-59da8fb7c7d8","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:13.021079Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:55.734650Z","description":"","domain_name":"tftestsfunctioncronn8orvlx9c-tf-tests-function-cron-name-update.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"ffbd1151-4c0c-4bc8-93b7-9eec8b9a84d6","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-function-cron-name-update","namespace_id":"58014314-847b-496a-8dbf-0d08e44c4ca3","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:55.734650Z"}'
         headers:
             Content-Length:
-                - "720"
+                - "756"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:19 GMT
+                - Wed, 27 Aug 2025 15:05:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1377,10 +1377,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 37f696b8-715e-4ba5-8b74-09867a7292b9
+                - 1fc20410-e898-45ec-973b-86be551bdf95
         status: 200 OK
         code: 200
-        duration: 67.8715ms
+        duration: 42.267834ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1396,29 +1396,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/547816d7-9352-46d4-863b-7113aeca29a3
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/d824667f-f96f-49be-b9b8-fced891a282b
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 724
+        content_length: 182
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:13.021079Z","description":"","domain_name":"tftestsfunctioncronnn2li4w6o-tf-tests-function-cron-name-update.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"547816d7-9352-46d4-863b-7113aeca29a3","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-function-cron-name-update","namespace_id":"509d2fdc-0136-4cce-8404-59da8fb7c7d8","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"deleting","timeout":"300s","updated_at":"2025-01-24T15:44:19.572495269Z"}'
+        body: '{"args":{"test":"scw"},"function_id":"ffbd1151-4c0c-4bc8-93b7-9eec8b9a84d6","id":"d824667f-f96f-49be-b9b8-fced891a282b","name":"name-changed","schedule":"0 0 * * *","status":"ready"}'
         headers:
             Content-Length:
-                - "724"
+                - "182"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:19 GMT
+                - Wed, 27 Aug 2025 15:05:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1426,10 +1426,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6b2dd87f-f29b-4442-a4f5-ed4278b01a76
+                - 1578016d-272e-4da5-a071-4bb262c95a07
         status: 200 OK
         code: 200
-        duration: 129.265917ms
+        duration: 53.453824ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1445,8 +1445,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/509d2fdc-0136-4cce-8404-59da8fb7c7d8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/d824667f-f96f-49be-b9b8-fced891a282b
         method: GET
       response:
         proto: HTTP/2.0
@@ -1454,20 +1454,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 569
+        content_length: 182
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.414749Z","description":"","environment_variables":{},"error_message":null,"id":"509d2fdc-0136-4cce-8404-59da8fb7c7d8","name":"tf-tests-function-cron-name-update","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronnn2li4w6o","registry_namespace_id":"6e2075a9-6b34-441e-841d-c04326a246f5","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:44:11.443788Z"}'
+        body: '{"args":{"test":"scw"},"function_id":"ffbd1151-4c0c-4bc8-93b7-9eec8b9a84d6","id":"d824667f-f96f-49be-b9b8-fced891a282b","name":"name-changed","schedule":"0 0 * * *","status":"ready"}'
         headers:
             Content-Length:
-                - "569"
+                - "182"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:19 GMT
+                - Wed, 27 Aug 2025 15:05:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1475,10 +1475,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9a18026a-dc0d-4152-9f9b-9daf5a3538b0
+                - f831fd23-44be-4ff2-8e33-a35e43bf18da
         status: 200 OK
         code: 200
-        duration: 92.266833ms
+        duration: 38.858487ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1494,8 +1494,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/509d2fdc-0136-4cce-8404-59da8fb7c7d8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/d824667f-f96f-49be-b9b8-fced891a282b
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1503,20 +1503,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 575
+        content_length: 185
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.414749Z","description":"","environment_variables":{},"error_message":null,"id":"509d2fdc-0136-4cce-8404-59da8fb7c7d8","name":"tf-tests-function-cron-name-update","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronnn2li4w6o","registry_namespace_id":"6e2075a9-6b34-441e-841d-c04326a246f5","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:44:19.780721251Z"}'
+        body: '{"args":{"test":"scw"},"function_id":"ffbd1151-4c0c-4bc8-93b7-9eec8b9a84d6","id":"d824667f-f96f-49be-b9b8-fced891a282b","name":"name-changed","schedule":"0 0 * * *","status":"deleting"}'
         headers:
             Content-Length:
-                - "575"
+                - "185"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:19 GMT
+                - Wed, 27 Aug 2025 15:05:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1524,10 +1524,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a130b50e-fd83-43f4-9870-b5ffab466b9c
+                - f4a7ffbd-8a52-49f5-a3a3-2ec22bb39384
         status: 200 OK
         code: 200
-        duration: 199.644792ms
+        duration: 101.96841ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1543,8 +1543,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/509d2fdc-0136-4cce-8404-59da8fb7c7d8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/ffbd1151-4c0c-4bc8-93b7-9eec8b9a84d6
         method: GET
       response:
         proto: HTTP/2.0
@@ -1552,20 +1552,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 572
+        content_length: 756
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.414749Z","description":"","environment_variables":{},"error_message":null,"id":"509d2fdc-0136-4cce-8404-59da8fb7c7d8","name":"tf-tests-function-cron-name-update","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronnn2li4w6o","registry_namespace_id":"6e2075a9-6b34-441e-841d-c04326a246f5","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:44:19.780721Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:55.734650Z","description":"","domain_name":"tftestsfunctioncronn8orvlx9c-tf-tests-function-cron-name-update.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"ffbd1151-4c0c-4bc8-93b7-9eec8b9a84d6","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-function-cron-name-update","namespace_id":"58014314-847b-496a-8dbf-0d08e44c4ca3","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:55.734650Z"}'
         headers:
             Content-Length:
-                - "572"
+                - "756"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:19 GMT
+                - Wed, 27 Aug 2025 15:05:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1573,10 +1573,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2684e7fc-6512-401d-ba3a-d909cae9ed74
+                - fcc544f7-359b-4cfb-aa4a-f667f8521050
         status: 200 OK
         code: 200
-        duration: 69.514292ms
+        duration: 99.691468ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1592,29 +1592,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/509d2fdc-0136-4cce-8404-59da8fb7c7d8
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/ffbd1151-4c0c-4bc8-93b7-9eec8b9a84d6
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 572
+        content_length: 760
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.414749Z","description":"","environment_variables":{},"error_message":null,"id":"509d2fdc-0136-4cce-8404-59da8fb7c7d8","name":"tf-tests-function-cron-name-update","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronnn2li4w6o","registry_namespace_id":"6e2075a9-6b34-441e-841d-c04326a246f5","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:44:19.780721Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:55.734650Z","description":"","domain_name":"tftestsfunctioncronn8orvlx9c-tf-tests-function-cron-name-update.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"ffbd1151-4c0c-4bc8-93b7-9eec8b9a84d6","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-function-cron-name-update","namespace_id":"58014314-847b-496a-8dbf-0d08e44c4ca3","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:59.437670879Z"}'
         headers:
             Content-Length:
-                - "572"
+                - "760"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:25 GMT
+                - Wed, 27 Aug 2025 15:05:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1622,10 +1622,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 42084221-71fe-4bbf-b9d6-1d023b4187ff
+                - 91660cef-c96a-45b9-99d1-668319649ba4
         status: 200 OK
         code: 200
-        duration: 66.824875ms
+        duration: 177.904431ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1641,8 +1641,645 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/509d2fdc-0136-4cce-8404-59da8fb7c7d8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/58014314-847b-496a-8dbf-0d08e44c4ca3
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 602
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:29.821363Z","description":"","environment_variables":{},"error_message":null,"id":"58014314-847b-496a-8dbf-0d08e44c4ca3","name":"tf-tests-function-cron-name-update","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronn8orvlx9c","registry_namespace_id":"781421b7-bf25-4500-a95a-6695e130e698","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:52.126517Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "602"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:05:59 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 572732e8-5454-460c-9197-672ab331b24f
+        status: 200 OK
+        code: 200
+        duration: 120.823321ms
+    - id: 34
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/58014314-847b-496a-8dbf-0d08e44c4ca3
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 608
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:29.821363Z","description":"","environment_variables":{},"error_message":null,"id":"58014314-847b-496a-8dbf-0d08e44c4ca3","name":"tf-tests-function-cron-name-update","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronn8orvlx9c","registry_namespace_id":"781421b7-bf25-4500-a95a-6695e130e698","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:59.678429217Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "608"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:05:59 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 36d923f0-d700-45d2-81da-73db9415175b
+        status: 200 OK
+        code: 200
+        duration: 220.253096ms
+    - id: 35
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/58014314-847b-496a-8dbf-0d08e44c4ca3
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 605
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:29.821363Z","description":"","environment_variables":{},"error_message":null,"id":"58014314-847b-496a-8dbf-0d08e44c4ca3","name":"tf-tests-function-cron-name-update","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronn8orvlx9c","registry_namespace_id":"781421b7-bf25-4500-a95a-6695e130e698","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:59.678429Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "605"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:05:59 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e668fa43-4772-4139-861f-bfc81f50d66d
+        status: 200 OK
+        code: 200
+        duration: 43.969898ms
+    - id: 36
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/58014314-847b-496a-8dbf-0d08e44c4ca3
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 605
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:29.821363Z","description":"","environment_variables":{},"error_message":null,"id":"58014314-847b-496a-8dbf-0d08e44c4ca3","name":"tf-tests-function-cron-name-update","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronn8orvlx9c","registry_namespace_id":"781421b7-bf25-4500-a95a-6695e130e698","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:59.678429Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "605"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:05 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 5849da0b-eac6-4bf5-b405-df3e727cff69
+        status: 200 OK
+        code: 200
+        duration: 43.49595ms
+    - id: 37
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/58014314-847b-496a-8dbf-0d08e44c4ca3
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 605
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:29.821363Z","description":"","environment_variables":{},"error_message":null,"id":"58014314-847b-496a-8dbf-0d08e44c4ca3","name":"tf-tests-function-cron-name-update","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronn8orvlx9c","registry_namespace_id":"781421b7-bf25-4500-a95a-6695e130e698","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:59.678429Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "605"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:10 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 6a71eee4-c53b-4a02-8218-c090e4a0dcf8
+        status: 200 OK
+        code: 200
+        duration: 41.048377ms
+    - id: 38
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/58014314-847b-496a-8dbf-0d08e44c4ca3
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 605
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:29.821363Z","description":"","environment_variables":{},"error_message":null,"id":"58014314-847b-496a-8dbf-0d08e44c4ca3","name":"tf-tests-function-cron-name-update","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronn8orvlx9c","registry_namespace_id":"781421b7-bf25-4500-a95a-6695e130e698","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:59.678429Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "605"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:15 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 2d0fc134-00f8-4750-baa4-9dc1729058f3
+        status: 200 OK
+        code: 200
+        duration: 56.240206ms
+    - id: 39
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/58014314-847b-496a-8dbf-0d08e44c4ca3
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 605
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:29.821363Z","description":"","environment_variables":{},"error_message":null,"id":"58014314-847b-496a-8dbf-0d08e44c4ca3","name":"tf-tests-function-cron-name-update","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronn8orvlx9c","registry_namespace_id":"781421b7-bf25-4500-a95a-6695e130e698","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:59.678429Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "605"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:20 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 315148c3-cf22-4473-a0d2-f119c5f896d0
+        status: 200 OK
+        code: 200
+        duration: 51.486536ms
+    - id: 40
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/58014314-847b-496a-8dbf-0d08e44c4ca3
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 605
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:29.821363Z","description":"","environment_variables":{},"error_message":null,"id":"58014314-847b-496a-8dbf-0d08e44c4ca3","name":"tf-tests-function-cron-name-update","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronn8orvlx9c","registry_namespace_id":"781421b7-bf25-4500-a95a-6695e130e698","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:59.678429Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "605"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:25 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 8fb0353f-3b50-4c36-9148-caa89aa63ea5
+        status: 200 OK
+        code: 200
+        duration: 50.320328ms
+    - id: 41
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/58014314-847b-496a-8dbf-0d08e44c4ca3
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 605
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:29.821363Z","description":"","environment_variables":{},"error_message":null,"id":"58014314-847b-496a-8dbf-0d08e44c4ca3","name":"tf-tests-function-cron-name-update","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronn8orvlx9c","registry_namespace_id":"781421b7-bf25-4500-a95a-6695e130e698","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:59.678429Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "605"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:30 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b6521bd8-9e7a-4d9b-a93b-949742cf37b2
+        status: 200 OK
+        code: 200
+        duration: 51.676865ms
+    - id: 42
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/58014314-847b-496a-8dbf-0d08e44c4ca3
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 605
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:29.821363Z","description":"","environment_variables":{},"error_message":null,"id":"58014314-847b-496a-8dbf-0d08e44c4ca3","name":"tf-tests-function-cron-name-update","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronn8orvlx9c","registry_namespace_id":"781421b7-bf25-4500-a95a-6695e130e698","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:59.678429Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "605"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3171cd47-062a-465b-8579-2070edacc462
+        status: 200 OK
+        code: 200
+        duration: 47.374101ms
+    - id: 43
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/58014314-847b-496a-8dbf-0d08e44c4ca3
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 605
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:29.821363Z","description":"","environment_variables":{},"error_message":null,"id":"58014314-847b-496a-8dbf-0d08e44c4ca3","name":"tf-tests-function-cron-name-update","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronn8orvlx9c","registry_namespace_id":"781421b7-bf25-4500-a95a-6695e130e698","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:59.678429Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "605"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:40 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - fcdb0ad6-fd18-45ce-80ea-a80d2955be44
+        status: 200 OK
+        code: 200
+        duration: 51.604551ms
+    - id: 44
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/58014314-847b-496a-8dbf-0d08e44c4ca3
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 605
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:29.821363Z","description":"","environment_variables":{},"error_message":null,"id":"58014314-847b-496a-8dbf-0d08e44c4ca3","name":"tf-tests-function-cron-name-update","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronn8orvlx9c","registry_namespace_id":"781421b7-bf25-4500-a95a-6695e130e698","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:59.678429Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "605"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:45 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 35075a63-b770-473e-9829-9756c0cef71a
+        status: 200 OK
+        code: 200
+        duration: 46.861121ms
+    - id: 45
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/58014314-847b-496a-8dbf-0d08e44c4ca3
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 605
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:29.821363Z","description":"","environment_variables":{},"error_message":null,"id":"58014314-847b-496a-8dbf-0d08e44c4ca3","name":"tf-tests-function-cron-name-update","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronn8orvlx9c","registry_namespace_id":"781421b7-bf25-4500-a95a-6695e130e698","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:59.678429Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "605"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:50 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3a5da64f-bc4b-4569-8808-04485bcc74c7
+        status: 200 OK
+        code: 200
+        duration: 36.624711ms
+    - id: 46
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/58014314-847b-496a-8dbf-0d08e44c4ca3
         method: GET
       response:
         proto: HTTP/2.0
@@ -1661,9 +2298,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:30 GMT
+                - Wed, 27 Aug 2025 15:06:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1671,11 +2308,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 12fe07b6-de8a-431f-84ff-38a6a0dc5275
+                - 932b9b99-c08f-4d5b-8e6c-6b65f98f4cce
         status: 404 Not Found
         code: 404
-        duration: 24.7745ms
-    - id: 34
+        duration: 22.610852ms
+    - id: 47
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1690,8 +2327,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/43d8dcd6-c01c-4fc8-a73b-6d1fa9f586ae
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/d824667f-f96f-49be-b9b8-fced891a282b
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1710,9 +2347,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:30 GMT
+                - Wed, 27 Aug 2025 15:06:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1720,7 +2357,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 558e2137-9c53-4c32-8a7e-c4936991f52a
+                - 342cf28f-005a-45a1-8e4e-2200d84d0a9b
         status: 404 Not Found
         code: 404
-        duration: 25.391333ms
+        duration: 26.777582ms

--- a/internal/services/function/testdata/function-cron-with-args.cassette.yaml
+++ b/internal/services/function/testdata/function-cron-with-args.cassette.yaml
@@ -6,19 +6,19 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 168
+        content_length: 200
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-tests-function-cron-with-args","environment_variables":{},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","secret_environment_variables":[],"tags":null}'
+        body: '{"name":"tf-tests-function-cron-with-args","environment_variables":{},"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","secret_environment_variables":[],"tags":null,"activate_vpc_integration":true}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces
         method: POST
       response:
@@ -27,20 +27,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 484
+        content_length: 517
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.699918448Z","description":"","environment_variables":{},"error_message":null,"id":"8a5583b8-d6ea-4fb7-b3eb-00fd0c8ae4f6","name":"tf-tests-function-cron-with-args","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:44:07.699918448Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.711092448Z","description":"","environment_variables":{},"error_message":null,"id":"78c17595-1278-4417-901e-b3dbbbd5c8a0","name":"tf-tests-function-cron-with-args","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:13.711092448Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "484"
+                - "517"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:07 GMT
+                - Wed, 27 Aug 2025 15:05:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bd624dfb-06e0-4f5c-bd10-14dd121629d6
+                - 47a23ceb-284a-4284-ad8a-37ac75ea38b6
         status: 200 OK
         code: 200
-        duration: 854.06475ms
+        duration: 5.518304657s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -67,8 +67,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8a5583b8-d6ea-4fb7-b3eb-00fd0c8ae4f6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/78c17595-1278-4417-901e-b3dbbbd5c8a0
         method: GET
       response:
         proto: HTTP/2.0
@@ -76,20 +76,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 478
+        content_length: 511
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.699918Z","description":"","environment_variables":{},"error_message":null,"id":"8a5583b8-d6ea-4fb7-b3eb-00fd0c8ae4f6","name":"tf-tests-function-cron-with-args","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:44:07.699918Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.711092Z","description":"","environment_variables":{},"error_message":null,"id":"78c17595-1278-4417-901e-b3dbbbd5c8a0","name":"tf-tests-function-cron-with-args","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:13.711092Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "478"
+                - "511"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:07 GMT
+                - Wed, 27 Aug 2025 15:05:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0f300eaa-0dfb-46fc-a811-1b4b854a2f90
+                - 35bb9338-dfa6-48b9-baad-e6398ee4db0b
         status: 200 OK
         code: 200
-        duration: 81.631917ms
+        duration: 41.458159ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -116,8 +116,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8a5583b8-d6ea-4fb7-b3eb-00fd0c8ae4f6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/78c17595-1278-4417-901e-b3dbbbd5c8a0
         method: GET
       response:
         proto: HTTP/2.0
@@ -125,20 +125,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 478
+        content_length: 511
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.699918Z","description":"","environment_variables":{},"error_message":null,"id":"8a5583b8-d6ea-4fb7-b3eb-00fd0c8ae4f6","name":"tf-tests-function-cron-with-args","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:44:12.458406Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.711092Z","description":"","environment_variables":{},"error_message":null,"id":"78c17595-1278-4417-901e-b3dbbbd5c8a0","name":"tf-tests-function-cron-with-args","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:13.711092Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "478"
+                - "511"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:12 GMT
+                - Wed, 27 Aug 2025 15:05:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -146,10 +146,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d28ed264-9ef9-4ae2-8f62-915913c61e66
+                - b523bd79-d811-4842-afe6-a795be508478
         status: 200 OK
         code: 200
-        duration: 66.8755ms
+        duration: 543.701783ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -165,8 +165,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8a5583b8-d6ea-4fb7-b3eb-00fd0c8ae4f6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/78c17595-1278-4417-901e-b3dbbbd5c8a0
         method: GET
       response:
         proto: HTTP/2.0
@@ -174,20 +174,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 567
+        content_length: 600
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.699918Z","description":"","environment_variables":{},"error_message":null,"id":"8a5583b8-d6ea-4fb7-b3eb-00fd0c8ae4f6","name":"tf-tests-function-cron-with-args","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronwkuvolxrc","registry_namespace_id":"9b89c97f-99ad-4f65-a042-fbb41839f5ef","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:44:13.297839Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.711092Z","description":"","environment_variables":{},"error_message":null,"id":"78c17595-1278-4417-901e-b3dbbbd5c8a0","name":"tf-tests-function-cron-with-args","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronwrvvbf8vd","registry_namespace_id":"259b7f09-b6f2-47ea-9ebe-e0cbb7107632","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:21.132812Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "567"
+                - "600"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:17 GMT
+                - Wed, 27 Aug 2025 15:05:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -195,10 +195,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 32f531f7-cf36-431e-b086-33ba78104b2e
+                - 1be9584a-5d6b-4920-8270-1d3bec14c107
         status: 200 OK
         code: 200
-        duration: 70.039042ms
+        duration: 42.564957ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -214,8 +214,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8a5583b8-d6ea-4fb7-b3eb-00fd0c8ae4f6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/78c17595-1278-4417-901e-b3dbbbd5c8a0
         method: GET
       response:
         proto: HTTP/2.0
@@ -223,20 +223,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 567
+        content_length: 600
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.699918Z","description":"","environment_variables":{},"error_message":null,"id":"8a5583b8-d6ea-4fb7-b3eb-00fd0c8ae4f6","name":"tf-tests-function-cron-with-args","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronwkuvolxrc","registry_namespace_id":"9b89c97f-99ad-4f65-a042-fbb41839f5ef","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:44:13.297839Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.711092Z","description":"","environment_variables":{},"error_message":null,"id":"78c17595-1278-4417-901e-b3dbbbd5c8a0","name":"tf-tests-function-cron-with-args","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronwrvvbf8vd","registry_namespace_id":"259b7f09-b6f2-47ea-9ebe-e0cbb7107632","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:21.132812Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "567"
+                - "600"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:18 GMT
+                - Wed, 27 Aug 2025 15:05:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -244,28 +244,28 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 52899b23-bb74-4089-8d86-be7997c5f048
+                - aa65a8b3-910a-41b6-a1ea-54afcf57af7a
         status: 200 OK
         code: 200
-        duration: 83.465709ms
+        duration: 42.112417ms
     - id: 5
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 315
+        content_length: 327
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-tests-cron-with-args","namespace_id":"8a5583b8-d6ea-4fb7-b3eb-00fd0c8ae4f6","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"node20","memory_limit":256,"handler":"handler.handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox"}'
+        body: '{"name":"tf-tests-cron-with-args","namespace_id":"78c17595-1278-4417-901e-b3dbbbd5c8a0","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"node20","memory_limit":256,"handler":"handler.handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox","tags":null}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions
         method: POST
       response:
@@ -274,20 +274,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 704
+        content_length: 740
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:18.234116785Z","description":"","domain_name":"tftestsfunctioncronwkuvolxrc-tf-tests-cron-with-args.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"a97dfd06-da39-4ff9-bcc1-df9685f2185d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-cron-with-args","namespace_id":"8a5583b8-d6ea-4fb7-b3eb-00fd0c8ae4f6","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:18.234116785Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:26.162689312Z","description":"","domain_name":"tftestsfunctioncronwrvvbf8vd-tf-tests-cron-with-args.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"f42ffa54-f443-4b3b-926a-2e3884626abe","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-cron-with-args","namespace_id":"78c17595-1278-4417-901e-b3dbbbd5c8a0","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:26.162689312Z"}'
         headers:
             Content-Length:
-                - "704"
+                - "740"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:18 GMT
+                - Wed, 27 Aug 2025 15:05:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -295,10 +295,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8e7c0c4e-79eb-4729-b5d3-b2c356cb5419
+                - ead8a72a-6952-4152-8803-e0918dddffd5
         status: 200 OK
         code: 200
-        duration: 227.7895ms
+        duration: 1.924210984s
     - id: 6
       request:
         proto: HTTP/1.1
@@ -314,8 +314,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/a97dfd06-da39-4ff9-bcc1-df9685f2185d
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/f42ffa54-f443-4b3b-926a-2e3884626abe
         method: GET
       response:
         proto: HTTP/2.0
@@ -323,20 +323,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 698
+        content_length: 734
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:18.234117Z","description":"","domain_name":"tftestsfunctioncronwkuvolxrc-tf-tests-cron-with-args.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"a97dfd06-da39-4ff9-bcc1-df9685f2185d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-cron-with-args","namespace_id":"8a5583b8-d6ea-4fb7-b3eb-00fd0c8ae4f6","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:18.234117Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:26.162689Z","description":"","domain_name":"tftestsfunctioncronwrvvbf8vd-tf-tests-cron-with-args.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"f42ffa54-f443-4b3b-926a-2e3884626abe","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-cron-with-args","namespace_id":"78c17595-1278-4417-901e-b3dbbbd5c8a0","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:26.162689Z"}'
         headers:
             Content-Length:
-                - "698"
+                - "734"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:18 GMT
+                - Wed, 27 Aug 2025 15:05:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -344,10 +344,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7b55c874-330c-47fa-a457-d7d586e3586b
+                - d71ad984-e646-4360-bae9-6e6be821f812
         status: 200 OK
         code: 200
-        duration: 84.3265ms
+        duration: 46.658408ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -363,8 +363,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/a97dfd06-da39-4ff9-bcc1-df9685f2185d
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/f42ffa54-f443-4b3b-926a-2e3884626abe
         method: GET
       response:
         proto: HTTP/2.0
@@ -372,20 +372,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 698
+        content_length: 734
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:18.234117Z","description":"","domain_name":"tftestsfunctioncronwkuvolxrc-tf-tests-cron-with-args.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"a97dfd06-da39-4ff9-bcc1-df9685f2185d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-cron-with-args","namespace_id":"8a5583b8-d6ea-4fb7-b3eb-00fd0c8ae4f6","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:18.234117Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:26.162689Z","description":"","domain_name":"tftestsfunctioncronwrvvbf8vd-tf-tests-cron-with-args.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"f42ffa54-f443-4b3b-926a-2e3884626abe","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-cron-with-args","namespace_id":"78c17595-1278-4417-901e-b3dbbbd5c8a0","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:26.162689Z"}'
         headers:
             Content-Length:
-                - "698"
+                - "734"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:18 GMT
+                - Wed, 27 Aug 2025 15:05:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -393,10 +393,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 408abc52-2792-4b08-987f-0dab47110042
+                - 396b5bc7-2dc5-4313-91b1-c56f5ca155e8
         status: 200 OK
         code: 200
-        duration: 87.042ms
+        duration: 50.171179ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -412,8 +412,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/a97dfd06-da39-4ff9-bcc1-df9685f2185d
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/f42ffa54-f443-4b3b-926a-2e3884626abe
         method: GET
       response:
         proto: HTTP/2.0
@@ -421,20 +421,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 698
+        content_length: 734
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:18.234117Z","description":"","domain_name":"tftestsfunctioncronwkuvolxrc-tf-tests-cron-with-args.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"a97dfd06-da39-4ff9-bcc1-df9685f2185d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-cron-with-args","namespace_id":"8a5583b8-d6ea-4fb7-b3eb-00fd0c8ae4f6","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:18.234117Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:26.162689Z","description":"","domain_name":"tftestsfunctioncronwrvvbf8vd-tf-tests-cron-with-args.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"f42ffa54-f443-4b3b-926a-2e3884626abe","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-cron-with-args","namespace_id":"78c17595-1278-4417-901e-b3dbbbd5c8a0","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:26.162689Z"}'
         headers:
             Content-Length:
-                - "698"
+                - "734"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:18 GMT
+                - Wed, 27 Aug 2025 15:05:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -442,10 +442,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b600c6f3-fc60-48a7-8e93-1501494cf1cb
+                - 9f9a2c88-4b6a-4705-8806-7c8ae85b0127
         status: 200 OK
         code: 200
-        duration: 75.035541ms
+        duration: 59.43967ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -457,13 +457,13 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"function_id":"a97dfd06-da39-4ff9-bcc1-df9685f2185d","schedule":"0 0 * * *","args":{"test":"scw"},"name":"tf-tests-cron-with-args"}'
+        body: '{"function_id":"f42ffa54-f443-4b3b-926a-2e3884626abe","schedule":"0 0 * * *","args":{"test":"scw"},"name":"tf-tests-cron-with-args"}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons
         method: POST
       response:
@@ -474,7 +474,7 @@ interactions:
         trailer: {}
         content_length: 195
         uncompressed: false
-        body: '{"args":{"test":"scw"},"function_id":"a97dfd06-da39-4ff9-bcc1-df9685f2185d","id":"06bd4e93-7c5f-4563-82dd-ad411d62d02a","name":"tf-tests-cron-with-args","schedule":"0 0 * * *","status":"pending"}'
+        body: '{"args":{"test":"scw"},"function_id":"f42ffa54-f443-4b3b-926a-2e3884626abe","id":"0b9e8033-d401-40e2-a8c0-0d9f5302e2db","name":"tf-tests-cron-with-args","schedule":"0 0 * * *","status":"pending"}'
         headers:
             Content-Length:
                 - "195"
@@ -483,9 +483,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:18 GMT
+                - Wed, 27 Aug 2025 15:05:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -493,10 +493,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 41ce45b0-7d07-4041-932d-3284bab74703
+                - 0c99486c-5adc-4648-a37a-8e62db13d1bf
         status: 200 OK
         code: 200
-        duration: 106.067708ms
+        duration: 75.48143ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -512,8 +512,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/06bd4e93-7c5f-4563-82dd-ad411d62d02a
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/0b9e8033-d401-40e2-a8c0-0d9f5302e2db
         method: GET
       response:
         proto: HTTP/2.0
@@ -523,7 +523,7 @@ interactions:
         trailer: {}
         content_length: 195
         uncompressed: false
-        body: '{"args":{"test":"scw"},"function_id":"a97dfd06-da39-4ff9-bcc1-df9685f2185d","id":"06bd4e93-7c5f-4563-82dd-ad411d62d02a","name":"tf-tests-cron-with-args","schedule":"0 0 * * *","status":"pending"}'
+        body: '{"args":{"test":"scw"},"function_id":"f42ffa54-f443-4b3b-926a-2e3884626abe","id":"0b9e8033-d401-40e2-a8c0-0d9f5302e2db","name":"tf-tests-cron-with-args","schedule":"0 0 * * *","status":"pending"}'
         headers:
             Content-Length:
                 - "195"
@@ -532,9 +532,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:18 GMT
+                - Wed, 27 Aug 2025 15:05:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -542,10 +542,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9cb44b6c-6cc9-4bdb-b02d-492eff8f2c1f
+                - be8203c6-7be9-4dc2-a8e8-aa0faf4c70e8
         status: 200 OK
         code: 200
-        duration: 72.865417ms
+        duration: 105.389398ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -561,8 +561,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/06bd4e93-7c5f-4563-82dd-ad411d62d02a
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/0b9e8033-d401-40e2-a8c0-0d9f5302e2db
         method: GET
       response:
         proto: HTTP/2.0
@@ -572,7 +572,7 @@ interactions:
         trailer: {}
         content_length: 193
         uncompressed: false
-        body: '{"args":{"test":"scw"},"function_id":"a97dfd06-da39-4ff9-bcc1-df9685f2185d","id":"06bd4e93-7c5f-4563-82dd-ad411d62d02a","name":"tf-tests-cron-with-args","schedule":"0 0 * * *","status":"ready"}'
+        body: '{"args":{"test":"scw"},"function_id":"f42ffa54-f443-4b3b-926a-2e3884626abe","id":"0b9e8033-d401-40e2-a8c0-0d9f5302e2db","name":"tf-tests-cron-with-args","schedule":"0 0 * * *","status":"ready"}'
         headers:
             Content-Length:
                 - "193"
@@ -581,9 +581,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:23 GMT
+                - Wed, 27 Aug 2025 15:05:31 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -591,10 +591,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5877e48d-3756-4450-b2ad-a778f99ab9e0
+                - 06d15b39-e0ae-4f81-a75a-a7b16b676199
         status: 200 OK
         code: 200
-        duration: 84.969542ms
+        duration: 76.750242ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -610,8 +610,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/06bd4e93-7c5f-4563-82dd-ad411d62d02a
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/0b9e8033-d401-40e2-a8c0-0d9f5302e2db
         method: GET
       response:
         proto: HTTP/2.0
@@ -621,7 +621,7 @@ interactions:
         trailer: {}
         content_length: 193
         uncompressed: false
-        body: '{"args":{"test":"scw"},"function_id":"a97dfd06-da39-4ff9-bcc1-df9685f2185d","id":"06bd4e93-7c5f-4563-82dd-ad411d62d02a","name":"tf-tests-cron-with-args","schedule":"0 0 * * *","status":"ready"}'
+        body: '{"args":{"test":"scw"},"function_id":"f42ffa54-f443-4b3b-926a-2e3884626abe","id":"0b9e8033-d401-40e2-a8c0-0d9f5302e2db","name":"tf-tests-cron-with-args","schedule":"0 0 * * *","status":"ready"}'
         headers:
             Content-Length:
                 - "193"
@@ -630,9 +630,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:23 GMT
+                - Wed, 27 Aug 2025 15:05:31 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -640,10 +640,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e2e85c26-d1b2-4823-be37-490ed1d634e8
+                - 17227f84-b365-4e79-954f-a71ae8d3193a
         status: 200 OK
         code: 200
-        duration: 88.059292ms
+        duration: 59.765893ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -659,8 +659,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/06bd4e93-7c5f-4563-82dd-ad411d62d02a
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/0b9e8033-d401-40e2-a8c0-0d9f5302e2db
         method: GET
       response:
         proto: HTTP/2.0
@@ -670,7 +670,7 @@ interactions:
         trailer: {}
         content_length: 193
         uncompressed: false
-        body: '{"args":{"test":"scw"},"function_id":"a97dfd06-da39-4ff9-bcc1-df9685f2185d","id":"06bd4e93-7c5f-4563-82dd-ad411d62d02a","name":"tf-tests-cron-with-args","schedule":"0 0 * * *","status":"ready"}'
+        body: '{"args":{"test":"scw"},"function_id":"f42ffa54-f443-4b3b-926a-2e3884626abe","id":"0b9e8033-d401-40e2-a8c0-0d9f5302e2db","name":"tf-tests-cron-with-args","schedule":"0 0 * * *","status":"ready"}'
         headers:
             Content-Length:
                 - "193"
@@ -679,9 +679,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:24 GMT
+                - Wed, 27 Aug 2025 15:05:31 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -689,10 +689,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1b46c6bf-043e-4654-8dce-f8a925a85a0d
+                - 7637a340-9cbf-4b52-8609-dde7fbaea939
         status: 200 OK
         code: 200
-        duration: 78.891083ms
+        duration: 59.004064ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -708,8 +708,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8a5583b8-d6ea-4fb7-b3eb-00fd0c8ae4f6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/78c17595-1278-4417-901e-b3dbbbd5c8a0
         method: GET
       response:
         proto: HTTP/2.0
@@ -717,20 +717,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 567
+        content_length: 600
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.699918Z","description":"","environment_variables":{},"error_message":null,"id":"8a5583b8-d6ea-4fb7-b3eb-00fd0c8ae4f6","name":"tf-tests-function-cron-with-args","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronwkuvolxrc","registry_namespace_id":"9b89c97f-99ad-4f65-a042-fbb41839f5ef","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:44:13.297839Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.711092Z","description":"","environment_variables":{},"error_message":null,"id":"78c17595-1278-4417-901e-b3dbbbd5c8a0","name":"tf-tests-function-cron-with-args","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronwrvvbf8vd","registry_namespace_id":"259b7f09-b6f2-47ea-9ebe-e0cbb7107632","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:21.132812Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "567"
+                - "600"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:24 GMT
+                - Wed, 27 Aug 2025 15:05:32 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -738,10 +738,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7f93d5e3-0432-4cda-a0b1-761526287a23
+                - 822ebcdd-b316-40cd-b6b1-68453062cee0
         status: 200 OK
         code: 200
-        duration: 69.442375ms
+        duration: 45.745445ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -757,8 +757,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/a97dfd06-da39-4ff9-bcc1-df9685f2185d
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/f42ffa54-f443-4b3b-926a-2e3884626abe
         method: GET
       response:
         proto: HTTP/2.0
@@ -766,20 +766,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 698
+        content_length: 734
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:18.234117Z","description":"","domain_name":"tftestsfunctioncronwkuvolxrc-tf-tests-cron-with-args.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"a97dfd06-da39-4ff9-bcc1-df9685f2185d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-cron-with-args","namespace_id":"8a5583b8-d6ea-4fb7-b3eb-00fd0c8ae4f6","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:18.234117Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:26.162689Z","description":"","domain_name":"tftestsfunctioncronwrvvbf8vd-tf-tests-cron-with-args.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"f42ffa54-f443-4b3b-926a-2e3884626abe","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-cron-with-args","namespace_id":"78c17595-1278-4417-901e-b3dbbbd5c8a0","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:26.162689Z"}'
         headers:
             Content-Length:
-                - "698"
+                - "734"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:24 GMT
+                - Wed, 27 Aug 2025 15:05:32 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -787,10 +787,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - dcb426ec-39a2-45f7-b257-7eab85e10cc2
+                - 7c062590-984c-41e6-9b37-de131b3ce1b5
         status: 200 OK
         code: 200
-        duration: 82.805458ms
+        duration: 56.797683ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -806,8 +806,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/06bd4e93-7c5f-4563-82dd-ad411d62d02a
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/0b9e8033-d401-40e2-a8c0-0d9f5302e2db
         method: GET
       response:
         proto: HTTP/2.0
@@ -817,7 +817,7 @@ interactions:
         trailer: {}
         content_length: 193
         uncompressed: false
-        body: '{"args":{"test":"scw"},"function_id":"a97dfd06-da39-4ff9-bcc1-df9685f2185d","id":"06bd4e93-7c5f-4563-82dd-ad411d62d02a","name":"tf-tests-cron-with-args","schedule":"0 0 * * *","status":"ready"}'
+        body: '{"args":{"test":"scw"},"function_id":"f42ffa54-f443-4b3b-926a-2e3884626abe","id":"0b9e8033-d401-40e2-a8c0-0d9f5302e2db","name":"tf-tests-cron-with-args","schedule":"0 0 * * *","status":"ready"}'
         headers:
             Content-Length:
                 - "193"
@@ -826,9 +826,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:25 GMT
+                - Wed, 27 Aug 2025 15:05:32 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -836,10 +836,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3c4bc7c1-a507-4de2-bec8-8b4cbc873a0e
+                - 985425e3-7bd7-468a-b008-29ac904b1f41
         status: 200 OK
         code: 200
-        duration: 84.450334ms
+        duration: 68.331847ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -855,8 +855,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/06bd4e93-7c5f-4563-82dd-ad411d62d02a
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/0b9e8033-d401-40e2-a8c0-0d9f5302e2db
         method: GET
       response:
         proto: HTTP/2.0
@@ -866,7 +866,7 @@ interactions:
         trailer: {}
         content_length: 193
         uncompressed: false
-        body: '{"args":{"test":"scw"},"function_id":"a97dfd06-da39-4ff9-bcc1-df9685f2185d","id":"06bd4e93-7c5f-4563-82dd-ad411d62d02a","name":"tf-tests-cron-with-args","schedule":"0 0 * * *","status":"ready"}'
+        body: '{"args":{"test":"scw"},"function_id":"f42ffa54-f443-4b3b-926a-2e3884626abe","id":"0b9e8033-d401-40e2-a8c0-0d9f5302e2db","name":"tf-tests-cron-with-args","schedule":"0 0 * * *","status":"ready"}'
         headers:
             Content-Length:
                 - "193"
@@ -875,9 +875,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:25 GMT
+                - Wed, 27 Aug 2025 15:05:32 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -885,10 +885,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a93424e6-aa64-4209-9af2-b7798dc9b428
+                - 13c03be4-a20a-4977-8654-ffb1cfeba0b2
         status: 200 OK
         code: 200
-        duration: 86.324917ms
+        duration: 51.230097ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -904,8 +904,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/06bd4e93-7c5f-4563-82dd-ad411d62d02a
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/0b9e8033-d401-40e2-a8c0-0d9f5302e2db
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -915,7 +915,7 @@ interactions:
         trailer: {}
         content_length: 196
         uncompressed: false
-        body: '{"args":{"test":"scw"},"function_id":"a97dfd06-da39-4ff9-bcc1-df9685f2185d","id":"06bd4e93-7c5f-4563-82dd-ad411d62d02a","name":"tf-tests-cron-with-args","schedule":"0 0 * * *","status":"deleting"}'
+        body: '{"args":{"test":"scw"},"function_id":"f42ffa54-f443-4b3b-926a-2e3884626abe","id":"0b9e8033-d401-40e2-a8c0-0d9f5302e2db","name":"tf-tests-cron-with-args","schedule":"0 0 * * *","status":"deleting"}'
         headers:
             Content-Length:
                 - "196"
@@ -924,9 +924,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:25 GMT
+                - Wed, 27 Aug 2025 15:05:32 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -934,10 +934,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9b1c6f66-59b9-4b41-ac78-e4b4a7e55558
+                - 3734ad36-a9ec-4488-a837-69ca15ce1493
         status: 200 OK
         code: 200
-        duration: 108.226125ms
+        duration: 82.325664ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -953,8 +953,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/a97dfd06-da39-4ff9-bcc1-df9685f2185d
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/f42ffa54-f443-4b3b-926a-2e3884626abe
         method: GET
       response:
         proto: HTTP/2.0
@@ -962,20 +962,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 698
+        content_length: 734
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:18.234117Z","description":"","domain_name":"tftestsfunctioncronwkuvolxrc-tf-tests-cron-with-args.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"a97dfd06-da39-4ff9-bcc1-df9685f2185d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-cron-with-args","namespace_id":"8a5583b8-d6ea-4fb7-b3eb-00fd0c8ae4f6","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:18.234117Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:26.162689Z","description":"","domain_name":"tftestsfunctioncronwrvvbf8vd-tf-tests-cron-with-args.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"f42ffa54-f443-4b3b-926a-2e3884626abe","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-cron-with-args","namespace_id":"78c17595-1278-4417-901e-b3dbbbd5c8a0","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:26.162689Z"}'
         headers:
             Content-Length:
-                - "698"
+                - "734"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:26 GMT
+                - Wed, 27 Aug 2025 15:05:33 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -983,10 +983,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 26d24ebe-a82d-47ad-aadd-84b7f61a9976
+                - f0748b44-19ff-49d6-8b01-6e32444e2c0d
         status: 200 OK
         code: 200
-        duration: 73.835417ms
+        duration: 55.623762ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1002,8 +1002,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/a97dfd06-da39-4ff9-bcc1-df9685f2185d
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/f42ffa54-f443-4b3b-926a-2e3884626abe
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1011,20 +1011,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 702
+        content_length: 738
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:18.234117Z","description":"","domain_name":"tftestsfunctioncronwkuvolxrc-tf-tests-cron-with-args.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"a97dfd06-da39-4ff9-bcc1-df9685f2185d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-cron-with-args","namespace_id":"8a5583b8-d6ea-4fb7-b3eb-00fd0c8ae4f6","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"deleting","timeout":"300s","updated_at":"2025-01-24T15:44:26.113099049Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:26.162689Z","description":"","domain_name":"tftestsfunctioncronwrvvbf8vd-tf-tests-cron-with-args.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"f42ffa54-f443-4b3b-926a-2e3884626abe","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-cron-with-args","namespace_id":"78c17595-1278-4417-901e-b3dbbbd5c8a0","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:33.139240639Z"}'
         headers:
             Content-Length:
-                - "702"
+                - "738"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:26 GMT
+                - Wed, 27 Aug 2025 15:05:33 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1032,10 +1032,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 024b5577-28af-46e1-96b0-7e5efeb92a57
+                - 9fbc7b3f-3df1-49a1-9710-9fc631a330e2
         status: 200 OK
         code: 200
-        duration: 148.969833ms
+        duration: 110.397598ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1051,8 +1051,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8a5583b8-d6ea-4fb7-b3eb-00fd0c8ae4f6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/78c17595-1278-4417-901e-b3dbbbd5c8a0
         method: GET
       response:
         proto: HTTP/2.0
@@ -1060,20 +1060,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 567
+        content_length: 600
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.699918Z","description":"","environment_variables":{},"error_message":null,"id":"8a5583b8-d6ea-4fb7-b3eb-00fd0c8ae4f6","name":"tf-tests-function-cron-with-args","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronwkuvolxrc","registry_namespace_id":"9b89c97f-99ad-4f65-a042-fbb41839f5ef","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:44:13.297839Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.711092Z","description":"","environment_variables":{},"error_message":null,"id":"78c17595-1278-4417-901e-b3dbbbd5c8a0","name":"tf-tests-function-cron-with-args","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronwrvvbf8vd","registry_namespace_id":"259b7f09-b6f2-47ea-9ebe-e0cbb7107632","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:21.132812Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "567"
+                - "600"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:26 GMT
+                - Wed, 27 Aug 2025 15:05:33 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1081,10 +1081,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - acb07a7d-3251-4a64-b33d-e320110850a8
+                - a4f63481-066c-4eae-99ae-fc7daef52191
         status: 200 OK
         code: 200
-        duration: 115.906708ms
+        duration: 51.45007ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1100,8 +1100,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8a5583b8-d6ea-4fb7-b3eb-00fd0c8ae4f6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/78c17595-1278-4417-901e-b3dbbbd5c8a0
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1109,20 +1109,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 573
+        content_length: 606
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.699918Z","description":"","environment_variables":{},"error_message":null,"id":"8a5583b8-d6ea-4fb7-b3eb-00fd0c8ae4f6","name":"tf-tests-function-cron-with-args","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronwkuvolxrc","registry_namespace_id":"9b89c97f-99ad-4f65-a042-fbb41839f5ef","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:44:26.358545209Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.711092Z","description":"","environment_variables":{},"error_message":null,"id":"78c17595-1278-4417-901e-b3dbbbd5c8a0","name":"tf-tests-function-cron-with-args","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronwrvvbf8vd","registry_namespace_id":"259b7f09-b6f2-47ea-9ebe-e0cbb7107632","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:33.293975099Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "573"
+                - "606"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:26 GMT
+                - Wed, 27 Aug 2025 15:05:33 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1130,10 +1130,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3e6e8ce3-9992-4e30-aef8-4821c0b5bd55
+                - 248eef3b-b234-4a65-949e-5e590fcf12a5
         status: 200 OK
         code: 200
-        duration: 191.114042ms
+        duration: 282.998322ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1149,8 +1149,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8a5583b8-d6ea-4fb7-b3eb-00fd0c8ae4f6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/78c17595-1278-4417-901e-b3dbbbd5c8a0
         method: GET
       response:
         proto: HTTP/2.0
@@ -1158,20 +1158,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 570
+        content_length: 603
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.699918Z","description":"","environment_variables":{},"error_message":null,"id":"8a5583b8-d6ea-4fb7-b3eb-00fd0c8ae4f6","name":"tf-tests-function-cron-with-args","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronwkuvolxrc","registry_namespace_id":"9b89c97f-99ad-4f65-a042-fbb41839f5ef","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:44:26.358545Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.711092Z","description":"","environment_variables":{},"error_message":null,"id":"78c17595-1278-4417-901e-b3dbbbd5c8a0","name":"tf-tests-function-cron-with-args","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronwrvvbf8vd","registry_namespace_id":"259b7f09-b6f2-47ea-9ebe-e0cbb7107632","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:33.293975Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "570"
+                - "603"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:26 GMT
+                - Wed, 27 Aug 2025 15:05:33 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1179,10 +1179,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 09ecae68-2d89-4406-9be1-deab0831598c
+                - fcaf7910-a5c7-4a89-b849-3cbfa79946cf
         status: 200 OK
         code: 200
-        duration: 85.551208ms
+        duration: 41.422394ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1198,253 +1198,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8a5583b8-d6ea-4fb7-b3eb-00fd0c8ae4f6
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 570
-        uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.699918Z","description":"","environment_variables":{},"error_message":null,"id":"8a5583b8-d6ea-4fb7-b3eb-00fd0c8ae4f6","name":"tf-tests-function-cron-with-args","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronwkuvolxrc","registry_namespace_id":"9b89c97f-99ad-4f65-a042-fbb41839f5ef","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:44:26.358545Z"}'
-        headers:
-            Content-Length:
-                - "570"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:44:31 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 2630bf15-8c41-469e-8fed-2467c1df4e5b
-        status: 200 OK
-        code: 200
-        duration: 67.337208ms
-    - id: 25
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8a5583b8-d6ea-4fb7-b3eb-00fd0c8ae4f6
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 570
-        uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.699918Z","description":"","environment_variables":{},"error_message":null,"id":"8a5583b8-d6ea-4fb7-b3eb-00fd0c8ae4f6","name":"tf-tests-function-cron-with-args","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronwkuvolxrc","registry_namespace_id":"9b89c97f-99ad-4f65-a042-fbb41839f5ef","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:44:26.358545Z"}'
-        headers:
-            Content-Length:
-                - "570"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:44:36 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 7b1af765-ee0a-4dd1-a44f-594f1f42a99c
-        status: 200 OK
-        code: 200
-        duration: 69.364792ms
-    - id: 26
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8a5583b8-d6ea-4fb7-b3eb-00fd0c8ae4f6
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 570
-        uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.699918Z","description":"","environment_variables":{},"error_message":null,"id":"8a5583b8-d6ea-4fb7-b3eb-00fd0c8ae4f6","name":"tf-tests-function-cron-with-args","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronwkuvolxrc","registry_namespace_id":"9b89c97f-99ad-4f65-a042-fbb41839f5ef","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:44:26.358545Z"}'
-        headers:
-            Content-Length:
-                - "570"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:44:41 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 0f214b0b-2b18-4458-ae77-abe31079433f
-        status: 200 OK
-        code: 200
-        duration: 69.8725ms
-    - id: 27
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8a5583b8-d6ea-4fb7-b3eb-00fd0c8ae4f6
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 570
-        uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.699918Z","description":"","environment_variables":{},"error_message":null,"id":"8a5583b8-d6ea-4fb7-b3eb-00fd0c8ae4f6","name":"tf-tests-function-cron-with-args","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronwkuvolxrc","registry_namespace_id":"9b89c97f-99ad-4f65-a042-fbb41839f5ef","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:44:26.358545Z"}'
-        headers:
-            Content-Length:
-                - "570"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:44:46 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - ca7547b6-bbb9-4b33-a92c-40750f2cd983
-        status: 200 OK
-        code: 200
-        duration: 67.389625ms
-    - id: 28
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8a5583b8-d6ea-4fb7-b3eb-00fd0c8ae4f6
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 570
-        uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.699918Z","description":"","environment_variables":{},"error_message":null,"id":"8a5583b8-d6ea-4fb7-b3eb-00fd0c8ae4f6","name":"tf-tests-function-cron-with-args","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronwkuvolxrc","registry_namespace_id":"9b89c97f-99ad-4f65-a042-fbb41839f5ef","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:44:26.358545Z"}'
-        headers:
-            Content-Length:
-                - "570"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:44:51 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - a38654f1-528c-472e-966f-0e55c733258e
-        status: 200 OK
-        code: 200
-        duration: 63.624292ms
-    - id: 29
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8a5583b8-d6ea-4fb7-b3eb-00fd0c8ae4f6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/78c17595-1278-4417-901e-b3dbbbd5c8a0
         method: GET
       response:
         proto: HTTP/2.0
@@ -1463,9 +1218,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:56 GMT
+                - Wed, 27 Aug 2025 15:05:38 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1473,11 +1228,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bfcb83f2-10eb-4763-b85c-95d57c3697e2
+                - 465ba514-7f44-4b69-8705-ebea08b67e45
         status: 404 Not Found
         code: 404
-        duration: 25.885958ms
-    - id: 30
+        duration: 21.512897ms
+    - id: 25
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1492,8 +1247,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/06bd4e93-7c5f-4563-82dd-ad411d62d02a
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/0b9e8033-d401-40e2-a8c0-0d9f5302e2db
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1512,9 +1267,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:57 GMT
+                - Wed, 27 Aug 2025 15:05:38 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1522,7 +1277,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a7aa6af7-e674-428e-bce4-be58af1533bf
+                - 90eb2cad-39ea-4c1f-80f1-b2dc7cd8b311
         status: 404 Not Found
         code: 404
-        duration: 33.614625ms
+        duration: 21.223313ms

--- a/internal/services/function/testdata/function-deploy.cassette.yaml
+++ b/internal/services/function/testdata/function-deploy.cassette.yaml
@@ -6,19 +6,19 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 159
+        content_length: 190
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-func-exciting-leakey","environment_variables":{},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","secret_environment_variables":[],"tags":null}'
+        body: '{"name":"tf-func-jovial-pasteur","environment_variables":{},"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","secret_environment_variables":[],"tags":null,"activate_vpc_integration":true}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces
         method: POST
       response:
@@ -27,20 +27,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 475
+        content_length: 507
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:50.833868946Z","description":"","environment_variables":{},"error_message":null,"id":"75c5583a-6dcc-404f-955a-8ae46b97d533","name":"tf-func-exciting-leakey","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:44:50.833868946Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.632525491Z","description":"","environment_variables":{},"error_message":null,"id":"507327cc-ab4a-4f8b-abf1-e25f7432f64a","name":"tf-func-jovial-pasteur","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:13.632525491Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "475"
+                - "507"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:50 GMT
+                - Wed, 27 Aug 2025 15:05:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8d9ec82e-6d27-4ba6-b7e7-6ecd42ba5a13
+                - 8fda667a-ebb3-4e7e-a61e-a330bb839c53
         status: 200 OK
         code: 200
-        duration: 272.615291ms
+        duration: 5.541593624s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -67,8 +67,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/75c5583a-6dcc-404f-955a-8ae46b97d533
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/507327cc-ab4a-4f8b-abf1-e25f7432f64a
         method: GET
       response:
         proto: HTTP/2.0
@@ -76,20 +76,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 469
+        content_length: 501
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:50.833869Z","description":"","environment_variables":{},"error_message":null,"id":"75c5583a-6dcc-404f-955a-8ae46b97d533","name":"tf-func-exciting-leakey","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:44:50.833869Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.632525Z","description":"","environment_variables":{},"error_message":null,"id":"507327cc-ab4a-4f8b-abf1-e25f7432f64a","name":"tf-func-jovial-pasteur","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:13.632525Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "469"
+                - "501"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:50 GMT
+                - Wed, 27 Aug 2025 15:05:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - aac6bb96-394b-4407-bfa5-e61e112eabf9
+                - a0b0218a-8f54-4467-b81b-fd302cd81e49
         status: 200 OK
         code: 200
-        duration: 65.478333ms
+        duration: 43.017584ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -116,8 +116,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/75c5583a-6dcc-404f-955a-8ae46b97d533
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/507327cc-ab4a-4f8b-abf1-e25f7432f64a
         method: GET
       response:
         proto: HTTP/2.0
@@ -125,20 +125,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 469
+        content_length: 589
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:50.833869Z","description":"","environment_variables":{},"error_message":null,"id":"75c5583a-6dcc-404f-955a-8ae46b97d533","name":"tf-func-exciting-leakey","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:44:52.445918Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.632525Z","description":"","environment_variables":{},"error_message":null,"id":"507327cc-ab4a-4f8b-abf1-e25f7432f64a","name":"tf-func-jovial-pasteur","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncjovialpasteurst27xd26","registry_namespace_id":"af4cd7ef-d784-4fb3-b3e3-f557e91b290a","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:17.402330Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "469"
+                - "589"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:55 GMT
+                - Wed, 27 Aug 2025 15:05:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -146,10 +146,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1fa8be47-0cfb-446f-a079-1af76f4ddc76
+                - b335690a-d3e8-4625-bde6-fe20514ccfb1
         status: 200 OK
         code: 200
-        duration: 64.591792ms
+        duration: 469.151091ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -165,8 +165,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/75c5583a-6dcc-404f-955a-8ae46b97d533
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/507327cc-ab4a-4f8b-abf1-e25f7432f64a
         method: GET
       response:
         proto: HTTP/2.0
@@ -174,20 +174,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 560
+        content_length: 589
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:50.833869Z","description":"","environment_variables":{},"error_message":null,"id":"75c5583a-6dcc-404f-955a-8ae46b97d533","name":"tf-func-exciting-leakey","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncexcitingleakeytr4vkroh","registry_namespace_id":"92adb1e5-9d7c-4dec-bf22-62388fdf0fbe","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:45:00.778998Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.632525Z","description":"","environment_variables":{},"error_message":null,"id":"507327cc-ab4a-4f8b-abf1-e25f7432f64a","name":"tf-func-jovial-pasteur","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncjovialpasteurst27xd26","registry_namespace_id":"af4cd7ef-d784-4fb3-b3e3-f557e91b290a","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:17.402330Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "560"
+                - "589"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:01 GMT
+                - Wed, 27 Aug 2025 15:05:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -195,48 +195,50 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 35e4e43d-b75a-438f-9145-8e3c6038d947
+                - 991470c1-d62f-4ab8-8cef-2d8dd22bc9f5
         status: 200 OK
         code: 200
-        duration: 74.210875ms
+        duration: 66.259565ms
     - id: 4
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 301
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"name":"foobar","namespace_id":"507327cc-ab4a-4f8b-abf1-e25f7432f64a","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"go122","memory_limit":256,"handler":"Handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox","tags":null}'
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/75c5583a-6dcc-404f-955a-8ae46b97d533
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 558
+        content_length: 696
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:50.833869Z","description":"","environment_variables":{},"error_message":null,"id":"75c5583a-6dcc-404f-955a-8ae46b97d533","name":"tf-func-exciting-leakey","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncexcitingleakeytr4vkroh","registry_namespace_id":"92adb1e5-9d7c-4dec-bf22-62388fdf0fbe","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:45:01.113442Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:20.016585452Z","description":"","domain_name":"tffuncjovialpasteurst27xd26-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"d1d7b7b1-c997-4a1d-9f81-36cd61c20518","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"507327cc-ab4a-4f8b-abf1-e25f7432f64a","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:20.016585452Z"}'
         headers:
             Content-Length:
-                - "558"
+                - "696"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:06 GMT
+                - Wed, 27 Aug 2025 15:05:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -244,10 +246,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ae18c68d-9be7-4324-a912-445e84a4842f
+                - bbd29469-f498-4733-bcf3-d4cb78189f4b
         status: 200 OK
         code: 200
-        duration: 66.481709ms
+        duration: 755.000881ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -263,108 +265,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/75c5583a-6dcc-404f-955a-8ae46b97d533
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 558
-        uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:50.833869Z","description":"","environment_variables":{},"error_message":null,"id":"75c5583a-6dcc-404f-955a-8ae46b97d533","name":"tf-func-exciting-leakey","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncexcitingleakeytr4vkroh","registry_namespace_id":"92adb1e5-9d7c-4dec-bf22-62388fdf0fbe","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:45:01.113442Z"}'
-        headers:
-            Content-Length:
-                - "558"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:45:06 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 52b491e5-24f2-4279-8bc6-dc9e02ce7b1e
-        status: 200 OK
-        code: 200
-        duration: 67.466ms
-    - id: 6
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 289
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"name":"foobar","namespace_id":"75c5583a-6dcc-404f-955a-8ae46b97d533","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"go122","memory_limit":256,"handler":"Handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox"}'
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 661
-        uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:45:06.413856781Z","description":"","domain_name":"tffuncexcitingleakeytr4vkroh-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"4e3b9b42-adce-4a43-9843-80524f7580af","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"75c5583a-6dcc-404f-955a-8ae46b97d533","privacy":"private","ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:45:06.413856781Z"}'
-        headers:
-            Content-Length:
-                - "661"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:45:06 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 01241f50-a9b8-46aa-9b34-f1413a444b3d
-        status: 200 OK
-        code: 200
-        duration: 239.887209ms
-    - id: 7
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4e3b9b42-adce-4a43-9843-80524f7580af/upload-url?content_length=780
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1d7b7b1-c997-4a1d-9f81-36cd61c20518/upload-url?content_length=780
         method: GET
       response:
         proto: HTTP/2.0
@@ -374,7 +276,7 @@ interactions:
         trailer: {}
         content_length: 510
         uncompressed: false
-        body: '{"headers":{"content-length":["780"],"content-type":["application/octet-stream"]},"url":"https://s3.fr-par.scw.cloud/serverless-functions-code-prod-fr-par/uploads/function-4e3b9b42-adce-4a43-9843-80524f7580af.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256\u0026X-Amz-Credential=SCW3S98HDC0MAE9CBTQ5%2F20250124%2Ffr-par%2Fs3%2Faws4_request\u0026X-Amz-Date=20250124T154506Z\u0026X-Amz-Expires=3600\u0026X-Amz-SignedHeaders=content-length%3Bcontent-type%3Bhost\u0026X-Amz-Signature=e488b6a7ab4d012b38789205f7684cfc8b29ce3b91549ff0f9bb58ccc3ef90c1"}'
+        body: '{"headers":{"content-length":["780"],"content-type":["application/octet-stream"]},"url":"https://s3.fr-par.scw.cloud/serverless-functions-code-prod-fr-par/uploads/function-d1d7b7b1-c997-4a1d-9f81-36cd61c20518.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256\u0026X-Amz-Credential=SCW3S98HDC0MAE9CBTQ5%2F20250827%2Ffr-par%2Fs3%2Faws4_request\u0026X-Amz-Date=20250827T150520Z\u0026X-Amz-Expires=3600\u0026X-Amz-SignedHeaders=content-length%3Bcontent-type%3Bhost\u0026X-Amz-Signature=8cb760c2573a587252859480ba8b6ec83309a9cd141059bf3a647729631b6ff8"}'
         headers:
             Content-Length:
                 - "510"
@@ -383,9 +285,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:06 GMT
+                - Wed, 27 Aug 2025 15:05:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -393,11 +295,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - dd3959e0-fc5f-49fa-b11a-a61c58fe05e2
+                - ae3fb11b-a001-4940-af5b-aa68823ce5ac
         status: 200 OK
         code: 200
-        duration: 86.078625ms
-    - id: 8
+        duration: 50.769621ms
+    - id: 6
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -430,7 +332,7 @@ interactions:
                 - "780"
             Content-Type:
                 - application/octet-stream
-        url: https://s3.fr-par.scw.cloud/serverless-functions-code-prod-fr-par/uploads/function-4e3b9b42-adce-4a43-9843-80524f7580af.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=SCW3S98HDC0MAE9CBTQ5%2F20250124%2Ffr-par%2Fs3%2Faws4_request&X-Amz-Date=20250124T154506Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=content-length%3Bcontent-type%3Bhost&X-Amz-Signature=e488b6a7ab4d012b38789205f7684cfc8b29ce3b91549ff0f9bb58ccc3ef90c1
+        url: https://s3.fr-par.scw.cloud/serverless-functions-code-prod-fr-par/uploads/function-d1d7b7b1-c997-4a1d-9f81-36cd61c20518.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=SCW3S98HDC0MAE9CBTQ5%2F20250827%2Ffr-par%2Fs3%2Faws4_request&X-Amz-Date=20250827T150520Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=content-length%3Bcontent-type%3Bhost&X-Amz-Signature=8cb760c2573a587252859480ba8b6ec83309a9cd141059bf3a647729631b6ff8
         method: PUT
       response:
         proto: HTTP/2.0
@@ -445,17 +347,17 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Fri, 24 Jan 2025 15:45:06 GMT
+                - Wed, 27 Aug 2025 15:05:20 GMT
             Etag:
                 - '"10633bf7a5ff211d8f3eee3856a28101"'
             X-Amz-Id-2:
-                - txgab5d4a8d45794672bd95-006793b582
+                - txg306acc8ce59e4034ac67-0068af1eb0
             X-Amz-Request-Id:
-                - txgab5d4a8d45794672bd95-006793b582
+                - txg306acc8ce59e4034ac67-0068af1eb0
         status: 200 OK
         code: 200
-        duration: 261.66725ms
-    - id: 9
+        duration: 371.442921ms
+    - id: 7
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -472,8 +374,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4e3b9b42-adce-4a43-9843-80524f7580af/deploy
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1d7b7b1-c997-4a1d-9f81-36cd61c20518/deploy
         method: POST
       response:
         proto: HTTP/2.0
@@ -481,20 +383,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 658
+        content_length: 693
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:45:06.413857Z","description":"","domain_name":"tffuncexcitingleakeytr4vkroh-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"4e3b9b42-adce-4a43-9843-80524f7580af","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"75c5583a-6dcc-404f-955a-8ae46b97d533","privacy":"private","ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","timeout":"300s","updated_at":"2025-01-24T15:45:07.020223307Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:20.016585Z","description":"","domain_name":"tffuncjovialpasteurst27xd26-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"d1d7b7b1-c997-4a1d-9f81-36cd61c20518","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"507327cc-ab4a-4f8b-abf1-e25f7432f64a","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:20.538969554Z"}'
         headers:
             Content-Length:
-                - "658"
+                - "693"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:07 GMT
+                - Wed, 27 Aug 2025 15:05:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -502,10 +404,108 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0c0104c8-239b-4f17-94af-336e0fb94409
+                - b354e680-8b7c-4669-8e03-d2deab4ec64c
         status: 200 OK
         code: 200
-        duration: 276.948625ms
+        duration: 85.688951ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1d7b7b1-c997-4a1d-9f81-36cd61c20518
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 690
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:20.016585Z","description":"","domain_name":"tffuncjovialpasteurst27xd26-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"d1d7b7b1-c997-4a1d-9f81-36cd61c20518","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"507327cc-ab4a-4f8b-abf1-e25f7432f64a","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:20.538970Z"}'
+        headers:
+            Content-Length:
+                - "690"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:05:20 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 935a878e-98b3-45f2-9213-7e8c765c0208
+        status: 200 OK
+        code: 200
+        duration: 54.299023ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1d7b7b1-c997-4a1d-9f81-36cd61c20518
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 690
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:20.016585Z","description":"","domain_name":"tffuncjovialpasteurst27xd26-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"d1d7b7b1-c997-4a1d-9f81-36cd61c20518","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"507327cc-ab4a-4f8b-abf1-e25f7432f64a","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:21.957383Z"}'
+        headers:
+            Content-Length:
+                - "690"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:05:25 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 94e1fd9d-f0a0-4416-bf7b-82b79dca4a30
+        status: 200 OK
+        code: 200
+        duration: 58.305121ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -521,8 +521,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4e3b9b42-adce-4a43-9843-80524f7580af
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1d7b7b1-c997-4a1d-9f81-36cd61c20518
         method: GET
       response:
         proto: HTTP/2.0
@@ -530,20 +530,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 655
+        content_length: 727
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:45:06.413857Z","description":"","domain_name":"tffuncexcitingleakeytr4vkroh-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"4e3b9b42-adce-4a43-9843-80524f7580af","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"75c5583a-6dcc-404f-955a-8ae46b97d533","privacy":"private","ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","timeout":"300s","updated_at":"2025-01-24T15:45:07.020223Z"}'
+        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"created_at":"2025-08-27T15:05:20.016585Z","description":"","domain_name":"tffuncjovialpasteurst27xd26-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"d1d7b7b1-c997-4a1d-9f81-36cd61c20518","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"507327cc-ab4a-4f8b-abf1-e25f7432f64a","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:27.045937Z"}'
         headers:
             Content-Length:
-                - "655"
+                - "727"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:07 GMT
+                - Wed, 27 Aug 2025 15:05:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -551,10 +551,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 372740b7-75df-415c-8b81-85a6b6c4571f
+                - 8ec2bd55-1833-43f0-9460-d5cedb094b5a
         status: 200 OK
         code: 200
-        duration: 77.514875ms
+        duration: 47.245089ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -570,8 +570,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4e3b9b42-adce-4a43-9843-80524f7580af
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1d7b7b1-c997-4a1d-9f81-36cd61c20518
         method: GET
       response:
         proto: HTTP/2.0
@@ -579,20 +579,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 655
+        content_length: 727
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:45:06.413857Z","description":"","domain_name":"tffuncexcitingleakeytr4vkroh-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"4e3b9b42-adce-4a43-9843-80524f7580af","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"75c5583a-6dcc-404f-955a-8ae46b97d533","privacy":"private","ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","timeout":"300s","updated_at":"2025-01-24T15:45:07.389361Z"}'
+        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"created_at":"2025-08-27T15:05:20.016585Z","description":"","domain_name":"tffuncjovialpasteurst27xd26-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"d1d7b7b1-c997-4a1d-9f81-36cd61c20518","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"507327cc-ab4a-4f8b-abf1-e25f7432f64a","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:32.172025Z"}'
         headers:
             Content-Length:
-                - "655"
+                - "727"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:12 GMT
+                - Wed, 27 Aug 2025 15:05:35 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -600,10 +600,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e784e194-3d5e-47fc-b98d-cd359440421b
+                - eeba793b-7361-4a4c-b8f2-5277ce912fad
         status: 200 OK
         code: 200
-        duration: 81.78ms
+        duration: 57.79185ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -619,8 +619,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4e3b9b42-adce-4a43-9843-80524f7580af
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1d7b7b1-c997-4a1d-9f81-36cd61c20518
         method: GET
       response:
         proto: HTTP/2.0
@@ -628,20 +628,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 692
+        content_length: 727
         uncompressed: false
-        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"created_at":"2025-01-24T15:45:06.413857Z","description":"","domain_name":"tffuncexcitingleakeytr4vkroh-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"4e3b9b42-adce-4a43-9843-80524f7580af","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"75c5583a-6dcc-404f-955a-8ae46b97d533","privacy":"private","ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","timeout":"300s","updated_at":"2025-01-24T15:45:12.578918Z"}'
+        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"created_at":"2025-08-27T15:05:20.016585Z","description":"","domain_name":"tffuncjovialpasteurst27xd26-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"d1d7b7b1-c997-4a1d-9f81-36cd61c20518","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"507327cc-ab4a-4f8b-abf1-e25f7432f64a","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:37.314629Z"}'
         headers:
             Content-Length:
-                - "692"
+                - "727"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:17 GMT
+                - Wed, 27 Aug 2025 15:05:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -649,10 +649,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e3c63b0d-b33e-4dd6-aa0c-3640fe486c9f
+                - 224ccdd1-e529-417c-916f-f373b782ca7c
         status: 200 OK
         code: 200
-        duration: 74.514ms
+        duration: 58.05837ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -668,8 +668,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4e3b9b42-adce-4a43-9843-80524f7580af
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1d7b7b1-c997-4a1d-9f81-36cd61c20518
         method: GET
       response:
         proto: HTTP/2.0
@@ -677,20 +677,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 692
+        content_length: 727
         uncompressed: false
-        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"created_at":"2025-01-24T15:45:06.413857Z","description":"","domain_name":"tffuncexcitingleakeytr4vkroh-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"4e3b9b42-adce-4a43-9843-80524f7580af","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"75c5583a-6dcc-404f-955a-8ae46b97d533","privacy":"private","ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","timeout":"300s","updated_at":"2025-01-24T15:45:17.671227Z"}'
+        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"created_at":"2025-08-27T15:05:20.016585Z","description":"","domain_name":"tffuncjovialpasteurst27xd26-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"d1d7b7b1-c997-4a1d-9f81-36cd61c20518","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"507327cc-ab4a-4f8b-abf1-e25f7432f64a","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:44.298690Z"}'
         headers:
             Content-Length:
-                - "692"
+                - "727"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:22 GMT
+                - Wed, 27 Aug 2025 15:05:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -698,10 +698,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7b8d40b6-5e49-4e0a-9b01-8ee7044124c9
+                - 211680f9-061e-453b-aa06-95031120a194
         status: 200 OK
         code: 200
-        duration: 74.94475ms
+        duration: 55.635235ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -717,8 +717,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4e3b9b42-adce-4a43-9843-80524f7580af
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1d7b7b1-c997-4a1d-9f81-36cd61c20518
         method: GET
       response:
         proto: HTTP/2.0
@@ -726,20 +726,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 692
+        content_length: 727
         uncompressed: false
-        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"created_at":"2025-01-24T15:45:06.413857Z","description":"","domain_name":"tffuncexcitingleakeytr4vkroh-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"4e3b9b42-adce-4a43-9843-80524f7580af","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"75c5583a-6dcc-404f-955a-8ae46b97d533","privacy":"private","ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","timeout":"300s","updated_at":"2025-01-24T15:45:22.752187Z"}'
+        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"created_at":"2025-08-27T15:05:20.016585Z","description":"","domain_name":"tffuncjovialpasteurst27xd26-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"d1d7b7b1-c997-4a1d-9f81-36cd61c20518","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"507327cc-ab4a-4f8b-abf1-e25f7432f64a","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:49.379366Z"}'
         headers:
             Content-Length:
-                - "692"
+                - "727"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:27 GMT
+                - Wed, 27 Aug 2025 15:05:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -747,10 +747,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7051303d-441b-45fb-89a8-19a49ab536be
+                - 201785b3-6132-47b3-9729-30d619d826bb
         status: 200 OK
         code: 200
-        duration: 73.698583ms
+        duration: 67.584077ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -766,8 +766,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4e3b9b42-adce-4a43-9843-80524f7580af
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1d7b7b1-c997-4a1d-9f81-36cd61c20518
         method: GET
       response:
         proto: HTTP/2.0
@@ -775,20 +775,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 692
+        content_length: 727
         uncompressed: false
-        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"created_at":"2025-01-24T15:45:06.413857Z","description":"","domain_name":"tffuncexcitingleakeytr4vkroh-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"4e3b9b42-adce-4a43-9843-80524f7580af","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"75c5583a-6dcc-404f-955a-8ae46b97d533","privacy":"private","ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","timeout":"300s","updated_at":"2025-01-24T15:45:27.853820Z"}'
+        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"created_at":"2025-08-27T15:05:20.016585Z","description":"","domain_name":"tffuncjovialpasteurst27xd26-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"d1d7b7b1-c997-4a1d-9f81-36cd61c20518","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"507327cc-ab4a-4f8b-abf1-e25f7432f64a","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:54.485224Z"}'
         headers:
             Content-Length:
-                - "692"
+                - "727"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:32 GMT
+                - Wed, 27 Aug 2025 15:05:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -796,10 +796,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b6d0cadd-7d29-4eb3-b690-c76d2d38e650
+                - 883afce9-9650-4395-828a-a08c8708ca85
         status: 200 OK
         code: 200
-        duration: 65.51375ms
+        duration: 61.061429ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -815,8 +815,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4e3b9b42-adce-4a43-9843-80524f7580af
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1d7b7b1-c997-4a1d-9f81-36cd61c20518
         method: GET
       response:
         proto: HTTP/2.0
@@ -824,20 +824,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 692
+        content_length: 727
         uncompressed: false
-        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"created_at":"2025-01-24T15:45:06.413857Z","description":"","domain_name":"tffuncexcitingleakeytr4vkroh-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"4e3b9b42-adce-4a43-9843-80524f7580af","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"75c5583a-6dcc-404f-955a-8ae46b97d533","privacy":"private","ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","timeout":"300s","updated_at":"2025-01-24T15:45:32.942684Z"}'
+        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"created_at":"2025-08-27T15:05:20.016585Z","description":"","domain_name":"tffuncjovialpasteurst27xd26-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"d1d7b7b1-c997-4a1d-9f81-36cd61c20518","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"507327cc-ab4a-4f8b-abf1-e25f7432f64a","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:59.651765Z"}'
         headers:
             Content-Length:
-                - "692"
+                - "727"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:37 GMT
+                - Wed, 27 Aug 2025 15:06:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -845,10 +845,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a1c0eec7-12ff-4458-9af5-80815277fd44
+                - efb7edc2-fe25-402b-95dc-7f8d5263e46d
         status: 200 OK
         code: 200
-        duration: 76.921459ms
+        duration: 65.078498ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -864,8 +864,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4e3b9b42-adce-4a43-9843-80524f7580af
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1d7b7b1-c997-4a1d-9f81-36cd61c20518
         method: GET
       response:
         proto: HTTP/2.0
@@ -873,20 +873,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 718
+        content_length: 727
         uncompressed: false
-        body: '{"build_message":"step 3 of 3: function image is being pushed to container registry","cpu_limit":140,"created_at":"2025-01-24T15:45:06.413857Z","description":"","domain_name":"tffuncexcitingleakeytr4vkroh-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"4e3b9b42-adce-4a43-9843-80524f7580af","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"75c5583a-6dcc-404f-955a-8ae46b97d533","privacy":"private","ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","timeout":"300s","updated_at":"2025-01-24T15:45:38.029871Z"}'
+        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"created_at":"2025-08-27T15:05:20.016585Z","description":"","domain_name":"tffuncjovialpasteurst27xd26-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"d1d7b7b1-c997-4a1d-9f81-36cd61c20518","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"507327cc-ab4a-4f8b-abf1-e25f7432f64a","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:04.779092Z"}'
         headers:
             Content-Length:
-                - "718"
+                - "727"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:42 GMT
+                - Wed, 27 Aug 2025 15:06:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -894,10 +894,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 78de1737-b6b2-4194-baf5-3fa7c34678eb
+                - 3016776f-abb7-4ecd-ba9a-d7c2fff50083
         status: 200 OK
         code: 200
-        duration: 104.861167ms
+        duration: 44.291643ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -913,8 +913,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4e3b9b42-adce-4a43-9843-80524f7580af
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1d7b7b1-c997-4a1d-9f81-36cd61c20518
         method: GET
       response:
         proto: HTTP/2.0
@@ -922,20 +922,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 718
+        content_length: 727
         uncompressed: false
-        body: '{"build_message":"step 3 of 3: function image is being pushed to container registry","cpu_limit":140,"created_at":"2025-01-24T15:45:06.413857Z","description":"","domain_name":"tffuncexcitingleakeytr4vkroh-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"4e3b9b42-adce-4a43-9843-80524f7580af","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"75c5583a-6dcc-404f-955a-8ae46b97d533","privacy":"private","ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","timeout":"300s","updated_at":"2025-01-24T15:45:43.128068Z"}'
+        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"created_at":"2025-08-27T15:05:20.016585Z","description":"","domain_name":"tffuncjovialpasteurst27xd26-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"d1d7b7b1-c997-4a1d-9f81-36cd61c20518","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"507327cc-ab4a-4f8b-abf1-e25f7432f64a","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:10.068185Z"}'
         headers:
             Content-Length:
-                - "718"
+                - "727"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:47 GMT
+                - Wed, 27 Aug 2025 15:06:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -943,10 +943,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 43c98563-a843-432a-9563-0171ddbb64fc
+                - 98d37af0-7b46-4555-9cab-d20b3983e038
         status: 200 OK
         code: 200
-        duration: 88.337708ms
+        duration: 70.909953ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -962,8 +962,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4e3b9b42-adce-4a43-9843-80524f7580af
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1d7b7b1-c997-4a1d-9f81-36cd61c20518
         method: GET
       response:
         proto: HTTP/2.0
@@ -971,20 +971,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 655
+        content_length: 727
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:45:06.413857Z","description":"","domain_name":"tffuncexcitingleakeytr4vkroh-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"4e3b9b42-adce-4a43-9843-80524f7580af","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"75c5583a-6dcc-404f-955a-8ae46b97d533","privacy":"private","ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","timeout":"300s","updated_at":"2025-01-24T15:45:48.241992Z"}'
+        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"created_at":"2025-08-27T15:05:20.016585Z","description":"","domain_name":"tffuncjovialpasteurst27xd26-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"d1d7b7b1-c997-4a1d-9f81-36cd61c20518","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"507327cc-ab4a-4f8b-abf1-e25f7432f64a","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:15.293458Z"}'
         headers:
             Content-Length:
-                - "655"
+                - "727"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:53 GMT
+                - Wed, 27 Aug 2025 15:06:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -992,10 +992,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f3ef7a43-5c5d-44b5-a776-bee5905b33d1
+                - 5b9884a6-09d8-4ff4-9300-f74b4c130234
         status: 200 OK
         code: 200
-        duration: 334.58125ms
+        duration: 40.865956ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1011,8 +1011,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4e3b9b42-adce-4a43-9843-80524f7580af
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1d7b7b1-c997-4a1d-9f81-36cd61c20518
         method: GET
       response:
         proto: HTTP/2.0
@@ -1020,20 +1020,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 655
+        content_length: 727
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:45:06.413857Z","description":"","domain_name":"tffuncexcitingleakeytr4vkroh-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"4e3b9b42-adce-4a43-9843-80524f7580af","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"75c5583a-6dcc-404f-955a-8ae46b97d533","privacy":"private","ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","timeout":"300s","updated_at":"2025-01-24T15:45:53.347356Z"}'
+        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"created_at":"2025-08-27T15:05:20.016585Z","description":"","domain_name":"tffuncjovialpasteurst27xd26-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"d1d7b7b1-c997-4a1d-9f81-36cd61c20518","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"507327cc-ab4a-4f8b-abf1-e25f7432f64a","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:20.381906Z"}'
         headers:
             Content-Length:
-                - "655"
+                - "727"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:58 GMT
+                - Wed, 27 Aug 2025 15:06:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1041,10 +1041,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2c2f4316-873b-4431-9016-ee1ab697cfc6
+                - b302d6d8-4afe-4a9f-9a15-c1f18c128844
         status: 200 OK
         code: 200
-        duration: 75.79175ms
+        duration: 57.450537ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1060,8 +1060,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4e3b9b42-adce-4a43-9843-80524f7580af
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1d7b7b1-c997-4a1d-9f81-36cd61c20518
         method: GET
       response:
         proto: HTTP/2.0
@@ -1069,20 +1069,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 655
+        content_length: 753
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:45:06.413857Z","description":"","domain_name":"tffuncexcitingleakeytr4vkroh-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"4e3b9b42-adce-4a43-9843-80524f7580af","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"75c5583a-6dcc-404f-955a-8ae46b97d533","privacy":"private","ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","timeout":"300s","updated_at":"2025-01-24T15:45:53.347356Z"}'
+        body: '{"build_message":"step 3 of 3: function image is being pushed to container registry","cpu_limit":140,"created_at":"2025-08-27T15:05:20.016585Z","description":"","domain_name":"tffuncjovialpasteurst27xd26-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"d1d7b7b1-c997-4a1d-9f81-36cd61c20518","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"507327cc-ab4a-4f8b-abf1-e25f7432f64a","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:26.250689Z"}'
         headers:
             Content-Length:
-                - "655"
+                - "753"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:46:03 GMT
+                - Wed, 27 Aug 2025 15:06:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1090,10 +1090,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8a56bb41-592f-4b59-b961-20507b035491
+                - da5b71ad-4c93-4ca8-b4cd-deea1d855a36
         status: 200 OK
         code: 200
-        duration: 91.188167ms
+        duration: 42.898271ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1109,8 +1109,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4e3b9b42-adce-4a43-9843-80524f7580af
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1d7b7b1-c997-4a1d-9f81-36cd61c20518
         method: GET
       response:
         proto: HTTP/2.0
@@ -1118,20 +1118,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 678
+        content_length: 753
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:45:06.413857Z","description":"","domain_name":"tffuncexcitingleakeytr4vkroh-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"4e3b9b42-adce-4a43-9843-80524f7580af","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"75c5583a-6dcc-404f-955a-8ae46b97d533","privacy":"private","ready_at":"2025-01-24T15:46:03.993414Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"ready","timeout":"300s","updated_at":"2025-01-24T15:46:04.004277Z"}'
+        body: '{"build_message":"step 3 of 3: function image is being pushed to container registry","cpu_limit":140,"created_at":"2025-08-27T15:05:20.016585Z","description":"","domain_name":"tffuncjovialpasteurst27xd26-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"d1d7b7b1-c997-4a1d-9f81-36cd61c20518","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"507327cc-ab4a-4f8b-abf1-e25f7432f64a","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:26.250689Z"}'
         headers:
             Content-Length:
-                - "678"
+                - "753"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:46:08 GMT
+                - Wed, 27 Aug 2025 15:06:31 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1139,10 +1139,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 672b380e-c829-4e32-83df-1b52a56a3817
+                - f7ce699a-5777-4c1b-a349-8c722e362509
         status: 200 OK
         code: 200
-        duration: 81.878125ms
+        duration: 49.120037ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1158,8 +1158,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4e3b9b42-adce-4a43-9843-80524f7580af
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1d7b7b1-c997-4a1d-9f81-36cd61c20518
         method: GET
       response:
         proto: HTTP/2.0
@@ -1167,20 +1167,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 678
+        content_length: 753
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:45:06.413857Z","description":"","domain_name":"tffuncexcitingleakeytr4vkroh-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"4e3b9b42-adce-4a43-9843-80524f7580af","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"75c5583a-6dcc-404f-955a-8ae46b97d533","privacy":"private","ready_at":"2025-01-24T15:46:03.993414Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"ready","timeout":"300s","updated_at":"2025-01-24T15:46:04.004277Z"}'
+        body: '{"build_message":"step 3 of 3: function image is being pushed to container registry","cpu_limit":140,"created_at":"2025-08-27T15:05:20.016585Z","description":"","domain_name":"tffuncjovialpasteurst27xd26-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"d1d7b7b1-c997-4a1d-9f81-36cd61c20518","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"507327cc-ab4a-4f8b-abf1-e25f7432f64a","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:26.250689Z"}'
         headers:
             Content-Length:
-                - "678"
+                - "753"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:46:08 GMT
+                - Wed, 27 Aug 2025 15:06:36 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1188,10 +1188,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1f4cfebc-322b-4281-bde9-c8a9b396630e
+                - a781cd9e-cf9d-44fa-8878-15e8bfd004e8
         status: 200 OK
         code: 200
-        duration: 76.26625ms
+        duration: 62.128929ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1207,8 +1207,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4e3b9b42-adce-4a43-9843-80524f7580af
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1d7b7b1-c997-4a1d-9f81-36cd61c20518
         method: GET
       response:
         proto: HTTP/2.0
@@ -1216,20 +1216,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 678
+        content_length: 753
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:45:06.413857Z","description":"","domain_name":"tffuncexcitingleakeytr4vkroh-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"4e3b9b42-adce-4a43-9843-80524f7580af","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"75c5583a-6dcc-404f-955a-8ae46b97d533","privacy":"private","ready_at":"2025-01-24T15:46:03.993414Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"ready","timeout":"300s","updated_at":"2025-01-24T15:46:04.004277Z"}'
+        body: '{"build_message":"step 3 of 3: function image is being pushed to container registry","cpu_limit":140,"created_at":"2025-08-27T15:05:20.016585Z","description":"","domain_name":"tffuncjovialpasteurst27xd26-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"d1d7b7b1-c997-4a1d-9f81-36cd61c20518","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"507327cc-ab4a-4f8b-abf1-e25f7432f64a","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:26.250689Z"}'
         headers:
             Content-Length:
-                - "678"
+                - "753"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:46:08 GMT
+                - Wed, 27 Aug 2025 15:06:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1237,10 +1237,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 301b6302-7a0c-46c3-95de-61e15278bc02
+                - 700c936d-8eca-4f0f-a1bc-06ae1b3e6d68
         status: 200 OK
         code: 200
-        duration: 83.946417ms
+        duration: 63.408674ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1256,8 +1256,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/75c5583a-6dcc-404f-955a-8ae46b97d533
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1d7b7b1-c997-4a1d-9f81-36cd61c20518
         method: GET
       response:
         proto: HTTP/2.0
@@ -1265,20 +1265,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 558
+        content_length: 753
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:50.833869Z","description":"","environment_variables":{},"error_message":null,"id":"75c5583a-6dcc-404f-955a-8ae46b97d533","name":"tf-func-exciting-leakey","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncexcitingleakeytr4vkroh","registry_namespace_id":"92adb1e5-9d7c-4dec-bf22-62388fdf0fbe","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:45:01.113442Z"}'
+        body: '{"build_message":"step 3 of 3: function image is being pushed to container registry","cpu_limit":140,"created_at":"2025-08-27T15:05:20.016585Z","description":"","domain_name":"tffuncjovialpasteurst27xd26-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"d1d7b7b1-c997-4a1d-9f81-36cd61c20518","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"507327cc-ab4a-4f8b-abf1-e25f7432f64a","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:26.250689Z"}'
         headers:
             Content-Length:
-                - "558"
+                - "753"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:46:09 GMT
+                - Wed, 27 Aug 2025 15:06:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1286,10 +1286,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cbc72122-43a4-4886-a8e6-4c3d9afcd323
+                - 4efa5287-fdbd-48b1-88dd-40ccf24554a2
         status: 200 OK
         code: 200
-        duration: 71.269ms
+        duration: 43.138634ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1305,8 +1305,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4e3b9b42-adce-4a43-9843-80524f7580af
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1d7b7b1-c997-4a1d-9f81-36cd61c20518
         method: GET
       response:
         proto: HTTP/2.0
@@ -1314,20 +1314,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 678
+        content_length: 753
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:45:06.413857Z","description":"","domain_name":"tffuncexcitingleakeytr4vkroh-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"4e3b9b42-adce-4a43-9843-80524f7580af","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"75c5583a-6dcc-404f-955a-8ae46b97d533","privacy":"private","ready_at":"2025-01-24T15:46:03.993414Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"ready","timeout":"300s","updated_at":"2025-01-24T15:46:04.004277Z"}'
+        body: '{"build_message":"step 3 of 3: function image is being pushed to container registry","cpu_limit":140,"created_at":"2025-08-27T15:05:20.016585Z","description":"","domain_name":"tffuncjovialpasteurst27xd26-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"d1d7b7b1-c997-4a1d-9f81-36cd61c20518","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"507327cc-ab4a-4f8b-abf1-e25f7432f64a","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:26.250689Z"}'
         headers:
             Content-Length:
-                - "678"
+                - "753"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:46:09 GMT
+                - Wed, 27 Aug 2025 15:06:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1335,10 +1335,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c606c7b6-dfc0-4acd-98f2-61f0a5dffacc
+                - a9d22eb2-8fc5-41b7-b70b-3765ddfe39d6
         status: 200 OK
         code: 200
-        duration: 82.620375ms
+        duration: 40.978972ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1354,8 +1354,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/75c5583a-6dcc-404f-955a-8ae46b97d533
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1d7b7b1-c997-4a1d-9f81-36cd61c20518
         method: GET
       response:
         proto: HTTP/2.0
@@ -1363,20 +1363,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 558
+        content_length: 690
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:50.833869Z","description":"","environment_variables":{},"error_message":null,"id":"75c5583a-6dcc-404f-955a-8ae46b97d533","name":"tf-func-exciting-leakey","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncexcitingleakeytr4vkroh","registry_namespace_id":"92adb1e5-9d7c-4dec-bf22-62388fdf0fbe","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:45:01.113442Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:20.016585Z","description":"","domain_name":"tffuncjovialpasteurst27xd26-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"d1d7b7b1-c997-4a1d-9f81-36cd61c20518","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"507327cc-ab4a-4f8b-abf1-e25f7432f64a","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:52.173773Z"}'
         headers:
             Content-Length:
-                - "558"
+                - "690"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:46:10 GMT
+                - Wed, 27 Aug 2025 15:06:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1384,10 +1384,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 04fdbace-a8d9-49e5-a915-b34effe840e7
+                - bb4bbe2b-b761-4dd9-9658-f60ed53c49d6
         status: 200 OK
         code: 200
-        duration: 71.61875ms
+        duration: 58.418821ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1403,8 +1403,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4e3b9b42-adce-4a43-9843-80524f7580af
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1d7b7b1-c997-4a1d-9f81-36cd61c20518
         method: GET
       response:
         proto: HTTP/2.0
@@ -1412,20 +1412,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 678
+        content_length: 690
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:45:06.413857Z","description":"","domain_name":"tffuncexcitingleakeytr4vkroh-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"4e3b9b42-adce-4a43-9843-80524f7580af","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"75c5583a-6dcc-404f-955a-8ae46b97d533","privacy":"private","ready_at":"2025-01-24T15:46:03.993414Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"ready","timeout":"300s","updated_at":"2025-01-24T15:46:04.004277Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:20.016585Z","description":"","domain_name":"tffuncjovialpasteurst27xd26-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"d1d7b7b1-c997-4a1d-9f81-36cd61c20518","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"507327cc-ab4a-4f8b-abf1-e25f7432f64a","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:52.173773Z"}'
         headers:
             Content-Length:
-                - "678"
+                - "690"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:46:10 GMT
+                - Wed, 27 Aug 2025 15:07:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1433,10 +1433,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d47c7567-cdf5-4843-9015-639157734a4a
+                - 3c229032-86d8-4ee2-b2d3-49ade308d923
         status: 200 OK
         code: 200
-        duration: 72.061416ms
+        duration: 68.313841ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1452,8 +1452,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4e3b9b42-adce-4a43-9843-80524f7580af
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1d7b7b1-c997-4a1d-9f81-36cd61c20518
         method: GET
       response:
         proto: HTTP/2.0
@@ -1461,20 +1461,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 678
+        content_length: 713
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:45:06.413857Z","description":"","domain_name":"tffuncexcitingleakeytr4vkroh-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"4e3b9b42-adce-4a43-9843-80524f7580af","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"75c5583a-6dcc-404f-955a-8ae46b97d533","privacy":"private","ready_at":"2025-01-24T15:46:03.993414Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"ready","timeout":"300s","updated_at":"2025-01-24T15:46:04.004277Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:20.016585Z","description":"","domain_name":"tffuncjovialpasteurst27xd26-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"d1d7b7b1-c997-4a1d-9f81-36cd61c20518","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"507327cc-ab4a-4f8b-abf1-e25f7432f64a","privacy":"private","private_network_id":null,"ready_at":"2025-08-27T15:07:03.087668Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"ready","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:07:03.102725Z"}'
         headers:
             Content-Length:
-                - "678"
+                - "713"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:46:11 GMT
+                - Wed, 27 Aug 2025 15:07:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1482,10 +1482,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 975cabb8-377f-406e-bb01-def9d839b0cc
+                - f408f4f2-2fe6-454b-9eee-21e2395fadac
         status: 200 OK
         code: 200
-        duration: 74.197042ms
+        duration: 43.338721ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1501,8 +1501,351 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4e3b9b42-adce-4a43-9843-80524f7580af/upload-url?content_length=780
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1d7b7b1-c997-4a1d-9f81-36cd61c20518
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 713
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:20.016585Z","description":"","domain_name":"tffuncjovialpasteurst27xd26-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"d1d7b7b1-c997-4a1d-9f81-36cd61c20518","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"507327cc-ab4a-4f8b-abf1-e25f7432f64a","privacy":"private","private_network_id":null,"ready_at":"2025-08-27T15:07:03.087668Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"ready","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:07:03.102725Z"}'
+        headers:
+            Content-Length:
+                - "713"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:07:06 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - c0fc7704-1992-497b-8ee0-b9b833490a92
+        status: 200 OK
+        code: 200
+        duration: 66.948099ms
+    - id: 31
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1d7b7b1-c997-4a1d-9f81-36cd61c20518
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 713
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:20.016585Z","description":"","domain_name":"tffuncjovialpasteurst27xd26-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"d1d7b7b1-c997-4a1d-9f81-36cd61c20518","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"507327cc-ab4a-4f8b-abf1-e25f7432f64a","privacy":"private","private_network_id":null,"ready_at":"2025-08-27T15:07:03.087668Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"ready","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:07:03.102725Z"}'
+        headers:
+            Content-Length:
+                - "713"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:07:07 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 234cd136-9ee0-4747-a6c6-b77bdb04412c
+        status: 200 OK
+        code: 200
+        duration: 57.746801ms
+    - id: 32
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/507327cc-ab4a-4f8b-abf1-e25f7432f64a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 589
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:13.632525Z","description":"","environment_variables":{},"error_message":null,"id":"507327cc-ab4a-4f8b-abf1-e25f7432f64a","name":"tf-func-jovial-pasteur","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncjovialpasteurst27xd26","registry_namespace_id":"af4cd7ef-d784-4fb3-b3e3-f557e91b290a","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:17.402330Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "589"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:07:07 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - d951d37c-7e51-479b-81a2-74f621049e40
+        status: 200 OK
+        code: 200
+        duration: 53.305267ms
+    - id: 33
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1d7b7b1-c997-4a1d-9f81-36cd61c20518
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 713
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:20.016585Z","description":"","domain_name":"tffuncjovialpasteurst27xd26-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"d1d7b7b1-c997-4a1d-9f81-36cd61c20518","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"507327cc-ab4a-4f8b-abf1-e25f7432f64a","privacy":"private","private_network_id":null,"ready_at":"2025-08-27T15:07:03.087668Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"ready","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:07:03.102725Z"}'
+        headers:
+            Content-Length:
+                - "713"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:07:07 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - dc08e692-f970-4b8d-a711-00ec4344e968
+        status: 200 OK
+        code: 200
+        duration: 65.542892ms
+    - id: 34
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/507327cc-ab4a-4f8b-abf1-e25f7432f64a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 589
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:13.632525Z","description":"","environment_variables":{},"error_message":null,"id":"507327cc-ab4a-4f8b-abf1-e25f7432f64a","name":"tf-func-jovial-pasteur","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncjovialpasteurst27xd26","registry_namespace_id":"af4cd7ef-d784-4fb3-b3e3-f557e91b290a","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:17.402330Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "589"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:07:07 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b184fd02-f588-411e-8976-eba667eb415e
+        status: 200 OK
+        code: 200
+        duration: 53.922945ms
+    - id: 35
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1d7b7b1-c997-4a1d-9f81-36cd61c20518
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 713
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:20.016585Z","description":"","domain_name":"tffuncjovialpasteurst27xd26-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"d1d7b7b1-c997-4a1d-9f81-36cd61c20518","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"507327cc-ab4a-4f8b-abf1-e25f7432f64a","privacy":"private","private_network_id":null,"ready_at":"2025-08-27T15:07:03.087668Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"ready","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:07:03.102725Z"}'
+        headers:
+            Content-Length:
+                - "713"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:07:07 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f2b8c3f0-2848-4f45-99b8-53a66fe8df7a
+        status: 200 OK
+        code: 200
+        duration: 58.557392ms
+    - id: 36
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1d7b7b1-c997-4a1d-9f81-36cd61c20518
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 713
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:20.016585Z","description":"","domain_name":"tffuncjovialpasteurst27xd26-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"d1d7b7b1-c997-4a1d-9f81-36cd61c20518","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"507327cc-ab4a-4f8b-abf1-e25f7432f64a","privacy":"private","private_network_id":null,"ready_at":"2025-08-27T15:07:03.087668Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"ready","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:07:03.102725Z"}'
+        headers:
+            Content-Length:
+                - "713"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:07:08 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - d840016a-aa32-4f6c-a414-72027e7eaed2
+        status: 200 OK
+        code: 200
+        duration: 51.448923ms
+    - id: 37
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1d7b7b1-c997-4a1d-9f81-36cd61c20518/upload-url?content_length=780
         method: GET
       response:
         proto: HTTP/2.0
@@ -1512,7 +1855,7 @@ interactions:
         trailer: {}
         content_length: 510
         uncompressed: false
-        body: '{"headers":{"content-length":["780"],"content-type":["application/octet-stream"]},"url":"https://s3.fr-par.scw.cloud/serverless-functions-code-prod-fr-par/uploads/function-4e3b9b42-adce-4a43-9843-80524f7580af.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256\u0026X-Amz-Credential=SCW3S98HDC0MAE9CBTQ5%2F20250124%2Ffr-par%2Fs3%2Faws4_request\u0026X-Amz-Date=20250124T154611Z\u0026X-Amz-Expires=3600\u0026X-Amz-SignedHeaders=content-length%3Bcontent-type%3Bhost\u0026X-Amz-Signature=6250c1b43442f79d225a887787fea5fd4675f40806694ea848c59cf816eb4869"}'
+        body: '{"headers":{"content-length":["780"],"content-type":["application/octet-stream"]},"url":"https://s3.fr-par.scw.cloud/serverless-functions-code-prod-fr-par/uploads/function-d1d7b7b1-c997-4a1d-9f81-36cd61c20518.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256\u0026X-Amz-Credential=SCW3S98HDC0MAE9CBTQ5%2F20250827%2Ffr-par%2Fs3%2Faws4_request\u0026X-Amz-Date=20250827T150708Z\u0026X-Amz-Expires=3600\u0026X-Amz-SignedHeaders=content-length%3Bcontent-type%3Bhost\u0026X-Amz-Signature=032d172d4f75e18b6932379088d2e43c96fe2e29855d566908fbae44b2fca968"}'
         headers:
             Content-Length:
                 - "510"
@@ -1521,9 +1864,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:46:11 GMT
+                - Wed, 27 Aug 2025 15:07:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1531,11 +1874,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ce912c40-27c7-401f-9dd3-f6d408404846
+                - f8f8912d-e77f-4f50-82df-f750d4ad298c
         status: 200 OK
         code: 200
-        duration: 81.993417ms
-    - id: 31
+        duration: 50.980113ms
+    - id: 38
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1568,7 +1911,7 @@ interactions:
                 - "780"
             Content-Type:
                 - application/octet-stream
-        url: https://s3.fr-par.scw.cloud/serverless-functions-code-prod-fr-par/uploads/function-4e3b9b42-adce-4a43-9843-80524f7580af.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=SCW3S98HDC0MAE9CBTQ5%2F20250124%2Ffr-par%2Fs3%2Faws4_request&X-Amz-Date=20250124T154611Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=content-length%3Bcontent-type%3Bhost&X-Amz-Signature=6250c1b43442f79d225a887787fea5fd4675f40806694ea848c59cf816eb4869
+        url: https://s3.fr-par.scw.cloud/serverless-functions-code-prod-fr-par/uploads/function-d1d7b7b1-c997-4a1d-9f81-36cd61c20518.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=SCW3S98HDC0MAE9CBTQ5%2F20250827%2Ffr-par%2Fs3%2Faws4_request&X-Amz-Date=20250827T150708Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=content-length%3Bcontent-type%3Bhost&X-Amz-Signature=032d172d4f75e18b6932379088d2e43c96fe2e29855d566908fbae44b2fca968
         method: PUT
       response:
         proto: HTTP/2.0
@@ -1583,17 +1926,17 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Fri, 24 Jan 2025 15:46:11 GMT
+                - Wed, 27 Aug 2025 15:07:08 GMT
             Etag:
                 - '"10633bf7a5ff211d8f3eee3856a28101"'
             X-Amz-Id-2:
-                - txg5fdeff8e1eb141b38b00-006793b5c3
+                - txg6c109b55e3404d05aeed-0068af1f1c
             X-Amz-Request-Id:
-                - txg5fdeff8e1eb141b38b00-006793b5c3
+                - txg6c109b55e3404d05aeed-0068af1f1c
         status: 200 OK
         code: 200
-        duration: 361.075541ms
-    - id: 32
+        duration: 462.709292ms
+    - id: 39
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1608,8 +1951,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4e3b9b42-adce-4a43-9843-80524f7580af
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1d7b7b1-c997-4a1d-9f81-36cd61c20518
         method: GET
       response:
         proto: HTTP/2.0
@@ -1617,20 +1960,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 678
+        content_length: 713
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:45:06.413857Z","description":"","domain_name":"tffuncexcitingleakeytr4vkroh-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"4e3b9b42-adce-4a43-9843-80524f7580af","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"75c5583a-6dcc-404f-955a-8ae46b97d533","privacy":"private","ready_at":"2025-01-24T15:46:03.993414Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"ready","timeout":"300s","updated_at":"2025-01-24T15:46:04.004277Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:20.016585Z","description":"","domain_name":"tffuncjovialpasteurst27xd26-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"d1d7b7b1-c997-4a1d-9f81-36cd61c20518","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"507327cc-ab4a-4f8b-abf1-e25f7432f64a","privacy":"private","private_network_id":null,"ready_at":"2025-08-27T15:07:03.087668Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"ready","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:07:03.102725Z"}'
         headers:
             Content-Length:
-                - "678"
+                - "713"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:46:11 GMT
+                - Wed, 27 Aug 2025 15:07:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1638,11 +1981,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e9085fd7-8fda-4068-9dee-06beb24688b5
+                - 6878baae-b396-4d88-ae1c-cc3576b3a9b3
         status: 200 OK
         code: 200
-        duration: 74.24925ms
-    - id: 33
+        duration: 74.744812ms
+    - id: 40
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1659,8 +2002,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4e3b9b42-adce-4a43-9843-80524f7580af/deploy
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1d7b7b1-c997-4a1d-9f81-36cd61c20518/deploy
         method: POST
       response:
         proto: HTTP/2.0
@@ -1668,20 +2011,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 683
+        content_length: 718
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:45:06.413857Z","description":"","domain_name":"tffuncexcitingleakeytr4vkroh-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"4e3b9b42-adce-4a43-9843-80524f7580af","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"75c5583a-6dcc-404f-955a-8ae46b97d533","privacy":"private","ready_at":"2025-01-24T15:46:03.993414Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","timeout":"300s","updated_at":"2025-01-24T15:46:11.747421338Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:20.016585Z","description":"","domain_name":"tffuncjovialpasteurst27xd26-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"d1d7b7b1-c997-4a1d-9f81-36cd61c20518","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"507327cc-ab4a-4f8b-abf1-e25f7432f64a","privacy":"private","private_network_id":null,"ready_at":"2025-08-27T15:07:03.087668Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:07:08.852548222Z"}'
         headers:
             Content-Length:
-                - "683"
+                - "718"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:46:11 GMT
+                - Wed, 27 Aug 2025 15:07:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1689,353 +2032,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d550b84e-e8b3-4277-9237-03dd9b093764
+                - e3109d44-eeb7-4b36-8b24-a0245d7ae1bf
         status: 200 OK
         code: 200
-        duration: 112.431833ms
-    - id: 34
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4e3b9b42-adce-4a43-9843-80524f7580af
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 680
-        uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:45:06.413857Z","description":"","domain_name":"tffuncexcitingleakeytr4vkroh-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"4e3b9b42-adce-4a43-9843-80524f7580af","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"75c5583a-6dcc-404f-955a-8ae46b97d533","privacy":"private","ready_at":"2025-01-24T15:46:03.993414Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","timeout":"300s","updated_at":"2025-01-24T15:46:11.747421Z"}'
-        headers:
-            Content-Length:
-                - "680"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:46:11 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - bc11c02e-cc60-4c0c-9448-55e53bd55dd9
-        status: 200 OK
-        code: 200
-        duration: 78.873334ms
-    - id: 35
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4e3b9b42-adce-4a43-9843-80524f7580af
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 717
-        uncompressed: false
-        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"created_at":"2025-01-24T15:45:06.413857Z","description":"","domain_name":"tffuncexcitingleakeytr4vkroh-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"4e3b9b42-adce-4a43-9843-80524f7580af","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"75c5583a-6dcc-404f-955a-8ae46b97d533","privacy":"private","ready_at":"2025-01-24T15:46:03.993414Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","timeout":"300s","updated_at":"2025-01-24T15:46:17.218714Z"}'
-        headers:
-            Content-Length:
-                - "717"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:46:17 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 601627e0-74bc-4a67-acbe-30a0ed45415c
-        status: 200 OK
-        code: 200
-        duration: 485.781334ms
-    - id: 36
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4e3b9b42-adce-4a43-9843-80524f7580af
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 717
-        uncompressed: false
-        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"created_at":"2025-01-24T15:45:06.413857Z","description":"","domain_name":"tffuncexcitingleakeytr4vkroh-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"4e3b9b42-adce-4a43-9843-80524f7580af","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"75c5583a-6dcc-404f-955a-8ae46b97d533","privacy":"private","ready_at":"2025-01-24T15:46:03.993414Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","timeout":"300s","updated_at":"2025-01-24T15:46:22.317990Z"}'
-        headers:
-            Content-Length:
-                - "717"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:46:22 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 4567d2d0-39d6-480b-b84c-abcdda5679af
-        status: 200 OK
-        code: 200
-        duration: 76.237041ms
-    - id: 37
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4e3b9b42-adce-4a43-9843-80524f7580af
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 717
-        uncompressed: false
-        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"created_at":"2025-01-24T15:45:06.413857Z","description":"","domain_name":"tffuncexcitingleakeytr4vkroh-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"4e3b9b42-adce-4a43-9843-80524f7580af","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"75c5583a-6dcc-404f-955a-8ae46b97d533","privacy":"private","ready_at":"2025-01-24T15:46:03.993414Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","timeout":"300s","updated_at":"2025-01-24T15:46:27.394362Z"}'
-        headers:
-            Content-Length:
-                - "717"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:46:27 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - f868c868-3a17-4485-8094-b4ab9ddf94f0
-        status: 200 OK
-        code: 200
-        duration: 89.687375ms
-    - id: 38
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4e3b9b42-adce-4a43-9843-80524f7580af
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 717
-        uncompressed: false
-        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"created_at":"2025-01-24T15:45:06.413857Z","description":"","domain_name":"tffuncexcitingleakeytr4vkroh-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"4e3b9b42-adce-4a43-9843-80524f7580af","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"75c5583a-6dcc-404f-955a-8ae46b97d533","privacy":"private","ready_at":"2025-01-24T15:46:03.993414Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","timeout":"300s","updated_at":"2025-01-24T15:46:32.495557Z"}'
-        headers:
-            Content-Length:
-                - "717"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:46:32 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 6e1bce0f-d72b-487f-ad39-0cdb5fd1a243
-        status: 200 OK
-        code: 200
-        duration: 81.9595ms
-    - id: 39
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4e3b9b42-adce-4a43-9843-80524f7580af
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 717
-        uncompressed: false
-        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"created_at":"2025-01-24T15:45:06.413857Z","description":"","domain_name":"tffuncexcitingleakeytr4vkroh-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"4e3b9b42-adce-4a43-9843-80524f7580af","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"75c5583a-6dcc-404f-955a-8ae46b97d533","privacy":"private","ready_at":"2025-01-24T15:46:03.993414Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","timeout":"300s","updated_at":"2025-01-24T15:46:37.581896Z"}'
-        headers:
-            Content-Length:
-                - "717"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:46:37 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 50abe140-a66e-4759-8d61-e06803724a6a
-        status: 200 OK
-        code: 200
-        duration: 72.290167ms
-    - id: 40
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4e3b9b42-adce-4a43-9843-80524f7580af
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 717
-        uncompressed: false
-        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"created_at":"2025-01-24T15:45:06.413857Z","description":"","domain_name":"tffuncexcitingleakeytr4vkroh-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"4e3b9b42-adce-4a43-9843-80524f7580af","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"75c5583a-6dcc-404f-955a-8ae46b97d533","privacy":"private","ready_at":"2025-01-24T15:46:03.993414Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","timeout":"300s","updated_at":"2025-01-24T15:46:37.581896Z"}'
-        headers:
-            Content-Length:
-                - "717"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:46:42 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - fa38ad95-1ed0-4fbf-9a80-cbc9b38cf342
-        status: 200 OK
-        code: 200
-        duration: 69.835792ms
+        duration: 93.739389ms
     - id: 41
       request:
         proto: HTTP/1.1
@@ -2051,8 +2051,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4e3b9b42-adce-4a43-9843-80524f7580af
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1d7b7b1-c997-4a1d-9f81-36cd61c20518
         method: GET
       response:
         proto: HTTP/2.0
@@ -2060,20 +2060,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 717
+        content_length: 715
         uncompressed: false
-        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"created_at":"2025-01-24T15:45:06.413857Z","description":"","domain_name":"tffuncexcitingleakeytr4vkroh-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"4e3b9b42-adce-4a43-9843-80524f7580af","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"75c5583a-6dcc-404f-955a-8ae46b97d533","privacy":"private","ready_at":"2025-01-24T15:46:03.993414Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","timeout":"300s","updated_at":"2025-01-24T15:46:42.763776Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:20.016585Z","description":"","domain_name":"tffuncjovialpasteurst27xd26-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"d1d7b7b1-c997-4a1d-9f81-36cd61c20518","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"507327cc-ab4a-4f8b-abf1-e25f7432f64a","privacy":"private","private_network_id":null,"ready_at":"2025-08-27T15:07:03.087668Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:07:08.852548Z"}'
         headers:
             Content-Length:
-                - "717"
+                - "715"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:46:47 GMT
+                - Wed, 27 Aug 2025 15:07:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2081,10 +2081,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d6faf8bf-13ea-43fe-8711-7cf891c9d17d
+                - 8cc6288e-e334-4aec-b220-912c6e43443e
         status: 200 OK
         code: 200
-        duration: 75.51775ms
+        duration: 151.471211ms
     - id: 42
       request:
         proto: HTTP/1.1
@@ -2100,8 +2100,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4e3b9b42-adce-4a43-9843-80524f7580af
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1d7b7b1-c997-4a1d-9f81-36cd61c20518
         method: GET
       response:
         proto: HTTP/2.0
@@ -2109,20 +2109,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 743
+        content_length: 715
         uncompressed: false
-        body: '{"build_message":"step 3 of 3: function image is being pushed to container registry","cpu_limit":140,"created_at":"2025-01-24T15:45:06.413857Z","description":"","domain_name":"tffuncexcitingleakeytr4vkroh-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"4e3b9b42-adce-4a43-9843-80524f7580af","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"75c5583a-6dcc-404f-955a-8ae46b97d533","privacy":"private","ready_at":"2025-01-24T15:46:03.993414Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","timeout":"300s","updated_at":"2025-01-24T15:46:47.896329Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:20.016585Z","description":"","domain_name":"tffuncjovialpasteurst27xd26-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"d1d7b7b1-c997-4a1d-9f81-36cd61c20518","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"507327cc-ab4a-4f8b-abf1-e25f7432f64a","privacy":"private","private_network_id":null,"ready_at":"2025-08-27T15:07:03.087668Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:07:08.852548Z"}'
         headers:
             Content-Length:
-                - "743"
+                - "715"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:46:52 GMT
+                - Wed, 27 Aug 2025 15:07:14 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2130,10 +2130,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9b936329-e195-48f5-ad90-d7a8cf2cc77c
+                - 22982e20-ed7c-46bd-8733-7fcee6ad4fa1
         status: 200 OK
         code: 200
-        duration: 71.013167ms
+        duration: 73.89659ms
     - id: 43
       request:
         proto: HTTP/1.1
@@ -2149,8 +2149,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4e3b9b42-adce-4a43-9843-80524f7580af
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1d7b7b1-c997-4a1d-9f81-36cd61c20518
         method: GET
       response:
         proto: HTTP/2.0
@@ -2158,20 +2158,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 743
+        content_length: 715
         uncompressed: false
-        body: '{"build_message":"step 3 of 3: function image is being pushed to container registry","cpu_limit":140,"created_at":"2025-01-24T15:45:06.413857Z","description":"","domain_name":"tffuncexcitingleakeytr4vkroh-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"4e3b9b42-adce-4a43-9843-80524f7580af","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"75c5583a-6dcc-404f-955a-8ae46b97d533","privacy":"private","ready_at":"2025-01-24T15:46:03.993414Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","timeout":"300s","updated_at":"2025-01-24T15:46:52.967726Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:20.016585Z","description":"","domain_name":"tffuncjovialpasteurst27xd26-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"d1d7b7b1-c997-4a1d-9f81-36cd61c20518","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"507327cc-ab4a-4f8b-abf1-e25f7432f64a","privacy":"private","private_network_id":null,"ready_at":"2025-08-27T15:07:03.087668Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:07:08.852548Z"}'
         headers:
             Content-Length:
-                - "743"
+                - "715"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:46:57 GMT
+                - Wed, 27 Aug 2025 15:07:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2179,10 +2179,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 71748427-f56d-4362-a966-6b2480856764
+                - 35600520-4aa4-4a9d-a025-f3c0d76f8f71
         status: 200 OK
         code: 200
-        duration: 68.538917ms
+        duration: 73.553377ms
     - id: 44
       request:
         proto: HTTP/1.1
@@ -2198,8 +2198,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4e3b9b42-adce-4a43-9843-80524f7580af
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1d7b7b1-c997-4a1d-9f81-36cd61c20518
         method: GET
       response:
         proto: HTTP/2.0
@@ -2207,20 +2207,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 680
+        content_length: 715
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:45:06.413857Z","description":"","domain_name":"tffuncexcitingleakeytr4vkroh-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"4e3b9b42-adce-4a43-9843-80524f7580af","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"75c5583a-6dcc-404f-955a-8ae46b97d533","privacy":"private","ready_at":"2025-01-24T15:46:03.993414Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","timeout":"300s","updated_at":"2025-01-24T15:46:58.093771Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:20.016585Z","description":"","domain_name":"tffuncjovialpasteurst27xd26-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"d1d7b7b1-c997-4a1d-9f81-36cd61c20518","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"507327cc-ab4a-4f8b-abf1-e25f7432f64a","privacy":"private","private_network_id":null,"ready_at":"2025-08-27T15:07:03.087668Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:07:08.852548Z"}'
         headers:
             Content-Length:
-                - "680"
+                - "715"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:47:03 GMT
+                - Wed, 27 Aug 2025 15:07:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2228,10 +2228,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - de2ffa36-9bd1-459a-b2ec-a994702aa39b
+                - 861ab6cc-ce91-4fdf-a5a4-eee0881e2158
         status: 200 OK
         code: 200
-        duration: 77.98875ms
+        duration: 58.211276ms
     - id: 45
       request:
         proto: HTTP/1.1
@@ -2247,8 +2247,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4e3b9b42-adce-4a43-9843-80524f7580af
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1d7b7b1-c997-4a1d-9f81-36cd61c20518
         method: GET
       response:
         proto: HTTP/2.0
@@ -2256,20 +2256,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 680
+        content_length: 715
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:45:06.413857Z","description":"","domain_name":"tffuncexcitingleakeytr4vkroh-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"4e3b9b42-adce-4a43-9843-80524f7580af","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"75c5583a-6dcc-404f-955a-8ae46b97d533","privacy":"private","ready_at":"2025-01-24T15:46:03.993414Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","timeout":"300s","updated_at":"2025-01-24T15:46:58.093771Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:20.016585Z","description":"","domain_name":"tffuncjovialpasteurst27xd26-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"d1d7b7b1-c997-4a1d-9f81-36cd61c20518","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"507327cc-ab4a-4f8b-abf1-e25f7432f64a","privacy":"private","private_network_id":null,"ready_at":"2025-08-27T15:07:03.087668Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:07:08.852548Z"}'
         headers:
             Content-Length:
-                - "680"
+                - "715"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:47:08 GMT
+                - Wed, 27 Aug 2025 15:07:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2277,10 +2277,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 81d280f7-58e9-42ea-bef4-88f8c3f2efc3
+                - 87301401-5cb6-49fa-a719-4d37d4d82404
         status: 200 OK
         code: 200
-        duration: 85.305ms
+        duration: 53.15133ms
     - id: 46
       request:
         proto: HTTP/1.1
@@ -2296,8 +2296,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4e3b9b42-adce-4a43-9843-80524f7580af
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1d7b7b1-c997-4a1d-9f81-36cd61c20518
         method: GET
       response:
         proto: HTTP/2.0
@@ -2305,20 +2305,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 678
+        content_length: 764
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:45:06.413857Z","description":"","domain_name":"tffuncexcitingleakeytr4vkroh-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"4e3b9b42-adce-4a43-9843-80524f7580af","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"75c5583a-6dcc-404f-955a-8ae46b97d533","privacy":"private","ready_at":"2025-01-24T15:46:03.993414Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"ready","timeout":"300s","updated_at":"2025-01-24T15:47:08.800861Z"}'
+        body: '{"build_message":"step 1 of 3: function build preparation in progress","cpu_limit":140,"created_at":"2025-08-27T15:05:20.016585Z","description":"","domain_name":"tffuncjovialpasteurst27xd26-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"d1d7b7b1-c997-4a1d-9f81-36cd61c20518","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"507327cc-ab4a-4f8b-abf1-e25f7432f64a","privacy":"private","private_network_id":null,"ready_at":"2025-08-27T15:07:03.087668Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:07:29.456645Z"}'
         headers:
             Content-Length:
-                - "678"
+                - "764"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:47:13 GMT
+                - Wed, 27 Aug 2025 15:07:34 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2326,10 +2326,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3a362306-e118-4799-a126-ecc1b077f901
+                - 1dc50165-0f24-4ac5-a604-61b7a0ae788e
         status: 200 OK
         code: 200
-        duration: 107.923084ms
+        duration: 52.216548ms
     - id: 47
       request:
         proto: HTTP/1.1
@@ -2345,8 +2345,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4e3b9b42-adce-4a43-9843-80524f7580af
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1d7b7b1-c997-4a1d-9f81-36cd61c20518
         method: GET
       response:
         proto: HTTP/2.0
@@ -2354,20 +2354,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 678
+        content_length: 752
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:45:06.413857Z","description":"","domain_name":"tffuncexcitingleakeytr4vkroh-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"4e3b9b42-adce-4a43-9843-80524f7580af","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"75c5583a-6dcc-404f-955a-8ae46b97d533","privacy":"private","ready_at":"2025-01-24T15:46:03.993414Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"ready","timeout":"300s","updated_at":"2025-01-24T15:47:08.800861Z"}'
+        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"created_at":"2025-08-27T15:05:20.016585Z","description":"","domain_name":"tffuncjovialpasteurst27xd26-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"d1d7b7b1-c997-4a1d-9f81-36cd61c20518","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"507327cc-ab4a-4f8b-abf1-e25f7432f64a","privacy":"private","private_network_id":null,"ready_at":"2025-08-27T15:07:03.087668Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:07:34.562520Z"}'
         headers:
             Content-Length:
-                - "678"
+                - "752"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:47:13 GMT
+                - Wed, 27 Aug 2025 15:07:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2375,10 +2375,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 23b4fc05-c4fc-4906-8385-ba7971a98722
+                - 08860dea-c02e-46b4-ab41-0e0839c24347
         status: 200 OK
         code: 200
-        duration: 79.789875ms
+        duration: 55.146387ms
     - id: 48
       request:
         proto: HTTP/1.1
@@ -2394,8 +2394,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/75c5583a-6dcc-404f-955a-8ae46b97d533
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1d7b7b1-c997-4a1d-9f81-36cd61c20518
         method: GET
       response:
         proto: HTTP/2.0
@@ -2403,20 +2403,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 558
+        content_length: 752
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:50.833869Z","description":"","environment_variables":{},"error_message":null,"id":"75c5583a-6dcc-404f-955a-8ae46b97d533","name":"tf-func-exciting-leakey","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncexcitingleakeytr4vkroh","registry_namespace_id":"92adb1e5-9d7c-4dec-bf22-62388fdf0fbe","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:45:01.113442Z"}'
+        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"created_at":"2025-08-27T15:05:20.016585Z","description":"","domain_name":"tffuncjovialpasteurst27xd26-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"d1d7b7b1-c997-4a1d-9f81-36cd61c20518","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"507327cc-ab4a-4f8b-abf1-e25f7432f64a","privacy":"private","private_network_id":null,"ready_at":"2025-08-27T15:07:03.087668Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:07:39.691726Z"}'
         headers:
             Content-Length:
-                - "558"
+                - "752"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:47:14 GMT
+                - Wed, 27 Aug 2025 15:07:44 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2424,10 +2424,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6b642bdd-722f-4a9e-93ee-902302522305
+                - d1ecb6bd-9336-404e-bd3d-f2b353c7d524
         status: 200 OK
         code: 200
-        duration: 68.596958ms
+        duration: 63.553295ms
     - id: 49
       request:
         proto: HTTP/1.1
@@ -2443,8 +2443,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4e3b9b42-adce-4a43-9843-80524f7580af
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1d7b7b1-c997-4a1d-9f81-36cd61c20518
         method: GET
       response:
         proto: HTTP/2.0
@@ -2452,20 +2452,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 678
+        content_length: 752
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:45:06.413857Z","description":"","domain_name":"tffuncexcitingleakeytr4vkroh-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"4e3b9b42-adce-4a43-9843-80524f7580af","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"75c5583a-6dcc-404f-955a-8ae46b97d533","privacy":"private","ready_at":"2025-01-24T15:46:03.993414Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"ready","timeout":"300s","updated_at":"2025-01-24T15:47:08.800861Z"}'
+        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"created_at":"2025-08-27T15:05:20.016585Z","description":"","domain_name":"tffuncjovialpasteurst27xd26-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"d1d7b7b1-c997-4a1d-9f81-36cd61c20518","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"507327cc-ab4a-4f8b-abf1-e25f7432f64a","privacy":"private","private_network_id":null,"ready_at":"2025-08-27T15:07:03.087668Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:07:44.886878Z"}'
         headers:
             Content-Length:
-                - "678"
+                - "752"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:47:14 GMT
+                - Wed, 27 Aug 2025 15:07:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2473,10 +2473,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2c47d1fe-8631-4d39-bad6-f2e99fbb8cb7
+                - d1c1593c-04b5-44e4-9c0c-c78801b944f8
         status: 200 OK
         code: 200
-        duration: 122.045958ms
+        duration: 51.351546ms
     - id: 50
       request:
         proto: HTTP/1.1
@@ -2492,8 +2492,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4e3b9b42-adce-4a43-9843-80524f7580af
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1d7b7b1-c997-4a1d-9f81-36cd61c20518
         method: GET
       response:
         proto: HTTP/2.0
@@ -2501,20 +2501,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 678
+        content_length: 752
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:45:06.413857Z","description":"","domain_name":"tffuncexcitingleakeytr4vkroh-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"4e3b9b42-adce-4a43-9843-80524f7580af","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"75c5583a-6dcc-404f-955a-8ae46b97d533","privacy":"private","ready_at":"2025-01-24T15:46:03.993414Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"ready","timeout":"300s","updated_at":"2025-01-24T15:47:08.800861Z"}'
+        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"created_at":"2025-08-27T15:05:20.016585Z","description":"","domain_name":"tffuncjovialpasteurst27xd26-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"d1d7b7b1-c997-4a1d-9f81-36cd61c20518","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"507327cc-ab4a-4f8b-abf1-e25f7432f64a","privacy":"private","private_network_id":null,"ready_at":"2025-08-27T15:07:03.087668Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:07:49.968523Z"}'
         headers:
             Content-Length:
-                - "678"
+                - "752"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:47:15 GMT
+                - Wed, 27 Aug 2025 15:07:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2522,10 +2522,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ec1a5381-7c5c-458e-aca4-44c61b55509b
+                - 2354c633-96b8-452b-92bd-96b93cb33b00
         status: 200 OK
         code: 200
-        duration: 73.081959ms
+        duration: 59.510328ms
     - id: 51
       request:
         proto: HTTP/1.1
@@ -2541,29 +2541,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4e3b9b42-adce-4a43-9843-80524f7580af
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1d7b7b1-c997-4a1d-9f81-36cd61c20518
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 684
+        content_length: 752
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:45:06.413857Z","description":"","domain_name":"tffuncexcitingleakeytr4vkroh-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"4e3b9b42-adce-4a43-9843-80524f7580af","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"75c5583a-6dcc-404f-955a-8ae46b97d533","privacy":"private","ready_at":"2025-01-24T15:46:03.993414Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"deleting","timeout":"300s","updated_at":"2025-01-24T15:47:15.280838284Z"}'
+        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"created_at":"2025-08-27T15:05:20.016585Z","description":"","domain_name":"tffuncjovialpasteurst27xd26-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"d1d7b7b1-c997-4a1d-9f81-36cd61c20518","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"507327cc-ab4a-4f8b-abf1-e25f7432f64a","privacy":"private","private_network_id":null,"ready_at":"2025-08-27T15:07:03.087668Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:07:55.065356Z"}'
         headers:
             Content-Length:
-                - "684"
+                - "752"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:47:15 GMT
+                - Wed, 27 Aug 2025 15:07:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2571,10 +2571,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 46ede4c2-1dff-4a06-84c4-d2ec51891f32
+                - e7804fe2-70ad-49f0-b597-d19c9f32fc40
         status: 200 OK
         code: 200
-        duration: 143.239666ms
+        duration: 44.613311ms
     - id: 52
       request:
         proto: HTTP/1.1
@@ -2590,8 +2590,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/75c5583a-6dcc-404f-955a-8ae46b97d533
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1d7b7b1-c997-4a1d-9f81-36cd61c20518
         method: GET
       response:
         proto: HTTP/2.0
@@ -2599,20 +2599,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 558
+        content_length: 752
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:50.833869Z","description":"","environment_variables":{},"error_message":null,"id":"75c5583a-6dcc-404f-955a-8ae46b97d533","name":"tf-func-exciting-leakey","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncexcitingleakeytr4vkroh","registry_namespace_id":"92adb1e5-9d7c-4dec-bf22-62388fdf0fbe","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:45:01.113442Z"}'
+        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"created_at":"2025-08-27T15:05:20.016585Z","description":"","domain_name":"tffuncjovialpasteurst27xd26-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"d1d7b7b1-c997-4a1d-9f81-36cd61c20518","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"507327cc-ab4a-4f8b-abf1-e25f7432f64a","privacy":"private","private_network_id":null,"ready_at":"2025-08-27T15:07:03.087668Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:08:00.198952Z"}'
         headers:
             Content-Length:
-                - "558"
+                - "752"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:47:15 GMT
+                - Wed, 27 Aug 2025 15:08:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2620,10 +2620,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5c5f51db-eb71-47e0-881e-9736dd16f5b0
+                - 6b66d4c4-8c69-4f99-9d7d-e5ebcf897713
         status: 200 OK
         code: 200
-        duration: 75.514917ms
+        duration: 75.270759ms
     - id: 53
       request:
         proto: HTTP/1.1
@@ -2639,29 +2639,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/75c5583a-6dcc-404f-955a-8ae46b97d533
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1d7b7b1-c997-4a1d-9f81-36cd61c20518
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 564
+        content_length: 752
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:50.833869Z","description":"","environment_variables":{},"error_message":null,"id":"75c5583a-6dcc-404f-955a-8ae46b97d533","name":"tf-func-exciting-leakey","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncexcitingleakeytr4vkroh","registry_namespace_id":"92adb1e5-9d7c-4dec-bf22-62388fdf0fbe","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:47:15.501206698Z"}'
+        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"created_at":"2025-08-27T15:05:20.016585Z","description":"","domain_name":"tffuncjovialpasteurst27xd26-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"d1d7b7b1-c997-4a1d-9f81-36cd61c20518","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"507327cc-ab4a-4f8b-abf1-e25f7432f64a","privacy":"private","private_network_id":null,"ready_at":"2025-08-27T15:07:03.087668Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:08:05.431151Z"}'
         headers:
             Content-Length:
-                - "564"
+                - "752"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:47:15 GMT
+                - Wed, 27 Aug 2025 15:08:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2669,10 +2669,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 80e26e64-7b2e-4759-958b-ff0d21e9d022
+                - 9460fece-5a4c-4a97-817a-c964456b4336
         status: 200 OK
         code: 200
-        duration: 229.722083ms
+        duration: 64.61398ms
     - id: 54
       request:
         proto: HTTP/1.1
@@ -2688,8 +2688,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/75c5583a-6dcc-404f-955a-8ae46b97d533
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1d7b7b1-c997-4a1d-9f81-36cd61c20518
         method: GET
       response:
         proto: HTTP/2.0
@@ -2697,20 +2697,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 561
+        content_length: 752
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:50.833869Z","description":"","environment_variables":{},"error_message":null,"id":"75c5583a-6dcc-404f-955a-8ae46b97d533","name":"tf-func-exciting-leakey","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncexcitingleakeytr4vkroh","registry_namespace_id":"92adb1e5-9d7c-4dec-bf22-62388fdf0fbe","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:47:15.501207Z"}'
+        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"created_at":"2025-08-27T15:05:20.016585Z","description":"","domain_name":"tffuncjovialpasteurst27xd26-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"d1d7b7b1-c997-4a1d-9f81-36cd61c20518","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"507327cc-ab4a-4f8b-abf1-e25f7432f64a","privacy":"private","private_network_id":null,"ready_at":"2025-08-27T15:07:03.087668Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:08:10.679935Z"}'
         headers:
             Content-Length:
-                - "561"
+                - "752"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:47:15 GMT
+                - Wed, 27 Aug 2025 15:08:14 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2718,10 +2718,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 722a1c5d-fcb1-4ca9-b840-c4dd2c6bd0b5
+                - 82a5b4b5-df01-47c1-ad77-d4bf6ad874fe
         status: 200 OK
         code: 200
-        duration: 56.868667ms
+        duration: 68.307374ms
     - id: 55
       request:
         proto: HTTP/1.1
@@ -2737,8 +2737,1037 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/75c5583a-6dcc-404f-955a-8ae46b97d533
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1d7b7b1-c997-4a1d-9f81-36cd61c20518
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 752
+        uncompressed: false
+        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"created_at":"2025-08-27T15:05:20.016585Z","description":"","domain_name":"tffuncjovialpasteurst27xd26-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"d1d7b7b1-c997-4a1d-9f81-36cd61c20518","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"507327cc-ab4a-4f8b-abf1-e25f7432f64a","privacy":"private","private_network_id":null,"ready_at":"2025-08-27T15:07:03.087668Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:08:15.803864Z"}'
+        headers:
+            Content-Length:
+                - "752"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:08:19 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 6e314b21-7344-40e5-b5e6-a0fd8e0003e0
+        status: 200 OK
+        code: 200
+        duration: 55.986268ms
+    - id: 56
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1d7b7b1-c997-4a1d-9f81-36cd61c20518
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 752
+        uncompressed: false
+        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"created_at":"2025-08-27T15:05:20.016585Z","description":"","domain_name":"tffuncjovialpasteurst27xd26-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"d1d7b7b1-c997-4a1d-9f81-36cd61c20518","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"507327cc-ab4a-4f8b-abf1-e25f7432f64a","privacy":"private","private_network_id":null,"ready_at":"2025-08-27T15:07:03.087668Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:08:20.919493Z"}'
+        headers:
+            Content-Length:
+                - "752"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:08:24 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 939cc666-ce9b-4d90-a364-b6861f09cff3
+        status: 200 OK
+        code: 200
+        duration: 49.485427ms
+    - id: 57
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1d7b7b1-c997-4a1d-9f81-36cd61c20518
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 778
+        uncompressed: false
+        body: '{"build_message":"step 3 of 3: function image is being pushed to container registry","cpu_limit":140,"created_at":"2025-08-27T15:05:20.016585Z","description":"","domain_name":"tffuncjovialpasteurst27xd26-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"d1d7b7b1-c997-4a1d-9f81-36cd61c20518","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"507327cc-ab4a-4f8b-abf1-e25f7432f64a","privacy":"private","private_network_id":null,"ready_at":"2025-08-27T15:07:03.087668Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:08:26.022627Z"}'
+        headers:
+            Content-Length:
+                - "778"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:08:30 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - fa0329b1-a802-4d14-873d-98344df3dafe
+        status: 200 OK
+        code: 200
+        duration: 62.647903ms
+    - id: 58
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1d7b7b1-c997-4a1d-9f81-36cd61c20518
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 778
+        uncompressed: false
+        body: '{"build_message":"step 3 of 3: function image is being pushed to container registry","cpu_limit":140,"created_at":"2025-08-27T15:05:20.016585Z","description":"","domain_name":"tffuncjovialpasteurst27xd26-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"d1d7b7b1-c997-4a1d-9f81-36cd61c20518","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"507327cc-ab4a-4f8b-abf1-e25f7432f64a","privacy":"private","private_network_id":null,"ready_at":"2025-08-27T15:07:03.087668Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:08:31.161572Z"}'
+        headers:
+            Content-Length:
+                - "778"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:08:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 85c1839d-25cf-4c8b-bbda-639c732916f4
+        status: 200 OK
+        code: 200
+        duration: 71.761799ms
+    - id: 59
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1d7b7b1-c997-4a1d-9f81-36cd61c20518
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 715
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:20.016585Z","description":"","domain_name":"tffuncjovialpasteurst27xd26-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"d1d7b7b1-c997-4a1d-9f81-36cd61c20518","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"507327cc-ab4a-4f8b-abf1-e25f7432f64a","privacy":"private","private_network_id":null,"ready_at":"2025-08-27T15:07:03.087668Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:08:36.272713Z"}'
+        headers:
+            Content-Length:
+                - "715"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:08:40 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 514bf7d4-d8e7-41c9-95e6-aa2dc4e7a096
+        status: 200 OK
+        code: 200
+        duration: 47.884424ms
+    - id: 60
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1d7b7b1-c997-4a1d-9f81-36cd61c20518
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 715
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:20.016585Z","description":"","domain_name":"tffuncjovialpasteurst27xd26-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"d1d7b7b1-c997-4a1d-9f81-36cd61c20518","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"507327cc-ab4a-4f8b-abf1-e25f7432f64a","privacy":"private","private_network_id":null,"ready_at":"2025-08-27T15:07:03.087668Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:08:41.421996Z"}'
+        headers:
+            Content-Length:
+                - "715"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:08:45 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - dbb4c13b-c346-4d62-a596-f8228fec8eb0
+        status: 200 OK
+        code: 200
+        duration: 64.564283ms
+    - id: 61
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1d7b7b1-c997-4a1d-9f81-36cd61c20518
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 715
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:20.016585Z","description":"","domain_name":"tffuncjovialpasteurst27xd26-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"d1d7b7b1-c997-4a1d-9f81-36cd61c20518","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"507327cc-ab4a-4f8b-abf1-e25f7432f64a","privacy":"private","private_network_id":null,"ready_at":"2025-08-27T15:07:03.087668Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:08:41.421996Z"}'
+        headers:
+            Content-Length:
+                - "715"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:08:50 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 9ccfce39-89ba-4a6c-bdbe-0087b17d96ea
+        status: 200 OK
+        code: 200
+        duration: 58.265229ms
+    - id: 62
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1d7b7b1-c997-4a1d-9f81-36cd61c20518
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 713
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:20.016585Z","description":"","domain_name":"tffuncjovialpasteurst27xd26-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"d1d7b7b1-c997-4a1d-9f81-36cd61c20518","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"507327cc-ab4a-4f8b-abf1-e25f7432f64a","privacy":"private","private_network_id":null,"ready_at":"2025-08-27T15:07:03.087668Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"ready","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:08:52.190045Z"}'
+        headers:
+            Content-Length:
+                - "713"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:08:55 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 616bf3a3-1a4a-4386-8544-d10b1f607a28
+        status: 200 OK
+        code: 200
+        duration: 47.394095ms
+    - id: 63
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1d7b7b1-c997-4a1d-9f81-36cd61c20518
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 713
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:20.016585Z","description":"","domain_name":"tffuncjovialpasteurst27xd26-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"d1d7b7b1-c997-4a1d-9f81-36cd61c20518","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"507327cc-ab4a-4f8b-abf1-e25f7432f64a","privacy":"private","private_network_id":null,"ready_at":"2025-08-27T15:07:03.087668Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"ready","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:08:52.190045Z"}'
+        headers:
+            Content-Length:
+                - "713"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:08:55 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 866ea4f1-9ab8-47ef-8744-61d3958d047c
+        status: 200 OK
+        code: 200
+        duration: 48.452362ms
+    - id: 64
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/507327cc-ab4a-4f8b-abf1-e25f7432f64a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 589
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:13.632525Z","description":"","environment_variables":{},"error_message":null,"id":"507327cc-ab4a-4f8b-abf1-e25f7432f64a","name":"tf-func-jovial-pasteur","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncjovialpasteurst27xd26","registry_namespace_id":"af4cd7ef-d784-4fb3-b3e3-f557e91b290a","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:17.402330Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "589"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:08:55 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - aca3dded-7bc2-4e2b-9fa3-1c0d6c1f10b6
+        status: 200 OK
+        code: 200
+        duration: 48.265191ms
+    - id: 65
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1d7b7b1-c997-4a1d-9f81-36cd61c20518
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 713
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:20.016585Z","description":"","domain_name":"tffuncjovialpasteurst27xd26-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"d1d7b7b1-c997-4a1d-9f81-36cd61c20518","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"507327cc-ab4a-4f8b-abf1-e25f7432f64a","privacy":"private","private_network_id":null,"ready_at":"2025-08-27T15:07:03.087668Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"ready","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:08:52.190045Z"}'
+        headers:
+            Content-Length:
+                - "713"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:08:55 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 24c9e34f-2fcd-4bb5-a111-e4536be47a3f
+        status: 200 OK
+        code: 200
+        duration: 55.026571ms
+    - id: 66
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1d7b7b1-c997-4a1d-9f81-36cd61c20518
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 713
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:20.016585Z","description":"","domain_name":"tffuncjovialpasteurst27xd26-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"d1d7b7b1-c997-4a1d-9f81-36cd61c20518","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"507327cc-ab4a-4f8b-abf1-e25f7432f64a","privacy":"private","private_network_id":null,"ready_at":"2025-08-27T15:07:03.087668Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"ready","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:08:52.190045Z"}'
+        headers:
+            Content-Length:
+                - "713"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:08:56 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - c06554db-7dd5-432c-a0e6-4252b2f55dc9
+        status: 200 OK
+        code: 200
+        duration: 136.52562ms
+    - id: 67
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1d7b7b1-c997-4a1d-9f81-36cd61c20518
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 719
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:20.016585Z","description":"","domain_name":"tffuncjovialpasteurst27xd26-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"d1d7b7b1-c997-4a1d-9f81-36cd61c20518","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"507327cc-ab4a-4f8b-abf1-e25f7432f64a","privacy":"private","private_network_id":null,"ready_at":"2025-08-27T15:07:03.087668Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:08:56.462712767Z"}'
+        headers:
+            Content-Length:
+                - "719"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:08:56 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 8f2e656a-4b18-41fa-87bd-47459ab9611e
+        status: 200 OK
+        code: 200
+        duration: 137.435068ms
+    - id: 68
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/507327cc-ab4a-4f8b-abf1-e25f7432f64a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 589
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:13.632525Z","description":"","environment_variables":{},"error_message":null,"id":"507327cc-ab4a-4f8b-abf1-e25f7432f64a","name":"tf-func-jovial-pasteur","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncjovialpasteurst27xd26","registry_namespace_id":"af4cd7ef-d784-4fb3-b3e3-f557e91b290a","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:17.402330Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "589"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:08:56 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 304184a8-4098-4464-89b3-dd26f389a11e
+        status: 200 OK
+        code: 200
+        duration: 58.57427ms
+    - id: 69
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/507327cc-ab4a-4f8b-abf1-e25f7432f64a
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 595
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:13.632525Z","description":"","environment_variables":{},"error_message":null,"id":"507327cc-ab4a-4f8b-abf1-e25f7432f64a","name":"tf-func-jovial-pasteur","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncjovialpasteurst27xd26","registry_namespace_id":"af4cd7ef-d784-4fb3-b3e3-f557e91b290a","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:08:56.604060908Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "595"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:08:56 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 5088e359-f840-41c2-85bd-2a21ac946a3e
+        status: 200 OK
+        code: 200
+        duration: 261.85724ms
+    - id: 70
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/507327cc-ab4a-4f8b-abf1-e25f7432f64a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 592
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:13.632525Z","description":"","environment_variables":{},"error_message":null,"id":"507327cc-ab4a-4f8b-abf1-e25f7432f64a","name":"tf-func-jovial-pasteur","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncjovialpasteurst27xd26","registry_namespace_id":"af4cd7ef-d784-4fb3-b3e3-f557e91b290a","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:08:56.604061Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "592"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:08:56 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e875da2e-01a1-4826-93a5-cdf627d7ead9
+        status: 200 OK
+        code: 200
+        duration: 52.068611ms
+    - id: 71
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/507327cc-ab4a-4f8b-abf1-e25f7432f64a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 592
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:13.632525Z","description":"","environment_variables":{},"error_message":null,"id":"507327cc-ab4a-4f8b-abf1-e25f7432f64a","name":"tf-func-jovial-pasteur","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncjovialpasteurst27xd26","registry_namespace_id":"af4cd7ef-d784-4fb3-b3e3-f557e91b290a","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:08:56.604061Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "592"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:09:01 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 2295ae08-06c6-4359-8b30-2a8a8453a7da
+        status: 200 OK
+        code: 200
+        duration: 43.267811ms
+    - id: 72
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/507327cc-ab4a-4f8b-abf1-e25f7432f64a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 592
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:13.632525Z","description":"","environment_variables":{},"error_message":null,"id":"507327cc-ab4a-4f8b-abf1-e25f7432f64a","name":"tf-func-jovial-pasteur","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncjovialpasteurst27xd26","registry_namespace_id":"af4cd7ef-d784-4fb3-b3e3-f557e91b290a","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:08:56.604061Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "592"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:09:06 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - c656823f-8fcb-425b-b829-f7e4c2362a30
+        status: 200 OK
+        code: 200
+        duration: 110.75354ms
+    - id: 73
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/507327cc-ab4a-4f8b-abf1-e25f7432f64a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 592
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:13.632525Z","description":"","environment_variables":{},"error_message":null,"id":"507327cc-ab4a-4f8b-abf1-e25f7432f64a","name":"tf-func-jovial-pasteur","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncjovialpasteurst27xd26","registry_namespace_id":"af4cd7ef-d784-4fb3-b3e3-f557e91b290a","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:08:56.604061Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "592"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:09:12 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f73ccd5c-ae38-4c32-9d1d-bc47fd78adcc
+        status: 200 OK
+        code: 200
+        duration: 113.438231ms
+    - id: 74
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/507327cc-ab4a-4f8b-abf1-e25f7432f64a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 592
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:13.632525Z","description":"","environment_variables":{},"error_message":null,"id":"507327cc-ab4a-4f8b-abf1-e25f7432f64a","name":"tf-func-jovial-pasteur","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncjovialpasteurst27xd26","registry_namespace_id":"af4cd7ef-d784-4fb3-b3e3-f557e91b290a","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:08:56.604061Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "592"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:09:17 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 39b7308a-a8ec-40f9-8937-6083489aff58
+        status: 200 OK
+        code: 200
+        duration: 164.631311ms
+    - id: 75
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/507327cc-ab4a-4f8b-abf1-e25f7432f64a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 592
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:13.632525Z","description":"","environment_variables":{},"error_message":null,"id":"507327cc-ab4a-4f8b-abf1-e25f7432f64a","name":"tf-func-jovial-pasteur","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncjovialpasteurst27xd26","registry_namespace_id":"af4cd7ef-d784-4fb3-b3e3-f557e91b290a","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:08:56.604061Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "592"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:09:22 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 16639a84-0293-45f5-82e6-e4453f7be3f6
+        status: 200 OK
+        code: 200
+        duration: 60.215234ms
+    - id: 76
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/507327cc-ab4a-4f8b-abf1-e25f7432f64a
         method: GET
       response:
         proto: HTTP/2.0
@@ -2757,9 +3786,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:47:20 GMT
+                - Wed, 27 Aug 2025 15:09:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2767,11 +3796,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 773ae03d-086e-491f-b874-94735780ccea
+                - 00914824-09d8-46b6-912a-2b7d552ae04c
         status: 404 Not Found
         code: 404
-        duration: 27.093292ms
-    - id: 56
+        duration: 33.18607ms
+    - id: 77
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2786,8 +3815,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4e3b9b42-adce-4a43-9843-80524f7580af
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1d7b7b1-c997-4a1d-9f81-36cd61c20518
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -2806,9 +3835,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:47:20 GMT
+                - Wed, 27 Aug 2025 15:09:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2816,7 +3845,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 974c1202-8fbf-43e4-8830-936644f454d9
+                - 3367e8da-fb02-4e71-a3ab-b684bcdd6d34
         status: 404 Not Found
         code: 404
-        duration: 34.013375ms
+        duration: 22.487669ms

--- a/internal/services/function/testdata/function-domain-basic.cassette.yaml
+++ b/internal/services/function/testdata/function-domain-basic.cassette.yaml
@@ -6,19 +6,19 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 155
+        content_length: 190
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-func-exciting-tu","environment_variables":{},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","secret_environment_variables":[],"tags":null}'
+        body: '{"name":"tf-func-friendly-wiles","environment_variables":{},"project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","secret_environment_variables":[],"tags":null,"activate_vpc_integration":true}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces
         method: POST
       response:
@@ -27,18 +27,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 485
+        content_length: 507
         uncompressed: false
-        body: '{"created_at":"2025-06-11T12:18:18.952635087Z","description":"","environment_variables":{},"error_message":null,"id":"4b3ebb33-4816-4ece-be11-9d59f6642926","name":"tf-func-exciting-tu","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-06-11T12:18:18.952635087Z"}'
+        body: '{"created_at":"2025-08-27T15:16:19.410439030Z","description":"","environment_variables":{},"error_message":null,"id":"3c7cd189-d8eb-4405-bf13-c55be0d32b06","name":"tf-func-friendly-wiles","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:16:19.410439030Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "485"
+                - "507"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:18:18 GMT
+                - Wed, 27 Aug 2025 15:16:19 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cdebe9b7-49c1-4844-acad-5255c468ab35
+                - a150cdca-e476-4f5c-a882-c083e7b70060
         status: 200 OK
         code: 200
-        duration: 794.066583ms
+        duration: 982.835108ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -67,8 +67,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/4b3ebb33-4816-4ece-be11-9d59f6642926
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/3c7cd189-d8eb-4405-bf13-c55be0d32b06
         method: GET
       response:
         proto: HTTP/2.0
@@ -76,18 +76,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 479
+        content_length: 501
         uncompressed: false
-        body: '{"created_at":"2025-06-11T12:18:18.952635Z","description":"","environment_variables":{},"error_message":null,"id":"4b3ebb33-4816-4ece-be11-9d59f6642926","name":"tf-func-exciting-tu","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-06-11T12:18:18.952635Z"}'
+        body: '{"created_at":"2025-08-27T15:16:19.410439Z","description":"","environment_variables":{},"error_message":null,"id":"3c7cd189-d8eb-4405-bf13-c55be0d32b06","name":"tf-func-friendly-wiles","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:16:19.410439Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "479"
+                - "501"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:18:19 GMT
+                - Wed, 27 Aug 2025 15:16:19 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 031eac46-bfd8-4ff3-b49d-6680df19e1c1
+                - 9bb9b767-0d7d-4a27-a525-1b7a06048b96
         status: 200 OK
         code: 200
-        duration: 90.552834ms
+        duration: 84.377528ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -116,8 +116,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/4b3ebb33-4816-4ece-be11-9d59f6642926
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/3c7cd189-d8eb-4405-bf13-c55be0d32b06
         method: GET
       response:
         proto: HTTP/2.0
@@ -125,18 +125,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 564
+        content_length: 591
         uncompressed: false
-        body: '{"created_at":"2025-06-11T12:18:18.952635Z","description":"","environment_variables":{},"error_message":null,"id":"4b3ebb33-4816-4ece-be11-9d59f6642926","name":"tf-func-exciting-tu","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncexcitingtuzibjceyb","registry_namespace_id":"193ec47b-3958-4c15-b8cc-eaf927c47ab8","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-11T12:18:21.245163Z"}'
+        body: '{"created_at":"2025-08-27T15:16:19.410439Z","description":"","environment_variables":{},"error_message":null,"id":"3c7cd189-d8eb-4405-bf13-c55be0d32b06","name":"tf-func-friendly-wiles","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncfriendlywilesvp0xo6l3","registry_namespace_id":"e7984d4a-dd63-4a93-81f7-b59d291416bb","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:16:22.094556Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "564"
+                - "591"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:18:24 GMT
+                - Wed, 27 Aug 2025 15:16:24 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -146,10 +146,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 574ea6bb-fb93-49e2-be54-dcbfeabc1608
+                - 5c144417-998a-4a63-afab-5a749c246eb4
         status: 200 OK
         code: 200
-        duration: 71.838708ms
+        duration: 90.258181ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -165,8 +165,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/4b3ebb33-4816-4ece-be11-9d59f6642926
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/3c7cd189-d8eb-4405-bf13-c55be0d32b06
         method: GET
       response:
         proto: HTTP/2.0
@@ -174,18 +174,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 564
+        content_length: 589
         uncompressed: false
-        body: '{"created_at":"2025-06-11T12:18:18.952635Z","description":"","environment_variables":{},"error_message":null,"id":"4b3ebb33-4816-4ece-be11-9d59f6642926","name":"tf-func-exciting-tu","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncexcitingtuzibjceyb","registry_namespace_id":"193ec47b-3958-4c15-b8cc-eaf927c47ab8","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-11T12:18:21.245163Z"}'
+        body: '{"created_at":"2025-08-27T15:16:19.410439Z","description":"","environment_variables":{},"error_message":null,"id":"3c7cd189-d8eb-4405-bf13-c55be0d32b06","name":"tf-func-friendly-wiles","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncfriendlywilesvp0xo6l3","registry_namespace_id":"e7984d4a-dd63-4a93-81f7-b59d291416bb","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:16:24.751810Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "564"
+                - "589"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:18:24 GMT
+                - Wed, 27 Aug 2025 15:16:29 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -195,62 +195,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 95090ad3-055d-4674-a6e3-c09b3ad35d47
+                - 480a0674-4a5e-4a22-9424-1fc07d6148e0
         status: 200 OK
         code: 200
-        duration: 91.452041ms
+        duration: 86.562211ms
     - id: 4
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 320
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"name":"tf-func-cranky-tereshkova","namespace_id":"4b3ebb33-4816-4ece-be11-9d59f6642926","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"go122","memory_limit":256,"handler":"Handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox","tags":null}'
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 730
-        uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-11T12:18:24.558397517Z","description":"","domain_name":"tffuncexcitingtuzibjceyb-tf-func-cranky-tereshkova.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"2a8109ee-4580-416a-a897-5b064d886bc3","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-cranky-tereshkova","namespace_id":"4b3ebb33-4816-4ece-be11-9d59f6642926","privacy":"private","ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-11T12:18:24.558397517Z"}'
-        headers:
-            Content-Length:
-                - "730"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 11 Jun 2025 12:18:24 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - a9694e27-a310-48b0-bd20-752d128d1ea5
-        status: 200 OK
-        code: 200
-        duration: 343.750541ms
-    - id: 5
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -265,8 +214,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/2a8109ee-4580-416a-a897-5b064d886bc3/upload-url?content_length=780
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/3c7cd189-d8eb-4405-bf13-c55be0d32b06
         method: GET
       response:
         proto: HTTP/2.0
@@ -274,18 +223,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 512
+        content_length: 589
         uncompressed: false
-        body: '{"headers":{"content-length":["780"],"content-type":["application/octet-stream"]},"url":"https://s3.fr-par.scw.cloud/serverless-functions-code-prod-fr-par/uploads/function-2a8109ee-4580-416a-a897-5b064d886bc3.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256\u0026X-Amz-Credential=SCW3S98HDC0MAE9CBTQ5%2F20250611%2Ffr-par%2Fs3%2Faws4_request\u0026X-Amz-Date=20250611T121824Z\u0026X-Amz-Expires=3600\u0026X-Amz-SignedHeaders=content-length%3Bcontent-type%3Bhost\u0026X-Amz-Signature=04724d4616bf80234856fabfe31c728aedef8ba952bd1c394184e93cb141d19a"}'
+        body: '{"created_at":"2025-08-27T15:16:19.410439Z","description":"","environment_variables":{},"error_message":null,"id":"3c7cd189-d8eb-4405-bf13-c55be0d32b06","name":"tf-func-friendly-wiles","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncfriendlywilesvp0xo6l3","registry_namespace_id":"e7984d4a-dd63-4a93-81f7-b59d291416bb","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:16:24.751810Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "512"
+                - "589"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:18:24 GMT
+                - Wed, 27 Aug 2025 15:16:29 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -295,11 +244,111 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - dde10dd9-931a-440a-90ee-6572ee6c3a35
+                - 32d15a9f-3b49-4302-8759-2f3171027fc6
         status: 200 OK
         code: 200
-        duration: 98.551292ms
+        duration: 98.109512ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 320
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"name":"tf-func-bold-visvesvaraya","namespace_id":"3c7cd189-d8eb-4405-bf13-c55be0d32b06","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"go122","memory_limit":256,"handler":"Handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox","tags":null}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 734
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:16:30.158333479Z","description":"","domain_name":"tffuncfriendlywilesvp0xo6l3-tf-func-bold-visvesvaraya.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-bold-visvesvaraya","namespace_id":"3c7cd189-d8eb-4405-bf13-c55be0d32b06","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:16:30.158333479Z"}'
+        headers:
+            Content-Length:
+                - "734"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:16:30 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 958f0ae7-2d20-4eaa-9e6c-2d5fd949a2eb
+        status: 200 OK
+        code: 200
+        duration: 459.718648ms
     - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e/upload-url?content_length=780
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 510
+        uncompressed: false
+        body: '{"headers":{"content-length":["780"],"content-type":["application/octet-stream"]},"url":"https://s3.fr-par.scw.cloud/serverless-functions-code-prod-fr-par/uploads/function-90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256\u0026X-Amz-Credential=SCW3S98HDC0MAE9CBTQ5%2F20250827%2Ffr-par%2Fs3%2Faws4_request\u0026X-Amz-Date=20250827T151630Z\u0026X-Amz-Expires=3600\u0026X-Amz-SignedHeaders=content-length%3Bcontent-type%3Bhost\u0026X-Amz-Signature=9e0a37b8eee801df6652a593a98a0a894494c6f6353dd4cbbeb2ac768c6401d3"}'
+        headers:
+            Content-Length:
+                - "510"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:16:30 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 4b0e9ec1-0b76-440f-a992-d10494bb7fa4
+        status: 200 OK
+        code: 200
+        duration: 97.854723ms
+    - id: 7
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -332,7 +381,7 @@ interactions:
                 - "780"
             Content-Type:
                 - application/octet-stream
-        url: https://s3.fr-par.scw.cloud/serverless-functions-code-prod-fr-par/uploads/function-2a8109ee-4580-416a-a897-5b064d886bc3.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=SCW3S98HDC0MAE9CBTQ5%2F20250611%2Ffr-par%2Fs3%2Faws4_request&X-Amz-Date=20250611T121824Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=content-length%3Bcontent-type%3Bhost&X-Amz-Signature=04724d4616bf80234856fabfe31c728aedef8ba952bd1c394184e93cb141d19a
+        url: https://s3.fr-par.scw.cloud/serverless-functions-code-prod-fr-par/uploads/function-90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=SCW3S98HDC0MAE9CBTQ5%2F20250827%2Ffr-par%2Fs3%2Faws4_request&X-Amz-Date=20250827T151630Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=content-length%3Bcontent-type%3Bhost&X-Amz-Signature=9e0a37b8eee801df6652a593a98a0a894494c6f6353dd4cbbeb2ac768c6401d3
         method: PUT
       response:
         proto: HTTP/2.0
@@ -347,17 +396,17 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Wed, 11 Jun 2025 12:18:24 GMT
+                - Wed, 27 Aug 2025 15:16:30 GMT
             Etag:
                 - '"10633bf7a5ff211d8f3eee3856a28101"'
             X-Amz-Id-2:
-                - txg50aadc30e3c246ed8c5d-0068497410
+                - txg570081024db84ab8a71d-0068af214e
             X-Amz-Request-Id:
-                - txg50aadc30e3c246ed8c5d-0068497410
+                - txg570081024db84ab8a71d-0068af214e
         status: 200 OK
         code: 200
-        duration: 504.342041ms
-    - id: 7
+        duration: 133.064674ms
+    - id: 8
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -374,8 +423,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/2a8109ee-4580-416a-a897-5b064d886bc3/deploy
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e/deploy
         method: POST
       response:
         proto: HTTP/2.0
@@ -383,18 +432,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 727
+        content_length: 731
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-11T12:18:24.558398Z","description":"","domain_name":"tffuncexcitingtuzibjceyb-tf-func-cranky-tereshkova.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"2a8109ee-4580-416a-a897-5b064d886bc3","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-cranky-tereshkova","namespace_id":"4b3ebb33-4816-4ece-be11-9d59f6642926","privacy":"private","ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-06-11T12:18:25.273039678Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:16:30.158333Z","description":"","domain_name":"tffuncfriendlywilesvp0xo6l3-tf-func-bold-visvesvaraya.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-bold-visvesvaraya","namespace_id":"3c7cd189-d8eb-4405-bf13-c55be0d32b06","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:16:30.578315623Z"}'
         headers:
             Content-Length:
-                - "727"
+                - "731"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:18:25 GMT
+                - Wed, 27 Aug 2025 15:16:30 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -404,59 +453,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9cd619d2-1447-4df8-872d-c34e7ba4c763
+                - cf9cd863-874c-4001-bfec-d0d2f6ca4e99
         status: 200 OK
         code: 200
-        duration: 102.303792ms
-    - id: 8
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/2a8109ee-4580-416a-a897-5b064d886bc3
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 724
-        uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-11T12:18:24.558398Z","description":"","domain_name":"tffuncexcitingtuzibjceyb-tf-func-cranky-tereshkova.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"2a8109ee-4580-416a-a897-5b064d886bc3","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-cranky-tereshkova","namespace_id":"4b3ebb33-4816-4ece-be11-9d59f6642926","privacy":"private","ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-06-11T12:18:25.273040Z"}'
-        headers:
-            Content-Length:
-                - "724"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 11 Jun 2025 12:18:25 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 8aa13727-c999-4c24-b9eb-b11f128563dc
-        status: 200 OK
-        code: 200
-        duration: 97.715583ms
+        duration: 102.313626ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -472,8 +472,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/2a8109ee-4580-416a-a897-5b064d886bc3
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e
         method: GET
       response:
         proto: HTTP/2.0
@@ -481,18 +481,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 724
+        content_length: 728
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-11T12:18:24.558398Z","description":"","domain_name":"tffuncexcitingtuzibjceyb-tf-func-cranky-tereshkova.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"2a8109ee-4580-416a-a897-5b064d886bc3","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-cranky-tereshkova","namespace_id":"4b3ebb33-4816-4ece-be11-9d59f6642926","privacy":"private","ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-06-11T12:18:25.708692Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:16:30.158333Z","description":"","domain_name":"tffuncfriendlywilesvp0xo6l3-tf-func-bold-visvesvaraya.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-bold-visvesvaraya","namespace_id":"3c7cd189-d8eb-4405-bf13-c55be0d32b06","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:16:30.578316Z"}'
         headers:
             Content-Length:
-                - "724"
+                - "728"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:18:30 GMT
+                - Wed, 27 Aug 2025 15:16:30 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -502,10 +502,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a6c2cd6e-d331-45aa-ba57-8244fc9bd56f
+                - ed59c6cc-7744-4ff7-9d4c-0cf5ebfc2597
         status: 200 OK
         code: 200
-        duration: 83.097208ms
+        duration: 106.867226ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -521,8 +521,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/2a8109ee-4580-416a-a897-5b064d886bc3
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e
         method: GET
       response:
         proto: HTTP/2.0
@@ -530,18 +530,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 761
+        content_length: 728
         uncompressed: false
-        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"created_at":"2025-06-11T12:18:24.558398Z","description":"","domain_name":"tffuncexcitingtuzibjceyb-tf-func-cranky-tereshkova.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"2a8109ee-4580-416a-a897-5b064d886bc3","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-cranky-tereshkova","namespace_id":"4b3ebb33-4816-4ece-be11-9d59f6642926","privacy":"private","ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-06-11T12:18:30.809669Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:16:30.158333Z","description":"","domain_name":"tffuncfriendlywilesvp0xo6l3-tf-func-bold-visvesvaraya.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-bold-visvesvaraya","namespace_id":"3c7cd189-d8eb-4405-bf13-c55be0d32b06","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:16:30.987105Z"}'
         headers:
             Content-Length:
-                - "761"
+                - "728"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:18:35 GMT
+                - Wed, 27 Aug 2025 15:16:35 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -551,10 +551,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 091968c0-8450-4334-91cf-2bd133122c1b
+                - 08275a56-525f-4c42-98ca-078197d7b043
         status: 200 OK
         code: 200
-        duration: 93.414583ms
+        duration: 108.784767ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -570,8 +570,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/2a8109ee-4580-416a-a897-5b064d886bc3
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e
         method: GET
       response:
         proto: HTTP/2.0
@@ -579,18 +579,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 761
+        content_length: 777
         uncompressed: false
-        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"created_at":"2025-06-11T12:18:24.558398Z","description":"","domain_name":"tffuncexcitingtuzibjceyb-tf-func-cranky-tereshkova.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"2a8109ee-4580-416a-a897-5b064d886bc3","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-cranky-tereshkova","namespace_id":"4b3ebb33-4816-4ece-be11-9d59f6642926","privacy":"private","ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-06-11T12:18:35.881406Z"}'
+        body: '{"build_message":"step 1 of 3: function build preparation in progress","cpu_limit":140,"created_at":"2025-08-27T15:16:30.158333Z","description":"","domain_name":"tffuncfriendlywilesvp0xo6l3-tf-func-bold-visvesvaraya.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-bold-visvesvaraya","namespace_id":"3c7cd189-d8eb-4405-bf13-c55be0d32b06","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:16:36.078456Z"}'
         headers:
             Content-Length:
-                - "761"
+                - "777"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:18:40 GMT
+                - Wed, 27 Aug 2025 15:16:40 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -600,10 +600,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 961b9dbb-9daa-4546-8e04-78be3648c8eb
+                - cb692871-e442-4e1f-888d-0c0d54eeac6f
         status: 200 OK
         code: 200
-        duration: 84.749917ms
+        duration: 106.13896ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -619,8 +619,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/2a8109ee-4580-416a-a897-5b064d886bc3
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e
         method: GET
       response:
         proto: HTTP/2.0
@@ -628,18 +628,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 761
+        content_length: 765
         uncompressed: false
-        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"created_at":"2025-06-11T12:18:24.558398Z","description":"","domain_name":"tffuncexcitingtuzibjceyb-tf-func-cranky-tereshkova.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"2a8109ee-4580-416a-a897-5b064d886bc3","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-cranky-tereshkova","namespace_id":"4b3ebb33-4816-4ece-be11-9d59f6642926","privacy":"private","ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-06-11T12:18:40.958769Z"}'
+        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"created_at":"2025-08-27T15:16:30.158333Z","description":"","domain_name":"tffuncfriendlywilesvp0xo6l3-tf-func-bold-visvesvaraya.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-bold-visvesvaraya","namespace_id":"3c7cd189-d8eb-4405-bf13-c55be0d32b06","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:16:41.169043Z"}'
         headers:
             Content-Length:
-                - "761"
+                - "765"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:18:45 GMT
+                - Wed, 27 Aug 2025 15:16:46 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -649,10 +649,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cd83e339-84e5-4a14-9790-65e653103115
+                - fb97ec08-3937-4501-86a6-cc665b1c9601
         status: 200 OK
         code: 200
-        duration: 102.860083ms
+        duration: 148.509737ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -668,8 +668,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/2a8109ee-4580-416a-a897-5b064d886bc3
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e
         method: GET
       response:
         proto: HTTP/2.0
@@ -677,18 +677,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 761
+        content_length: 765
         uncompressed: false
-        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"created_at":"2025-06-11T12:18:24.558398Z","description":"","domain_name":"tffuncexcitingtuzibjceyb-tf-func-cranky-tereshkova.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"2a8109ee-4580-416a-a897-5b064d886bc3","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-cranky-tereshkova","namespace_id":"4b3ebb33-4816-4ece-be11-9d59f6642926","privacy":"private","ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-06-11T12:18:46.084784Z"}'
+        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"created_at":"2025-08-27T15:16:30.158333Z","description":"","domain_name":"tffuncfriendlywilesvp0xo6l3-tf-func-bold-visvesvaraya.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-bold-visvesvaraya","namespace_id":"3c7cd189-d8eb-4405-bf13-c55be0d32b06","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:16:46.286178Z"}'
         headers:
             Content-Length:
-                - "761"
+                - "765"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:18:50 GMT
+                - Wed, 27 Aug 2025 15:16:51 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -698,10 +698,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9ad33bd1-608d-4069-9e90-b228f9d0c03e
+                - d56c979a-93f2-4fcb-9dae-d3bc277a0396
         status: 200 OK
         code: 200
-        duration: 93.418083ms
+        duration: 95.635088ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -717,8 +717,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/2a8109ee-4580-416a-a897-5b064d886bc3
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e
         method: GET
       response:
         proto: HTTP/2.0
@@ -726,18 +726,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 761
+        content_length: 765
         uncompressed: false
-        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"created_at":"2025-06-11T12:18:24.558398Z","description":"","domain_name":"tffuncexcitingtuzibjceyb-tf-func-cranky-tereshkova.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"2a8109ee-4580-416a-a897-5b064d886bc3","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-cranky-tereshkova","namespace_id":"4b3ebb33-4816-4ece-be11-9d59f6642926","privacy":"private","ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-06-11T12:18:51.143827Z"}'
+        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"created_at":"2025-08-27T15:16:30.158333Z","description":"","domain_name":"tffuncfriendlywilesvp0xo6l3-tf-func-bold-visvesvaraya.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-bold-visvesvaraya","namespace_id":"3c7cd189-d8eb-4405-bf13-c55be0d32b06","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:16:51.405134Z"}'
         headers:
             Content-Length:
-                - "761"
+                - "765"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:18:55 GMT
+                - Wed, 27 Aug 2025 15:16:56 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -747,10 +747,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c07f0d09-0a23-4540-a556-438e7fcc2e48
+                - d99f7fcb-4db3-4744-8fd1-0a156c6cda69
         status: 200 OK
         code: 200
-        duration: 88.198791ms
+        duration: 93.956958ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -766,8 +766,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/2a8109ee-4580-416a-a897-5b064d886bc3
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e
         method: GET
       response:
         proto: HTTP/2.0
@@ -775,18 +775,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 761
+        content_length: 765
         uncompressed: false
-        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"created_at":"2025-06-11T12:18:24.558398Z","description":"","domain_name":"tffuncexcitingtuzibjceyb-tf-func-cranky-tereshkova.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"2a8109ee-4580-416a-a897-5b064d886bc3","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-cranky-tereshkova","namespace_id":"4b3ebb33-4816-4ece-be11-9d59f6642926","privacy":"private","ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-06-11T12:18:56.230439Z"}'
+        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"created_at":"2025-08-27T15:16:30.158333Z","description":"","domain_name":"tffuncfriendlywilesvp0xo6l3-tf-func-bold-visvesvaraya.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-bold-visvesvaraya","namespace_id":"3c7cd189-d8eb-4405-bf13-c55be0d32b06","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:16:56.496184Z"}'
         headers:
             Content-Length:
-                - "761"
+                - "765"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:19:01 GMT
+                - Wed, 27 Aug 2025 15:17:01 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -796,10 +796,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8c9bccbf-45f2-409d-b86e-ff3ccc7889d6
+                - 1974f55d-7682-4d2d-ad85-dfb3f43408ba
         status: 200 OK
         code: 200
-        duration: 159.508791ms
+        duration: 103.498372ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -815,8 +815,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/2a8109ee-4580-416a-a897-5b064d886bc3
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e
         method: GET
       response:
         proto: HTTP/2.0
@@ -824,18 +824,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 761
+        content_length: 765
         uncompressed: false
-        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"created_at":"2025-06-11T12:18:24.558398Z","description":"","domain_name":"tffuncexcitingtuzibjceyb-tf-func-cranky-tereshkova.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"2a8109ee-4580-416a-a897-5b064d886bc3","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-cranky-tereshkova","namespace_id":"4b3ebb33-4816-4ece-be11-9d59f6642926","privacy":"private","ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-06-11T12:19:01.314096Z"}'
+        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"created_at":"2025-08-27T15:16:30.158333Z","description":"","domain_name":"tffuncfriendlywilesvp0xo6l3-tf-func-bold-visvesvaraya.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-bold-visvesvaraya","namespace_id":"3c7cd189-d8eb-4405-bf13-c55be0d32b06","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:17:01.936043Z"}'
         headers:
             Content-Length:
-                - "761"
+                - "765"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:19:06 GMT
+                - Wed, 27 Aug 2025 15:17:06 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -845,10 +845,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 46a3f5a1-c31d-4030-ad91-f51c6c3fde29
+                - bebb698c-c511-4156-ac0a-5860549a07fd
         status: 200 OK
         code: 200
-        duration: 89.677041ms
+        duration: 106.895953ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -864,8 +864,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/2a8109ee-4580-416a-a897-5b064d886bc3
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e
         method: GET
       response:
         proto: HTTP/2.0
@@ -873,18 +873,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 787
+        content_length: 765
         uncompressed: false
-        body: '{"build_message":"step 3 of 3: function image is being pushed to container registry","cpu_limit":140,"created_at":"2025-06-11T12:18:24.558398Z","description":"","domain_name":"tffuncexcitingtuzibjceyb-tf-func-cranky-tereshkova.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"2a8109ee-4580-416a-a897-5b064d886bc3","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-cranky-tereshkova","namespace_id":"4b3ebb33-4816-4ece-be11-9d59f6642926","privacy":"private","ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-06-11T12:19:06.478471Z"}'
+        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"created_at":"2025-08-27T15:16:30.158333Z","description":"","domain_name":"tffuncfriendlywilesvp0xo6l3-tf-func-bold-visvesvaraya.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-bold-visvesvaraya","namespace_id":"3c7cd189-d8eb-4405-bf13-c55be0d32b06","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:17:07.065623Z"}'
         headers:
             Content-Length:
-                - "787"
+                - "765"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:19:11 GMT
+                - Wed, 27 Aug 2025 15:17:11 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -894,10 +894,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 02c49b9d-6f88-4adf-b5da-6358cdafeda0
+                - ffdc2709-1dcf-44ac-9964-07e69b6a7c97
         status: 200 OK
         code: 200
-        duration: 95.097084ms
+        duration: 105.975956ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -913,8 +913,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/2a8109ee-4580-416a-a897-5b064d886bc3
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e
         method: GET
       response:
         proto: HTTP/2.0
@@ -922,18 +922,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 787
+        content_length: 765
         uncompressed: false
-        body: '{"build_message":"step 3 of 3: function image is being pushed to container registry","cpu_limit":140,"created_at":"2025-06-11T12:18:24.558398Z","description":"","domain_name":"tffuncexcitingtuzibjceyb-tf-func-cranky-tereshkova.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"2a8109ee-4580-416a-a897-5b064d886bc3","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-cranky-tereshkova","namespace_id":"4b3ebb33-4816-4ece-be11-9d59f6642926","privacy":"private","ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-06-11T12:19:11.550374Z"}'
+        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"created_at":"2025-08-27T15:16:30.158333Z","description":"","domain_name":"tffuncfriendlywilesvp0xo6l3-tf-func-bold-visvesvaraya.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-bold-visvesvaraya","namespace_id":"3c7cd189-d8eb-4405-bf13-c55be0d32b06","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:17:12.228663Z"}'
         headers:
             Content-Length:
-                - "787"
+                - "765"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:19:16 GMT
+                - Wed, 27 Aug 2025 15:17:16 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -943,10 +943,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 06b7ff41-acef-449e-ba36-a110230572fd
+                - 170f10a3-419b-4c41-840a-ecaf2a868479
         status: 200 OK
         code: 200
-        duration: 174.757709ms
+        duration: 105.518648ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -962,8 +962,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/2a8109ee-4580-416a-a897-5b064d886bc3
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e
         method: GET
       response:
         proto: HTTP/2.0
@@ -971,18 +971,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 724
+        content_length: 765
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-11T12:18:24.558398Z","description":"","domain_name":"tffuncexcitingtuzibjceyb-tf-func-cranky-tereshkova.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"2a8109ee-4580-416a-a897-5b064d886bc3","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-cranky-tereshkova","namespace_id":"4b3ebb33-4816-4ece-be11-9d59f6642926","privacy":"private","ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-06-11T12:19:16.621652Z"}'
+        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"created_at":"2025-08-27T15:16:30.158333Z","description":"","domain_name":"tffuncfriendlywilesvp0xo6l3-tf-func-bold-visvesvaraya.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-bold-visvesvaraya","namespace_id":"3c7cd189-d8eb-4405-bf13-c55be0d32b06","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:17:17.420760Z"}'
         headers:
             Content-Length:
-                - "724"
+                - "765"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:19:21 GMT
+                - Wed, 27 Aug 2025 15:17:21 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -992,10 +992,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 03cc0a8c-f1fe-4825-883b-cd4535b83a24
+                - 700314e3-a69b-4f08-ad3e-99a12c2e02fe
         status: 200 OK
         code: 200
-        duration: 133.461042ms
+        duration: 126.40198ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1011,8 +1011,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/2a8109ee-4580-416a-a897-5b064d886bc3
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e
         method: GET
       response:
         proto: HTTP/2.0
@@ -1020,18 +1020,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 724
+        content_length: 765
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-11T12:18:24.558398Z","description":"","domain_name":"tffuncexcitingtuzibjceyb-tf-func-cranky-tereshkova.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"2a8109ee-4580-416a-a897-5b064d886bc3","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-cranky-tereshkova","namespace_id":"4b3ebb33-4816-4ece-be11-9d59f6642926","privacy":"private","ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-06-11T12:19:16.621652Z"}'
+        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"created_at":"2025-08-27T15:16:30.158333Z","description":"","domain_name":"tffuncfriendlywilesvp0xo6l3-tf-func-bold-visvesvaraya.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-bold-visvesvaraya","namespace_id":"3c7cd189-d8eb-4405-bf13-c55be0d32b06","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:17:22.504319Z"}'
         headers:
             Content-Length:
-                - "724"
+                - "765"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:19:26 GMT
+                - Wed, 27 Aug 2025 15:17:26 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -1041,10 +1041,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3c3cb117-03dd-497e-b716-8ea22099ad0b
+                - 82d8015e-437c-4c7d-8c26-8e2c13457a5a
         status: 200 OK
         code: 200
-        duration: 88.835041ms
+        duration: 118.164744ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1060,8 +1060,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/2a8109ee-4580-416a-a897-5b064d886bc3
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e
         method: GET
       response:
         proto: HTTP/2.0
@@ -1069,18 +1069,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 747
+        content_length: 765
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-11T12:18:24.558398Z","description":"","domain_name":"tffuncexcitingtuzibjceyb-tf-func-cranky-tereshkova.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"2a8109ee-4580-416a-a897-5b064d886bc3","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-cranky-tereshkova","namespace_id":"4b3ebb33-4816-4ece-be11-9d59f6642926","privacy":"private","ready_at":"2025-06-11T12:19:27.286433Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"ready","tags":[],"timeout":"300s","updated_at":"2025-06-11T12:19:27.295660Z"}'
+        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"created_at":"2025-08-27T15:16:30.158333Z","description":"","domain_name":"tffuncfriendlywilesvp0xo6l3-tf-func-bold-visvesvaraya.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-bold-visvesvaraya","namespace_id":"3c7cd189-d8eb-4405-bf13-c55be0d32b06","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:17:27.632753Z"}'
         headers:
             Content-Length:
-                - "747"
+                - "765"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:19:31 GMT
+                - Wed, 27 Aug 2025 15:17:32 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -1090,10 +1090,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 104add50-d2be-4340-a4cc-77088386255d
+                - 4d333ba2-b34a-458f-97ad-b62c97b3e1d7
         status: 200 OK
         code: 200
-        duration: 81.126959ms
+        duration: 112.002475ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1109,8 +1109,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/2a8109ee-4580-416a-a897-5b064d886bc3
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e
         method: GET
       response:
         proto: HTTP/2.0
@@ -1118,18 +1118,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 747
+        content_length: 765
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-11T12:18:24.558398Z","description":"","domain_name":"tffuncexcitingtuzibjceyb-tf-func-cranky-tereshkova.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"2a8109ee-4580-416a-a897-5b064d886bc3","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-cranky-tereshkova","namespace_id":"4b3ebb33-4816-4ece-be11-9d59f6642926","privacy":"private","ready_at":"2025-06-11T12:19:27.286433Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"ready","tags":[],"timeout":"300s","updated_at":"2025-06-11T12:19:27.295660Z"}'
+        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"created_at":"2025-08-27T15:16:30.158333Z","description":"","domain_name":"tffuncfriendlywilesvp0xo6l3-tf-func-bold-visvesvaraya.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-bold-visvesvaraya","namespace_id":"3c7cd189-d8eb-4405-bf13-c55be0d32b06","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:17:32.754803Z"}'
         headers:
             Content-Length:
-                - "747"
+                - "765"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:19:31 GMT
+                - Wed, 27 Aug 2025 15:17:37 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -1139,48 +1139,46 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 045e398c-37a9-4a4a-a7df-ee4d7a60477c
+                - 56acb03b-b2b1-4c74-8b2e-f48b2f0ca089
         status: 200 OK
         code: 200
-        duration: 95.590416ms
+        duration: 101.997548ms
     - id: 23
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 269
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"changes":[{"add":{"records":[{"data":"tffuncexcitingtuzibjceyb-tf-func-cranky-tereshkova.functions.fnc.fr-par.scw.cloud.","name":"function","priority":0,"ttl":60,"type":"CNAME","comment":null,"id":""}]}}],"return_all_records":false,"disallow_new_zone_creation":false}'
+        body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/domain/v2beta1/dns-zones/function-basic.scaleway-terraform.com/records
-        method: PATCH
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 227
+        content_length: 765
         uncompressed: false
-        body: '{"records":[{"comment":null,"data":"tffuncexcitingtuzibjceyb-tf-func-cranky-tereshkova.functions.fnc.fr-par.scw.cloud.","id":"76f83914-d24e-448e-a1b7-3cf1776e48aa","name":"function","priority":0,"ttl":60,"type":"CNAME"}]}'
+        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"created_at":"2025-08-27T15:16:30.158333Z","description":"","domain_name":"tffuncfriendlywilesvp0xo6l3-tf-func-bold-visvesvaraya.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-bold-visvesvaraya","namespace_id":"3c7cd189-d8eb-4405-bf13-c55be0d32b06","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:17:37.857393Z"}'
         headers:
             Content-Length:
-                - "227"
+                - "765"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:19:32 GMT
+                - Wed, 27 Aug 2025 15:17:42 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -1190,10 +1188,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 01afdfa6-a0ed-43f2-a7cc-54c65c34b8b3
+                - d68a5d00-ce9a-4fee-800f-6d5085f7060e
         status: 200 OK
         code: 200
-        duration: 722.022375ms
+        duration: 109.429844ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1209,8 +1207,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/domain/v2beta1/dns-zones/function-basic.scaleway-terraform.com/records?name=function&order_by=name_asc&type=CNAME
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e
         method: GET
       response:
         proto: HTTP/2.0
@@ -1218,18 +1216,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 244
+        content_length: 765
         uncompressed: false
-        body: '{"records":[{"comment":null,"data":"tffuncexcitingtuzibjceyb-tf-func-cranky-tereshkova.functions.fnc.fr-par.scw.cloud.","id":"76f83914-d24e-448e-a1b7-3cf1776e48aa","name":"function","priority":0,"ttl":60,"type":"CNAME"}],"total_count":1}'
+        body: '{"build_message":"step 2 of 3: function build in progress","cpu_limit":140,"created_at":"2025-08-27T15:16:30.158333Z","description":"","domain_name":"tffuncfriendlywilesvp0xo6l3-tf-func-bold-visvesvaraya.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-bold-visvesvaraya","namespace_id":"3c7cd189-d8eb-4405-bf13-c55be0d32b06","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:17:42.984288Z"}'
         headers:
             Content-Length:
-                - "244"
+                - "765"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:19:32 GMT
+                - Wed, 27 Aug 2025 15:17:47 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -1239,10 +1237,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 62a76bc1-5082-4767-be4c-d54db9cfb32e
+                - 20d244de-7274-4de8-a41a-fd5a36b9ce40
         status: 200 OK
         code: 200
-        duration: 98.284875ms
+        duration: 126.632255ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1258,8 +1256,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/domain/v2beta1/dns-zones/function-basic.scaleway-terraform.com/records?name=function&order_by=name_asc&page=1&type=CNAME
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e
         method: GET
       response:
         proto: HTTP/2.0
@@ -1267,18 +1265,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 244
+        content_length: 791
         uncompressed: false
-        body: '{"records":[{"comment":null,"data":"tffuncexcitingtuzibjceyb-tf-func-cranky-tereshkova.functions.fnc.fr-par.scw.cloud.","id":"76f83914-d24e-448e-a1b7-3cf1776e48aa","name":"function","priority":0,"ttl":60,"type":"CNAME"}],"total_count":1}'
+        body: '{"build_message":"step 3 of 3: function image is being pushed to container registry","cpu_limit":140,"created_at":"2025-08-27T15:16:30.158333Z","description":"","domain_name":"tffuncfriendlywilesvp0xo6l3-tf-func-bold-visvesvaraya.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-bold-visvesvaraya","namespace_id":"3c7cd189-d8eb-4405-bf13-c55be0d32b06","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:17:48.110260Z"}'
         headers:
             Content-Length:
-                - "244"
+                - "791"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:19:32 GMT
+                - Wed, 27 Aug 2025 15:17:52 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -1288,10 +1286,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 84002654-c437-4f54-a134-f4965c38658b
+                - c378b874-6231-4ab7-a4be-afb7cfbf1265
         status: 200 OK
         code: 200
-        duration: 87.15375ms
+        duration: 92.59779ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1307,8 +1305,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/domain/v2beta1/dns-zones/function-basic.scaleway-terraform.com/records?id=76f83914-d24e-448e-a1b7-3cf1776e48aa&name=&order_by=name_asc&page=1&type=unknown
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e
         method: GET
       response:
         proto: HTTP/2.0
@@ -1316,18 +1314,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 244
+        content_length: 791
         uncompressed: false
-        body: '{"records":[{"comment":null,"data":"tffuncexcitingtuzibjceyb-tf-func-cranky-tereshkova.functions.fnc.fr-par.scw.cloud.","id":"76f83914-d24e-448e-a1b7-3cf1776e48aa","name":"function","priority":0,"ttl":60,"type":"CNAME"}],"total_count":1}'
+        body: '{"build_message":"step 3 of 3: function image is being pushed to container registry","cpu_limit":140,"created_at":"2025-08-27T15:16:30.158333Z","description":"","domain_name":"tffuncfriendlywilesvp0xo6l3-tf-func-bold-visvesvaraya.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-bold-visvesvaraya","namespace_id":"3c7cd189-d8eb-4405-bf13-c55be0d32b06","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:17:53.310705Z"}'
         headers:
             Content-Length:
-                - "244"
+                - "791"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:19:32 GMT
+                - Wed, 27 Aug 2025 15:17:57 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -1337,10 +1335,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 102e9bd9-2e3d-43ea-9b1f-eb764910f229
+                - ea0fac81-2a79-4a64-93ca-d6590b5e2b21
         status: 200 OK
         code: 200
-        duration: 86.804209ms
+        duration: 284.639276ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1356,8 +1354,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zones=function-basic.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e
         method: GET
       response:
         proto: HTTP/2.0
@@ -1365,18 +1363,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 368
+        content_length: 728
         uncompressed: false
-        body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"function-basic","updated_at":"2025-06-11T12:19:32Z"}],"total_count":1}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:16:30.158333Z","description":"","domain_name":"tffuncfriendlywilesvp0xo6l3-tf-func-bold-visvesvaraya.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-bold-visvesvaraya","namespace_id":"3c7cd189-d8eb-4405-bf13-c55be0d32b06","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:17:58.624467Z"}'
         headers:
             Content-Length:
-                - "368"
+                - "728"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:19:32 GMT
+                - Wed, 27 Aug 2025 15:18:02 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -1386,10 +1384,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cfec8d0e-ba2b-45a9-9c64-e7c4d17f57ff
+                - 2fbb9c4b-6b6f-40bb-baf0-92e77db5e1f2
         status: 200 OK
         code: 200
-        duration: 89.486959ms
+        duration: 100.088286ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1405,8 +1403,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/2a8109ee-4580-416a-a897-5b064d886bc3
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e
         method: GET
       response:
         proto: HTTP/2.0
@@ -1414,18 +1412,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 747
+        content_length: 728
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-11T12:18:24.558398Z","description":"","domain_name":"tffuncexcitingtuzibjceyb-tf-func-cranky-tereshkova.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"2a8109ee-4580-416a-a897-5b064d886bc3","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-cranky-tereshkova","namespace_id":"4b3ebb33-4816-4ece-be11-9d59f6642926","privacy":"private","ready_at":"2025-06-11T12:19:27.286433Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"ready","tags":[],"timeout":"300s","updated_at":"2025-06-11T12:19:27.295660Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:16:30.158333Z","description":"","domain_name":"tffuncfriendlywilesvp0xo6l3-tf-func-bold-visvesvaraya.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-bold-visvesvaraya","namespace_id":"3c7cd189-d8eb-4405-bf13-c55be0d32b06","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:18:03.732600Z"}'
         headers:
             Content-Length:
-                - "747"
+                - "728"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:19:33 GMT
+                - Wed, 27 Aug 2025 15:18:08 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -1435,48 +1433,46 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c80549de-7ebd-4960-9fc6-01fe2d5c71dd
+                - 570cb8fa-02c8-4ef1-bffc-7e11508c7a49
         status: 200 OK
         code: 200
-        duration: 97.377292ms
+        duration: 98.475678ms
     - id: 29
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 114
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"hostname":"function.function-basic.scaleway-terraform.com","function_id":"2a8109ee-4580-416a-a897-5b064d886bc3"}'
+        body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains
-        method: POST
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 212
+        content_length: 728
         uncompressed: false
-        body: '{"error_message":null,"function_id":"2a8109ee-4580-416a-a897-5b064d886bc3","hostname":"function.function-basic.scaleway-terraform.com","id":"837f7439-47e0-4e01-880a-1e4abb784c7c","status":"pending","url":""}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:16:30.158333Z","description":"","domain_name":"tffuncfriendlywilesvp0xo6l3-tf-func-bold-visvesvaraya.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-bold-visvesvaraya","namespace_id":"3c7cd189-d8eb-4405-bf13-c55be0d32b06","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:18:03.732600Z"}'
         headers:
             Content-Length:
-                - "212"
+                - "728"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:19:38 GMT
+                - Wed, 27 Aug 2025 15:18:13 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -1486,10 +1482,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2ac1ba20-b087-4e41-bae4-776130ee748f
+                - 48476555-c2de-4a96-9834-bd31ef8ba959
         status: 200 OK
         code: 200
-        duration: 109.063375ms
+        duration: 110.209271ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1505,8 +1501,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/837f7439-47e0-4e01-880a-1e4abb784c7c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e
         method: GET
       response:
         proto: HTTP/2.0
@@ -1514,18 +1510,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 212
+        content_length: 751
         uncompressed: false
-        body: '{"error_message":null,"function_id":"2a8109ee-4580-416a-a897-5b064d886bc3","hostname":"function.function-basic.scaleway-terraform.com","id":"837f7439-47e0-4e01-880a-1e4abb784c7c","status":"pending","url":""}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:16:30.158333Z","description":"","domain_name":"tffuncfriendlywilesvp0xo6l3-tf-func-bold-visvesvaraya.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-bold-visvesvaraya","namespace_id":"3c7cd189-d8eb-4405-bf13-c55be0d32b06","privacy":"private","private_network_id":null,"ready_at":"2025-08-27T15:18:14.776681Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"ready","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:18:14.790915Z"}'
         headers:
             Content-Length:
-                - "212"
+                - "751"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:19:38 GMT
+                - Wed, 27 Aug 2025 15:18:18 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -1535,10 +1531,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fc939037-6bd1-4e13-a1e4-7d7391b1195c
+                - 15109861-d22b-4f4a-a791-2def6d5d3045
         status: 200 OK
         code: 200
-        duration: 129.335458ms
+        duration: 107.539958ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1554,8 +1550,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/837f7439-47e0-4e01-880a-1e4abb784c7c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e
         method: GET
       response:
         proto: HTTP/2.0
@@ -1563,18 +1559,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 212
+        content_length: 751
         uncompressed: false
-        body: '{"error_message":null,"function_id":"2a8109ee-4580-416a-a897-5b064d886bc3","hostname":"function.function-basic.scaleway-terraform.com","id":"837f7439-47e0-4e01-880a-1e4abb784c7c","status":"pending","url":""}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:16:30.158333Z","description":"","domain_name":"tffuncfriendlywilesvp0xo6l3-tf-func-bold-visvesvaraya.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-bold-visvesvaraya","namespace_id":"3c7cd189-d8eb-4405-bf13-c55be0d32b06","privacy":"private","private_network_id":null,"ready_at":"2025-08-27T15:18:14.776681Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"ready","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:18:14.790915Z"}'
         headers:
             Content-Length:
-                - "212"
+                - "751"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:19:43 GMT
+                - Wed, 27 Aug 2025 15:18:18 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -1584,46 +1580,48 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c86852d9-f6fb-4dc3-82d6-5a76df249309
+                - 9c752415-9cb0-4ed8-b480-36cf1578c6c5
         status: 200 OK
         code: 200
-        duration: 104.426416ms
+        duration: 79.85779ms
     - id: 32
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 272
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"changes":[{"add":{"records":[{"data":"tffuncfriendlywilesvp0xo6l3-tf-func-bold-visvesvaraya.functions.fnc.fr-par.scw.cloud.","name":"function","priority":0,"ttl":60,"type":"CNAME","comment":null,"id":""}]}}],"return_all_records":false,"disallow_new_zone_creation":false}'
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/837f7439-47e0-4e01-880a-1e4abb784c7c
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/domain/v2beta1/dns-zones/function-basic.scaleway-terraform.com/records
+        method: PATCH
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 212
+        content_length: 224
         uncompressed: false
-        body: '{"error_message":null,"function_id":"2a8109ee-4580-416a-a897-5b064d886bc3","hostname":"function.function-basic.scaleway-terraform.com","id":"837f7439-47e0-4e01-880a-1e4abb784c7c","status":"pending","url":""}'
+        body: '{"records":[{"comment":null,"data":"tffuncfriendlywilesvp0xo6l3-tf-func-bold-visvesvaraya.functions.fnc.fr-par.scw.cloud.","id":"707e77cd-6792-4d3f-9123-d0345b3522c1","name":"function","priority":0,"ttl":60,"type":"CNAME"}]}'
         headers:
             Content-Length:
-                - "212"
+                - "224"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:19:48 GMT
+                - Wed, 27 Aug 2025 15:18:18 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -1633,10 +1631,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e8818cbe-9181-4334-8a55-e7c6bbd1219b
+                - 1850e707-acb8-47b7-9c5c-be406759d4b2
         status: 200 OK
         code: 200
-        duration: 152.676125ms
+        duration: 161.361811ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1652,8 +1650,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/837f7439-47e0-4e01-880a-1e4abb784c7c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/domain/v2beta1/dns-zones/function-basic.scaleway-terraform.com/records?name=function&order_by=name_asc&type=CNAME
         method: GET
       response:
         proto: HTTP/2.0
@@ -1661,18 +1659,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 212
+        content_length: 240
         uncompressed: false
-        body: '{"error_message":null,"function_id":"2a8109ee-4580-416a-a897-5b064d886bc3","hostname":"function.function-basic.scaleway-terraform.com","id":"837f7439-47e0-4e01-880a-1e4abb784c7c","status":"pending","url":""}'
+        body: '{"records":[{"comment":null,"data":"tffuncfriendlywilesvp0xo6l3-tf-func-bold-visvesvaraya.functions.fnc.fr-par.scw.cloud.","id":"707e77cd-6792-4d3f-9123-d0345b3522c1","name":"function","priority":0,"ttl":60,"type":"CNAME"}],"total_count":1}'
         headers:
             Content-Length:
-                - "212"
+                - "240"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:19:53 GMT
+                - Wed, 27 Aug 2025 15:18:18 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -1682,10 +1680,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b61f0480-36ef-4f2f-82af-643a4427d98b
+                - e4787177-211b-488e-a23d-b9775f05e09a
         status: 200 OK
         code: 200
-        duration: 92.671125ms
+        duration: 85.309887ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1701,8 +1699,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/837f7439-47e0-4e01-880a-1e4abb784c7c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/domain/v2beta1/dns-zones/function-basic.scaleway-terraform.com/records?name=function&order_by=name_asc&page=1&type=CNAME
         method: GET
       response:
         proto: HTTP/2.0
@@ -1710,18 +1708,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 212
+        content_length: 240
         uncompressed: false
-        body: '{"error_message":null,"function_id":"2a8109ee-4580-416a-a897-5b064d886bc3","hostname":"function.function-basic.scaleway-terraform.com","id":"837f7439-47e0-4e01-880a-1e4abb784c7c","status":"pending","url":""}'
+        body: '{"records":[{"comment":null,"data":"tffuncfriendlywilesvp0xo6l3-tf-func-bold-visvesvaraya.functions.fnc.fr-par.scw.cloud.","id":"707e77cd-6792-4d3f-9123-d0345b3522c1","name":"function","priority":0,"ttl":60,"type":"CNAME"}],"total_count":1}'
         headers:
             Content-Length:
-                - "212"
+                - "240"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:19:58 GMT
+                - Wed, 27 Aug 2025 15:18:18 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -1731,10 +1729,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 84d0fd83-24eb-4a17-aa1f-41abc07a2e7d
+                - 13db22f7-f4f6-434e-9b2c-326004b5f300
         status: 200 OK
         code: 200
-        duration: 170.321542ms
+        duration: 77.863645ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1750,8 +1748,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/837f7439-47e0-4e01-880a-1e4abb784c7c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/domain/v2beta1/dns-zones/function-basic.scaleway-terraform.com/records?id=707e77cd-6792-4d3f-9123-d0345b3522c1&name=&order_by=name_asc&page=1&type=unknown
         method: GET
       response:
         proto: HTTP/2.0
@@ -1759,18 +1757,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 212
+        content_length: 240
         uncompressed: false
-        body: '{"error_message":null,"function_id":"2a8109ee-4580-416a-a897-5b064d886bc3","hostname":"function.function-basic.scaleway-terraform.com","id":"837f7439-47e0-4e01-880a-1e4abb784c7c","status":"pending","url":""}'
+        body: '{"records":[{"comment":null,"data":"tffuncfriendlywilesvp0xo6l3-tf-func-bold-visvesvaraya.functions.fnc.fr-par.scw.cloud.","id":"707e77cd-6792-4d3f-9123-d0345b3522c1","name":"function","priority":0,"ttl":60,"type":"CNAME"}],"total_count":1}'
         headers:
             Content-Length:
-                - "212"
+                - "240"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:20:03 GMT
+                - Wed, 27 Aug 2025 15:18:18 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -1780,10 +1778,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ad98820d-65b5-4782-b345-b78d06bf8d8d
+                - e49c80fd-77e6-45fb-a093-d13e346d7d40
         status: 200 OK
         code: 200
-        duration: 85.576542ms
+        duration: 90.555466ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1799,8 +1797,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/837f7439-47e0-4e01-880a-1e4abb784c7c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zones=function-basic.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -1808,18 +1806,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 212
+        content_length: 356
         uncompressed: false
-        body: '{"error_message":null,"function_id":"2a8109ee-4580-416a-a897-5b064d886bc3","hostname":"function.function-basic.scaleway-terraform.com","id":"837f7439-47e0-4e01-880a-1e4abb784c7c","status":"pending","url":""}'
+        body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"function-basic","updated_at":"2025-08-27T15:18:18Z"}],"total_count":1}'
         headers:
             Content-Length:
-                - "212"
+                - "356"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:20:09 GMT
+                - Wed, 27 Aug 2025 15:18:18 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -1829,10 +1827,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 387253bd-33af-447a-b02e-1decb881394c
+                - 56560b9a-c718-4d03-8237-85a8f91af466
         status: 200 OK
         code: 200
-        duration: 126.9745ms
+        duration: 85.274631ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1848,8 +1846,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/837f7439-47e0-4e01-880a-1e4abb784c7c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e
         method: GET
       response:
         proto: HTTP/2.0
@@ -1857,18 +1855,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 212
+        content_length: 751
         uncompressed: false
-        body: '{"error_message":null,"function_id":"2a8109ee-4580-416a-a897-5b064d886bc3","hostname":"function.function-basic.scaleway-terraform.com","id":"837f7439-47e0-4e01-880a-1e4abb784c7c","status":"pending","url":""}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:16:30.158333Z","description":"","domain_name":"tffuncfriendlywilesvp0xo6l3-tf-func-bold-visvesvaraya.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-bold-visvesvaraya","namespace_id":"3c7cd189-d8eb-4405-bf13-c55be0d32b06","privacy":"private","private_network_id":null,"ready_at":"2025-08-27T15:18:14.776681Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"ready","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:18:14.790915Z"}'
         headers:
             Content-Length:
-                - "212"
+                - "751"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:20:14 GMT
+                - Wed, 27 Aug 2025 15:18:18 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -1878,46 +1876,48 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 214d2211-bd6b-4949-b680-45451660307b
+                - 633d2ab7-31b7-4db4-bceb-b5f379c98802
         status: 200 OK
         code: 200
-        duration: 161.483708ms
+        duration: 122.692711ms
     - id: 38
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 114
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"hostname":"function.function-basic.scaleway-terraform.com","function_id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e"}'
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/837f7439-47e0-4e01-880a-1e4abb784c7c
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 212
+        content_length: 207
         uncompressed: false
-        body: '{"error_message":null,"function_id":"2a8109ee-4580-416a-a897-5b064d886bc3","hostname":"function.function-basic.scaleway-terraform.com","id":"837f7439-47e0-4e01-880a-1e4abb784c7c","status":"pending","url":""}'
+        body: '{"error_message":null,"function_id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e","hostname":"function.function-basic.scaleway-terraform.com","id":"3adbb702-818b-42e4-ac3a-51762a846f72","status":"pending","url":""}'
         headers:
             Content-Length:
-                - "212"
+                - "207"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:20:19 GMT
+                - Wed, 27 Aug 2025 15:18:24 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -1927,10 +1927,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 24a9ce54-807d-4b71-9cdd-824179b85c4d
+                - 34721d8e-4dfb-4440-8c65-eb6c254458fd
         status: 200 OK
         code: 200
-        duration: 101.216333ms
+        duration: 141.166291ms
     - id: 39
       request:
         proto: HTTP/1.1
@@ -1946,8 +1946,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/837f7439-47e0-4e01-880a-1e4abb784c7c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/3adbb702-818b-42e4-ac3a-51762a846f72
         method: GET
       response:
         proto: HTTP/2.0
@@ -1955,18 +1955,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 212
+        content_length: 207
         uncompressed: false
-        body: '{"error_message":null,"function_id":"2a8109ee-4580-416a-a897-5b064d886bc3","hostname":"function.function-basic.scaleway-terraform.com","id":"837f7439-47e0-4e01-880a-1e4abb784c7c","status":"pending","url":""}'
+        body: '{"error_message":null,"function_id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e","hostname":"function.function-basic.scaleway-terraform.com","id":"3adbb702-818b-42e4-ac3a-51762a846f72","status":"pending","url":""}'
         headers:
             Content-Length:
-                - "212"
+                - "207"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:20:24 GMT
+                - Wed, 27 Aug 2025 15:18:24 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -1976,10 +1976,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1d167445-ceb2-478d-a229-f148e8f22d7a
+                - cc8eaa2f-bb3e-4dcb-b550-7a39d73628b6
         status: 200 OK
         code: 200
-        duration: 440.862041ms
+        duration: 110.031648ms
     - id: 40
       request:
         proto: HTTP/1.1
@@ -1995,8 +1995,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/837f7439-47e0-4e01-880a-1e4abb784c7c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/3adbb702-818b-42e4-ac3a-51762a846f72
         method: GET
       response:
         proto: HTTP/2.0
@@ -2004,18 +2004,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 212
+        content_length: 207
         uncompressed: false
-        body: '{"error_message":null,"function_id":"2a8109ee-4580-416a-a897-5b064d886bc3","hostname":"function.function-basic.scaleway-terraform.com","id":"837f7439-47e0-4e01-880a-1e4abb784c7c","status":"pending","url":""}'
+        body: '{"error_message":null,"function_id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e","hostname":"function.function-basic.scaleway-terraform.com","id":"3adbb702-818b-42e4-ac3a-51762a846f72","status":"pending","url":""}'
         headers:
             Content-Length:
-                - "212"
+                - "207"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:20:29 GMT
+                - Wed, 27 Aug 2025 15:18:29 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -2025,10 +2025,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2066fe38-e506-4de4-a65e-1c8912b9d9cf
+                - 1bc15b15-67a2-488f-8b9a-cc40f87b3e77
         status: 200 OK
         code: 200
-        duration: 89.240667ms
+        duration: 128.587161ms
     - id: 41
       request:
         proto: HTTP/1.1
@@ -2044,8 +2044,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/837f7439-47e0-4e01-880a-1e4abb784c7c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/3adbb702-818b-42e4-ac3a-51762a846f72
         method: GET
       response:
         proto: HTTP/2.0
@@ -2053,18 +2053,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 212
+        content_length: 207
         uncompressed: false
-        body: '{"error_message":null,"function_id":"2a8109ee-4580-416a-a897-5b064d886bc3","hostname":"function.function-basic.scaleway-terraform.com","id":"837f7439-47e0-4e01-880a-1e4abb784c7c","status":"pending","url":""}'
+        body: '{"error_message":null,"function_id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e","hostname":"function.function-basic.scaleway-terraform.com","id":"3adbb702-818b-42e4-ac3a-51762a846f72","status":"pending","url":""}'
         headers:
             Content-Length:
-                - "212"
+                - "207"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:20:34 GMT
+                - Wed, 27 Aug 2025 15:18:34 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -2074,10 +2074,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3893ba6b-bff2-4b38-a870-d5a8c4fc0113
+                - d7b3e8d0-5b16-458b-a4dd-aca037bd1a13
         status: 200 OK
         code: 200
-        duration: 117.158958ms
+        duration: 110.672512ms
     - id: 42
       request:
         proto: HTTP/1.1
@@ -2093,8 +2093,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/837f7439-47e0-4e01-880a-1e4abb784c7c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/3adbb702-818b-42e4-ac3a-51762a846f72
         method: GET
       response:
         proto: HTTP/2.0
@@ -2102,18 +2102,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 264
+        content_length: 207
         uncompressed: false
-        body: '{"error_message":null,"function_id":"2a8109ee-4580-416a-a897-5b064d886bc3","hostname":"function.function-basic.scaleway-terraform.com","id":"837f7439-47e0-4e01-880a-1e4abb784c7c","status":"ready","url":"https://function.function-basic.scaleway-terraform.com"}'
+        body: '{"error_message":null,"function_id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e","hostname":"function.function-basic.scaleway-terraform.com","id":"3adbb702-818b-42e4-ac3a-51762a846f72","status":"pending","url":""}'
         headers:
             Content-Length:
-                - "264"
+                - "207"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:20:40 GMT
+                - Wed, 27 Aug 2025 15:18:39 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -2123,10 +2123,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4a37f028-0f6b-4e50-b81c-63cda37dd420
+                - 8fdcae07-7c7f-4a97-8c12-e0c549bfb530
         status: 200 OK
         code: 200
-        duration: 89.46125ms
+        duration: 80.370954ms
     - id: 43
       request:
         proto: HTTP/1.1
@@ -2142,8 +2142,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/837f7439-47e0-4e01-880a-1e4abb784c7c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/3adbb702-818b-42e4-ac3a-51762a846f72
         method: GET
       response:
         proto: HTTP/2.0
@@ -2151,18 +2151,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 264
+        content_length: 207
         uncompressed: false
-        body: '{"error_message":null,"function_id":"2a8109ee-4580-416a-a897-5b064d886bc3","hostname":"function.function-basic.scaleway-terraform.com","id":"837f7439-47e0-4e01-880a-1e4abb784c7c","status":"ready","url":"https://function.function-basic.scaleway-terraform.com"}'
+        body: '{"error_message":null,"function_id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e","hostname":"function.function-basic.scaleway-terraform.com","id":"3adbb702-818b-42e4-ac3a-51762a846f72","status":"pending","url":""}'
         headers:
             Content-Length:
-                - "264"
+                - "207"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:20:40 GMT
+                - Wed, 27 Aug 2025 15:18:44 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -2172,10 +2172,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ea89762e-9825-4a16-aa01-478d0d7c8a77
+                - ab1af183-501f-425a-bb6f-28d7450f1fcd
         status: 200 OK
         code: 200
-        duration: 106.123792ms
+        duration: 81.479256ms
     - id: 44
       request:
         proto: HTTP/1.1
@@ -2191,8 +2191,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/837f7439-47e0-4e01-880a-1e4abb784c7c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/3adbb702-818b-42e4-ac3a-51762a846f72
         method: GET
       response:
         proto: HTTP/2.0
@@ -2200,18 +2200,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 264
+        content_length: 207
         uncompressed: false
-        body: '{"error_message":null,"function_id":"2a8109ee-4580-416a-a897-5b064d886bc3","hostname":"function.function-basic.scaleway-terraform.com","id":"837f7439-47e0-4e01-880a-1e4abb784c7c","status":"ready","url":"https://function.function-basic.scaleway-terraform.com"}'
+        body: '{"error_message":null,"function_id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e","hostname":"function.function-basic.scaleway-terraform.com","id":"3adbb702-818b-42e4-ac3a-51762a846f72","status":"pending","url":""}'
         headers:
             Content-Length:
-                - "264"
+                - "207"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:20:40 GMT
+                - Wed, 27 Aug 2025 15:18:49 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -2221,10 +2221,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 56fc5fe3-7dd0-4704-ad2d-8cb669c5a194
+                - 91f0511a-f005-4eae-8171-47fa03df91b4
         status: 200 OK
         code: 200
-        duration: 94.151167ms
+        duration: 101.639702ms
     - id: 45
       request:
         proto: HTTP/1.1
@@ -2240,8 +2240,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/4b3ebb33-4816-4ece-be11-9d59f6642926
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/3adbb702-818b-42e4-ac3a-51762a846f72
         method: GET
       response:
         proto: HTTP/2.0
@@ -2249,18 +2249,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 564
+        content_length: 207
         uncompressed: false
-        body: '{"created_at":"2025-06-11T12:18:18.952635Z","description":"","environment_variables":{},"error_message":null,"id":"4b3ebb33-4816-4ece-be11-9d59f6642926","name":"tf-func-exciting-tu","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncexcitingtuzibjceyb","registry_namespace_id":"193ec47b-3958-4c15-b8cc-eaf927c47ab8","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-11T12:18:21.245163Z"}'
+        body: '{"error_message":null,"function_id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e","hostname":"function.function-basic.scaleway-terraform.com","id":"3adbb702-818b-42e4-ac3a-51762a846f72","status":"pending","url":""}'
         headers:
             Content-Length:
-                - "564"
+                - "207"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:20:40 GMT
+                - Wed, 27 Aug 2025 15:18:54 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -2270,10 +2270,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c980eeaf-65c8-4126-b511-94b741454503
+                - cc069265-4b0b-4cfd-b8e3-50f4d9301f3f
         status: 200 OK
         code: 200
-        duration: 77.591166ms
+        duration: 116.141092ms
     - id: 46
       request:
         proto: HTTP/1.1
@@ -2289,8 +2289,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/2a8109ee-4580-416a-a897-5b064d886bc3
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/3adbb702-818b-42e4-ac3a-51762a846f72
         method: GET
       response:
         proto: HTTP/2.0
@@ -2298,18 +2298,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 747
+        content_length: 207
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-11T12:18:24.558398Z","description":"","domain_name":"tffuncexcitingtuzibjceyb-tf-func-cranky-tereshkova.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"2a8109ee-4580-416a-a897-5b064d886bc3","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-cranky-tereshkova","namespace_id":"4b3ebb33-4816-4ece-be11-9d59f6642926","privacy":"private","ready_at":"2025-06-11T12:19:27.286433Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"ready","tags":[],"timeout":"300s","updated_at":"2025-06-11T12:19:27.295660Z"}'
+        body: '{"error_message":null,"function_id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e","hostname":"function.function-basic.scaleway-terraform.com","id":"3adbb702-818b-42e4-ac3a-51762a846f72","status":"pending","url":""}'
         headers:
             Content-Length:
-                - "747"
+                - "207"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:20:40 GMT
+                - Wed, 27 Aug 2025 15:18:59 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -2319,10 +2319,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ed70c129-b01f-44df-95f3-94c65f926c20
+                - 620b4a34-5fb0-4b11-b75b-b4f22d687cab
         status: 200 OK
         code: 200
-        duration: 90.140958ms
+        duration: 112.938549ms
     - id: 47
       request:
         proto: HTTP/1.1
@@ -2338,8 +2338,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/domain/v2beta1/dns-zones/function-basic.scaleway-terraform.com/records?id=76f83914-d24e-448e-a1b7-3cf1776e48aa&name=function&order_by=name_asc&page=1&type=CNAME
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/3adbb702-818b-42e4-ac3a-51762a846f72
         method: GET
       response:
         proto: HTTP/2.0
@@ -2347,18 +2347,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 244
+        content_length: 207
         uncompressed: false
-        body: '{"records":[{"comment":null,"data":"tffuncexcitingtuzibjceyb-tf-func-cranky-tereshkova.functions.fnc.fr-par.scw.cloud.","id":"76f83914-d24e-448e-a1b7-3cf1776e48aa","name":"function","priority":0,"ttl":60,"type":"CNAME"}],"total_count":1}'
+        body: '{"error_message":null,"function_id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e","hostname":"function.function-basic.scaleway-terraform.com","id":"3adbb702-818b-42e4-ac3a-51762a846f72","status":"pending","url":""}'
         headers:
             Content-Length:
-                - "244"
+                - "207"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:20:40 GMT
+                - Wed, 27 Aug 2025 15:19:05 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -2368,10 +2368,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d94f6633-f28b-4d10-b911-d91a04c9ae00
+                - 5b91ea52-fb76-422c-9f4d-ff5c1f3a17dd
         status: 200 OK
         code: 200
-        duration: 93.113334ms
+        duration: 109.13054ms
     - id: 48
       request:
         proto: HTTP/1.1
@@ -2387,8 +2387,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zones=function-basic.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/3adbb702-818b-42e4-ac3a-51762a846f72
         method: GET
       response:
         proto: HTTP/2.0
@@ -2396,18 +2396,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 367
+        content_length: 207
         uncompressed: false
-        body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"function-basic","updated_at":"2025-06-11T12:19:37Z"}],"total_count":1}'
+        body: '{"error_message":null,"function_id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e","hostname":"function.function-basic.scaleway-terraform.com","id":"3adbb702-818b-42e4-ac3a-51762a846f72","status":"pending","url":""}'
         headers:
             Content-Length:
-                - "367"
+                - "207"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:20:40 GMT
+                - Wed, 27 Aug 2025 15:19:10 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -2417,10 +2417,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c42b36dc-58b5-4eaa-a28d-4653c64f2267
+                - 7128e811-d401-4d59-b617-5e02c5cbc7de
         status: 200 OK
         code: 200
-        duration: 79.977041ms
+        duration: 99.666204ms
     - id: 49
       request:
         proto: HTTP/1.1
@@ -2436,8 +2436,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/837f7439-47e0-4e01-880a-1e4abb784c7c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/3adbb702-818b-42e4-ac3a-51762a846f72
         method: GET
       response:
         proto: HTTP/2.0
@@ -2445,18 +2445,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 264
+        content_length: 207
         uncompressed: false
-        body: '{"error_message":null,"function_id":"2a8109ee-4580-416a-a897-5b064d886bc3","hostname":"function.function-basic.scaleway-terraform.com","id":"837f7439-47e0-4e01-880a-1e4abb784c7c","status":"ready","url":"https://function.function-basic.scaleway-terraform.com"}'
+        body: '{"error_message":null,"function_id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e","hostname":"function.function-basic.scaleway-terraform.com","id":"3adbb702-818b-42e4-ac3a-51762a846f72","status":"pending","url":""}'
         headers:
             Content-Length:
-                - "264"
+                - "207"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:20:41 GMT
+                - Wed, 27 Aug 2025 15:19:15 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -2466,10 +2466,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 25edb4c3-8147-4768-845e-9c5dff48e11c
+                - bf729c86-3be5-45d8-9e07-3f0ddeb89aee
         status: 200 OK
         code: 200
-        duration: 96.988667ms
+        duration: 138.510909ms
     - id: 50
       request:
         proto: HTTP/1.1
@@ -2485,8 +2485,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/837f7439-47e0-4e01-880a-1e4abb784c7c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/3adbb702-818b-42e4-ac3a-51762a846f72
         method: GET
       response:
         proto: HTTP/2.0
@@ -2494,18 +2494,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 264
+        content_length: 207
         uncompressed: false
-        body: '{"error_message":null,"function_id":"2a8109ee-4580-416a-a897-5b064d886bc3","hostname":"function.function-basic.scaleway-terraform.com","id":"837f7439-47e0-4e01-880a-1e4abb784c7c","status":"ready","url":"https://function.function-basic.scaleway-terraform.com"}'
+        body: '{"error_message":null,"function_id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e","hostname":"function.function-basic.scaleway-terraform.com","id":"3adbb702-818b-42e4-ac3a-51762a846f72","status":"pending","url":""}'
         headers:
             Content-Length:
-                - "264"
+                - "207"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:20:41 GMT
+                - Wed, 27 Aug 2025 15:19:20 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -2515,10 +2515,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bd511c12-56a1-4782-a3b8-6ef909df2292
+                - c8268c6f-06f7-49be-900f-c5ff5f09e2ba
         status: 200 OK
         code: 200
-        duration: 561.72275ms
+        duration: 134.270046ms
     - id: 51
       request:
         proto: HTTP/1.1
@@ -2534,27 +2534,27 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/837f7439-47e0-4e01-880a-1e4abb784c7c
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/3adbb702-818b-42e4-ac3a-51762a846f72
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 267
+        content_length: 207
         uncompressed: false
-        body: '{"error_message":null,"function_id":"2a8109ee-4580-416a-a897-5b064d886bc3","hostname":"function.function-basic.scaleway-terraform.com","id":"837f7439-47e0-4e01-880a-1e4abb784c7c","status":"deleting","url":"https://function.function-basic.scaleway-terraform.com"}'
+        body: '{"error_message":null,"function_id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e","hostname":"function.function-basic.scaleway-terraform.com","id":"3adbb702-818b-42e4-ac3a-51762a846f72","status":"pending","url":""}'
         headers:
             Content-Length:
-                - "267"
+                - "207"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:20:41 GMT
+                - Wed, 27 Aug 2025 15:19:25 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -2564,10 +2564,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ddb5768b-0304-4f4e-a101-934395f67396
+                - 67652762-a29c-4fcc-a426-127c057fb85f
         status: 200 OK
         code: 200
-        duration: 149.26825ms
+        duration: 108.495207ms
     - id: 52
       request:
         proto: HTTP/1.1
@@ -2583,8 +2583,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/837f7439-47e0-4e01-880a-1e4abb784c7c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/3adbb702-818b-42e4-ac3a-51762a846f72
         method: GET
       response:
         proto: HTTP/2.0
@@ -2592,18 +2592,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 267
+        content_length: 207
         uncompressed: false
-        body: '{"error_message":null,"function_id":"2a8109ee-4580-416a-a897-5b064d886bc3","hostname":"function.function-basic.scaleway-terraform.com","id":"837f7439-47e0-4e01-880a-1e4abb784c7c","status":"deleting","url":"https://function.function-basic.scaleway-terraform.com"}'
+        body: '{"error_message":null,"function_id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e","hostname":"function.function-basic.scaleway-terraform.com","id":"3adbb702-818b-42e4-ac3a-51762a846f72","status":"pending","url":""}'
         headers:
             Content-Length:
-                - "267"
+                - "207"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:20:42 GMT
+                - Wed, 27 Aug 2025 15:19:30 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -2613,10 +2613,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b06d9e78-9416-4c8b-a6dc-4deb4ded123d
+                - b5d43728-f4ea-46df-871e-667befb646a8
         status: 200 OK
         code: 200
-        duration: 161.006375ms
+        duration: 102.473441ms
     - id: 53
       request:
         proto: HTTP/1.1
@@ -2632,8 +2632,1625 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/837f7439-47e0-4e01-880a-1e4abb784c7c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/3adbb702-818b-42e4-ac3a-51762a846f72
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 207
+        uncompressed: false
+        body: '{"error_message":null,"function_id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e","hostname":"function.function-basic.scaleway-terraform.com","id":"3adbb702-818b-42e4-ac3a-51762a846f72","status":"pending","url":""}'
+        headers:
+            Content-Length:
+                - "207"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:19:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 8e5d2175-c4eb-4438-a4e6-e49a0ec22683
+        status: 200 OK
+        code: 200
+        duration: 113.948418ms
+    - id: 54
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/3adbb702-818b-42e4-ac3a-51762a846f72
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 207
+        uncompressed: false
+        body: '{"error_message":null,"function_id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e","hostname":"function.function-basic.scaleway-terraform.com","id":"3adbb702-818b-42e4-ac3a-51762a846f72","status":"pending","url":""}'
+        headers:
+            Content-Length:
+                - "207"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:19:40 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 322895fd-57d6-43be-802f-f1dcae039096
+        status: 200 OK
+        code: 200
+        duration: 192.178607ms
+    - id: 55
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/3adbb702-818b-42e4-ac3a-51762a846f72
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 207
+        uncompressed: false
+        body: '{"error_message":null,"function_id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e","hostname":"function.function-basic.scaleway-terraform.com","id":"3adbb702-818b-42e4-ac3a-51762a846f72","status":"pending","url":""}'
+        headers:
+            Content-Length:
+                - "207"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:19:46 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 7d809505-1cc2-4175-aa2e-dfb32fe78ce7
+        status: 200 OK
+        code: 200
+        duration: 91.57661ms
+    - id: 56
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/3adbb702-818b-42e4-ac3a-51762a846f72
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 207
+        uncompressed: false
+        body: '{"error_message":null,"function_id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e","hostname":"function.function-basic.scaleway-terraform.com","id":"3adbb702-818b-42e4-ac3a-51762a846f72","status":"pending","url":""}'
+        headers:
+            Content-Length:
+                - "207"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:19:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 29b351f2-58a9-40d8-b720-d753ba086eee
+        status: 200 OK
+        code: 200
+        duration: 121.016201ms
+    - id: 57
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/3adbb702-818b-42e4-ac3a-51762a846f72
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 207
+        uncompressed: false
+        body: '{"error_message":null,"function_id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e","hostname":"function.function-basic.scaleway-terraform.com","id":"3adbb702-818b-42e4-ac3a-51762a846f72","status":"pending","url":""}'
+        headers:
+            Content-Length:
+                - "207"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:19:56 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 0cb9c100-32e0-4934-b2e2-5c9eeebd2236
+        status: 200 OK
+        code: 200
+        duration: 113.577403ms
+    - id: 58
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/3adbb702-818b-42e4-ac3a-51762a846f72
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 207
+        uncompressed: false
+        body: '{"error_message":null,"function_id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e","hostname":"function.function-basic.scaleway-terraform.com","id":"3adbb702-818b-42e4-ac3a-51762a846f72","status":"pending","url":""}'
+        headers:
+            Content-Length:
+                - "207"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:20:01 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ab700880-9f7c-4bc0-a2a5-15b6339b7827
+        status: 200 OK
+        code: 200
+        duration: 104.596931ms
+    - id: 59
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/3adbb702-818b-42e4-ac3a-51762a846f72
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 207
+        uncompressed: false
+        body: '{"error_message":null,"function_id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e","hostname":"function.function-basic.scaleway-terraform.com","id":"3adbb702-818b-42e4-ac3a-51762a846f72","status":"pending","url":""}'
+        headers:
+            Content-Length:
+                - "207"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:20:06 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - fd176523-1398-482a-b958-1fb55ef220e0
+        status: 200 OK
+        code: 200
+        duration: 120.835593ms
+    - id: 60
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/3adbb702-818b-42e4-ac3a-51762a846f72
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 207
+        uncompressed: false
+        body: '{"error_message":null,"function_id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e","hostname":"function.function-basic.scaleway-terraform.com","id":"3adbb702-818b-42e4-ac3a-51762a846f72","status":"pending","url":""}'
+        headers:
+            Content-Length:
+                - "207"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:20:11 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 6636c569-d6ef-48e4-bbd2-ffa045e0932d
+        status: 200 OK
+        code: 200
+        duration: 84.142173ms
+    - id: 61
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/3adbb702-818b-42e4-ac3a-51762a846f72
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 207
+        uncompressed: false
+        body: '{"error_message":null,"function_id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e","hostname":"function.function-basic.scaleway-terraform.com","id":"3adbb702-818b-42e4-ac3a-51762a846f72","status":"pending","url":""}'
+        headers:
+            Content-Length:
+                - "207"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:20:16 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b3c3c03a-4e99-4c8c-acc5-6e2218ce0dfd
+        status: 200 OK
+        code: 200
+        duration: 85.33398ms
+    - id: 62
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/3adbb702-818b-42e4-ac3a-51762a846f72
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 207
+        uncompressed: false
+        body: '{"error_message":null,"function_id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e","hostname":"function.function-basic.scaleway-terraform.com","id":"3adbb702-818b-42e4-ac3a-51762a846f72","status":"pending","url":""}'
+        headers:
+            Content-Length:
+                - "207"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:20:21 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 4ac244d0-0b22-4746-ab43-ddaa6616f56f
+        status: 200 OK
+        code: 200
+        duration: 109.615395ms
+    - id: 63
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/3adbb702-818b-42e4-ac3a-51762a846f72
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 207
+        uncompressed: false
+        body: '{"error_message":null,"function_id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e","hostname":"function.function-basic.scaleway-terraform.com","id":"3adbb702-818b-42e4-ac3a-51762a846f72","status":"pending","url":""}'
+        headers:
+            Content-Length:
+                - "207"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:20:26 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 2e7002a8-1963-4ca8-86c7-85061e40ed1f
+        status: 200 OK
+        code: 200
+        duration: 111.821329ms
+    - id: 64
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/3adbb702-818b-42e4-ac3a-51762a846f72
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 207
+        uncompressed: false
+        body: '{"error_message":null,"function_id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e","hostname":"function.function-basic.scaleway-terraform.com","id":"3adbb702-818b-42e4-ac3a-51762a846f72","status":"pending","url":""}'
+        headers:
+            Content-Length:
+                - "207"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:20:32 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f046aedb-7b44-46fe-b177-4b032db0666f
+        status: 200 OK
+        code: 200
+        duration: 111.12868ms
+    - id: 65
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/3adbb702-818b-42e4-ac3a-51762a846f72
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 207
+        uncompressed: false
+        body: '{"error_message":null,"function_id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e","hostname":"function.function-basic.scaleway-terraform.com","id":"3adbb702-818b-42e4-ac3a-51762a846f72","status":"pending","url":""}'
+        headers:
+            Content-Length:
+                - "207"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:20:37 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - c963524f-e4f6-4b9f-9099-fc18726d4954
+        status: 200 OK
+        code: 200
+        duration: 96.316704ms
+    - id: 66
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/3adbb702-818b-42e4-ac3a-51762a846f72
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 207
+        uncompressed: false
+        body: '{"error_message":null,"function_id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e","hostname":"function.function-basic.scaleway-terraform.com","id":"3adbb702-818b-42e4-ac3a-51762a846f72","status":"pending","url":""}'
+        headers:
+            Content-Length:
+                - "207"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:20:42 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f896c268-5676-4be8-a8cc-b79ab521bd1b
+        status: 200 OK
+        code: 200
+        duration: 111.569294ms
+    - id: 67
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/3adbb702-818b-42e4-ac3a-51762a846f72
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 207
+        uncompressed: false
+        body: '{"error_message":null,"function_id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e","hostname":"function.function-basic.scaleway-terraform.com","id":"3adbb702-818b-42e4-ac3a-51762a846f72","status":"pending","url":""}'
+        headers:
+            Content-Length:
+                - "207"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:20:47 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 741e93f5-a2d0-4c35-b603-0ff552448e61
+        status: 200 OK
+        code: 200
+        duration: 104.163758ms
+    - id: 68
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/3adbb702-818b-42e4-ac3a-51762a846f72
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 207
+        uncompressed: false
+        body: '{"error_message":null,"function_id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e","hostname":"function.function-basic.scaleway-terraform.com","id":"3adbb702-818b-42e4-ac3a-51762a846f72","status":"pending","url":""}'
+        headers:
+            Content-Length:
+                - "207"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:20:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ecd49e35-bafa-47e5-addf-43955ebdb755
+        status: 200 OK
+        code: 200
+        duration: 107.398715ms
+    - id: 69
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/3adbb702-818b-42e4-ac3a-51762a846f72
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 207
+        uncompressed: false
+        body: '{"error_message":null,"function_id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e","hostname":"function.function-basic.scaleway-terraform.com","id":"3adbb702-818b-42e4-ac3a-51762a846f72","status":"pending","url":""}'
+        headers:
+            Content-Length:
+                - "207"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:20:57 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 8bc2b626-cf37-4fa9-85a0-37f1ebb615af
+        status: 200 OK
+        code: 200
+        duration: 109.39836ms
+    - id: 70
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/3adbb702-818b-42e4-ac3a-51762a846f72
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 207
+        uncompressed: false
+        body: '{"error_message":null,"function_id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e","hostname":"function.function-basic.scaleway-terraform.com","id":"3adbb702-818b-42e4-ac3a-51762a846f72","status":"pending","url":""}'
+        headers:
+            Content-Length:
+                - "207"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:21:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3ec30b56-7182-4eb5-a7a6-52788cf65842
+        status: 200 OK
+        code: 200
+        duration: 91.921532ms
+    - id: 71
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/3adbb702-818b-42e4-ac3a-51762a846f72
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 207
+        uncompressed: false
+        body: '{"error_message":null,"function_id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e","hostname":"function.function-basic.scaleway-terraform.com","id":"3adbb702-818b-42e4-ac3a-51762a846f72","status":"pending","url":""}'
+        headers:
+            Content-Length:
+                - "207"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:21:07 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 383509bb-4625-48b3-989e-129119452ad1
+        status: 200 OK
+        code: 200
+        duration: 96.797608ms
+    - id: 72
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/3adbb702-818b-42e4-ac3a-51762a846f72
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 207
+        uncompressed: false
+        body: '{"error_message":null,"function_id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e","hostname":"function.function-basic.scaleway-terraform.com","id":"3adbb702-818b-42e4-ac3a-51762a846f72","status":"pending","url":""}'
+        headers:
+            Content-Length:
+                - "207"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:21:12 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b73a53f8-65b1-4b10-9fe0-9f0d8ecbd04c
+        status: 200 OK
+        code: 200
+        duration: 96.731975ms
+    - id: 73
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/3adbb702-818b-42e4-ac3a-51762a846f72
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 207
+        uncompressed: false
+        body: '{"error_message":null,"function_id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e","hostname":"function.function-basic.scaleway-terraform.com","id":"3adbb702-818b-42e4-ac3a-51762a846f72","status":"pending","url":""}'
+        headers:
+            Content-Length:
+                - "207"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:21:18 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f55d05b8-50d7-453e-8de5-4fec8afa7db4
+        status: 200 OK
+        code: 200
+        duration: 112.381832ms
+    - id: 74
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/3adbb702-818b-42e4-ac3a-51762a846f72
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 207
+        uncompressed: false
+        body: '{"error_message":null,"function_id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e","hostname":"function.function-basic.scaleway-terraform.com","id":"3adbb702-818b-42e4-ac3a-51762a846f72","status":"pending","url":""}'
+        headers:
+            Content-Length:
+                - "207"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:21:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 10b36391-6537-4f8b-9888-bef37f60cf6e
+        status: 200 OK
+        code: 200
+        duration: 80.908352ms
+    - id: 75
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/3adbb702-818b-42e4-ac3a-51762a846f72
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 381
+        uncompressed: false
+        body: '{"error_message":"failed to create domain: check that the domain correctly points to the function URL (https://tffuncfriendlywilesvp0xo6l3-tf-func-bold-visvesvaraya.functions.fnc.fr-par.scw.cloud)","function_id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e","hostname":"function.function-basic.scaleway-terraform.com","id":"3adbb702-818b-42e4-ac3a-51762a846f72","status":"error","url":""}'
+        headers:
+            Content-Length:
+                - "381"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:21:28 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 87e30bcc-b91e-4c0d-b6d8-bf5f5aa9c190
+        status: 200 OK
+        code: 200
+        duration: 84.414947ms
+    - id: 76
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/3adbb702-818b-42e4-ac3a-51762a846f72
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 381
+        uncompressed: false
+        body: '{"error_message":"failed to create domain: check that the domain correctly points to the function URL (https://tffuncfriendlywilesvp0xo6l3-tf-func-bold-visvesvaraya.functions.fnc.fr-par.scw.cloud)","function_id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e","hostname":"function.function-basic.scaleway-terraform.com","id":"3adbb702-818b-42e4-ac3a-51762a846f72","status":"error","url":""}'
+        headers:
+            Content-Length:
+                - "381"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:21:28 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 1185a055-2f6a-4fbc-834d-6e1d60f48093
+        status: 200 OK
+        code: 200
+        duration: 100.410193ms
+    - id: 77
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/3adbb702-818b-42e4-ac3a-51762a846f72
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 381
+        uncompressed: false
+        body: '{"error_message":"failed to create domain: check that the domain correctly points to the function URL (https://tffuncfriendlywilesvp0xo6l3-tf-func-bold-visvesvaraya.functions.fnc.fr-par.scw.cloud)","function_id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e","hostname":"function.function-basic.scaleway-terraform.com","id":"3adbb702-818b-42e4-ac3a-51762a846f72","status":"error","url":""}'
+        headers:
+            Content-Length:
+                - "381"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:21:28 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ce985e74-b76d-4d72-bb91-fde3103c166d
+        status: 200 OK
+        code: 200
+        duration: 124.620275ms
+    - id: 78
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/3c7cd189-d8eb-4405-bf13-c55be0d32b06
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 589
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:16:19.410439Z","description":"","environment_variables":{},"error_message":null,"id":"3c7cd189-d8eb-4405-bf13-c55be0d32b06","name":"tf-func-friendly-wiles","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncfriendlywilesvp0xo6l3","registry_namespace_id":"e7984d4a-dd63-4a93-81f7-b59d291416bb","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:16:24.751810Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "589"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:21:28 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 93b9c20c-a931-48e5-94cf-83dd160d6aa6
+        status: 200 OK
+        code: 200
+        duration: 86.544055ms
+    - id: 79
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 751
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:16:30.158333Z","description":"","domain_name":"tffuncfriendlywilesvp0xo6l3-tf-func-bold-visvesvaraya.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-bold-visvesvaraya","namespace_id":"3c7cd189-d8eb-4405-bf13-c55be0d32b06","privacy":"private","private_network_id":null,"ready_at":"2025-08-27T15:18:14.776681Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"ready","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:18:14.790915Z"}'
+        headers:
+            Content-Length:
+                - "751"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:21:28 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 7549dcd5-db03-462d-b709-3ebad190bcf8
+        status: 200 OK
+        code: 200
+        duration: 100.809002ms
+    - id: 80
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/domain/v2beta1/dns-zones/function-basic.scaleway-terraform.com/records?id=707e77cd-6792-4d3f-9123-d0345b3522c1&name=function&order_by=name_asc&page=1&type=CNAME
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 240
+        uncompressed: false
+        body: '{"records":[{"comment":null,"data":"tffuncfriendlywilesvp0xo6l3-tf-func-bold-visvesvaraya.functions.fnc.fr-par.scw.cloud.","id":"707e77cd-6792-4d3f-9123-d0345b3522c1","name":"function","priority":0,"ttl":60,"type":"CNAME"}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "240"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:21:29 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - a0710811-95e2-4f89-9f21-967b41deabd2
+        status: 200 OK
+        code: 200
+        duration: 113.781763ms
+    - id: 81
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zones=function-basic.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 355
+        uncompressed: false
+        body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"function-basic","updated_at":"2025-08-27T15:18:38Z"}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "355"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:21:29 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 1910de22-fdb2-4b55-a81a-a15ca66f3219
+        status: 200 OK
+        code: 200
+        duration: 98.748733ms
+    - id: 82
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/3adbb702-818b-42e4-ac3a-51762a846f72
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 381
+        uncompressed: false
+        body: '{"error_message":"failed to create domain: check that the domain correctly points to the function URL (https://tffuncfriendlywilesvp0xo6l3-tf-func-bold-visvesvaraya.functions.fnc.fr-par.scw.cloud)","function_id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e","hostname":"function.function-basic.scaleway-terraform.com","id":"3adbb702-818b-42e4-ac3a-51762a846f72","status":"error","url":""}'
+        headers:
+            Content-Length:
+                - "381"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:21:29 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 5c65553d-eedb-4f3b-b665-39dcdeca9be9
+        status: 200 OK
+        code: 200
+        duration: 110.747805ms
+    - id: 83
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/3adbb702-818b-42e4-ac3a-51762a846f72
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 381
+        uncompressed: false
+        body: '{"error_message":"failed to create domain: check that the domain correctly points to the function URL (https://tffuncfriendlywilesvp0xo6l3-tf-func-bold-visvesvaraya.functions.fnc.fr-par.scw.cloud)","function_id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e","hostname":"function.function-basic.scaleway-terraform.com","id":"3adbb702-818b-42e4-ac3a-51762a846f72","status":"error","url":""}'
+        headers:
+            Content-Length:
+                - "381"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:21:29 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 17ae7191-7f7c-4754-9f40-c9fe5ceda08f
+        status: 200 OK
+        code: 200
+        duration: 88.705013ms
+    - id: 84
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/3adbb702-818b-42e4-ac3a-51762a846f72
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 208
+        uncompressed: false
+        body: '{"error_message":null,"function_id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e","hostname":"function.function-basic.scaleway-terraform.com","id":"3adbb702-818b-42e4-ac3a-51762a846f72","status":"deleting","url":""}'
+        headers:
+            Content-Length:
+                - "208"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:21:29 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 8cd13dbd-51ba-4ac9-810f-40c289546573
+        status: 200 OK
+        code: 200
+        duration: 120.638801ms
+    - id: 85
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/3adbb702-818b-42e4-ac3a-51762a846f72
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 208
+        uncompressed: false
+        body: '{"error_message":null,"function_id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e","hostname":"function.function-basic.scaleway-terraform.com","id":"3adbb702-818b-42e4-ac3a-51762a846f72","status":"deleting","url":""}'
+        headers:
+            Content-Length:
+                - "208"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:21:30 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 84857be1-9d99-4bce-96ae-d9239bb60e70
+        status: 200 OK
+        code: 200
+        duration: 83.231695ms
+    - id: 86
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/3adbb702-818b-42e4-ac3a-51762a846f72
         method: GET
       response:
         proto: HTTP/2.0
@@ -2652,7 +4269,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:20:47 GMT
+                - Wed, 27 Aug 2025 15:21:35 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -2662,11 +4279,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8be366dc-71e3-4d40-9712-ba2e3fb4dc62
+                - 9bee19bd-71cd-487e-9ee8-3806f8afa507
         status: 404 Not Found
         code: 404
-        duration: 19.795416ms
-    - id: 54
+        duration: 21.314826ms
+    - id: 87
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2677,13 +4294,13 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"changes":[{"delete":{"id":"76f83914-d24e-448e-a1b7-3cf1776e48aa"}}],"return_all_records":false,"disallow_new_zone_creation":false}'
+        body: '{"changes":[{"delete":{"id":"707e77cd-6792-4d3f-9123-d0345b3522c1"}}],"return_all_records":false,"disallow_new_zone_creation":false}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/domain/v2beta1/dns-zones/function-basic.scaleway-terraform.com/records
         method: PATCH
       response:
@@ -2703,7 +4320,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:20:47 GMT
+                - Wed, 27 Aug 2025 15:21:35 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -2713,11 +4330,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a67ea55b-2e0c-4b14-b777-298a413fcc98
+                - 6fb0b413-fb89-4a38-b86a-a293876b8329
         status: 200 OK
         code: 200
-        duration: 122.739375ms
-    - id: 55
+        duration: 138.994349ms
+    - id: 88
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2732,8 +4349,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/domain/v2beta1/dns-zones/function-basic.scaleway-terraform.com/records?name=&order_by=name_asc&type=unknown
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e
         method: GET
       response:
         proto: HTTP/2.0
@@ -2741,18 +4358,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 313
+        content_length: 751
         uncompressed: false
-        body: '{"records":[{"comment":null,"data":"ns0.dom.scw.cloud.","id":"85dcbd83-092c-4acf-94d5-d3d6cba99997","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns1.dom.scw.cloud.","id":"1eb52e0e-ff1c-4ad4-9ad9-389b954f4348","name":"","priority":0,"ttl":1800,"type":"NS"}],"total_count":2}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:16:30.158333Z","description":"","domain_name":"tffuncfriendlywilesvp0xo6l3-tf-func-bold-visvesvaraya.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-bold-visvesvaraya","namespace_id":"3c7cd189-d8eb-4405-bf13-c55be0d32b06","privacy":"private","private_network_id":null,"ready_at":"2025-08-27T15:18:14.776681Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"ready","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:18:14.790915Z"}'
         headers:
             Content-Length:
-                - "313"
+                - "751"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:20:47 GMT
+                - Wed, 27 Aug 2025 15:21:35 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -2762,11 +4379,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c532508f-ac48-4d40-8e37-875f317f83f1
+                - 3917d722-98e8-48ce-bd46-424bb784275a
         status: 200 OK
         code: 200
-        duration: 98.577583ms
-    - id: 56
+        duration: 91.080343ms
+    - id: 89
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2781,106 +4398,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=function-basic.scaleway-terraform.com&domain=&order_by=domain_asc
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 368
-        uncompressed: false
-        body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"function-basic","updated_at":"2025-06-11T12:20:47Z"}],"total_count":1}'
-        headers:
-            Content-Length:
-                - "368"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 11 Jun 2025 12:20:47 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - b53802fe-4618-4aad-9ece-e7465bb4654a
-        status: 200 OK
-        code: 200
-        duration: 80.181792ms
-    - id: 57
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=function-basic.scaleway-terraform.com&domain=&order_by=domain_asc
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 367
-        uncompressed: false
-        body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"function-basic","updated_at":"2025-06-11T12:20:51Z"}],"total_count":1}'
-        headers:
-            Content-Length:
-                - "367"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 11 Jun 2025 12:20:52 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 6a1e50c7-b031-439e-96c3-dbbeaf9987f4
-        status: 200 OK
-        code: 200
-        duration: 85.543958ms
-    - id: 58
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/domain/v2beta1/dns-zones/function-basic.scaleway-terraform.com?project_id=105bdce1-64c0-48ab-899d-868455867ecf
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -2888,18 +4407,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2
+        content_length: 757
         uncompressed: false
-        body: '{}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:16:30.158333Z","description":"","domain_name":"tffuncfriendlywilesvp0xo6l3-tf-func-bold-visvesvaraya.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"90fc64ea-fa2d-4b5e-a7af-bbb11a9cf69e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-bold-visvesvaraya","namespace_id":"3c7cd189-d8eb-4405-bf13-c55be0d32b06","privacy":"private","private_network_id":null,"ready_at":"2025-08-27T15:18:14.776681Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:21:35.403172556Z"}'
         headers:
             Content-Length:
-                - "2"
+                - "757"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:20:52 GMT
+                - Wed, 27 Aug 2025 15:21:35 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -2909,11 +4428,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f5d96711-0b5e-4eeb-b45c-13b618af9f13
+                - 8e6df3c5-6e71-4536-91d9-802eb34118d2
         status: 200 OK
         code: 200
-        duration: 148.485375ms
-    - id: 59
+        duration: 187.55663ms
+    - id: 90
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2928,8 +4447,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/2a8109ee-4580-416a-a897-5b064d886bc3
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/3c7cd189-d8eb-4405-bf13-c55be0d32b06
         method: GET
       response:
         proto: HTTP/2.0
@@ -2937,18 +4456,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 747
+        content_length: 589
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-11T12:18:24.558398Z","description":"","domain_name":"tffuncexcitingtuzibjceyb-tf-func-cranky-tereshkova.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"2a8109ee-4580-416a-a897-5b064d886bc3","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-cranky-tereshkova","namespace_id":"4b3ebb33-4816-4ece-be11-9d59f6642926","privacy":"private","ready_at":"2025-06-11T12:19:27.286433Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"ready","tags":[],"timeout":"300s","updated_at":"2025-06-11T12:19:27.295660Z"}'
+        body: '{"created_at":"2025-08-27T15:16:19.410439Z","description":"","environment_variables":{},"error_message":null,"id":"3c7cd189-d8eb-4405-bf13-c55be0d32b06","name":"tf-func-friendly-wiles","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncfriendlywilesvp0xo6l3","registry_namespace_id":"e7984d4a-dd63-4a93-81f7-b59d291416bb","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:16:24.751810Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "747"
+                - "589"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:20:52 GMT
+                - Wed, 27 Aug 2025 15:21:35 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -2958,11 +4477,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f9857f8e-ba16-4346-b560-16e2fff98a98
+                - 66882fd2-923a-4077-a4d1-b8859ccde7c9
         status: 200 OK
         code: 200
-        duration: 89.394375ms
-    - id: 60
+        duration: 88.256922ms
+    - id: 91
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2977,8 +4496,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/2a8109ee-4580-416a-a897-5b064d886bc3
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/3c7cd189-d8eb-4405-bf13-c55be0d32b06
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -2986,18 +4505,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 753
+        content_length: 595
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-11T12:18:24.558398Z","description":"","domain_name":"tffuncexcitingtuzibjceyb-tf-func-cranky-tereshkova.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"2a8109ee-4580-416a-a897-5b064d886bc3","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-cranky-tereshkova","namespace_id":"4b3ebb33-4816-4ece-be11-9d59f6642926","privacy":"private","ready_at":"2025-06-11T12:19:27.286433Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2025-06-11T12:20:52.908831848Z"}'
+        body: '{"created_at":"2025-08-27T15:16:19.410439Z","description":"","environment_variables":{},"error_message":null,"id":"3c7cd189-d8eb-4405-bf13-c55be0d32b06","name":"tf-func-friendly-wiles","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncfriendlywilesvp0xo6l3","registry_namespace_id":"e7984d4a-dd63-4a93-81f7-b59d291416bb","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:21:35.661027365Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "753"
+                - "595"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:20:52 GMT
+                - Wed, 27 Aug 2025 15:21:35 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -3007,11 +4526,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f67a51b8-6a9f-4187-a847-a964597465a0
+                - 568de879-4a30-4b8e-9fcf-6e8047aea96e
         status: 200 OK
         code: 200
-        duration: 181.502042ms
-    - id: 61
+        duration: 220.380327ms
+    - id: 92
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3026,8 +4545,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/4b3ebb33-4816-4ece-be11-9d59f6642926
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/3c7cd189-d8eb-4405-bf13-c55be0d32b06
         method: GET
       response:
         proto: HTTP/2.0
@@ -3035,18 +4554,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 564
+        content_length: 592
         uncompressed: false
-        body: '{"created_at":"2025-06-11T12:18:18.952635Z","description":"","environment_variables":{},"error_message":null,"id":"4b3ebb33-4816-4ece-be11-9d59f6642926","name":"tf-func-exciting-tu","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncexcitingtuzibjceyb","registry_namespace_id":"193ec47b-3958-4c15-b8cc-eaf927c47ab8","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-11T12:18:21.245163Z"}'
+        body: '{"created_at":"2025-08-27T15:16:19.410439Z","description":"","environment_variables":{},"error_message":null,"id":"3c7cd189-d8eb-4405-bf13-c55be0d32b06","name":"tf-func-friendly-wiles","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncfriendlywilesvp0xo6l3","registry_namespace_id":"e7984d4a-dd63-4a93-81f7-b59d291416bb","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:21:35.661027Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "564"
+                - "592"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:20:53 GMT
+                - Wed, 27 Aug 2025 15:21:35 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -3056,11 +4575,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7ff5fe6f-1d27-48c5-9db0-111921467420
+                - 468e2281-b054-42bc-ab51-96ba3aea9104
         status: 200 OK
         code: 200
-        duration: 71.599625ms
-    - id: 62
+        duration: 86.220768ms
+    - id: 93
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3075,57 +4594,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/4b3ebb33-4816-4ece-be11-9d59f6642926
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 570
-        uncompressed: false
-        body: '{"created_at":"2025-06-11T12:18:18.952635Z","description":"","environment_variables":{},"error_message":null,"id":"4b3ebb33-4816-4ece-be11-9d59f6642926","name":"tf-func-exciting-tu","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncexcitingtuzibjceyb","registry_namespace_id":"193ec47b-3958-4c15-b8cc-eaf927c47ab8","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-06-11T12:20:53.157674556Z"}'
-        headers:
-            Content-Length:
-                - "570"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 11 Jun 2025 12:20:53 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 10efcdbc-c51a-47c6-8be2-f8d8c704c448
-        status: 200 OK
-        code: 200
-        duration: 317.523958ms
-    - id: 63
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/4b3ebb33-4816-4ece-be11-9d59f6642926
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/3c7cd189-d8eb-4405-bf13-c55be0d32b06
         method: GET
       response:
         proto: HTTP/2.0
@@ -3133,18 +4603,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 567
+        content_length: 592
         uncompressed: false
-        body: '{"created_at":"2025-06-11T12:18:18.952635Z","description":"","environment_variables":{},"error_message":null,"id":"4b3ebb33-4816-4ece-be11-9d59f6642926","name":"tf-func-exciting-tu","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncexcitingtuzibjceyb","registry_namespace_id":"193ec47b-3958-4c15-b8cc-eaf927c47ab8","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-06-11T12:20:53.157675Z"}'
+        body: '{"created_at":"2025-08-27T15:16:19.410439Z","description":"","environment_variables":{},"error_message":null,"id":"3c7cd189-d8eb-4405-bf13-c55be0d32b06","name":"tf-func-friendly-wiles","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncfriendlywilesvp0xo6l3","registry_namespace_id":"e7984d4a-dd63-4a93-81f7-b59d291416bb","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:21:35.661027Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "567"
+                - "592"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:20:53 GMT
+                - Wed, 27 Aug 2025 15:21:40 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -3154,11 +4624,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 08a3f9ef-5d73-4bd7-a01d-87e640d427e6
+                - 090bb9bd-52ad-4ce2-9a68-96a3ae77d9e1
         status: 200 OK
         code: 200
-        duration: 75.272334ms
-    - id: 64
+        duration: 76.986297ms
+    - id: 94
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3173,8 +4643,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/4b3ebb33-4816-4ece-be11-9d59f6642926
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/3c7cd189-d8eb-4405-bf13-c55be0d32b06
         method: GET
       response:
         proto: HTTP/2.0
@@ -3182,18 +4652,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 567
+        content_length: 592
         uncompressed: false
-        body: '{"created_at":"2025-06-11T12:18:18.952635Z","description":"","environment_variables":{},"error_message":null,"id":"4b3ebb33-4816-4ece-be11-9d59f6642926","name":"tf-func-exciting-tu","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncexcitingtuzibjceyb","registry_namespace_id":"193ec47b-3958-4c15-b8cc-eaf927c47ab8","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-06-11T12:20:53.157675Z"}'
+        body: '{"created_at":"2025-08-27T15:16:19.410439Z","description":"","environment_variables":{},"error_message":null,"id":"3c7cd189-d8eb-4405-bf13-c55be0d32b06","name":"tf-func-friendly-wiles","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncfriendlywilesvp0xo6l3","registry_namespace_id":"e7984d4a-dd63-4a93-81f7-b59d291416bb","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:21:35.661027Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "567"
+                - "592"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:20:58 GMT
+                - Wed, 27 Aug 2025 15:21:46 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -3203,11 +4673,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0628257d-a9a6-40a0-95c0-c7a7d8eee6cf
+                - 2668cdd7-f1a8-4877-bda7-3df7883be2a9
         status: 200 OK
         code: 200
-        duration: 79.639375ms
-    - id: 65
+        duration: 96.060366ms
+    - id: 95
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3222,8 +4692,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/4b3ebb33-4816-4ece-be11-9d59f6642926
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/3c7cd189-d8eb-4405-bf13-c55be0d32b06
         method: GET
       response:
         proto: HTTP/2.0
@@ -3231,18 +4701,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 567
+        content_length: 592
         uncompressed: false
-        body: '{"created_at":"2025-06-11T12:18:18.952635Z","description":"","environment_variables":{},"error_message":null,"id":"4b3ebb33-4816-4ece-be11-9d59f6642926","name":"tf-func-exciting-tu","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncexcitingtuzibjceyb","registry_namespace_id":"193ec47b-3958-4c15-b8cc-eaf927c47ab8","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-06-11T12:20:53.157675Z"}'
+        body: '{"created_at":"2025-08-27T15:16:19.410439Z","description":"","environment_variables":{},"error_message":null,"id":"3c7cd189-d8eb-4405-bf13-c55be0d32b06","name":"tf-func-friendly-wiles","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncfriendlywilesvp0xo6l3","registry_namespace_id":"e7984d4a-dd63-4a93-81f7-b59d291416bb","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:21:35.661027Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "567"
+                - "592"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:21:03 GMT
+                - Wed, 27 Aug 2025 15:21:51 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -3252,11 +4722,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 716b8821-0023-4327-9ecb-c1da89f9e9d1
+                - 8efa66bf-99b1-4de4-aade-820f718cb6cc
         status: 200 OK
         code: 200
-        duration: 73.375375ms
-    - id: 66
+        duration: 90.687747ms
+    - id: 96
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3271,8 +4741,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/4b3ebb33-4816-4ece-be11-9d59f6642926
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/3c7cd189-d8eb-4405-bf13-c55be0d32b06
         method: GET
       response:
         proto: HTTP/2.0
@@ -3280,18 +4750,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 567
+        content_length: 592
         uncompressed: false
-        body: '{"created_at":"2025-06-11T12:18:18.952635Z","description":"","environment_variables":{},"error_message":null,"id":"4b3ebb33-4816-4ece-be11-9d59f6642926","name":"tf-func-exciting-tu","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncexcitingtuzibjceyb","registry_namespace_id":"193ec47b-3958-4c15-b8cc-eaf927c47ab8","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-06-11T12:20:53.157675Z"}'
+        body: '{"created_at":"2025-08-27T15:16:19.410439Z","description":"","environment_variables":{},"error_message":null,"id":"3c7cd189-d8eb-4405-bf13-c55be0d32b06","name":"tf-func-friendly-wiles","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncfriendlywilesvp0xo6l3","registry_namespace_id":"e7984d4a-dd63-4a93-81f7-b59d291416bb","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:21:35.661027Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "567"
+                - "592"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:21:08 GMT
+                - Wed, 27 Aug 2025 15:21:56 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -3301,11 +4771,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 07ba97d8-c10e-4520-9575-26e638e476fd
+                - f65a93c9-870a-4337-bd6f-e37011bbd84b
         status: 200 OK
         code: 200
-        duration: 75.977625ms
-    - id: 67
+        duration: 72.601955ms
+    - id: 97
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3320,8 +4790,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/4b3ebb33-4816-4ece-be11-9d59f6642926
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/3c7cd189-d8eb-4405-bf13-c55be0d32b06
         method: GET
       response:
         proto: HTTP/2.0
@@ -3329,18 +4799,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 567
+        content_length: 592
         uncompressed: false
-        body: '{"created_at":"2025-06-11T12:18:18.952635Z","description":"","environment_variables":{},"error_message":null,"id":"4b3ebb33-4816-4ece-be11-9d59f6642926","name":"tf-func-exciting-tu","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncexcitingtuzibjceyb","registry_namespace_id":"193ec47b-3958-4c15-b8cc-eaf927c47ab8","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-06-11T12:20:53.157675Z"}'
+        body: '{"created_at":"2025-08-27T15:16:19.410439Z","description":"","environment_variables":{},"error_message":null,"id":"3c7cd189-d8eb-4405-bf13-c55be0d32b06","name":"tf-func-friendly-wiles","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncfriendlywilesvp0xo6l3","registry_namespace_id":"e7984d4a-dd63-4a93-81f7-b59d291416bb","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:21:35.661027Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "567"
+                - "592"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:21:13 GMT
+                - Wed, 27 Aug 2025 15:22:01 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -3350,11 +4820,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - dac76854-ea5d-4f15-ad46-c7d38555b6d0
+                - 6b976597-38fa-44c6-9921-92bb5d38b236
         status: 200 OK
         code: 200
-        duration: 137.719667ms
-    - id: 68
+        duration: 86.558083ms
+    - id: 98
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3369,8 +4839,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/4b3ebb33-4816-4ece-be11-9d59f6642926
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/3c7cd189-d8eb-4405-bf13-c55be0d32b06
         method: GET
       response:
         proto: HTTP/2.0
@@ -3378,18 +4848,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 567
+        content_length: 592
         uncompressed: false
-        body: '{"created_at":"2025-06-11T12:18:18.952635Z","description":"","environment_variables":{},"error_message":null,"id":"4b3ebb33-4816-4ece-be11-9d59f6642926","name":"tf-func-exciting-tu","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncexcitingtuzibjceyb","registry_namespace_id":"193ec47b-3958-4c15-b8cc-eaf927c47ab8","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-06-11T12:20:53.157675Z"}'
+        body: '{"created_at":"2025-08-27T15:16:19.410439Z","description":"","environment_variables":{},"error_message":null,"id":"3c7cd189-d8eb-4405-bf13-c55be0d32b06","name":"tf-func-friendly-wiles","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncfriendlywilesvp0xo6l3","registry_namespace_id":"e7984d4a-dd63-4a93-81f7-b59d291416bb","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:21:35.661027Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "567"
+                - "592"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:21:18 GMT
+                - Wed, 27 Aug 2025 15:22:06 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -3399,11 +4869,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 52af7764-3a07-4b41-bf39-320080d98e15
+                - fea6f7ac-4f9e-4ac7-b145-b65b8af221b9
         status: 200 OK
         code: 200
-        duration: 94.033125ms
-    - id: 69
+        duration: 90.858578ms
+    - id: 99
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3418,8 +4888,57 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/4b3ebb33-4816-4ece-be11-9d59f6642926
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/3c7cd189-d8eb-4405-bf13-c55be0d32b06
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 592
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:16:19.410439Z","description":"","environment_variables":{},"error_message":null,"id":"3c7cd189-d8eb-4405-bf13-c55be0d32b06","name":"tf-func-friendly-wiles","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"d03c0af1-fec9-44aa-a12c-54cb13072778","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncfriendlywilesvp0xo6l3","registry_namespace_id":"e7984d4a-dd63-4a93-81f7-b59d291416bb","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:21:35.661027Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "592"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:22:11 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 4d073c41-59fe-417a-a371-b4a22807c95f
+        status: 200 OK
+        code: 200
+        duration: 82.54655ms
+    - id: 100
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/3c7cd189-d8eb-4405-bf13-c55be0d32b06
         method: GET
       response:
         proto: HTTP/2.0
@@ -3438,7 +4957,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:21:23 GMT
+                - Wed, 27 Aug 2025 15:22:16 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -3448,11 +4967,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b2c43fd4-9438-4aee-8d15-e33ef20ad93e
+                - bd50b5c7-60f6-433f-8d27-4d3faa3ce027
         status: 404 Not Found
         code: 404
-        duration: 28.535875ms
-    - id: 70
+        duration: 29.314538ms
+    - id: 101
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3467,8 +4986,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/837f7439-47e0-4e01-880a-1e4abb784c7c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/3adbb702-818b-42e4-ac3a-51762a846f72
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -3487,7 +5006,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 11 Jun 2025 12:21:24 GMT
+                - Wed, 27 Aug 2025 15:22:16 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -3497,7 +5016,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 87a21731-9d39-4cc6-8839-e22725b3bf95
+                - 00973ddd-a341-4d5c-9ccc-c3308d89f8c8
         status: 404 Not Found
         code: 404
-        duration: 25.66225ms
+        duration: 21.028889ms

--- a/internal/services/function/testdata/function-environment-variables.cassette.yaml
+++ b/internal/services/function/testdata/function-environment-variables.cassette.yaml
@@ -6,19 +6,19 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 159
+        content_length: 191
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-func-reverent-kepler","environment_variables":{},"project_id":"6867048b-fe12-4e96-835e-41c79a39604b","secret_environment_variables":[],"tags":null}'
+        body: '{"name":"tf-func-inspiring-kirch","environment_variables":{},"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","secret_environment_variables":[],"tags":null,"activate_vpc_integration":true}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces
         method: POST
       response:
@@ -27,18 +27,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 489
+        content_length: 508
         uncompressed: false
-        body: '{"created_at":"2025-04-28T08:37:13.069764971Z","description":"","environment_variables":{},"error_message":null,"id":"37d7e438-1812-4d7b-b9f1-da7e3d5a18fb","name":"tf-func-reverent-kepler","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-04-28T08:37:13.069764971Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.800959598Z","description":"","environment_variables":{},"error_message":null,"id":"10b555ff-87fe-4a38-847b-c3947aa45730","name":"tf-func-inspiring-kirch","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:13.800959598Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "489"
+                - "508"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 08:37:13 GMT
+                - Wed, 27 Aug 2025 15:05:13 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8424688e-b70a-475b-ab70-93b7e880435c
+                - 05bd4ed6-c8df-431d-85b6-414680b33240
         status: 200 OK
         code: 200
-        duration: 765.936958ms
+        duration: 5.681615767s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -67,8 +67,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/37d7e438-1812-4d7b-b9f1-da7e3d5a18fb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/10b555ff-87fe-4a38-847b-c3947aa45730
         method: GET
       response:
         proto: HTTP/2.0
@@ -76,18 +76,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 483
+        content_length: 502
         uncompressed: false
-        body: '{"created_at":"2025-04-28T08:37:13.069765Z","description":"","environment_variables":{},"error_message":null,"id":"37d7e438-1812-4d7b-b9f1-da7e3d5a18fb","name":"tf-func-reverent-kepler","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-04-28T08:37:13.069765Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.800960Z","description":"","environment_variables":{},"error_message":null,"id":"10b555ff-87fe-4a38-847b-c3947aa45730","name":"tf-func-inspiring-kirch","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:13.800960Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "483"
+                - "502"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 08:37:13 GMT
+                - Wed, 27 Aug 2025 15:05:13 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7e604913-5d2e-4147-86a3-81b39e43f706
+                - e9b217e0-d447-4009-a2cb-3eb699cc23ca
         status: 200 OK
         code: 200
-        duration: 42.471917ms
+        duration: 39.580936ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -116,8 +116,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/37d7e438-1812-4d7b-b9f1-da7e3d5a18fb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/10b555ff-87fe-4a38-847b-c3947aa45730
         method: GET
       response:
         proto: HTTP/2.0
@@ -125,18 +125,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 572
+        content_length: 591
         uncompressed: false
-        body: '{"created_at":"2025-04-28T08:37:13.069765Z","description":"","environment_variables":{},"error_message":null,"id":"37d7e438-1812-4d7b-b9f1-da7e3d5a18fb","name":"tf-func-reverent-kepler","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncreverentkeplertbfkmeps","registry_namespace_id":"031bda64-f468-4c05-b60a-24fc9a832406","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-28T08:37:16.558315Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.800960Z","description":"","environment_variables":{},"error_message":null,"id":"10b555ff-87fe-4a38-847b-c3947aa45730","name":"tf-func-inspiring-kirch","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncinspiringkirche592ql8v","registry_namespace_id":"340d4307-01a1-4bdd-806c-9d6f4e22b1a4","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:17.501813Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "572"
+                - "591"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 08:37:18 GMT
+                - Wed, 27 Aug 2025 15:05:19 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -146,10 +146,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 325e75e6-7f62-4842-af60-83d27e182806
+                - c2741948-0bd1-4ec8-b7cc-cd12601d69b8
         status: 200 OK
         code: 200
-        duration: 46.844958ms
+        duration: 451.544399ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -165,8 +165,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/37d7e438-1812-4d7b-b9f1-da7e3d5a18fb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/10b555ff-87fe-4a38-847b-c3947aa45730
         method: GET
       response:
         proto: HTTP/2.0
@@ -174,18 +174,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 572
+        content_length: 591
         uncompressed: false
-        body: '{"created_at":"2025-04-28T08:37:13.069765Z","description":"","environment_variables":{},"error_message":null,"id":"37d7e438-1812-4d7b-b9f1-da7e3d5a18fb","name":"tf-func-reverent-kepler","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncreverentkeplertbfkmeps","registry_namespace_id":"031bda64-f468-4c05-b60a-24fc9a832406","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-28T08:37:16.558315Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.800960Z","description":"","environment_variables":{},"error_message":null,"id":"10b555ff-87fe-4a38-847b-c3947aa45730","name":"tf-func-inspiring-kirch","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncinspiringkirche592ql8v","registry_namespace_id":"340d4307-01a1-4bdd-806c-9d6f4e22b1a4","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:17.501813Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "572"
+                - "591"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 08:37:18 GMT
+                - Wed, 27 Aug 2025 15:05:19 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -195,28 +195,28 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - eebd590b-eae1-45a6-875c-8d7087bb6c24
+                - 5cab42ec-d826-4a2d-b7e3-e11207d86520
         status: 200 OK
         code: 200
-        duration: 40.816167ms
+        duration: 45.037055ms
     - id: 4
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 354
+        content_length: 366
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"foobar","namespace_id":"37d7e438-1812-4d7b-b9f1-da7e3d5a18fb","environment_variables":{"test":"test"},"min_scale":0,"max_scale":20,"runtime":"node22","memory_limit":256,"handler":"handler.handle","privacy":"private","secret_environment_variables":[{"key":"test_secret","value":"test_secret"}],"http_option":"enabled","sandbox":"unknown_sandbox"}'
+        body: '{"name":"foobar","namespace_id":"10b555ff-87fe-4a38-847b-c3947aa45730","environment_variables":{"test":"test"},"min_scale":0,"max_scale":20,"runtime":"node22","memory_limit":256,"handler":"handler.handle","privacy":"private","secret_environment_variables":[{"key":"test_secret","value":"test_secret"}],"http_option":"enabled","sandbox":"unknown_sandbox","tags":null}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions
         method: POST
       response:
@@ -225,18 +225,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 844
+        content_length: 855
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-04-28T08:37:18.886970757Z","description":"","domain_name":"tffuncreverentkeplertbfkmeps-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"test":"test"},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"4ba9bbb1-ac4d-4ed0-a379-23c5c79a709e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"37d7e438-1812-4d7b-b9f1-da7e3d5a18fb","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$XjeG4QgvzHenESD5gjZZIA$3kWeeaIrcLwE0t4eCqUkmDQeFiWNSP13A28qDoO3rro","key":"test_secret"}],"status":"created","timeout":"300s","updated_at":"2025-04-28T08:37:18.886970757Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:20.067880407Z","description":"","domain_name":"tffuncinspiringkirche592ql8v-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"test":"test"},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"2f7d7960-37a2-4eaf-b20f-1500a16a6c44","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"10b555ff-87fe-4a38-847b-c3947aa45730","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$V0d5nmbtj6sXnqFcCI6W3A$95FHsjtElW7KG563zBWZgnOFZoOUFYVert9slAbpyo4","key":"test_secret"}],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:20.067880407Z"}'
         headers:
             Content-Length:
-                - "844"
+                - "855"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 08:37:18 GMT
+                - Wed, 27 Aug 2025 15:05:20 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -246,10 +246,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b5432b2e-ffcc-4abc-9e64-14c15ce91e72
+                - 43a228bf-08d4-47a2-89c7-f9ce3ceee84b
         status: 200 OK
         code: 200
-        duration: 689.772834ms
+        duration: 712.955601ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -265,8 +265,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4ba9bbb1-ac4d-4ed0-a379-23c5c79a709e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/2f7d7960-37a2-4eaf-b20f-1500a16a6c44
         method: GET
       response:
         proto: HTTP/2.0
@@ -274,18 +274,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 838
+        content_length: 849
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-04-28T08:37:18.886971Z","description":"","domain_name":"tffuncreverentkeplertbfkmeps-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"test":"test"},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"4ba9bbb1-ac4d-4ed0-a379-23c5c79a709e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"37d7e438-1812-4d7b-b9f1-da7e3d5a18fb","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$XjeG4QgvzHenESD5gjZZIA$3kWeeaIrcLwE0t4eCqUkmDQeFiWNSP13A28qDoO3rro","key":"test_secret"}],"status":"created","timeout":"300s","updated_at":"2025-04-28T08:37:18.886971Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:20.067880Z","description":"","domain_name":"tffuncinspiringkirche592ql8v-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"test":"test"},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"2f7d7960-37a2-4eaf-b20f-1500a16a6c44","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"10b555ff-87fe-4a38-847b-c3947aa45730","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$V0d5nmbtj6sXnqFcCI6W3A$95FHsjtElW7KG563zBWZgnOFZoOUFYVert9slAbpyo4","key":"test_secret"}],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:20.067880Z"}'
         headers:
             Content-Length:
-                - "838"
+                - "849"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 08:37:18 GMT
+                - Wed, 27 Aug 2025 15:05:20 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -295,10 +295,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 470ec595-462a-4c2b-897a-82d966324c22
+                - bf6f5b1d-51b3-4099-ad12-96906200253e
         status: 200 OK
         code: 200
-        duration: 54.056666ms
+        duration: 62.738358ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -314,8 +314,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4ba9bbb1-ac4d-4ed0-a379-23c5c79a709e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/2f7d7960-37a2-4eaf-b20f-1500a16a6c44
         method: GET
       response:
         proto: HTTP/2.0
@@ -323,18 +323,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 838
+        content_length: 849
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-04-28T08:37:18.886971Z","description":"","domain_name":"tffuncreverentkeplertbfkmeps-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"test":"test"},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"4ba9bbb1-ac4d-4ed0-a379-23c5c79a709e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"37d7e438-1812-4d7b-b9f1-da7e3d5a18fb","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$XjeG4QgvzHenESD5gjZZIA$3kWeeaIrcLwE0t4eCqUkmDQeFiWNSP13A28qDoO3rro","key":"test_secret"}],"status":"created","timeout":"300s","updated_at":"2025-04-28T08:37:18.886971Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:20.067880Z","description":"","domain_name":"tffuncinspiringkirche592ql8v-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"test":"test"},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"2f7d7960-37a2-4eaf-b20f-1500a16a6c44","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"10b555ff-87fe-4a38-847b-c3947aa45730","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$V0d5nmbtj6sXnqFcCI6W3A$95FHsjtElW7KG563zBWZgnOFZoOUFYVert9slAbpyo4","key":"test_secret"}],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:20.067880Z"}'
         headers:
             Content-Length:
-                - "838"
+                - "849"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 08:37:19 GMT
+                - Wed, 27 Aug 2025 15:05:20 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -344,10 +344,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 49d37bb8-0b92-4e58-b5f1-bbe7822babbf
+                - f4ed2224-5d06-47bf-8f68-df6cea45cee0
         status: 200 OK
         code: 200
-        duration: 49.910417ms
+        duration: 221.969879ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -363,8 +363,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4ba9bbb1-ac4d-4ed0-a379-23c5c79a709e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/2f7d7960-37a2-4eaf-b20f-1500a16a6c44
         method: GET
       response:
         proto: HTTP/2.0
@@ -372,18 +372,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 838
+        content_length: 849
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-04-28T08:37:18.886971Z","description":"","domain_name":"tffuncreverentkeplertbfkmeps-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"test":"test"},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"4ba9bbb1-ac4d-4ed0-a379-23c5c79a709e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"37d7e438-1812-4d7b-b9f1-da7e3d5a18fb","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$XjeG4QgvzHenESD5gjZZIA$3kWeeaIrcLwE0t4eCqUkmDQeFiWNSP13A28qDoO3rro","key":"test_secret"}],"status":"created","timeout":"300s","updated_at":"2025-04-28T08:37:18.886971Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:20.067880Z","description":"","domain_name":"tffuncinspiringkirche592ql8v-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"test":"test"},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"2f7d7960-37a2-4eaf-b20f-1500a16a6c44","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"10b555ff-87fe-4a38-847b-c3947aa45730","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$V0d5nmbtj6sXnqFcCI6W3A$95FHsjtElW7KG563zBWZgnOFZoOUFYVert9slAbpyo4","key":"test_secret"}],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:20.067880Z"}'
         headers:
             Content-Length:
-                - "838"
+                - "849"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 08:37:19 GMT
+                - Wed, 27 Aug 2025 15:05:20 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -393,10 +393,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c836d84d-4a5e-428d-8b8a-aba52d7f2243
+                - e1759435-dedc-4196-b634-cd3f13857e3c
         status: 200 OK
         code: 200
-        duration: 48.699084ms
+        duration: 50.553175ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -412,8 +412,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/37d7e438-1812-4d7b-b9f1-da7e3d5a18fb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/10b555ff-87fe-4a38-847b-c3947aa45730
         method: GET
       response:
         proto: HTTP/2.0
@@ -421,18 +421,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 572
+        content_length: 591
         uncompressed: false
-        body: '{"created_at":"2025-04-28T08:37:13.069765Z","description":"","environment_variables":{},"error_message":null,"id":"37d7e438-1812-4d7b-b9f1-da7e3d5a18fb","name":"tf-func-reverent-kepler","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncreverentkeplertbfkmeps","registry_namespace_id":"031bda64-f468-4c05-b60a-24fc9a832406","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-28T08:37:16.558315Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.800960Z","description":"","environment_variables":{},"error_message":null,"id":"10b555ff-87fe-4a38-847b-c3947aa45730","name":"tf-func-inspiring-kirch","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncinspiringkirche592ql8v","registry_namespace_id":"340d4307-01a1-4bdd-806c-9d6f4e22b1a4","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:17.501813Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "572"
+                - "591"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 08:37:19 GMT
+                - Wed, 27 Aug 2025 15:05:21 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -442,10 +442,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a6a8f6bf-cadd-4122-a2dd-60c361488e19
+                - 709afdc4-fe74-400b-ace9-f810b9074c2f
         status: 200 OK
         code: 200
-        duration: 40.653083ms
+        duration: 45.242189ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -461,8 +461,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4ba9bbb1-ac4d-4ed0-a379-23c5c79a709e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/2f7d7960-37a2-4eaf-b20f-1500a16a6c44
         method: GET
       response:
         proto: HTTP/2.0
@@ -470,18 +470,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 838
+        content_length: 849
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-04-28T08:37:18.886971Z","description":"","domain_name":"tffuncreverentkeplertbfkmeps-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"test":"test"},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"4ba9bbb1-ac4d-4ed0-a379-23c5c79a709e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"37d7e438-1812-4d7b-b9f1-da7e3d5a18fb","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$XjeG4QgvzHenESD5gjZZIA$3kWeeaIrcLwE0t4eCqUkmDQeFiWNSP13A28qDoO3rro","key":"test_secret"}],"status":"created","timeout":"300s","updated_at":"2025-04-28T08:37:18.886971Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:20.067880Z","description":"","domain_name":"tffuncinspiringkirche592ql8v-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"test":"test"},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"2f7d7960-37a2-4eaf-b20f-1500a16a6c44","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"10b555ff-87fe-4a38-847b-c3947aa45730","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$V0d5nmbtj6sXnqFcCI6W3A$95FHsjtElW7KG563zBWZgnOFZoOUFYVert9slAbpyo4","key":"test_secret"}],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:20.067880Z"}'
         headers:
             Content-Length:
-                - "838"
+                - "849"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 08:37:19 GMT
+                - Wed, 27 Aug 2025 15:05:21 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -491,10 +491,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fb755597-b2cf-4c28-b801-8edc0f7ffa7d
+                - 4ac765cc-fed9-46f8-8db9-666b544533e5
         status: 200 OK
         code: 200
-        duration: 52.471875ms
+        duration: 80.543747ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -510,8 +510,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/37d7e438-1812-4d7b-b9f1-da7e3d5a18fb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/10b555ff-87fe-4a38-847b-c3947aa45730
         method: GET
       response:
         proto: HTTP/2.0
@@ -519,18 +519,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 572
+        content_length: 591
         uncompressed: false
-        body: '{"created_at":"2025-04-28T08:37:13.069765Z","description":"","environment_variables":{},"error_message":null,"id":"37d7e438-1812-4d7b-b9f1-da7e3d5a18fb","name":"tf-func-reverent-kepler","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncreverentkeplertbfkmeps","registry_namespace_id":"031bda64-f468-4c05-b60a-24fc9a832406","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-28T08:37:16.558315Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.800960Z","description":"","environment_variables":{},"error_message":null,"id":"10b555ff-87fe-4a38-847b-c3947aa45730","name":"tf-func-inspiring-kirch","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncinspiringkirche592ql8v","registry_namespace_id":"340d4307-01a1-4bdd-806c-9d6f4e22b1a4","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:17.501813Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "572"
+                - "591"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 08:37:19 GMT
+                - Wed, 27 Aug 2025 15:05:21 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -540,10 +540,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8040c231-6321-4235-b9bc-1cc51188936a
+                - 47799027-aab1-4e18-9251-479c7017c69d
         status: 200 OK
         code: 200
-        duration: 45.518375ms
+        duration: 53.672988ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -559,8 +559,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4ba9bbb1-ac4d-4ed0-a379-23c5c79a709e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/2f7d7960-37a2-4eaf-b20f-1500a16a6c44
         method: GET
       response:
         proto: HTTP/2.0
@@ -568,18 +568,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 838
+        content_length: 849
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-04-28T08:37:18.886971Z","description":"","domain_name":"tffuncreverentkeplertbfkmeps-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"test":"test"},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"4ba9bbb1-ac4d-4ed0-a379-23c5c79a709e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"37d7e438-1812-4d7b-b9f1-da7e3d5a18fb","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$XjeG4QgvzHenESD5gjZZIA$3kWeeaIrcLwE0t4eCqUkmDQeFiWNSP13A28qDoO3rro","key":"test_secret"}],"status":"created","timeout":"300s","updated_at":"2025-04-28T08:37:18.886971Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:20.067880Z","description":"","domain_name":"tffuncinspiringkirche592ql8v-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"test":"test"},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"2f7d7960-37a2-4eaf-b20f-1500a16a6c44","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"10b555ff-87fe-4a38-847b-c3947aa45730","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$V0d5nmbtj6sXnqFcCI6W3A$95FHsjtElW7KG563zBWZgnOFZoOUFYVert9slAbpyo4","key":"test_secret"}],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:20.067880Z"}'
         headers:
             Content-Length:
-                - "838"
+                - "849"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 08:37:19 GMT
+                - Wed, 27 Aug 2025 15:05:21 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -589,10 +589,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5f950bb0-b0ff-4a61-b43a-a683804b2766
+                - 3d09ddef-2fcb-4496-af1f-96c8c0fa1d0f
         status: 200 OK
         code: 200
-        duration: 52.16725ms
+        duration: 71.062106ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -608,8 +608,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4ba9bbb1-ac4d-4ed0-a379-23c5c79a709e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/2f7d7960-37a2-4eaf-b20f-1500a16a6c44
         method: GET
       response:
         proto: HTTP/2.0
@@ -617,18 +617,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 838
+        content_length: 849
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-04-28T08:37:18.886971Z","description":"","domain_name":"tffuncreverentkeplertbfkmeps-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"test":"test"},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"4ba9bbb1-ac4d-4ed0-a379-23c5c79a709e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"37d7e438-1812-4d7b-b9f1-da7e3d5a18fb","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$XjeG4QgvzHenESD5gjZZIA$3kWeeaIrcLwE0t4eCqUkmDQeFiWNSP13A28qDoO3rro","key":"test_secret"}],"status":"created","timeout":"300s","updated_at":"2025-04-28T08:37:18.886971Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:20.067880Z","description":"","domain_name":"tffuncinspiringkirche592ql8v-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"test":"test"},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"2f7d7960-37a2-4eaf-b20f-1500a16a6c44","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"10b555ff-87fe-4a38-847b-c3947aa45730","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$V0d5nmbtj6sXnqFcCI6W3A$95FHsjtElW7KG563zBWZgnOFZoOUFYVert9slAbpyo4","key":"test_secret"}],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:20.067880Z"}'
         headers:
             Content-Length:
-                - "838"
+                - "849"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 08:37:20 GMT
+                - Wed, 27 Aug 2025 15:05:22 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -638,10 +638,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c1eb84d0-8a52-45aa-9ea1-1c615df854ac
+                - e8f1825c-e78f-4ee4-af09-81faafd4abcf
         status: 200 OK
         code: 200
-        duration: 55.844ms
+        duration: 77.70462ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -659,8 +659,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4ba9bbb1-ac4d-4ed0-a379-23c5c79a709e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/2f7d7960-37a2-4eaf-b20f-1500a16a6c44
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -668,18 +668,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 838
+        content_length: 849
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-04-28T08:37:18.886971Z","description":"","domain_name":"tffuncreverentkeplertbfkmeps-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"bar"},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"4ba9bbb1-ac4d-4ed0-a379-23c5c79a709e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"37d7e438-1812-4d7b-b9f1-da7e3d5a18fb","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$qeoLW0cT3iRyBgAMm7acNQ$n3vjIhLoiDgXJJF3BBckw4Z9e4HJno/SQkP1ntlgIkI","key":"foo_secret"}],"status":"pending","timeout":"300s","updated_at":"2025-04-28T08:37:20.657402177Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:20.067880Z","description":"","domain_name":"tffuncinspiringkirche592ql8v-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"bar"},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"2f7d7960-37a2-4eaf-b20f-1500a16a6c44","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"10b555ff-87fe-4a38-847b-c3947aa45730","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$6jBuB6VTieL6ivniEX2abQ$ieYam9JapK2L/ArF6QXb0dK65joEjEhx9HoU7ewTGPA","key":"foo_secret"}],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:22.439315337Z"}'
         headers:
             Content-Length:
-                - "838"
+                - "849"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 08:37:20 GMT
+                - Wed, 27 Aug 2025 15:05:22 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -689,10 +689,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 101afaa8-b2f7-48f2-baad-f0b99673f015
+                - a613c7a6-4842-4be2-aa18-af491ab54c73
         status: 200 OK
         code: 200
-        duration: 566.0215ms
+        duration: 257.492914ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -708,8 +708,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4ba9bbb1-ac4d-4ed0-a379-23c5c79a709e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/2f7d7960-37a2-4eaf-b20f-1500a16a6c44
         method: GET
       response:
         proto: HTTP/2.0
@@ -717,18 +717,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 835
+        content_length: 846
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-04-28T08:37:18.886971Z","description":"","domain_name":"tffuncreverentkeplertbfkmeps-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"bar"},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"4ba9bbb1-ac4d-4ed0-a379-23c5c79a709e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"37d7e438-1812-4d7b-b9f1-da7e3d5a18fb","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$qeoLW0cT3iRyBgAMm7acNQ$n3vjIhLoiDgXJJF3BBckw4Z9e4HJno/SQkP1ntlgIkI","key":"foo_secret"}],"status":"pending","timeout":"300s","updated_at":"2025-04-28T08:37:20.657402Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:20.067880Z","description":"","domain_name":"tffuncinspiringkirche592ql8v-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"bar"},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"2f7d7960-37a2-4eaf-b20f-1500a16a6c44","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"10b555ff-87fe-4a38-847b-c3947aa45730","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$6jBuB6VTieL6ivniEX2abQ$ieYam9JapK2L/ArF6QXb0dK65joEjEhx9HoU7ewTGPA","key":"foo_secret"}],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:22.439315Z"}'
         headers:
             Content-Length:
-                - "835"
+                - "846"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 08:37:21 GMT
+                - Wed, 27 Aug 2025 15:05:23 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -738,10 +738,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a3a5a785-7839-4c9f-b6c8-49b83f2da531
+                - bd90ca4f-dfd1-4472-80d8-13bc58562552
         status: 200 OK
         code: 200
-        duration: 53.645292ms
+        duration: 62.895253ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -757,8 +757,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4ba9bbb1-ac4d-4ed0-a379-23c5c79a709e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/2f7d7960-37a2-4eaf-b20f-1500a16a6c44
         method: GET
       response:
         proto: HTTP/2.0
@@ -766,18 +766,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 845
+        content_length: 846
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-04-28T08:37:18.886971Z","description":"","domain_name":"tffuncreverentkeplertbfkmeps-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"bar"},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"4ba9bbb1-ac4d-4ed0-a379-23c5c79a709e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"37d7e438-1812-4d7b-b9f1-da7e3d5a18fb","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$qeoLW0cT3iRyBgAMm7acNQ$n3vjIhLoiDgXJJF3BBckw4Z9e4HJno/SQkP1ntlgIkI","key":"foo_secret"}],"status":"error","timeout":"300s","updated_at":"2025-04-28T08:37:26.577013Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:20.067880Z","description":"","domain_name":"tffuncinspiringkirche592ql8v-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"bar"},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"2f7d7960-37a2-4eaf-b20f-1500a16a6c44","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"10b555ff-87fe-4a38-847b-c3947aa45730","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$6jBuB6VTieL6ivniEX2abQ$ieYam9JapK2L/ArF6QXb0dK65joEjEhx9HoU7ewTGPA","key":"foo_secret"}],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:22.439315Z"}'
         headers:
             Content-Length:
-                - "845"
+                - "846"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 08:37:26 GMT
+                - Wed, 27 Aug 2025 15:05:28 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -787,10 +787,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - efb83c5b-318b-4d0a-b737-a2d9414802b5
+                - 0b60d27a-ad09-46d9-bbbd-55b1f4224c95
         status: 200 OK
         code: 200
-        duration: 57.808958ms
+        duration: 66.934123ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -806,8 +806,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4ba9bbb1-ac4d-4ed0-a379-23c5c79a709e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/2f7d7960-37a2-4eaf-b20f-1500a16a6c44
         method: GET
       response:
         proto: HTTP/2.0
@@ -815,18 +815,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 845
+        content_length: 846
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-04-28T08:37:18.886971Z","description":"","domain_name":"tffuncreverentkeplertbfkmeps-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"bar"},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"4ba9bbb1-ac4d-4ed0-a379-23c5c79a709e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"37d7e438-1812-4d7b-b9f1-da7e3d5a18fb","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$qeoLW0cT3iRyBgAMm7acNQ$n3vjIhLoiDgXJJF3BBckw4Z9e4HJno/SQkP1ntlgIkI","key":"foo_secret"}],"status":"error","timeout":"300s","updated_at":"2025-04-28T08:37:26.577013Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:20.067880Z","description":"","domain_name":"tffuncinspiringkirche592ql8v-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"bar"},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"2f7d7960-37a2-4eaf-b20f-1500a16a6c44","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"10b555ff-87fe-4a38-847b-c3947aa45730","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$6jBuB6VTieL6ivniEX2abQ$ieYam9JapK2L/ArF6QXb0dK65joEjEhx9HoU7ewTGPA","key":"foo_secret"}],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:22.439315Z"}'
         headers:
             Content-Length:
-                - "845"
+                - "846"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 08:37:26 GMT
+                - Wed, 27 Aug 2025 15:05:33 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -836,10 +836,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e551dc1e-22ea-4d72-8f94-d006b69dbae4
+                - ce5854ab-7dea-4aee-82e0-3ed6afdeb541
         status: 200 OK
         code: 200
-        duration: 54.824833ms
+        duration: 59.228866ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -855,8 +855,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/37d7e438-1812-4d7b-b9f1-da7e3d5a18fb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/2f7d7960-37a2-4eaf-b20f-1500a16a6c44
         method: GET
       response:
         proto: HTTP/2.0
@@ -864,18 +864,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 572
+        content_length: 846
         uncompressed: false
-        body: '{"created_at":"2025-04-28T08:37:13.069765Z","description":"","environment_variables":{},"error_message":null,"id":"37d7e438-1812-4d7b-b9f1-da7e3d5a18fb","name":"tf-func-reverent-kepler","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncreverentkeplertbfkmeps","registry_namespace_id":"031bda64-f468-4c05-b60a-24fc9a832406","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-28T08:37:16.558315Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:20.067880Z","description":"","domain_name":"tffuncinspiringkirche592ql8v-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"bar"},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"2f7d7960-37a2-4eaf-b20f-1500a16a6c44","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"10b555ff-87fe-4a38-847b-c3947aa45730","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$6jBuB6VTieL6ivniEX2abQ$ieYam9JapK2L/ArF6QXb0dK65joEjEhx9HoU7ewTGPA","key":"foo_secret"}],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:22.439315Z"}'
         headers:
             Content-Length:
-                - "572"
+                - "846"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 08:37:27 GMT
+                - Wed, 27 Aug 2025 15:05:38 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -885,10 +885,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d3063b71-aee5-4d26-a0be-feea4347e85c
+                - 40cc0ad8-91d3-4547-92eb-d7b283efd873
         status: 200 OK
         code: 200
-        duration: 36.908375ms
+        duration: 66.227619ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -904,8 +904,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4ba9bbb1-ac4d-4ed0-a379-23c5c79a709e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/2f7d7960-37a2-4eaf-b20f-1500a16a6c44
         method: GET
       response:
         proto: HTTP/2.0
@@ -913,18 +913,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 845
+        content_length: 846
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-04-28T08:37:18.886971Z","description":"","domain_name":"tffuncreverentkeplertbfkmeps-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"bar"},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"4ba9bbb1-ac4d-4ed0-a379-23c5c79a709e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"37d7e438-1812-4d7b-b9f1-da7e3d5a18fb","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$qeoLW0cT3iRyBgAMm7acNQ$n3vjIhLoiDgXJJF3BBckw4Z9e4HJno/SQkP1ntlgIkI","key":"foo_secret"}],"status":"error","timeout":"300s","updated_at":"2025-04-28T08:37:26.577013Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:20.067880Z","description":"","domain_name":"tffuncinspiringkirche592ql8v-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"bar"},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"2f7d7960-37a2-4eaf-b20f-1500a16a6c44","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"10b555ff-87fe-4a38-847b-c3947aa45730","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$6jBuB6VTieL6ivniEX2abQ$ieYam9JapK2L/ArF6QXb0dK65joEjEhx9HoU7ewTGPA","key":"foo_secret"}],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:22.439315Z"}'
         headers:
             Content-Length:
-                - "845"
+                - "846"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 08:37:27 GMT
+                - Wed, 27 Aug 2025 15:05:43 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -934,10 +934,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 14f4d7df-f8e0-4d46-9612-7e7fae86c03f
+                - 657c9ac0-ba41-42a5-aec7-c8481f093bdc
         status: 200 OK
         code: 200
-        duration: 52.735041ms
+        duration: 56.867787ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -953,8 +953,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4ba9bbb1-ac4d-4ed0-a379-23c5c79a709e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/2f7d7960-37a2-4eaf-b20f-1500a16a6c44
         method: GET
       response:
         proto: HTTP/2.0
@@ -962,18 +962,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 845
+        content_length: 856
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-04-28T08:37:18.886971Z","description":"","domain_name":"tffuncreverentkeplertbfkmeps-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"bar"},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"4ba9bbb1-ac4d-4ed0-a379-23c5c79a709e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"37d7e438-1812-4d7b-b9f1-da7e3d5a18fb","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$qeoLW0cT3iRyBgAMm7acNQ$n3vjIhLoiDgXJJF3BBckw4Z9e4HJno/SQkP1ntlgIkI","key":"foo_secret"}],"status":"error","timeout":"300s","updated_at":"2025-04-28T08:37:26.577013Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:20.067880Z","description":"","domain_name":"tffuncinspiringkirche592ql8v-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"bar"},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"2f7d7960-37a2-4eaf-b20f-1500a16a6c44","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"10b555ff-87fe-4a38-847b-c3947aa45730","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$6jBuB6VTieL6ivniEX2abQ$ieYam9JapK2L/ArF6QXb0dK65joEjEhx9HoU7ewTGPA","key":"foo_secret"}],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:44.410871Z"}'
         headers:
             Content-Length:
-                - "845"
+                - "856"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 08:37:27 GMT
+                - Wed, 27 Aug 2025 15:05:48 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -983,10 +983,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f26bb88b-71ba-4be9-a68c-7ea11180f02e
+                - bdec9584-d7ae-4ec1-b571-0caea57c6d2f
         status: 200 OK
         code: 200
-        duration: 56.183917ms
+        duration: 61.342114ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1002,27 +1002,27 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4ba9bbb1-ac4d-4ed0-a379-23c5c79a709e
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/2f7d7960-37a2-4eaf-b20f-1500a16a6c44
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 839
+        content_length: 856
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-04-28T08:37:18.886971Z","description":"","domain_name":"tffuncreverentkeplertbfkmeps-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"bar"},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"4ba9bbb1-ac4d-4ed0-a379-23c5c79a709e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"37d7e438-1812-4d7b-b9f1-da7e3d5a18fb","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$qeoLW0cT3iRyBgAMm7acNQ$n3vjIhLoiDgXJJF3BBckw4Z9e4HJno/SQkP1ntlgIkI","key":"foo_secret"}],"status":"deleting","timeout":"300s","updated_at":"2025-04-28T08:37:27.623771408Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:20.067880Z","description":"","domain_name":"tffuncinspiringkirche592ql8v-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"bar"},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"2f7d7960-37a2-4eaf-b20f-1500a16a6c44","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"10b555ff-87fe-4a38-847b-c3947aa45730","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$6jBuB6VTieL6ivniEX2abQ$ieYam9JapK2L/ArF6QXb0dK65joEjEhx9HoU7ewTGPA","key":"foo_secret"}],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:44.410871Z"}'
         headers:
             Content-Length:
-                - "839"
+                - "856"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 08:37:27 GMT
+                - Wed, 27 Aug 2025 15:05:49 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -1032,10 +1032,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c2c87576-856d-421b-8299-026ef9fd20e9
+                - f5822a08-4959-48e1-95b9-a5e3d44e01a1
         status: 200 OK
         code: 200
-        duration: 161.255167ms
+        duration: 119.693156ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1051,8 +1051,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/37d7e438-1812-4d7b-b9f1-da7e3d5a18fb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/10b555ff-87fe-4a38-847b-c3947aa45730
         method: GET
       response:
         proto: HTTP/2.0
@@ -1060,18 +1060,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 572
+        content_length: 591
         uncompressed: false
-        body: '{"created_at":"2025-04-28T08:37:13.069765Z","description":"","environment_variables":{},"error_message":null,"id":"37d7e438-1812-4d7b-b9f1-da7e3d5a18fb","name":"tf-func-reverent-kepler","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncreverentkeplertbfkmeps","registry_namespace_id":"031bda64-f468-4c05-b60a-24fc9a832406","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-28T08:37:16.558315Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.800960Z","description":"","environment_variables":{},"error_message":null,"id":"10b555ff-87fe-4a38-847b-c3947aa45730","name":"tf-func-inspiring-kirch","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncinspiringkirche592ql8v","registry_namespace_id":"340d4307-01a1-4bdd-806c-9d6f4e22b1a4","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:17.501813Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "572"
+                - "591"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 08:37:27 GMT
+                - Wed, 27 Aug 2025 15:05:49 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -1081,10 +1081,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7c15c7ae-6a1d-48ac-8d1c-46f12ba608f3
+                - 856d0280-70bc-4fdb-b99c-f5bee2b5fb1a
         status: 200 OK
         code: 200
-        duration: 37.653583ms
+        duration: 70.545884ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1100,27 +1100,27 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/37d7e438-1812-4d7b-b9f1-da7e3d5a18fb
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/2f7d7960-37a2-4eaf-b20f-1500a16a6c44
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 578
+        content_length: 856
         uncompressed: false
-        body: '{"created_at":"2025-04-28T08:37:13.069765Z","description":"","environment_variables":{},"error_message":null,"id":"37d7e438-1812-4d7b-b9f1-da7e3d5a18fb","name":"tf-func-reverent-kepler","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncreverentkeplertbfkmeps","registry_namespace_id":"031bda64-f468-4c05-b60a-24fc9a832406","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-04-28T08:37:27.808204145Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:20.067880Z","description":"","domain_name":"tffuncinspiringkirche592ql8v-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"bar"},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"2f7d7960-37a2-4eaf-b20f-1500a16a6c44","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"10b555ff-87fe-4a38-847b-c3947aa45730","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$6jBuB6VTieL6ivniEX2abQ$ieYam9JapK2L/ArF6QXb0dK65joEjEhx9HoU7ewTGPA","key":"foo_secret"}],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:44.410871Z"}'
         headers:
             Content-Length:
-                - "578"
+                - "856"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 08:37:27 GMT
+                - Wed, 27 Aug 2025 15:05:49 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -1130,10 +1130,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2416eea6-5a85-4f7a-bdfa-e313d2bdb840
+                - ba5d969f-a23e-4345-89c3-6c805ca32910
         status: 200 OK
         code: 200
-        duration: 205.745083ms
+        duration: 50.065024ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1149,8 +1149,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/37d7e438-1812-4d7b-b9f1-da7e3d5a18fb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/2f7d7960-37a2-4eaf-b20f-1500a16a6c44
         method: GET
       response:
         proto: HTTP/2.0
@@ -1158,18 +1158,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 575
+        content_length: 856
         uncompressed: false
-        body: '{"created_at":"2025-04-28T08:37:13.069765Z","description":"","environment_variables":{},"error_message":null,"id":"37d7e438-1812-4d7b-b9f1-da7e3d5a18fb","name":"tf-func-reverent-kepler","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncreverentkeplertbfkmeps","registry_namespace_id":"031bda64-f468-4c05-b60a-24fc9a832406","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-04-28T08:37:27.808204Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:20.067880Z","description":"","domain_name":"tffuncinspiringkirche592ql8v-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"bar"},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"2f7d7960-37a2-4eaf-b20f-1500a16a6c44","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"10b555ff-87fe-4a38-847b-c3947aa45730","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$6jBuB6VTieL6ivniEX2abQ$ieYam9JapK2L/ArF6QXb0dK65joEjEhx9HoU7ewTGPA","key":"foo_secret"}],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:44.410871Z"}'
         headers:
             Content-Length:
-                - "575"
+                - "856"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 08:37:28 GMT
+                - Wed, 27 Aug 2025 15:05:50 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -1179,10 +1179,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f04ba4ec-043e-4c76-a822-ba02d1e8f4ca
+                - a5e6bddf-387c-4c2c-9beb-5083159a2b2f
         status: 200 OK
         code: 200
-        duration: 41.814042ms
+        duration: 55.788142ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1198,27 +1198,27 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/37d7e438-1812-4d7b-b9f1-da7e3d5a18fb
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/2f7d7960-37a2-4eaf-b20f-1500a16a6c44
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 575
+        content_length: 850
         uncompressed: false
-        body: '{"created_at":"2025-04-28T08:37:13.069765Z","description":"","environment_variables":{},"error_message":null,"id":"37d7e438-1812-4d7b-b9f1-da7e3d5a18fb","name":"tf-func-reverent-kepler","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncreverentkeplertbfkmeps","registry_namespace_id":"031bda64-f468-4c05-b60a-24fc9a832406","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-04-28T08:37:27.808204Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:20.067880Z","description":"","domain_name":"tffuncinspiringkirche592ql8v-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"bar"},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"2f7d7960-37a2-4eaf-b20f-1500a16a6c44","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"10b555ff-87fe-4a38-847b-c3947aa45730","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$6jBuB6VTieL6ivniEX2abQ$ieYam9JapK2L/ArF6QXb0dK65joEjEhx9HoU7ewTGPA","key":"foo_secret"}],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:50.206278063Z"}'
         headers:
             Content-Length:
-                - "575"
+                - "850"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 08:37:33 GMT
+                - Wed, 27 Aug 2025 15:05:50 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -1228,10 +1228,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6fc030ac-484f-4811-8342-8f9a83ee67e1
+                - 31302c4b-f094-4f84-b0dc-746fd0e42771
         status: 200 OK
         code: 200
-        duration: 95.184583ms
+        duration: 106.682803ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1247,8 +1247,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/37d7e438-1812-4d7b-b9f1-da7e3d5a18fb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/10b555ff-87fe-4a38-847b-c3947aa45730
         method: GET
       response:
         proto: HTTP/2.0
@@ -1256,18 +1256,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 575
+        content_length: 591
         uncompressed: false
-        body: '{"created_at":"2025-04-28T08:37:13.069765Z","description":"","environment_variables":{},"error_message":null,"id":"37d7e438-1812-4d7b-b9f1-da7e3d5a18fb","name":"tf-func-reverent-kepler","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncreverentkeplertbfkmeps","registry_namespace_id":"031bda64-f468-4c05-b60a-24fc9a832406","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-04-28T08:37:27.808204Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.800960Z","description":"","environment_variables":{},"error_message":null,"id":"10b555ff-87fe-4a38-847b-c3947aa45730","name":"tf-func-inspiring-kirch","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncinspiringkirche592ql8v","registry_namespace_id":"340d4307-01a1-4bdd-806c-9d6f4e22b1a4","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:17.501813Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "575"
+                - "591"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 08:37:38 GMT
+                - Wed, 27 Aug 2025 15:05:50 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -1277,10 +1277,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d4b5beba-a17e-4a81-8c2c-0adf65f6298e
+                - 87d20cb3-c23a-490b-9b60-cb1f37a29843
         status: 200 OK
         code: 200
-        duration: 34.616417ms
+        duration: 50.203383ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1296,27 +1296,27 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/37d7e438-1812-4d7b-b9f1-da7e3d5a18fb
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/10b555ff-87fe-4a38-847b-c3947aa45730
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 575
+        content_length: 597
         uncompressed: false
-        body: '{"created_at":"2025-04-28T08:37:13.069765Z","description":"","environment_variables":{},"error_message":null,"id":"37d7e438-1812-4d7b-b9f1-da7e3d5a18fb","name":"tf-func-reverent-kepler","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncreverentkeplertbfkmeps","registry_namespace_id":"031bda64-f468-4c05-b60a-24fc9a832406","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-04-28T08:37:27.808204Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.800960Z","description":"","environment_variables":{},"error_message":null,"id":"10b555ff-87fe-4a38-847b-c3947aa45730","name":"tf-func-inspiring-kirch","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncinspiringkirche592ql8v","registry_namespace_id":"340d4307-01a1-4bdd-806c-9d6f4e22b1a4","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:50.355081245Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "575"
+                - "597"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 08:37:43 GMT
+                - Wed, 27 Aug 2025 15:05:50 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -1326,10 +1326,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f1ae99c3-ad3e-4ff8-af0c-1256d5a7da27
+                - 4c09be58-25d9-4aac-9f16-88a3ec6410d0
         status: 200 OK
         code: 200
-        duration: 41.26325ms
+        duration: 169.864019ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1345,8 +1345,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/37d7e438-1812-4d7b-b9f1-da7e3d5a18fb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/10b555ff-87fe-4a38-847b-c3947aa45730
         method: GET
       response:
         proto: HTTP/2.0
@@ -1354,18 +1354,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 575
+        content_length: 594
         uncompressed: false
-        body: '{"created_at":"2025-04-28T08:37:13.069765Z","description":"","environment_variables":{},"error_message":null,"id":"37d7e438-1812-4d7b-b9f1-da7e3d5a18fb","name":"tf-func-reverent-kepler","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncreverentkeplertbfkmeps","registry_namespace_id":"031bda64-f468-4c05-b60a-24fc9a832406","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-04-28T08:37:27.808204Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.800960Z","description":"","environment_variables":{},"error_message":null,"id":"10b555ff-87fe-4a38-847b-c3947aa45730","name":"tf-func-inspiring-kirch","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncinspiringkirche592ql8v","registry_namespace_id":"340d4307-01a1-4bdd-806c-9d6f4e22b1a4","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:50.355081Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "575"
+                - "594"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 08:37:48 GMT
+                - Wed, 27 Aug 2025 15:05:50 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -1375,10 +1375,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 36af2ef8-0296-404f-bf46-39f8d1adf78f
+                - 36d0d3fa-f9c7-49ca-9586-3adec11c98be
         status: 200 OK
         code: 200
-        duration: 46.745166ms
+        duration: 41.126972ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1394,8 +1394,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/37d7e438-1812-4d7b-b9f1-da7e3d5a18fb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/10b555ff-87fe-4a38-847b-c3947aa45730
         method: GET
       response:
         proto: HTTP/2.0
@@ -1403,18 +1403,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 575
+        content_length: 594
         uncompressed: false
-        body: '{"created_at":"2025-04-28T08:37:13.069765Z","description":"","environment_variables":{},"error_message":null,"id":"37d7e438-1812-4d7b-b9f1-da7e3d5a18fb","name":"tf-func-reverent-kepler","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncreverentkeplertbfkmeps","registry_namespace_id":"031bda64-f468-4c05-b60a-24fc9a832406","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-04-28T08:37:27.808204Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.800960Z","description":"","environment_variables":{},"error_message":null,"id":"10b555ff-87fe-4a38-847b-c3947aa45730","name":"tf-func-inspiring-kirch","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncinspiringkirche592ql8v","registry_namespace_id":"340d4307-01a1-4bdd-806c-9d6f4e22b1a4","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:50.355081Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "575"
+                - "594"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 08:37:53 GMT
+                - Wed, 27 Aug 2025 15:05:55 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -1424,10 +1424,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e1e6296c-fd1f-41a8-ac02-96af473ccd90
+                - a6a2c325-ed1c-4c71-b1f0-8d2105c21d99
         status: 200 OK
         code: 200
-        duration: 41.835458ms
+        duration: 42.925858ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1443,8 +1443,106 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/37d7e438-1812-4d7b-b9f1-da7e3d5a18fb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/10b555ff-87fe-4a38-847b-c3947aa45730
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 594
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:13.800960Z","description":"","environment_variables":{},"error_message":null,"id":"10b555ff-87fe-4a38-847b-c3947aa45730","name":"tf-func-inspiring-kirch","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncinspiringkirche592ql8v","registry_namespace_id":"340d4307-01a1-4bdd-806c-9d6f4e22b1a4","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:50.355081Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "594"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:00 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f4d4a0b8-000f-494e-a4a4-7156e6bb21ea
+        status: 200 OK
+        code: 200
+        duration: 56.282072ms
+    - id: 30
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/10b555ff-87fe-4a38-847b-c3947aa45730
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 594
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:13.800960Z","description":"","environment_variables":{},"error_message":null,"id":"10b555ff-87fe-4a38-847b-c3947aa45730","name":"tf-func-inspiring-kirch","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncinspiringkirche592ql8v","registry_namespace_id":"340d4307-01a1-4bdd-806c-9d6f4e22b1a4","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:50.355081Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "594"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:05 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 29807d5a-1a2f-448d-b6ad-102cf6c5a4c0
+        status: 200 OK
+        code: 200
+        duration: 39.8826ms
+    - id: 31
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/10b555ff-87fe-4a38-847b-c3947aa45730
         method: GET
       response:
         proto: HTTP/2.0
@@ -1463,7 +1561,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 08:37:58 GMT
+                - Wed, 27 Aug 2025 15:06:10 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -1473,11 +1571,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 53b3db35-5f14-4908-a68a-8f604dd0da05
+                - bf0c6a61-5f9e-460d-8982-ad60ffaa460b
         status: 404 Not Found
         code: 404
-        duration: 22.583ms
-    - id: 30
+        duration: 19.450499ms
+    - id: 32
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1492,8 +1590,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4ba9bbb1-ac4d-4ed0-a379-23c5c79a709e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/2f7d7960-37a2-4eaf-b20f-1500a16a6c44
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1512,7 +1610,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 08:37:58 GMT
+                - Wed, 27 Aug 2025 15:06:10 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
@@ -1522,7 +1620,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 50cc2ec4-73f2-4b61-9f99-76cd0f52965e
+                - 4eb2acfd-288a-4816-b78f-2b37ef3b7b51
         status: 404 Not Found
         code: 404
-        duration: 27.476417ms
+        duration: 25.866829ms

--- a/internal/services/function/testdata/function-http-option.cassette.yaml
+++ b/internal/services/function/testdata/function-http-option.cassette.yaml
@@ -6,19 +6,19 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 159
+        content_length: 188
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-func-tender-mahavira","environment_variables":{},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","secret_environment_variables":[],"tags":null}'
+        body: '{"name":"tf-func-crazy-agnesi","environment_variables":{},"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","secret_environment_variables":[],"tags":null,"activate_vpc_integration":true}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces
         method: POST
       response:
@@ -27,20 +27,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 475
+        content_length: 505
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:27.735113783Z","description":"","environment_variables":{},"error_message":null,"id":"8eb8f345-ba2e-4c96-a4fa-e033ca702001","name":"tf-func-tender-mahavira","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:44:27.735113783Z"}'
+        body: '{"created_at":"2025-08-27T15:05:33.909344530Z","description":"","environment_variables":{},"error_message":null,"id":"ed53546c-704b-477f-a26a-be53dc3d479a","name":"tf-func-crazy-agnesi","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:33.909344530Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "475"
+                - "505"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:27 GMT
+                - Wed, 27 Aug 2025 15:05:33 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e3c7c305-6567-41b4-83fe-6f4dfee5d51d
+                - 32761e84-b1d8-47ac-b9ff-d1cc369a87c4
         status: 200 OK
         code: 200
-        duration: 290.608125ms
+        duration: 1.021401745s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -67,8 +67,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8eb8f345-ba2e-4c96-a4fa-e033ca702001
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/ed53546c-704b-477f-a26a-be53dc3d479a
         method: GET
       response:
         proto: HTTP/2.0
@@ -76,20 +76,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 469
+        content_length: 499
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:27.735114Z","description":"","environment_variables":{},"error_message":null,"id":"8eb8f345-ba2e-4c96-a4fa-e033ca702001","name":"tf-func-tender-mahavira","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:44:27.735114Z"}'
+        body: '{"created_at":"2025-08-27T15:05:33.909345Z","description":"","environment_variables":{},"error_message":null,"id":"ed53546c-704b-477f-a26a-be53dc3d479a","name":"tf-func-crazy-agnesi","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:33.909345Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "469"
+                - "499"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:27 GMT
+                - Wed, 27 Aug 2025 15:05:33 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8027bb9a-7037-487c-b5f8-8c9751807364
+                - 024c20b4-0669-4615-8116-24a1b861b1a1
         status: 200 OK
         code: 200
-        duration: 67.690291ms
+        duration: 43.156869ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -116,8 +116,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8eb8f345-ba2e-4c96-a4fa-e033ca702001
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/ed53546c-704b-477f-a26a-be53dc3d479a
         method: GET
       response:
         proto: HTTP/2.0
@@ -125,20 +125,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 558
+        content_length: 587
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:27.735114Z","description":"","environment_variables":{},"error_message":null,"id":"8eb8f345-ba2e-4c96-a4fa-e033ca702001","name":"tf-func-tender-mahavira","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunctendermahavirafd8wbcil","registry_namespace_id":"68c82c14-5b95-40a1-aa66-e4a83dbb5e96","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:44:29.031470Z"}'
+        body: '{"created_at":"2025-08-27T15:05:33.909345Z","description":"","environment_variables":{},"error_message":null,"id":"ed53546c-704b-477f-a26a-be53dc3d479a","name":"tf-func-crazy-agnesi","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunccrazyagnesijpitejsy","registry_namespace_id":"cec6184c-4f79-444c-b3ad-2b2faf3eadf5","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:35.322016Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "558"
+                - "587"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:32 GMT
+                - Wed, 27 Aug 2025 15:05:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -146,10 +146,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9febe87f-2c07-45dd-9467-9222935533d5
+                - 17724ba8-e1b4-4523-9d61-27318f969ba4
         status: 200 OK
         code: 200
-        duration: 73.29025ms
+        duration: 41.186873ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -165,8 +165,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8eb8f345-ba2e-4c96-a4fa-e033ca702001
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/ed53546c-704b-477f-a26a-be53dc3d479a
         method: GET
       response:
         proto: HTTP/2.0
@@ -174,20 +174,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 558
+        content_length: 587
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:27.735114Z","description":"","environment_variables":{},"error_message":null,"id":"8eb8f345-ba2e-4c96-a4fa-e033ca702001","name":"tf-func-tender-mahavira","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunctendermahavirafd8wbcil","registry_namespace_id":"68c82c14-5b95-40a1-aa66-e4a83dbb5e96","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:44:29.031470Z"}'
+        body: '{"created_at":"2025-08-27T15:05:33.909345Z","description":"","environment_variables":{},"error_message":null,"id":"ed53546c-704b-477f-a26a-be53dc3d479a","name":"tf-func-crazy-agnesi","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunccrazyagnesijpitejsy","registry_namespace_id":"cec6184c-4f79-444c-b3ad-2b2faf3eadf5","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:35.322016Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "558"
+                - "587"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:32 GMT
+                - Wed, 27 Aug 2025 15:05:44 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -195,50 +195,48 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 894912c4-77e7-49af-a371-7d4feb050834
+                - 8ea6c140-d273-4632-9482-5200720495c2
         status: 200 OK
         code: 200
-        duration: 67.74025ms
+        duration: 44.421913ms
     - id: 4
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 298
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"foobar","namespace_id":"8eb8f345-ba2e-4c96-a4fa-e033ca702001","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"node22","memory_limit":256,"handler":"handler.handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox"}'
+        body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions
-        method: POST
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/ed53546c-704b-477f-a26a-be53dc3d479a
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 670
+        content_length: 587
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:33.190458644Z","description":"","domain_name":"tffunctendermahavirafd8wbcil-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"8db55bf0-de18-43dc-b273-00d1619c3a86","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"8eb8f345-ba2e-4c96-a4fa-e033ca702001","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:33.190458644Z"}'
+        body: '{"created_at":"2025-08-27T15:05:33.909345Z","description":"","environment_variables":{},"error_message":null,"id":"ed53546c-704b-477f-a26a-be53dc3d479a","name":"tf-func-crazy-agnesi","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunccrazyagnesijpitejsy","registry_namespace_id":"cec6184c-4f79-444c-b3ad-2b2faf3eadf5","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:35.322016Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "670"
+                - "587"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:33 GMT
+                - Wed, 27 Aug 2025 15:05:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -246,10 +244,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 91edcbd4-541e-4d96-9dff-7c4b899b4a4f
+                - dd545c07-ca1b-47e5-8442-c614f3179dad
         status: 200 OK
         code: 200
-        duration: 234.383584ms
+        duration: 70.914125ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -265,8 +263,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/8db55bf0-de18-43dc-b273-00d1619c3a86
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/ed53546c-704b-477f-a26a-be53dc3d479a
         method: GET
       response:
         proto: HTTP/2.0
@@ -274,20 +272,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 664
+        content_length: 585
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:33.190459Z","description":"","domain_name":"tffunctendermahavirafd8wbcil-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"8db55bf0-de18-43dc-b273-00d1619c3a86","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"8eb8f345-ba2e-4c96-a4fa-e033ca702001","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:33.190459Z"}'
+        body: '{"created_at":"2025-08-27T15:05:33.909345Z","description":"","environment_variables":{},"error_message":null,"id":"ed53546c-704b-477f-a26a-be53dc3d479a","name":"tf-func-crazy-agnesi","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunccrazyagnesijpitejsy","registry_namespace_id":"cec6184c-4f79-444c-b3ad-2b2faf3eadf5","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:53.194419Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "664"
+                - "585"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:33 GMT
+                - Wed, 27 Aug 2025 15:05:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -295,10 +293,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 23d5724a-3241-4839-b7d6-a80e84e83e11
+                - da7bab54-5b36-476b-844e-78706fa8a916
         status: 200 OK
         code: 200
-        duration: 65.512667ms
+        duration: 41.958584ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -314,8 +312,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/8db55bf0-de18-43dc-b273-00d1619c3a86
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/ed53546c-704b-477f-a26a-be53dc3d479a
         method: GET
       response:
         proto: HTTP/2.0
@@ -323,20 +321,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 664
+        content_length: 585
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:33.190459Z","description":"","domain_name":"tffunctendermahavirafd8wbcil-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"8db55bf0-de18-43dc-b273-00d1619c3a86","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"8eb8f345-ba2e-4c96-a4fa-e033ca702001","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:33.190459Z"}'
+        body: '{"created_at":"2025-08-27T15:05:33.909345Z","description":"","environment_variables":{},"error_message":null,"id":"ed53546c-704b-477f-a26a-be53dc3d479a","name":"tf-func-crazy-agnesi","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunccrazyagnesijpitejsy","registry_namespace_id":"cec6184c-4f79-444c-b3ad-2b2faf3eadf5","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:53.194419Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "664"
+                - "585"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:33 GMT
+                - Wed, 27 Aug 2025 15:05:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -344,48 +342,50 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d036cce2-6b0f-41e6-8c67-957db335ccba
+                - a9bbeb32-5d95-4758-99b0-96c7d120df9d
         status: 200 OK
         code: 200
-        duration: 79.290333ms
+        duration: 35.767736ms
     - id: 7
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 310
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"name":"foobar","namespace_id":"ed53546c-704b-477f-a26a-be53dc3d479a","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"node22","memory_limit":256,"handler":"handler.handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox","tags":null}'
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/8db55bf0-de18-43dc-b273-00d1619c3a86
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 664
+        content_length: 703
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:33.190459Z","description":"","domain_name":"tffunctendermahavirafd8wbcil-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"8db55bf0-de18-43dc-b273-00d1619c3a86","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"8eb8f345-ba2e-4c96-a4fa-e033ca702001","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:33.190459Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:54.892804449Z","description":"","domain_name":"tffunccrazyagnesijpitejsy-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"545a6aa8-2d3b-4fb7-a470-d926627b679a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"ed53546c-704b-477f-a26a-be53dc3d479a","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:54.892804449Z"}'
         headers:
             Content-Length:
-                - "664"
+                - "703"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:33 GMT
+                - Wed, 27 Aug 2025 15:05:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -393,10 +393,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 963c6d06-4ee2-4721-8e26-915f201c2589
+                - f63d4e4f-585f-4c10-94f8-347c225c3fbf
         status: 200 OK
         code: 200
-        duration: 73.7765ms
+        duration: 763.254697ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -412,8 +412,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8eb8f345-ba2e-4c96-a4fa-e033ca702001
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/545a6aa8-2d3b-4fb7-a470-d926627b679a
         method: GET
       response:
         proto: HTTP/2.0
@@ -421,20 +421,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 558
+        content_length: 697
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:27.735114Z","description":"","environment_variables":{},"error_message":null,"id":"8eb8f345-ba2e-4c96-a4fa-e033ca702001","name":"tf-func-tender-mahavira","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunctendermahavirafd8wbcil","registry_namespace_id":"68c82c14-5b95-40a1-aa66-e4a83dbb5e96","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:44:29.031470Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:54.892804Z","description":"","domain_name":"tffunccrazyagnesijpitejsy-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"545a6aa8-2d3b-4fb7-a470-d926627b679a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"ed53546c-704b-477f-a26a-be53dc3d479a","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:54.892804Z"}'
         headers:
             Content-Length:
-                - "558"
+                - "697"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:34 GMT
+                - Wed, 27 Aug 2025 15:05:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -442,10 +442,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1067be14-8930-4266-a595-664b2ab22738
+                - 69dd920a-7c2f-4311-a245-1ab0e301baf6
         status: 200 OK
         code: 200
-        duration: 65.143709ms
+        duration: 72.481828ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -461,8 +461,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/8db55bf0-de18-43dc-b273-00d1619c3a86
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/545a6aa8-2d3b-4fb7-a470-d926627b679a
         method: GET
       response:
         proto: HTTP/2.0
@@ -470,20 +470,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 664
+        content_length: 697
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:33.190459Z","description":"","domain_name":"tffunctendermahavirafd8wbcil-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"8db55bf0-de18-43dc-b273-00d1619c3a86","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"8eb8f345-ba2e-4c96-a4fa-e033ca702001","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:33.190459Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:54.892804Z","description":"","domain_name":"tffunccrazyagnesijpitejsy-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"545a6aa8-2d3b-4fb7-a470-d926627b679a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"ed53546c-704b-477f-a26a-be53dc3d479a","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:54.892804Z"}'
         headers:
             Content-Length:
-                - "664"
+                - "697"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:34 GMT
+                - Wed, 27 Aug 2025 15:05:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -491,10 +491,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fd608d68-96d3-4510-a62e-8f086bdabdae
+                - 0b064f78-e53e-4d0d-a8f6-a8a61a53504f
         status: 200 OK
         code: 200
-        duration: 76.373292ms
+        duration: 50.343898ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -510,8 +510,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8eb8f345-ba2e-4c96-a4fa-e033ca702001
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/545a6aa8-2d3b-4fb7-a470-d926627b679a
         method: GET
       response:
         proto: HTTP/2.0
@@ -519,20 +519,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 558
+        content_length: 697
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:27.735114Z","description":"","environment_variables":{},"error_message":null,"id":"8eb8f345-ba2e-4c96-a4fa-e033ca702001","name":"tf-func-tender-mahavira","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunctendermahavirafd8wbcil","registry_namespace_id":"68c82c14-5b95-40a1-aa66-e4a83dbb5e96","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:44:29.031470Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:54.892804Z","description":"","domain_name":"tffunccrazyagnesijpitejsy-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"545a6aa8-2d3b-4fb7-a470-d926627b679a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"ed53546c-704b-477f-a26a-be53dc3d479a","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:54.892804Z"}'
         headers:
             Content-Length:
-                - "558"
+                - "697"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:34 GMT
+                - Wed, 27 Aug 2025 15:05:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -540,10 +540,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6d6bc171-d2e4-418e-a6cc-733283e63c2c
+                - ee4fa7b6-90e7-4117-b129-5b131ac523bb
         status: 200 OK
         code: 200
-        duration: 67.516459ms
+        duration: 56.783782ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -559,8 +559,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/8db55bf0-de18-43dc-b273-00d1619c3a86
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/ed53546c-704b-477f-a26a-be53dc3d479a
         method: GET
       response:
         proto: HTTP/2.0
@@ -568,20 +568,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 664
+        content_length: 585
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:33.190459Z","description":"","domain_name":"tffunctendermahavirafd8wbcil-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"8db55bf0-de18-43dc-b273-00d1619c3a86","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"8eb8f345-ba2e-4c96-a4fa-e033ca702001","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:33.190459Z"}'
+        body: '{"created_at":"2025-08-27T15:05:33.909345Z","description":"","environment_variables":{},"error_message":null,"id":"ed53546c-704b-477f-a26a-be53dc3d479a","name":"tf-func-crazy-agnesi","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunccrazyagnesijpitejsy","registry_namespace_id":"cec6184c-4f79-444c-b3ad-2b2faf3eadf5","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:53.194419Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "664"
+                - "585"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:35 GMT
+                - Wed, 27 Aug 2025 15:05:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -589,10 +589,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 59814b7d-623b-4234-ac8d-47cec6c3ee3c
+                - 5a8233cc-51c8-4d8c-b401-7d1bcf4076ea
         status: 200 OK
         code: 200
-        duration: 68.456458ms
+        duration: 45.341962ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -608,8 +608,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/8db55bf0-de18-43dc-b273-00d1619c3a86
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/545a6aa8-2d3b-4fb7-a470-d926627b679a
         method: GET
       response:
         proto: HTTP/2.0
@@ -617,20 +617,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 664
+        content_length: 697
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:33.190459Z","description":"","domain_name":"tffunctendermahavirafd8wbcil-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"8db55bf0-de18-43dc-b273-00d1619c3a86","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"8eb8f345-ba2e-4c96-a4fa-e033ca702001","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:33.190459Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:54.892804Z","description":"","domain_name":"tffunccrazyagnesijpitejsy-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"545a6aa8-2d3b-4fb7-a470-d926627b679a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"ed53546c-704b-477f-a26a-be53dc3d479a","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:54.892804Z"}'
         headers:
             Content-Length:
-                - "664"
+                - "697"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:35 GMT
+                - Wed, 27 Aug 2025 15:05:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -638,11 +638,158 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 45e3c128-fea3-4083-bc73-876df0d68802
+                - 3ab74ea6-1ee6-484a-b0e6-15bedfcde3ad
         status: 200 OK
         code: 200
-        duration: 81.915209ms
+        duration: 56.215215ms
     - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/ed53546c-704b-477f-a26a-be53dc3d479a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 585
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:33.909345Z","description":"","environment_variables":{},"error_message":null,"id":"ed53546c-704b-477f-a26a-be53dc3d479a","name":"tf-func-crazy-agnesi","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunccrazyagnesijpitejsy","registry_namespace_id":"cec6184c-4f79-444c-b3ad-2b2faf3eadf5","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:53.194419Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "585"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:05:55 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - da498a43-d86c-4b4c-b96d-8e1ef179bbbc
+        status: 200 OK
+        code: 200
+        duration: 46.690712ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/545a6aa8-2d3b-4fb7-a470-d926627b679a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 697
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:54.892804Z","description":"","domain_name":"tffunccrazyagnesijpitejsy-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"545a6aa8-2d3b-4fb7-a470-d926627b679a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"ed53546c-704b-477f-a26a-be53dc3d479a","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:54.892804Z"}'
+        headers:
+            Content-Length:
+                - "697"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:05:55 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 39711e38-3089-43c9-a0e6-b2c68457228e
+        status: 200 OK
+        code: 200
+        duration: 53.481035ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/545a6aa8-2d3b-4fb7-a470-d926627b679a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 697
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:54.892804Z","description":"","domain_name":"tffunccrazyagnesijpitejsy-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"545a6aa8-2d3b-4fb7-a470-d926627b679a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"ed53546c-704b-477f-a26a-be53dc3d479a","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:54.892804Z"}'
+        headers:
+            Content-Length:
+                - "697"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:05:56 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ac296838-72f9-4f12-80b1-a4f5133ca64f
+        status: 200 OK
+        code: 200
+        duration: 60.27297ms
+    - id: 16
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -659,8 +806,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/8db55bf0-de18-43dc-b273-00d1619c3a86
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/545a6aa8-2d3b-4fb7-a470-d926627b679a
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -668,20 +815,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 670
+        content_length: 703
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:33.190459Z","description":"","domain_name":"tffunctendermahavirafd8wbcil-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"redirected","id":"8db55bf0-de18-43dc-b273-00d1619c3a86","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"8eb8f345-ba2e-4c96-a4fa-e033ca702001","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","timeout":"300s","updated_at":"2025-01-24T15:44:35.962976617Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:54.892804Z","description":"","domain_name":"tffunccrazyagnesijpitejsy-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"redirected","id":"545a6aa8-2d3b-4fb7-a470-d926627b679a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"ed53546c-704b-477f-a26a-be53dc3d479a","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:56.458192556Z"}'
         headers:
             Content-Length:
-                - "670"
+                - "703"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:35 GMT
+                - Wed, 27 Aug 2025 15:05:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -689,157 +836,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 161dc927-2987-4aad-849d-bfb0d2879d6b
+                - 83723b92-3788-4818-a549-58f37cf0029f
         status: 200 OK
         code: 200
-        duration: 102.628542ms
-    - id: 14
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/8db55bf0-de18-43dc-b273-00d1619c3a86
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 667
-        uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:33.190459Z","description":"","domain_name":"tffunctendermahavirafd8wbcil-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"redirected","id":"8db55bf0-de18-43dc-b273-00d1619c3a86","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"8eb8f345-ba2e-4c96-a4fa-e033ca702001","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","timeout":"300s","updated_at":"2025-01-24T15:44:35.962977Z"}'
-        headers:
-            Content-Length:
-                - "667"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:44:37 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 53ec8c0d-1634-4d22-8eeb-2e415b9c8772
-        status: 200 OK
-        code: 200
-        duration: 77.350292ms
-    - id: 15
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/8db55bf0-de18-43dc-b273-00d1619c3a86
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 677
-        uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:33.190459Z","description":"","domain_name":"tffunctendermahavirafd8wbcil-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"redirected","id":"8db55bf0-de18-43dc-b273-00d1619c3a86","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"8eb8f345-ba2e-4c96-a4fa-e033ca702001","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-24T15:44:41.553352Z"}'
-        headers:
-            Content-Length:
-                - "677"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:44:42 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 0f1c5e80-f576-4d0f-a0c9-e14966ea2622
-        status: 200 OK
-        code: 200
-        duration: 73.367917ms
-    - id: 16
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/8db55bf0-de18-43dc-b273-00d1619c3a86
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 677
-        uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:33.190459Z","description":"","domain_name":"tffunctendermahavirafd8wbcil-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"redirected","id":"8db55bf0-de18-43dc-b273-00d1619c3a86","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"8eb8f345-ba2e-4c96-a4fa-e033ca702001","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-24T15:44:41.553352Z"}'
-        headers:
-            Content-Length:
-                - "677"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:44:42 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 47fcc0e9-6621-40bc-83c1-7f1c6a7c188c
-        status: 200 OK
-        code: 200
-        duration: 75.42025ms
+        duration: 94.249384ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -855,8 +855,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8eb8f345-ba2e-4c96-a4fa-e033ca702001
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/545a6aa8-2d3b-4fb7-a470-d926627b679a
         method: GET
       response:
         proto: HTTP/2.0
@@ -864,20 +864,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 558
+        content_length: 700
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:27.735114Z","description":"","environment_variables":{},"error_message":null,"id":"8eb8f345-ba2e-4c96-a4fa-e033ca702001","name":"tf-func-tender-mahavira","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunctendermahavirafd8wbcil","registry_namespace_id":"68c82c14-5b95-40a1-aa66-e4a83dbb5e96","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:44:29.031470Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:54.892804Z","description":"","domain_name":"tffunccrazyagnesijpitejsy-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"redirected","id":"545a6aa8-2d3b-4fb7-a470-d926627b679a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"ed53546c-704b-477f-a26a-be53dc3d479a","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:56.458193Z"}'
         headers:
             Content-Length:
-                - "558"
+                - "700"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:43 GMT
+                - Wed, 27 Aug 2025 15:05:57 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -885,10 +885,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d46d2fd2-5f0e-448e-86b1-1fb921edcf17
+                - 5226cc27-b51e-4093-80f9-7b0fcbad0a7e
         status: 200 OK
         code: 200
-        duration: 60.120833ms
+        duration: 50.383562ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -904,8 +904,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/8db55bf0-de18-43dc-b273-00d1619c3a86
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/545a6aa8-2d3b-4fb7-a470-d926627b679a
         method: GET
       response:
         proto: HTTP/2.0
@@ -913,20 +913,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 677
+        content_length: 710
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:33.190459Z","description":"","domain_name":"tffunctendermahavirafd8wbcil-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"redirected","id":"8db55bf0-de18-43dc-b273-00d1619c3a86","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"8eb8f345-ba2e-4c96-a4fa-e033ca702001","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-24T15:44:41.553352Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:54.892804Z","description":"","domain_name":"tffunccrazyagnesijpitejsy-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"redirected","id":"545a6aa8-2d3b-4fb7-a470-d926627b679a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"ed53546c-704b-477f-a26a-be53dc3d479a","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:02.375234Z"}'
         headers:
             Content-Length:
-                - "677"
+                - "710"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:43 GMT
+                - Wed, 27 Aug 2025 15:06:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -934,10 +934,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - eec55ef9-73fd-4033-a330-b118a96a853f
+                - 56a1ea08-d9d3-46e5-b9d7-a16594793834
         status: 200 OK
         code: 200
-        duration: 68.2205ms
+        duration: 51.683202ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -953,8 +953,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8eb8f345-ba2e-4c96-a4fa-e033ca702001
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/545a6aa8-2d3b-4fb7-a470-d926627b679a
         method: GET
       response:
         proto: HTTP/2.0
@@ -962,20 +962,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 558
+        content_length: 710
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:27.735114Z","description":"","environment_variables":{},"error_message":null,"id":"8eb8f345-ba2e-4c96-a4fa-e033ca702001","name":"tf-func-tender-mahavira","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunctendermahavirafd8wbcil","registry_namespace_id":"68c82c14-5b95-40a1-aa66-e4a83dbb5e96","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:44:29.031470Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:54.892804Z","description":"","domain_name":"tffunccrazyagnesijpitejsy-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"redirected","id":"545a6aa8-2d3b-4fb7-a470-d926627b679a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"ed53546c-704b-477f-a26a-be53dc3d479a","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:02.375234Z"}'
         headers:
             Content-Length:
-                - "558"
+                - "710"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:44 GMT
+                - Wed, 27 Aug 2025 15:06:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -983,10 +983,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9b3f1916-95d9-4d43-8164-08f4b9ae869d
+                - 7ab3acf9-c477-4c17-8143-87c026eac97c
         status: 200 OK
         code: 200
-        duration: 82.649333ms
+        duration: 43.392946ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1002,8 +1002,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/8db55bf0-de18-43dc-b273-00d1619c3a86
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/ed53546c-704b-477f-a26a-be53dc3d479a
         method: GET
       response:
         proto: HTTP/2.0
@@ -1011,20 +1011,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 677
+        content_length: 585
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:33.190459Z","description":"","domain_name":"tffunctendermahavirafd8wbcil-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"redirected","id":"8db55bf0-de18-43dc-b273-00d1619c3a86","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"8eb8f345-ba2e-4c96-a4fa-e033ca702001","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-24T15:44:41.553352Z"}'
+        body: '{"created_at":"2025-08-27T15:05:33.909345Z","description":"","environment_variables":{},"error_message":null,"id":"ed53546c-704b-477f-a26a-be53dc3d479a","name":"tf-func-crazy-agnesi","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunccrazyagnesijpitejsy","registry_namespace_id":"cec6184c-4f79-444c-b3ad-2b2faf3eadf5","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:53.194419Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "677"
+                - "585"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:44 GMT
+                - Wed, 27 Aug 2025 15:06:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1032,10 +1032,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 04d77193-6dfe-4cfb-8a7e-7ca639ec4cfb
+                - 21c39a6a-b2df-468b-a253-359345a8b03b
         status: 200 OK
         code: 200
-        duration: 72.599542ms
+        duration: 44.181876ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1051,8 +1051,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/8db55bf0-de18-43dc-b273-00d1619c3a86
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/545a6aa8-2d3b-4fb7-a470-d926627b679a
         method: GET
       response:
         proto: HTTP/2.0
@@ -1060,20 +1060,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 677
+        content_length: 710
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:33.190459Z","description":"","domain_name":"tffunctendermahavirafd8wbcil-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"redirected","id":"8db55bf0-de18-43dc-b273-00d1619c3a86","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"8eb8f345-ba2e-4c96-a4fa-e033ca702001","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-24T15:44:41.553352Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:54.892804Z","description":"","domain_name":"tffunccrazyagnesijpitejsy-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"redirected","id":"545a6aa8-2d3b-4fb7-a470-d926627b679a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"ed53546c-704b-477f-a26a-be53dc3d479a","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:02.375234Z"}'
         headers:
             Content-Length:
-                - "677"
+                - "710"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:45 GMT
+                - Wed, 27 Aug 2025 15:06:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1081,11 +1081,158 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 427cf5c3-8c64-4b3b-9a5a-65f9563b68b2
+                - 872787cd-9bad-4a21-9b3c-ea7aa6722063
         status: 200 OK
         code: 200
-        duration: 80.685583ms
+        duration: 48.034896ms
     - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/ed53546c-704b-477f-a26a-be53dc3d479a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 585
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:33.909345Z","description":"","environment_variables":{},"error_message":null,"id":"ed53546c-704b-477f-a26a-be53dc3d479a","name":"tf-func-crazy-agnesi","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunccrazyagnesijpitejsy","registry_namespace_id":"cec6184c-4f79-444c-b3ad-2b2faf3eadf5","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:53.194419Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "585"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:03 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 60575308-8506-4392-a0dd-5f71f6e77c32
+        status: 200 OK
+        code: 200
+        duration: 41.845051ms
+    - id: 23
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/545a6aa8-2d3b-4fb7-a470-d926627b679a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 710
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:54.892804Z","description":"","domain_name":"tffunccrazyagnesijpitejsy-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"redirected","id":"545a6aa8-2d3b-4fb7-a470-d926627b679a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"ed53546c-704b-477f-a26a-be53dc3d479a","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:02.375234Z"}'
+        headers:
+            Content-Length:
+                - "710"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:03 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 7fad7afa-a935-476f-9cb7-e3788d3b0b8b
+        status: 200 OK
+        code: 200
+        duration: 51.525176ms
+    - id: 24
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/545a6aa8-2d3b-4fb7-a470-d926627b679a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 710
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:54.892804Z","description":"","domain_name":"tffunccrazyagnesijpitejsy-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"redirected","id":"545a6aa8-2d3b-4fb7-a470-d926627b679a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"ed53546c-704b-477f-a26a-be53dc3d479a","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:02.375234Z"}'
+        headers:
+            Content-Length:
+                - "710"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:03 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ed4b3064-2e00-4c18-977c-68e8b0b39f54
+        status: 200 OK
+        code: 200
+        duration: 54.21863ms
+    - id: 25
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1102,8 +1249,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/8db55bf0-de18-43dc-b273-00d1619c3a86
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/545a6aa8-2d3b-4fb7-a470-d926627b679a
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -1111,20 +1258,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 667
+        content_length: 700
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:33.190459Z","description":"","domain_name":"tffunctendermahavirafd8wbcil-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"8db55bf0-de18-43dc-b273-00d1619c3a86","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"8eb8f345-ba2e-4c96-a4fa-e033ca702001","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","timeout":"300s","updated_at":"2025-01-24T15:44:45.152255645Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:54.892804Z","description":"","domain_name":"tffunccrazyagnesijpitejsy-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"545a6aa8-2d3b-4fb7-a470-d926627b679a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"ed53546c-704b-477f-a26a-be53dc3d479a","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:03.989202752Z"}'
         headers:
             Content-Length:
-                - "667"
+                - "700"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:45 GMT
+                - Wed, 27 Aug 2025 15:06:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1132,157 +1279,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - af2c2713-3f9d-47a1-a88e-da0eabbbaab2
+                - 1ea1fcac-6fc8-4663-93d2-374d5a609fdf
         status: 200 OK
         code: 200
-        duration: 118.161042ms
-    - id: 23
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/8db55bf0-de18-43dc-b273-00d1619c3a86
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 664
-        uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:33.190459Z","description":"","domain_name":"tffunctendermahavirafd8wbcil-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"8db55bf0-de18-43dc-b273-00d1619c3a86","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"8eb8f345-ba2e-4c96-a4fa-e033ca702001","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","timeout":"300s","updated_at":"2025-01-24T15:44:45.152256Z"}'
-        headers:
-            Content-Length:
-                - "664"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:44:46 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 4a14fe61-ea9a-465b-8a76-aed7b8943a25
-        status: 200 OK
-        code: 200
-        duration: 89.417042ms
-    - id: 24
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/8db55bf0-de18-43dc-b273-00d1619c3a86
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 674
-        uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:33.190459Z","description":"","domain_name":"tffunctendermahavirafd8wbcil-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"8db55bf0-de18-43dc-b273-00d1619c3a86","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"8eb8f345-ba2e-4c96-a4fa-e033ca702001","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-24T15:44:50.624461Z"}'
-        headers:
-            Content-Length:
-                - "674"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:44:51 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 6ea89008-3116-4db7-a999-5dc9b7d82770
-        status: 200 OK
-        code: 200
-        duration: 75.051875ms
-    - id: 25
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/8db55bf0-de18-43dc-b273-00d1619c3a86
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 674
-        uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:33.190459Z","description":"","domain_name":"tffunctendermahavirafd8wbcil-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"8db55bf0-de18-43dc-b273-00d1619c3a86","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"8eb8f345-ba2e-4c96-a4fa-e033ca702001","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-24T15:44:50.624461Z"}'
-        headers:
-            Content-Length:
-                - "674"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:44:51 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 9a6ce912-2eeb-4893-8ead-4a8cedb2d2d7
-        status: 200 OK
-        code: 200
-        duration: 76.131667ms
+        duration: 69.148606ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1298,8 +1298,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8eb8f345-ba2e-4c96-a4fa-e033ca702001
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/545a6aa8-2d3b-4fb7-a470-d926627b679a
         method: GET
       response:
         proto: HTTP/2.0
@@ -1307,20 +1307,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 558
+        content_length: 697
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:27.735114Z","description":"","environment_variables":{},"error_message":null,"id":"8eb8f345-ba2e-4c96-a4fa-e033ca702001","name":"tf-func-tender-mahavira","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunctendermahavirafd8wbcil","registry_namespace_id":"68c82c14-5b95-40a1-aa66-e4a83dbb5e96","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:44:29.031470Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:54.892804Z","description":"","domain_name":"tffunccrazyagnesijpitejsy-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"545a6aa8-2d3b-4fb7-a470-d926627b679a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"ed53546c-704b-477f-a26a-be53dc3d479a","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:03.989203Z"}'
         headers:
             Content-Length:
-                - "558"
+                - "697"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:52 GMT
+                - Wed, 27 Aug 2025 15:06:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1328,10 +1328,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 75dcbae9-5ae3-45f7-9079-a0a7e88902c3
+                - 23781bdc-9b4b-4fd3-87d8-7e9fc7bc886f
         status: 200 OK
         code: 200
-        duration: 69.142667ms
+        duration: 58.749983ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1347,8 +1347,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/8db55bf0-de18-43dc-b273-00d1619c3a86
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/545a6aa8-2d3b-4fb7-a470-d926627b679a
         method: GET
       response:
         proto: HTTP/2.0
@@ -1356,20 +1356,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 674
+        content_length: 697
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:33.190459Z","description":"","domain_name":"tffunctendermahavirafd8wbcil-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"8db55bf0-de18-43dc-b273-00d1619c3a86","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"8eb8f345-ba2e-4c96-a4fa-e033ca702001","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-24T15:44:50.624461Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:54.892804Z","description":"","domain_name":"tffunccrazyagnesijpitejsy-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"545a6aa8-2d3b-4fb7-a470-d926627b679a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"ed53546c-704b-477f-a26a-be53dc3d479a","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:03.989203Z"}'
         headers:
             Content-Length:
-                - "674"
+                - "697"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:52 GMT
+                - Wed, 27 Aug 2025 15:06:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1377,10 +1377,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - aa4d02f5-cfcd-47a3-a76c-51ed4a25da96
+                - a5cdba88-4e17-44a2-ac98-60630906600d
         status: 200 OK
         code: 200
-        duration: 75.985791ms
+        duration: 52.978265ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1396,8 +1396,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/8db55bf0-de18-43dc-b273-00d1619c3a86
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/545a6aa8-2d3b-4fb7-a470-d926627b679a
         method: GET
       response:
         proto: HTTP/2.0
@@ -1405,20 +1405,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 674
+        content_length: 707
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:33.190459Z","description":"","domain_name":"tffunctendermahavirafd8wbcil-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"8db55bf0-de18-43dc-b273-00d1619c3a86","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"8eb8f345-ba2e-4c96-a4fa-e033ca702001","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-24T15:44:50.624461Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:54.892804Z","description":"","domain_name":"tffunccrazyagnesijpitejsy-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"545a6aa8-2d3b-4fb7-a470-d926627b679a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"ed53546c-704b-477f-a26a-be53dc3d479a","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:11.008703Z"}'
         headers:
             Content-Length:
-                - "674"
+                - "707"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:53 GMT
+                - Wed, 27 Aug 2025 15:06:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1426,10 +1426,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4b904031-27ae-4214-a649-9967001ac4a3
+                - 0e8bcc14-abba-41cb-b3e2-be3e6e6650ad
         status: 200 OK
         code: 200
-        duration: 71.865792ms
+        duration: 45.367022ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1445,29 +1445,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/8db55bf0-de18-43dc-b273-00d1619c3a86
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/545a6aa8-2d3b-4fb7-a470-d926627b679a
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 668
+        content_length: 707
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:33.190459Z","description":"","domain_name":"tffunctendermahavirafd8wbcil-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"8db55bf0-de18-43dc-b273-00d1619c3a86","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"8eb8f345-ba2e-4c96-a4fa-e033ca702001","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"deleting","timeout":"300s","updated_at":"2025-01-24T15:44:53.335646397Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:54.892804Z","description":"","domain_name":"tffunccrazyagnesijpitejsy-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"545a6aa8-2d3b-4fb7-a470-d926627b679a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"ed53546c-704b-477f-a26a-be53dc3d479a","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:11.008703Z"}'
         headers:
             Content-Length:
-                - "668"
+                - "707"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:53 GMT
+                - Wed, 27 Aug 2025 15:06:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1475,10 +1475,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9539f59c-8f70-40a8-b06e-f7854fe278d0
+                - 29c210f1-eba9-4429-96e8-3fb97812b300
         status: 200 OK
         code: 200
-        duration: 158.743417ms
+        duration: 61.312684ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1494,8 +1494,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8eb8f345-ba2e-4c96-a4fa-e033ca702001
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/ed53546c-704b-477f-a26a-be53dc3d479a
         method: GET
       response:
         proto: HTTP/2.0
@@ -1503,20 +1503,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 558
+        content_length: 585
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:27.735114Z","description":"","environment_variables":{},"error_message":null,"id":"8eb8f345-ba2e-4c96-a4fa-e033ca702001","name":"tf-func-tender-mahavira","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunctendermahavirafd8wbcil","registry_namespace_id":"68c82c14-5b95-40a1-aa66-e4a83dbb5e96","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:44:29.031470Z"}'
+        body: '{"created_at":"2025-08-27T15:05:33.909345Z","description":"","environment_variables":{},"error_message":null,"id":"ed53546c-704b-477f-a26a-be53dc3d479a","name":"tf-func-crazy-agnesi","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunccrazyagnesijpitejsy","registry_namespace_id":"cec6184c-4f79-444c-b3ad-2b2faf3eadf5","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:53.194419Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "558"
+                - "585"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:53 GMT
+                - Wed, 27 Aug 2025 15:06:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1524,10 +1524,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 981972a0-bc20-4c32-84ba-7d38a0d01822
+                - 7825667b-84aa-4855-9f99-9d5e025be1c8
         status: 200 OK
         code: 200
-        duration: 70.833958ms
+        duration: 38.447597ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1543,29 +1543,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8eb8f345-ba2e-4c96-a4fa-e033ca702001
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/545a6aa8-2d3b-4fb7-a470-d926627b679a
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 564
+        content_length: 707
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:27.735114Z","description":"","environment_variables":{},"error_message":null,"id":"8eb8f345-ba2e-4c96-a4fa-e033ca702001","name":"tf-func-tender-mahavira","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunctendermahavirafd8wbcil","registry_namespace_id":"68c82c14-5b95-40a1-aa66-e4a83dbb5e96","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:44:53.549146402Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:54.892804Z","description":"","domain_name":"tffunccrazyagnesijpitejsy-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"545a6aa8-2d3b-4fb7-a470-d926627b679a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"ed53546c-704b-477f-a26a-be53dc3d479a","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:11.008703Z"}'
         headers:
             Content-Length:
-                - "564"
+                - "707"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:53 GMT
+                - Wed, 27 Aug 2025 15:06:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1573,10 +1573,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4fac6de6-e823-4013-b8fc-cd5be74f651e
+                - 0c053e02-df19-4d7c-a7ec-b97aeee20904
         status: 200 OK
         code: 200
-        duration: 212.598ms
+        duration: 60.629933ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1592,8 +1592,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8eb8f345-ba2e-4c96-a4fa-e033ca702001
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/545a6aa8-2d3b-4fb7-a470-d926627b679a
         method: GET
       response:
         proto: HTTP/2.0
@@ -1601,20 +1601,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 561
+        content_length: 707
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:27.735114Z","description":"","environment_variables":{},"error_message":null,"id":"8eb8f345-ba2e-4c96-a4fa-e033ca702001","name":"tf-func-tender-mahavira","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunctendermahavirafd8wbcil","registry_namespace_id":"68c82c14-5b95-40a1-aa66-e4a83dbb5e96","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:44:53.549146Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:54.892804Z","description":"","domain_name":"tffunccrazyagnesijpitejsy-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"545a6aa8-2d3b-4fb7-a470-d926627b679a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"ed53546c-704b-477f-a26a-be53dc3d479a","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:11.008703Z"}'
         headers:
             Content-Length:
-                - "561"
+                - "707"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:53 GMT
+                - Wed, 27 Aug 2025 15:06:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1622,10 +1622,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 078e00ed-0c4a-4fc3-988e-53f16ae0f80b
+                - 972008c6-ed0d-4d0e-8d6b-0d9e82588d55
         status: 200 OK
         code: 200
-        duration: 66.499541ms
+        duration: 50.541072ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1641,29 +1641,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8eb8f345-ba2e-4c96-a4fa-e033ca702001
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/545a6aa8-2d3b-4fb7-a470-d926627b679a
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 561
+        content_length: 701
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:27.735114Z","description":"","environment_variables":{},"error_message":null,"id":"8eb8f345-ba2e-4c96-a4fa-e033ca702001","name":"tf-func-tender-mahavira","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunctendermahavirafd8wbcil","registry_namespace_id":"68c82c14-5b95-40a1-aa66-e4a83dbb5e96","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:44:53.549146Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:54.892804Z","description":"","domain_name":"tffunccrazyagnesijpitejsy-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"545a6aa8-2d3b-4fb7-a470-d926627b679a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"ed53546c-704b-477f-a26a-be53dc3d479a","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:16.206127772Z"}'
         headers:
             Content-Length:
-                - "561"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:58 GMT
+                - Wed, 27 Aug 2025 15:06:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1671,10 +1671,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 850526ee-fa79-42ce-9e67-bed75af3a656
+                - d0ca24ea-cfb4-4c08-be26-d562333139b3
         status: 200 OK
         code: 200
-        duration: 62.416291ms
+        duration: 187.622968ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1690,8 +1690,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8eb8f345-ba2e-4c96-a4fa-e033ca702001
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/ed53546c-704b-477f-a26a-be53dc3d479a
         method: GET
       response:
         proto: HTTP/2.0
@@ -1699,20 +1699,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 561
+        content_length: 585
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:27.735114Z","description":"","environment_variables":{},"error_message":null,"id":"8eb8f345-ba2e-4c96-a4fa-e033ca702001","name":"tf-func-tender-mahavira","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunctendermahavirafd8wbcil","registry_namespace_id":"68c82c14-5b95-40a1-aa66-e4a83dbb5e96","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:44:53.549146Z"}'
+        body: '{"created_at":"2025-08-27T15:05:33.909345Z","description":"","environment_variables":{},"error_message":null,"id":"ed53546c-704b-477f-a26a-be53dc3d479a","name":"tf-func-crazy-agnesi","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunccrazyagnesijpitejsy","registry_namespace_id":"cec6184c-4f79-444c-b3ad-2b2faf3eadf5","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:53.194419Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "561"
+                - "585"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:03 GMT
+                - Wed, 27 Aug 2025 15:06:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1720,10 +1720,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0a692e37-37db-4431-892a-4cdf57302983
+                - 67ad928c-6060-4201-a8ab-7da9262df76a
         status: 200 OK
         code: 200
-        duration: 65.6945ms
+        duration: 46.696466ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1739,29 +1739,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8eb8f345-ba2e-4c96-a4fa-e033ca702001
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/ed53546c-704b-477f-a26a-be53dc3d479a
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 561
+        content_length: 591
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:27.735114Z","description":"","environment_variables":{},"error_message":null,"id":"8eb8f345-ba2e-4c96-a4fa-e033ca702001","name":"tf-func-tender-mahavira","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunctendermahavirafd8wbcil","registry_namespace_id":"68c82c14-5b95-40a1-aa66-e4a83dbb5e96","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:44:53.549146Z"}'
+        body: '{"created_at":"2025-08-27T15:05:33.909345Z","description":"","environment_variables":{},"error_message":null,"id":"ed53546c-704b-477f-a26a-be53dc3d479a","name":"tf-func-crazy-agnesi","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunccrazyagnesijpitejsy","registry_namespace_id":"cec6184c-4f79-444c-b3ad-2b2faf3eadf5","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:16.389690809Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "561"
+                - "591"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:08 GMT
+                - Wed, 27 Aug 2025 15:06:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1769,10 +1769,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3f65a669-4ca0-402b-89c3-d8620fcd3897
+                - faac7098-01ea-443b-9f59-5d6b7de8767d
         status: 200 OK
         code: 200
-        duration: 67.117958ms
+        duration: 392.991655ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1788,8 +1788,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8eb8f345-ba2e-4c96-a4fa-e033ca702001
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/ed53546c-704b-477f-a26a-be53dc3d479a
         method: GET
       response:
         proto: HTTP/2.0
@@ -1797,20 +1797,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 561
+        content_length: 588
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:27.735114Z","description":"","environment_variables":{},"error_message":null,"id":"8eb8f345-ba2e-4c96-a4fa-e033ca702001","name":"tf-func-tender-mahavira","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunctendermahavirafd8wbcil","registry_namespace_id":"68c82c14-5b95-40a1-aa66-e4a83dbb5e96","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:44:53.549146Z"}'
+        body: '{"created_at":"2025-08-27T15:05:33.909345Z","description":"","environment_variables":{},"error_message":null,"id":"ed53546c-704b-477f-a26a-be53dc3d479a","name":"tf-func-crazy-agnesi","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunccrazyagnesijpitejsy","registry_namespace_id":"cec6184c-4f79-444c-b3ad-2b2faf3eadf5","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:16.389691Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "561"
+                - "588"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:14 GMT
+                - Wed, 27 Aug 2025 15:06:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1818,10 +1818,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 57d1301d-3ace-4272-99f6-81773ee939d2
+                - 4f003fed-0b93-4994-9e27-cd336d66bc89
         status: 200 OK
         code: 200
-        duration: 80.788125ms
+        duration: 80.888348ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1837,106 +1837,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8eb8f345-ba2e-4c96-a4fa-e033ca702001
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 561
-        uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:27.735114Z","description":"","environment_variables":{},"error_message":null,"id":"8eb8f345-ba2e-4c96-a4fa-e033ca702001","name":"tf-func-tender-mahavira","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunctendermahavirafd8wbcil","registry_namespace_id":"68c82c14-5b95-40a1-aa66-e4a83dbb5e96","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:44:53.549146Z"}'
-        headers:
-            Content-Length:
-                - "561"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:45:19 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 6494d13a-819e-405b-a322-cb90ad283e66
-        status: 200 OK
-        code: 200
-        duration: 58.302542ms
-    - id: 38
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8eb8f345-ba2e-4c96-a4fa-e033ca702001
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 561
-        uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:27.735114Z","description":"","environment_variables":{},"error_message":null,"id":"8eb8f345-ba2e-4c96-a4fa-e033ca702001","name":"tf-func-tender-mahavira","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunctendermahavirafd8wbcil","registry_namespace_id":"68c82c14-5b95-40a1-aa66-e4a83dbb5e96","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:44:53.549146Z"}'
-        headers:
-            Content-Length:
-                - "561"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:45:24 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - b09863c0-ab52-4cf5-ba89-3be8ac084996
-        status: 200 OK
-        code: 200
-        duration: 65.98825ms
-    - id: 39
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8eb8f345-ba2e-4c96-a4fa-e033ca702001
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/ed53546c-704b-477f-a26a-be53dc3d479a
         method: GET
       response:
         proto: HTTP/2.0
@@ -1955,9 +1857,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:29 GMT
+                - Wed, 27 Aug 2025 15:06:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1965,11 +1867,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ad565cff-a170-4ca8-9cc4-18b918022af3
+                - 034e801c-260c-40be-bc3d-583203f85e30
         status: 404 Not Found
         code: 404
-        duration: 26.413333ms
-    - id: 40
+        duration: 20.121629ms
+    - id: 38
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1984,8 +1886,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/8db55bf0-de18-43dc-b273-00d1619c3a86
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/545a6aa8-2d3b-4fb7-a470-d926627b679a
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -2004,9 +1906,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:29 GMT
+                - Wed, 27 Aug 2025 15:06:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2014,7 +1916,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 03ac4764-6de6-4094-8174-044e664a00e2
+                - 6930eec7-49c8-43b5-976a-e7f1ca820c63
         status: 404 Not Found
         code: 404
-        duration: 25.615875ms
+        duration: 22.441192ms

--- a/internal/services/function/testdata/function-namespace-basic.cassette.yaml
+++ b/internal/services/function/testdata/function-namespace-basic.cassette.yaml
@@ -6,19 +6,19 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 160
+        content_length: 192
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"test-cr-ns-01","environment_variables":{},"project_id":"6867048b-fe12-4e96-835e-41c79a39604b","secret_environment_variables":[],"tags":["tag1","tag2"]}'
+        body: '{"name":"test-cr-ns-01","environment_variables":{},"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","secret_environment_variables":[],"tags":["tag1","tag2"],"activate_vpc_integration":true}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces
         method: POST
       response:
@@ -27,20 +27,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 493
+        content_length: 511
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:22:40.494216669Z","description":"","environment_variables":{},"error_message":null,"id":"fc04be20-4e4e-453b-9ad3-525f34966b7c","name":"test-cr-ns-01","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":["tag1","tag2"],"updated_at":"2025-04-28T09:22:40.494216669Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.579176981Z","description":"","environment_variables":{},"error_message":null,"id":"7a163fbc-3009-45ba-bd7d-0e9d7fb19e7f","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":["tag1","tag2"],"updated_at":"2025-08-27T15:05:13.579176981Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "493"
+                - "511"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:40 GMT
+                - Wed, 27 Aug 2025 15:05:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ea5b22cb-1bb9-4566-91fd-aa632aafeab5
+                - 358475fe-ec5e-43f8-aae3-3e263d69ab0a
         status: 200 OK
         code: 200
-        duration: 2.533517125s
+        duration: 5.524412395s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -67,8 +67,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/fc04be20-4e4e-453b-9ad3-525f34966b7c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7a163fbc-3009-45ba-bd7d-0e9d7fb19e7f
         method: GET
       response:
         proto: HTTP/2.0
@@ -76,20 +76,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 487
+        content_length: 505
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:22:40.494217Z","description":"","environment_variables":{},"error_message":null,"id":"fc04be20-4e4e-453b-9ad3-525f34966b7c","name":"test-cr-ns-01","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":["tag1","tag2"],"updated_at":"2025-04-28T09:22:40.494217Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.579177Z","description":"","environment_variables":{},"error_message":null,"id":"7a163fbc-3009-45ba-bd7d-0e9d7fb19e7f","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":["tag1","tag2"],"updated_at":"2025-08-27T15:05:13.579177Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "487"
+                - "505"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:40 GMT
+                - Wed, 27 Aug 2025 15:05:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - af611572-e87d-45bc-bc4f-38b40a9b449e
+                - b86c81ba-33da-44a7-b8e0-8f49171758fd
         status: 200 OK
         code: 200
-        duration: 48.9635ms
+        duration: 70.509348ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -116,8 +116,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/fc04be20-4e4e-453b-9ad3-525f34966b7c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7a163fbc-3009-45ba-bd7d-0e9d7fb19e7f
         method: GET
       response:
         proto: HTTP/2.0
@@ -125,20 +125,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 566
+        content_length: 584
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:22:40.494217Z","description":"","environment_variables":{},"error_message":null,"id":"fc04be20-4e4e-453b-9ad3-525f34966b7c","name":"test-cr-ns-01","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01t9lb5wey","registry_namespace_id":"ad8d9981-507f-4741-9890-8f5a1a560971","secret_environment_variables":[],"status":"ready","tags":["tag1","tag2"],"updated_at":"2025-04-28T09:22:43.605084Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.579177Z","description":"","environment_variables":{},"error_message":null,"id":"7a163fbc-3009-45ba-bd7d-0e9d7fb19e7f","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01clubjwdn","registry_namespace_id":"dc93fed2-6c5e-4ef5-ada6-742bc69df18c","secret_environment_variables":[],"status":"ready","tags":["tag1","tag2"],"updated_at":"2025-08-27T15:05:18.111548Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "566"
+                - "584"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:45 GMT
+                - Wed, 27 Aug 2025 15:05:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -146,10 +146,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 44c8bfea-5ecb-45ed-828c-5a7d7882b952
+                - 65260c1e-5a21-45b6-a32d-7ace3ef50aba
         status: 200 OK
         code: 200
-        duration: 40.482041ms
+        duration: 496.199152ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -165,8 +165,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/fc04be20-4e4e-453b-9ad3-525f34966b7c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7a163fbc-3009-45ba-bd7d-0e9d7fb19e7f
         method: GET
       response:
         proto: HTTP/2.0
@@ -174,20 +174,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 566
+        content_length: 584
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:22:40.494217Z","description":"","environment_variables":{},"error_message":null,"id":"fc04be20-4e4e-453b-9ad3-525f34966b7c","name":"test-cr-ns-01","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01t9lb5wey","registry_namespace_id":"ad8d9981-507f-4741-9890-8f5a1a560971","secret_environment_variables":[],"status":"ready","tags":["tag1","tag2"],"updated_at":"2025-04-28T09:22:43.605084Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.579177Z","description":"","environment_variables":{},"error_message":null,"id":"7a163fbc-3009-45ba-bd7d-0e9d7fb19e7f","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01clubjwdn","registry_namespace_id":"dc93fed2-6c5e-4ef5-ada6-742bc69df18c","secret_environment_variables":[],"status":"ready","tags":["tag1","tag2"],"updated_at":"2025-08-27T15:05:18.111548Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "566"
+                - "584"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:45 GMT
+                - Wed, 27 Aug 2025 15:05:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -195,10 +195,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2c42455d-06b9-41ae-8846-e98eeae1415f
+                - 30d63781-2a69-4220-a1f8-3b690d7280c8
         status: 200 OK
         code: 200
-        duration: 98.836542ms
+        duration: 47.57161ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -214,8 +214,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/fc04be20-4e4e-453b-9ad3-525f34966b7c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7a163fbc-3009-45ba-bd7d-0e9d7fb19e7f
         method: GET
       response:
         proto: HTTP/2.0
@@ -223,20 +223,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 566
+        content_length: 584
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:22:40.494217Z","description":"","environment_variables":{},"error_message":null,"id":"fc04be20-4e4e-453b-9ad3-525f34966b7c","name":"test-cr-ns-01","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01t9lb5wey","registry_namespace_id":"ad8d9981-507f-4741-9890-8f5a1a560971","secret_environment_variables":[],"status":"ready","tags":["tag1","tag2"],"updated_at":"2025-04-28T09:22:43.605084Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.579177Z","description":"","environment_variables":{},"error_message":null,"id":"7a163fbc-3009-45ba-bd7d-0e9d7fb19e7f","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01clubjwdn","registry_namespace_id":"dc93fed2-6c5e-4ef5-ada6-742bc69df18c","secret_environment_variables":[],"status":"ready","tags":["tag1","tag2"],"updated_at":"2025-08-27T15:05:18.111548Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "566"
+                - "584"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:45 GMT
+                - Wed, 27 Aug 2025 15:05:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -244,10 +244,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 773e2d0d-68c8-4cd8-a4c6-a1292e58a371
+                - e3e7ade7-cc11-4301-b0d3-e094b73f448c
         status: 200 OK
         code: 200
-        duration: 44.297041ms
+        duration: 47.106087ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -263,8 +263,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/fc04be20-4e4e-453b-9ad3-525f34966b7c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7a163fbc-3009-45ba-bd7d-0e9d7fb19e7f
         method: GET
       response:
         proto: HTTP/2.0
@@ -272,20 +272,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 566
+        content_length: 584
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:22:40.494217Z","description":"","environment_variables":{},"error_message":null,"id":"fc04be20-4e4e-453b-9ad3-525f34966b7c","name":"test-cr-ns-01","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01t9lb5wey","registry_namespace_id":"ad8d9981-507f-4741-9890-8f5a1a560971","secret_environment_variables":[],"status":"ready","tags":["tag1","tag2"],"updated_at":"2025-04-28T09:22:43.605084Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.579177Z","description":"","environment_variables":{},"error_message":null,"id":"7a163fbc-3009-45ba-bd7d-0e9d7fb19e7f","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01clubjwdn","registry_namespace_id":"dc93fed2-6c5e-4ef5-ada6-742bc69df18c","secret_environment_variables":[],"status":"ready","tags":["tag1","tag2"],"updated_at":"2025-08-27T15:05:18.111548Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "566"
+                - "584"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:46 GMT
+                - Wed, 27 Aug 2025 15:05:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -293,10 +293,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cc1724da-91d3-4908-a76c-4aab6c8890f5
+                - 64497928-8d38-4a5f-93e0-fb1dcdbfd625
         status: 200 OK
         code: 200
-        duration: 98.133958ms
+        duration: 46.634552ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -312,8 +312,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/fc04be20-4e4e-453b-9ad3-525f34966b7c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7a163fbc-3009-45ba-bd7d-0e9d7fb19e7f
         method: GET
       response:
         proto: HTTP/2.0
@@ -321,20 +321,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 566
+        content_length: 584
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:22:40.494217Z","description":"","environment_variables":{},"error_message":null,"id":"fc04be20-4e4e-453b-9ad3-525f34966b7c","name":"test-cr-ns-01","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01t9lb5wey","registry_namespace_id":"ad8d9981-507f-4741-9890-8f5a1a560971","secret_environment_variables":[],"status":"ready","tags":["tag1","tag2"],"updated_at":"2025-04-28T09:22:43.605084Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.579177Z","description":"","environment_variables":{},"error_message":null,"id":"7a163fbc-3009-45ba-bd7d-0e9d7fb19e7f","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01clubjwdn","registry_namespace_id":"dc93fed2-6c5e-4ef5-ada6-742bc69df18c","secret_environment_variables":[],"status":"ready","tags":["tag1","tag2"],"updated_at":"2025-08-27T15:05:18.111548Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "566"
+                - "584"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:46 GMT
+                - Wed, 27 Aug 2025 15:05:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -342,10 +342,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e0ad6ffb-b127-4f77-be23-6758023ef2c6
+                - 36db3d53-363c-4a9d-8f0c-3ea21d367209
         status: 200 OK
         code: 200
-        duration: 39.063375ms
+        duration: 185.476766ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -361,8 +361,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/fc04be20-4e4e-453b-9ad3-525f34966b7c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7a163fbc-3009-45ba-bd7d-0e9d7fb19e7f
         method: GET
       response:
         proto: HTTP/2.0
@@ -370,20 +370,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 566
+        content_length: 584
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:22:40.494217Z","description":"","environment_variables":{},"error_message":null,"id":"fc04be20-4e4e-453b-9ad3-525f34966b7c","name":"test-cr-ns-01","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01t9lb5wey","registry_namespace_id":"ad8d9981-507f-4741-9890-8f5a1a560971","secret_environment_variables":[],"status":"ready","tags":["tag1","tag2"],"updated_at":"2025-04-28T09:22:43.605084Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.579177Z","description":"","environment_variables":{},"error_message":null,"id":"7a163fbc-3009-45ba-bd7d-0e9d7fb19e7f","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01clubjwdn","registry_namespace_id":"dc93fed2-6c5e-4ef5-ada6-742bc69df18c","secret_environment_variables":[],"status":"ready","tags":["tag1","tag2"],"updated_at":"2025-08-27T15:05:18.111548Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "566"
+                - "584"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:46 GMT
+                - Wed, 27 Aug 2025 15:05:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -391,10 +391,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4f307332-d279-4c66-b026-68bd5aeef6cb
+                - 9b6c470e-2e06-4817-958d-3b778982a99e
         status: 200 OK
         code: 200
-        duration: 101.122ms
+        duration: 47.811591ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -412,8 +412,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/fc04be20-4e4e-453b-9ad3-525f34966b7c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7a163fbc-3009-45ba-bd7d-0e9d7fb19e7f
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -421,20 +421,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 581
+        content_length: 600
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:22:40.494217Z","description":"test function namespace 01","environment_variables":{},"error_message":null,"id":"fc04be20-4e4e-453b-9ad3-525f34966b7c","name":"test-cr-ns-01","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01t9lb5wey","registry_namespace_id":"ad8d9981-507f-4741-9890-8f5a1a560971","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-28T09:22:46.591763228Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.579177Z","description":"test function namespace 01","environment_variables":{},"error_message":null,"id":"7a163fbc-3009-45ba-bd7d-0e9d7fb19e7f","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01clubjwdn","registry_namespace_id":"dc93fed2-6c5e-4ef5-ada6-742bc69df18c","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:20.795623505Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "581"
+                - "600"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:46 GMT
+                - Wed, 27 Aug 2025 15:05:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -442,10 +442,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0217a115-268c-4afe-8e67-7cf5522b3cf1
+                - b564435f-ab4f-480a-9e54-c9a8bed06cbb
         status: 200 OK
         code: 200
-        duration: 60.779625ms
+        duration: 69.692296ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -461,8 +461,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/fc04be20-4e4e-453b-9ad3-525f34966b7c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7a163fbc-3009-45ba-bd7d-0e9d7fb19e7f
         method: GET
       response:
         proto: HTTP/2.0
@@ -470,20 +470,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 578
+        content_length: 597
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:22:40.494217Z","description":"test function namespace 01","environment_variables":{},"error_message":null,"id":"fc04be20-4e4e-453b-9ad3-525f34966b7c","name":"test-cr-ns-01","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01t9lb5wey","registry_namespace_id":"ad8d9981-507f-4741-9890-8f5a1a560971","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-28T09:22:46.591763Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.579177Z","description":"test function namespace 01","environment_variables":{},"error_message":null,"id":"7a163fbc-3009-45ba-bd7d-0e9d7fb19e7f","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01clubjwdn","registry_namespace_id":"dc93fed2-6c5e-4ef5-ada6-742bc69df18c","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:20.795624Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "578"
+                - "597"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:46 GMT
+                - Wed, 27 Aug 2025 15:05:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -491,10 +491,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4fef9e88-363a-4e12-8a51-ea471e47246c
+                - 1447b56f-b93e-4943-9102-6c11a952b667
         status: 200 OK
         code: 200
-        duration: 52.158334ms
+        duration: 56.319114ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -510,8 +510,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/fc04be20-4e4e-453b-9ad3-525f34966b7c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7a163fbc-3009-45ba-bd7d-0e9d7fb19e7f
         method: GET
       response:
         proto: HTTP/2.0
@@ -519,20 +519,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 578
+        content_length: 597
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:22:40.494217Z","description":"test function namespace 01","environment_variables":{},"error_message":null,"id":"fc04be20-4e4e-453b-9ad3-525f34966b7c","name":"test-cr-ns-01","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01t9lb5wey","registry_namespace_id":"ad8d9981-507f-4741-9890-8f5a1a560971","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-28T09:22:46.591763Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.579177Z","description":"test function namespace 01","environment_variables":{},"error_message":null,"id":"7a163fbc-3009-45ba-bd7d-0e9d7fb19e7f","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01clubjwdn","registry_namespace_id":"dc93fed2-6c5e-4ef5-ada6-742bc69df18c","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:20.795624Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "578"
+                - "597"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:46 GMT
+                - Wed, 27 Aug 2025 15:05:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -540,10 +540,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 52130075-48f5-4823-9ef3-5588442b5a41
+                - 922ff581-5cc8-4fd9-be85-3617acf85c21
         status: 200 OK
         code: 200
-        duration: 92.636166ms
+        duration: 49.671881ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -559,8 +559,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/fc04be20-4e4e-453b-9ad3-525f34966b7c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7a163fbc-3009-45ba-bd7d-0e9d7fb19e7f
         method: GET
       response:
         proto: HTTP/2.0
@@ -568,20 +568,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 578
+        content_length: 597
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:22:40.494217Z","description":"test function namespace 01","environment_variables":{},"error_message":null,"id":"fc04be20-4e4e-453b-9ad3-525f34966b7c","name":"test-cr-ns-01","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01t9lb5wey","registry_namespace_id":"ad8d9981-507f-4741-9890-8f5a1a560971","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-28T09:22:46.591763Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.579177Z","description":"test function namespace 01","environment_variables":{},"error_message":null,"id":"7a163fbc-3009-45ba-bd7d-0e9d7fb19e7f","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01clubjwdn","registry_namespace_id":"dc93fed2-6c5e-4ef5-ada6-742bc69df18c","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:20.795624Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "578"
+                - "597"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:47 GMT
+                - Wed, 27 Aug 2025 15:05:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -589,10 +589,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - eb1ab234-f6b3-459d-a7d2-67a1ca73f860
+                - 4a6e919b-cc30-42bc-b8f7-795fe6364ef5
         status: 200 OK
         code: 200
-        duration: 360.20825ms
+        duration: 44.300814ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -608,8 +608,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/fc04be20-4e4e-453b-9ad3-525f34966b7c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7a163fbc-3009-45ba-bd7d-0e9d7fb19e7f
         method: GET
       response:
         proto: HTTP/2.0
@@ -617,20 +617,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 578
+        content_length: 597
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:22:40.494217Z","description":"test function namespace 01","environment_variables":{},"error_message":null,"id":"fc04be20-4e4e-453b-9ad3-525f34966b7c","name":"test-cr-ns-01","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01t9lb5wey","registry_namespace_id":"ad8d9981-507f-4741-9890-8f5a1a560971","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-28T09:22:46.591763Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.579177Z","description":"test function namespace 01","environment_variables":{},"error_message":null,"id":"7a163fbc-3009-45ba-bd7d-0e9d7fb19e7f","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01clubjwdn","registry_namespace_id":"dc93fed2-6c5e-4ef5-ada6-742bc69df18c","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:20.795624Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "578"
+                - "597"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:47 GMT
+                - Wed, 27 Aug 2025 15:05:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -638,10 +638,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f7d4185d-ed89-452d-88b5-cf40eb7169b8
+                - 65fa389b-1969-41f1-9a03-9aa69770a283
         status: 200 OK
         code: 200
-        duration: 35.451667ms
+        duration: 37.718923ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -657,8 +657,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/fc04be20-4e4e-453b-9ad3-525f34966b7c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7a163fbc-3009-45ba-bd7d-0e9d7fb19e7f
         method: GET
       response:
         proto: HTTP/2.0
@@ -666,20 +666,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 578
+        content_length: 597
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:22:40.494217Z","description":"test function namespace 01","environment_variables":{},"error_message":null,"id":"fc04be20-4e4e-453b-9ad3-525f34966b7c","name":"test-cr-ns-01","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01t9lb5wey","registry_namespace_id":"ad8d9981-507f-4741-9890-8f5a1a560971","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-28T09:22:46.591763Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.579177Z","description":"test function namespace 01","environment_variables":{},"error_message":null,"id":"7a163fbc-3009-45ba-bd7d-0e9d7fb19e7f","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01clubjwdn","registry_namespace_id":"dc93fed2-6c5e-4ef5-ada6-742bc69df18c","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:20.795624Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "578"
+                - "597"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:47 GMT
+                - Wed, 27 Aug 2025 15:05:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -687,10 +687,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 69446bc3-deaa-40b4-8d85-3db24e8ba1f4
+                - 09399db8-840f-4a49-be0d-429dc7e4fd3f
         status: 200 OK
         code: 200
-        duration: 85.425625ms
+        duration: 47.905727ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -708,8 +708,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/fc04be20-4e4e-453b-9ad3-525f34966b7c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7a163fbc-3009-45ba-bd7d-0e9d7fb19e7f
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -717,20 +717,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 707
+        content_length: 725
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:22:40.494217Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"fc04be20-4e4e-453b-9ad3-525f34966b7c","name":"test-cr-ns-01","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01t9lb5wey","registry_namespace_id":"ad8d9981-507f-4741-9890-8f5a1a560971","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$JeWATXYOwSI3HoSX0pOEKw$5+JS8+EXe5OepynxwiA6e2fL9Eyi8RM6H1b8xnv7EZM","key":"test_secret"}],"status":"pending","tags":[],"updated_at":"2025-04-28T09:22:48.243990782Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.579177Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"7a163fbc-3009-45ba-bd7d-0e9d7fb19e7f","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01clubjwdn","registry_namespace_id":"dc93fed2-6c5e-4ef5-ada6-742bc69df18c","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$HMmbRnMERK+V5dV0UPTIpQ$ahGOXBT31BnOZ2TvZNRHPvl6YKIMypEipczXpAiHtS8","key":"test_secret"}],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:22.355656658Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "707"
+                - "725"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:48 GMT
+                - Wed, 27 Aug 2025 15:05:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -738,10 +738,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a2083c0e-ad4f-44cd-b4f1-0918e55a1571
+                - 09c13310-1e27-469c-b9f9-46f17ba7a3e9
         status: 200 OK
         code: 200
-        duration: 562.586083ms
+        duration: 371.471496ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -757,8 +757,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/fc04be20-4e4e-453b-9ad3-525f34966b7c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7a163fbc-3009-45ba-bd7d-0e9d7fb19e7f
         method: GET
       response:
         proto: HTTP/2.0
@@ -766,20 +766,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 704
+        content_length: 722
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:22:40.494217Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"fc04be20-4e4e-453b-9ad3-525f34966b7c","name":"test-cr-ns-01","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01t9lb5wey","registry_namespace_id":"ad8d9981-507f-4741-9890-8f5a1a560971","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$JeWATXYOwSI3HoSX0pOEKw$5+JS8+EXe5OepynxwiA6e2fL9Eyi8RM6H1b8xnv7EZM","key":"test_secret"}],"status":"pending","tags":[],"updated_at":"2025-04-28T09:22:48.243991Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.579177Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"7a163fbc-3009-45ba-bd7d-0e9d7fb19e7f","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01clubjwdn","registry_namespace_id":"dc93fed2-6c5e-4ef5-ada6-742bc69df18c","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$HMmbRnMERK+V5dV0UPTIpQ$ahGOXBT31BnOZ2TvZNRHPvl6YKIMypEipczXpAiHtS8","key":"test_secret"}],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:22.355657Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "704"
+                - "722"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:48 GMT
+                - Wed, 27 Aug 2025 15:05:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -787,10 +787,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7e8480e1-a494-4c88-ac8a-bcf83c1d33f9
+                - e9fbb4a9-429c-4009-9182-50d7db297937
         status: 200 OK
         code: 200
-        duration: 91.182042ms
+        duration: 47.43247ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -806,8 +806,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/fc04be20-4e4e-453b-9ad3-525f34966b7c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7a163fbc-3009-45ba-bd7d-0e9d7fb19e7f
         method: GET
       response:
         proto: HTTP/2.0
@@ -815,20 +815,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 702
+        content_length: 720
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:22:40.494217Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"fc04be20-4e4e-453b-9ad3-525f34966b7c","name":"test-cr-ns-01","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01t9lb5wey","registry_namespace_id":"ad8d9981-507f-4741-9890-8f5a1a560971","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$JeWATXYOwSI3HoSX0pOEKw$5+JS8+EXe5OepynxwiA6e2fL9Eyi8RM6H1b8xnv7EZM","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2025-04-28T09:22:48.902011Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.579177Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"7a163fbc-3009-45ba-bd7d-0e9d7fb19e7f","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01clubjwdn","registry_namespace_id":"dc93fed2-6c5e-4ef5-ada6-742bc69df18c","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$HMmbRnMERK+V5dV0UPTIpQ$ahGOXBT31BnOZ2TvZNRHPvl6YKIMypEipczXpAiHtS8","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:22.851495Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "702"
+                - "720"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:53 GMT
+                - Wed, 27 Aug 2025 15:05:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -836,10 +836,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 31430b9e-0d73-40a3-9a4f-858fb52c9b2e
+                - cca80221-e1b7-428f-bcee-972a7d70e554
         status: 200 OK
         code: 200
-        duration: 32.854916ms
+        duration: 55.658335ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -855,8 +855,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/fc04be20-4e4e-453b-9ad3-525f34966b7c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7a163fbc-3009-45ba-bd7d-0e9d7fb19e7f
         method: GET
       response:
         proto: HTTP/2.0
@@ -864,20 +864,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 702
+        content_length: 720
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:22:40.494217Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"fc04be20-4e4e-453b-9ad3-525f34966b7c","name":"test-cr-ns-01","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01t9lb5wey","registry_namespace_id":"ad8d9981-507f-4741-9890-8f5a1a560971","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$JeWATXYOwSI3HoSX0pOEKw$5+JS8+EXe5OepynxwiA6e2fL9Eyi8RM6H1b8xnv7EZM","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2025-04-28T09:22:48.902011Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.579177Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"7a163fbc-3009-45ba-bd7d-0e9d7fb19e7f","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01clubjwdn","registry_namespace_id":"dc93fed2-6c5e-4ef5-ada6-742bc69df18c","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$HMmbRnMERK+V5dV0UPTIpQ$ahGOXBT31BnOZ2TvZNRHPvl6YKIMypEipczXpAiHtS8","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:22.851495Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "702"
+                - "720"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:53 GMT
+                - Wed, 27 Aug 2025 15:05:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -885,10 +885,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 40815627-38fa-4265-812f-0995c7eb2142
+                - d5633c7e-7e84-402e-b55f-5fd686b9674d
         status: 200 OK
         code: 200
-        duration: 61.984333ms
+        duration: 45.472162ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -904,8 +904,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/fc04be20-4e4e-453b-9ad3-525f34966b7c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7a163fbc-3009-45ba-bd7d-0e9d7fb19e7f
         method: GET
       response:
         proto: HTTP/2.0
@@ -913,20 +913,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 702
+        content_length: 720
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:22:40.494217Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"fc04be20-4e4e-453b-9ad3-525f34966b7c","name":"test-cr-ns-01","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01t9lb5wey","registry_namespace_id":"ad8d9981-507f-4741-9890-8f5a1a560971","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$JeWATXYOwSI3HoSX0pOEKw$5+JS8+EXe5OepynxwiA6e2fL9Eyi8RM6H1b8xnv7EZM","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2025-04-28T09:22:48.902011Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.579177Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"7a163fbc-3009-45ba-bd7d-0e9d7fb19e7f","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01clubjwdn","registry_namespace_id":"dc93fed2-6c5e-4ef5-ada6-742bc69df18c","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$HMmbRnMERK+V5dV0UPTIpQ$ahGOXBT31BnOZ2TvZNRHPvl6YKIMypEipczXpAiHtS8","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:22.851495Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "702"
+                - "720"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:53 GMT
+                - Wed, 27 Aug 2025 15:05:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -934,10 +934,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9a318eae-59b2-4244-a5a0-6eaf664eb264
+                - ea5c612e-fdee-4a72-b3db-bd6e0c5a1e5d
         status: 200 OK
         code: 200
-        duration: 39.664958ms
+        duration: 40.886388ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -953,8 +953,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/fc04be20-4e4e-453b-9ad3-525f34966b7c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7a163fbc-3009-45ba-bd7d-0e9d7fb19e7f
         method: GET
       response:
         proto: HTTP/2.0
@@ -962,20 +962,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 702
+        content_length: 720
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:22:40.494217Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"fc04be20-4e4e-453b-9ad3-525f34966b7c","name":"test-cr-ns-01","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01t9lb5wey","registry_namespace_id":"ad8d9981-507f-4741-9890-8f5a1a560971","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$JeWATXYOwSI3HoSX0pOEKw$5+JS8+EXe5OepynxwiA6e2fL9Eyi8RM6H1b8xnv7EZM","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2025-04-28T09:22:48.902011Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.579177Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"7a163fbc-3009-45ba-bd7d-0e9d7fb19e7f","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01clubjwdn","registry_namespace_id":"dc93fed2-6c5e-4ef5-ada6-742bc69df18c","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$HMmbRnMERK+V5dV0UPTIpQ$ahGOXBT31BnOZ2TvZNRHPvl6YKIMypEipczXpAiHtS8","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:22.851495Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "702"
+                - "720"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:54 GMT
+                - Wed, 27 Aug 2025 15:05:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -983,10 +983,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a4e0fcd1-a42f-459e-ac8a-37793ab9289f
+                - 77a0fe99-b5cf-436e-824d-c2ab9e5db6d0
         status: 200 OK
         code: 200
-        duration: 40.167583ms
+        duration: 84.134296ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1002,8 +1002,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/fc04be20-4e4e-453b-9ad3-525f34966b7c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7a163fbc-3009-45ba-bd7d-0e9d7fb19e7f
         method: GET
       response:
         proto: HTTP/2.0
@@ -1011,20 +1011,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 702
+        content_length: 720
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:22:40.494217Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"fc04be20-4e4e-453b-9ad3-525f34966b7c","name":"test-cr-ns-01","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01t9lb5wey","registry_namespace_id":"ad8d9981-507f-4741-9890-8f5a1a560971","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$JeWATXYOwSI3HoSX0pOEKw$5+JS8+EXe5OepynxwiA6e2fL9Eyi8RM6H1b8xnv7EZM","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2025-04-28T09:22:48.902011Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.579177Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"7a163fbc-3009-45ba-bd7d-0e9d7fb19e7f","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01clubjwdn","registry_namespace_id":"dc93fed2-6c5e-4ef5-ada6-742bc69df18c","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$HMmbRnMERK+V5dV0UPTIpQ$ahGOXBT31BnOZ2TvZNRHPvl6YKIMypEipczXpAiHtS8","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:22.851495Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "702"
+                - "720"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:54 GMT
+                - Wed, 27 Aug 2025 15:05:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1032,10 +1032,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d430714b-59b6-4d65-98a3-31233f105cd9
+                - e051b107-6a56-424a-8321-1fc189f74cae
         status: 200 OK
         code: 200
-        duration: 52.218375ms
+        duration: 53.281916ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1053,8 +1053,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/fc04be20-4e4e-453b-9ad3-525f34966b7c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7a163fbc-3009-45ba-bd7d-0e9d7fb19e7f
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -1062,20 +1062,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 719
+        content_length: 736
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:22:40.494217Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"fc04be20-4e4e-453b-9ad3-525f34966b7c","name":"test-cr-ns-01","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01t9lb5wey","registry_namespace_id":"ad8d9981-507f-4741-9890-8f5a1a560971","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$JeWATXYOwSI3HoSX0pOEKw$5+JS8+EXe5OepynxwiA6e2fL9Eyi8RM6H1b8xnv7EZM","key":"test_secret"}],"status":"ready","tags":["tag1","tag2"],"updated_at":"2025-04-28T09:22:54.480942521Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.579177Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"7a163fbc-3009-45ba-bd7d-0e9d7fb19e7f","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01clubjwdn","registry_namespace_id":"dc93fed2-6c5e-4ef5-ada6-742bc69df18c","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$HMmbRnMERK+V5dV0UPTIpQ$ahGOXBT31BnOZ2TvZNRHPvl6YKIMypEipczXpAiHtS8","key":"test_secret"}],"status":"ready","tags":["tag1","tag2"],"updated_at":"2025-08-27T15:05:29.104197082Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "719"
+                - "736"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:54 GMT
+                - Wed, 27 Aug 2025 15:05:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1083,10 +1083,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 31eff47c-b4df-4584-9e00-d5117cd87253
+                - b6c10252-84b9-4d9d-a49a-e33100605d9d
         status: 200 OK
         code: 200
-        duration: 64.07775ms
+        duration: 68.52593ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1102,8 +1102,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/fc04be20-4e4e-453b-9ad3-525f34966b7c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7a163fbc-3009-45ba-bd7d-0e9d7fb19e7f
         method: GET
       response:
         proto: HTTP/2.0
@@ -1111,20 +1111,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 716
+        content_length: 733
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:22:40.494217Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"fc04be20-4e4e-453b-9ad3-525f34966b7c","name":"test-cr-ns-01","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01t9lb5wey","registry_namespace_id":"ad8d9981-507f-4741-9890-8f5a1a560971","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$JeWATXYOwSI3HoSX0pOEKw$5+JS8+EXe5OepynxwiA6e2fL9Eyi8RM6H1b8xnv7EZM","key":"test_secret"}],"status":"ready","tags":["tag1","tag2"],"updated_at":"2025-04-28T09:22:54.480943Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.579177Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"7a163fbc-3009-45ba-bd7d-0e9d7fb19e7f","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01clubjwdn","registry_namespace_id":"dc93fed2-6c5e-4ef5-ada6-742bc69df18c","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$HMmbRnMERK+V5dV0UPTIpQ$ahGOXBT31BnOZ2TvZNRHPvl6YKIMypEipczXpAiHtS8","key":"test_secret"}],"status":"ready","tags":["tag1","tag2"],"updated_at":"2025-08-27T15:05:29.104197Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "716"
+                - "733"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:54 GMT
+                - Wed, 27 Aug 2025 15:05:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1132,10 +1132,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 167911b7-73f8-41e3-9b61-ab57db3d2703
+                - 09cce869-1876-4578-bf8d-827838b18d7c
         status: 200 OK
         code: 200
-        duration: 37.39025ms
+        duration: 47.806121ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1151,8 +1151,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/fc04be20-4e4e-453b-9ad3-525f34966b7c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7a163fbc-3009-45ba-bd7d-0e9d7fb19e7f
         method: GET
       response:
         proto: HTTP/2.0
@@ -1160,20 +1160,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 716
+        content_length: 733
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:22:40.494217Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"fc04be20-4e4e-453b-9ad3-525f34966b7c","name":"test-cr-ns-01","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01t9lb5wey","registry_namespace_id":"ad8d9981-507f-4741-9890-8f5a1a560971","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$JeWATXYOwSI3HoSX0pOEKw$5+JS8+EXe5OepynxwiA6e2fL9Eyi8RM6H1b8xnv7EZM","key":"test_secret"}],"status":"ready","tags":["tag1","tag2"],"updated_at":"2025-04-28T09:22:54.480943Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.579177Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"7a163fbc-3009-45ba-bd7d-0e9d7fb19e7f","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01clubjwdn","registry_namespace_id":"dc93fed2-6c5e-4ef5-ada6-742bc69df18c","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$HMmbRnMERK+V5dV0UPTIpQ$ahGOXBT31BnOZ2TvZNRHPvl6YKIMypEipczXpAiHtS8","key":"test_secret"}],"status":"ready","tags":["tag1","tag2"],"updated_at":"2025-08-27T15:05:29.104197Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "716"
+                - "733"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:54 GMT
+                - Wed, 27 Aug 2025 15:05:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1181,10 +1181,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4a1318b1-aa91-4f86-b949-250441a6f245
+                - 8ec167ba-0503-4fec-af5b-a81d256bb947
         status: 200 OK
         code: 200
-        duration: 39.613875ms
+        duration: 37.771403ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1200,8 +1200,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/fc04be20-4e4e-453b-9ad3-525f34966b7c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7a163fbc-3009-45ba-bd7d-0e9d7fb19e7f
         method: GET
       response:
         proto: HTTP/2.0
@@ -1209,20 +1209,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 716
+        content_length: 733
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:22:40.494217Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"fc04be20-4e4e-453b-9ad3-525f34966b7c","name":"test-cr-ns-01","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01t9lb5wey","registry_namespace_id":"ad8d9981-507f-4741-9890-8f5a1a560971","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$JeWATXYOwSI3HoSX0pOEKw$5+JS8+EXe5OepynxwiA6e2fL9Eyi8RM6H1b8xnv7EZM","key":"test_secret"}],"status":"ready","tags":["tag1","tag2"],"updated_at":"2025-04-28T09:22:54.480943Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.579177Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"7a163fbc-3009-45ba-bd7d-0e9d7fb19e7f","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01clubjwdn","registry_namespace_id":"dc93fed2-6c5e-4ef5-ada6-742bc69df18c","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$HMmbRnMERK+V5dV0UPTIpQ$ahGOXBT31BnOZ2TvZNRHPvl6YKIMypEipczXpAiHtS8","key":"test_secret"}],"status":"ready","tags":["tag1","tag2"],"updated_at":"2025-08-27T15:05:29.104197Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "716"
+                - "733"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:54 GMT
+                - Wed, 27 Aug 2025 15:05:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1230,10 +1230,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c0565cc2-3637-4da9-bc15-51cae2a22ea6
+                - 9615d382-cf08-46e8-b7cc-a2579bc6615e
         status: 200 OK
         code: 200
-        duration: 41.66775ms
+        duration: 49.857771ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1249,8 +1249,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/fc04be20-4e4e-453b-9ad3-525f34966b7c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7a163fbc-3009-45ba-bd7d-0e9d7fb19e7f
         method: GET
       response:
         proto: HTTP/2.0
@@ -1258,20 +1258,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 716
+        content_length: 733
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:22:40.494217Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"fc04be20-4e4e-453b-9ad3-525f34966b7c","name":"test-cr-ns-01","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01t9lb5wey","registry_namespace_id":"ad8d9981-507f-4741-9890-8f5a1a560971","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$JeWATXYOwSI3HoSX0pOEKw$5+JS8+EXe5OepynxwiA6e2fL9Eyi8RM6H1b8xnv7EZM","key":"test_secret"}],"status":"ready","tags":["tag1","tag2"],"updated_at":"2025-04-28T09:22:54.480943Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.579177Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"7a163fbc-3009-45ba-bd7d-0e9d7fb19e7f","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01clubjwdn","registry_namespace_id":"dc93fed2-6c5e-4ef5-ada6-742bc69df18c","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$HMmbRnMERK+V5dV0UPTIpQ$ahGOXBT31BnOZ2TvZNRHPvl6YKIMypEipczXpAiHtS8","key":"test_secret"}],"status":"ready","tags":["tag1","tag2"],"updated_at":"2025-08-27T15:05:29.104197Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "716"
+                - "733"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:55 GMT
+                - Wed, 27 Aug 2025 15:05:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1279,10 +1279,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - dff9f8f5-6458-4fd9-a630-5a65e8210f98
+                - e9d6ff6a-f027-4be2-b642-87ccdd679082
         status: 200 OK
         code: 200
-        duration: 37.281458ms
+        duration: 48.191835ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1298,8 +1298,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/fc04be20-4e4e-453b-9ad3-525f34966b7c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7a163fbc-3009-45ba-bd7d-0e9d7fb19e7f
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1307,20 +1307,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 722
+        content_length: 739
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:22:40.494217Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"fc04be20-4e4e-453b-9ad3-525f34966b7c","name":"test-cr-ns-01","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01t9lb5wey","registry_namespace_id":"ad8d9981-507f-4741-9890-8f5a1a560971","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$JeWATXYOwSI3HoSX0pOEKw$5+JS8+EXe5OepynxwiA6e2fL9Eyi8RM6H1b8xnv7EZM","key":"test_secret"}],"status":"deleting","tags":["tag1","tag2"],"updated_at":"2025-04-28T09:22:55.224263394Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.579177Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"7a163fbc-3009-45ba-bd7d-0e9d7fb19e7f","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01clubjwdn","registry_namespace_id":"dc93fed2-6c5e-4ef5-ada6-742bc69df18c","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$HMmbRnMERK+V5dV0UPTIpQ$ahGOXBT31BnOZ2TvZNRHPvl6YKIMypEipczXpAiHtS8","key":"test_secret"}],"status":"deleting","tags":["tag1","tag2"],"updated_at":"2025-08-27T15:05:30.309216025Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "722"
+                - "739"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:55 GMT
+                - Wed, 27 Aug 2025 15:05:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1328,10 +1328,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - abd8dcb5-7a1c-4c55-a6aa-a873861604b2
+                - 91ccf4a0-acb0-424c-9514-40789a3920ef
         status: 200 OK
         code: 200
-        duration: 198.518708ms
+        duration: 150.459287ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1347,8 +1347,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/fc04be20-4e4e-453b-9ad3-525f34966b7c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7a163fbc-3009-45ba-bd7d-0e9d7fb19e7f
         method: GET
       response:
         proto: HTTP/2.0
@@ -1356,20 +1356,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 719
+        content_length: 736
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:22:40.494217Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"fc04be20-4e4e-453b-9ad3-525f34966b7c","name":"test-cr-ns-01","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01t9lb5wey","registry_namespace_id":"ad8d9981-507f-4741-9890-8f5a1a560971","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$JeWATXYOwSI3HoSX0pOEKw$5+JS8+EXe5OepynxwiA6e2fL9Eyi8RM6H1b8xnv7EZM","key":"test_secret"}],"status":"deleting","tags":["tag1","tag2"],"updated_at":"2025-04-28T09:22:55.224263Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.579177Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"7a163fbc-3009-45ba-bd7d-0e9d7fb19e7f","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01clubjwdn","registry_namespace_id":"dc93fed2-6c5e-4ef5-ada6-742bc69df18c","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$HMmbRnMERK+V5dV0UPTIpQ$ahGOXBT31BnOZ2TvZNRHPvl6YKIMypEipczXpAiHtS8","key":"test_secret"}],"status":"deleting","tags":["tag1","tag2"],"updated_at":"2025-08-27T15:05:30.309216Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "719"
+                - "736"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:55 GMT
+                - Wed, 27 Aug 2025 15:05:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1377,10 +1377,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d3a3639c-d5e8-4f42-ab9f-2e2971169b75
+                - 49a5a481-725d-430c-b334-183b8e28ea72
         status: 200 OK
         code: 200
-        duration: 34.23575ms
+        duration: 55.739057ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1396,8 +1396,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/fc04be20-4e4e-453b-9ad3-525f34966b7c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7a163fbc-3009-45ba-bd7d-0e9d7fb19e7f
         method: GET
       response:
         proto: HTTP/2.0
@@ -1416,9 +1416,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:23:00 GMT
+                - Wed, 27 Aug 2025 15:05:35 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1426,10 +1426,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d940fedc-1bde-4f3f-8678-39da14efafbb
+                - 74048452-65d1-4e69-bb91-644d060b74fe
         status: 404 Not Found
         code: 404
-        duration: 29.702667ms
+        duration: 19.390404ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1445,8 +1445,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/fc04be20-4e4e-453b-9ad3-525f34966b7c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7a163fbc-3009-45ba-bd7d-0e9d7fb19e7f
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1465,9 +1465,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:23:00 GMT
+                - Wed, 27 Aug 2025 15:05:35 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1475,7 +1475,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9a5918a3-e9dd-4284-876f-7f84a5359e43
+                - 3b1b4a4b-0551-4c79-95f7-166cd3d8f0da
         status: 404 Not Found
         code: 404
-        duration: 25.548417ms
+        duration: 25.097162ms

--- a/internal/services/function/testdata/function-namespace-environment-variables.cassette.yaml
+++ b/internal/services/function/testdata/function-namespace-environment-variables.cassette.yaml
@@ -6,19 +6,19 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 203
+        content_length: 235
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-env-test","environment_variables":{"test":"test"},"project_id":"6867048b-fe12-4e96-835e-41c79a39604b","secret_environment_variables":[{"key":"test_secret","value":"test_secret"}],"tags":null}'
+        body: '{"name":"tf-env-test","environment_variables":{"test":"test"},"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","secret_environment_variables":[{"key":"test_secret","value":"test_secret"}],"tags":null,"activate_vpc_integration":true}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces
         method: POST
       response:
@@ -27,20 +27,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 627
+        content_length: 645
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:22:40.790655262Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"e62f7ceb-0adf-46b6-b311-506202abf05c","name":"tf-env-test","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$YRIgmAtqAHq2gkmxCQXljw$UKT6Ye9rq/aP5pzT5IH+eTnoAxo8x6mnCaYubw5ufZo","key":"test_secret"}],"status":"pending","tags":[],"updated_at":"2025-04-28T09:22:40.790655262Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.953576493Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"b93c01af-e1e0-4c65-9c67-b0aa96481775","name":"tf-env-test","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$tmc1gTzeHbqhnyAeItKijw$fsDAC0QZSNEwNFf3TkkV+YrTEcu9+5UOhD/yVK0UYd0","key":"test_secret"}],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:13.953576493Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "627"
+                - "645"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:40 GMT
+                - Wed, 27 Aug 2025 15:05:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2fbace1b-a845-4aa0-855f-421633faaaa2
+                - f272dac5-9bd1-4eb9-b14f-bdcaa6190071
         status: 200 OK
         code: 200
-        duration: 2.886259292s
+        duration: 5.81211216s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -67,8 +67,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e62f7ceb-0adf-46b6-b311-506202abf05c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b93c01af-e1e0-4c65-9c67-b0aa96481775
         method: GET
       response:
         proto: HTTP/2.0
@@ -76,20 +76,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 621
+        content_length: 639
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:22:40.790655Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"e62f7ceb-0adf-46b6-b311-506202abf05c","name":"tf-env-test","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$YRIgmAtqAHq2gkmxCQXljw$UKT6Ye9rq/aP5pzT5IH+eTnoAxo8x6mnCaYubw5ufZo","key":"test_secret"}],"status":"pending","tags":[],"updated_at":"2025-04-28T09:22:40.790655Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.953576Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"b93c01af-e1e0-4c65-9c67-b0aa96481775","name":"tf-env-test","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$tmc1gTzeHbqhnyAeItKijw$fsDAC0QZSNEwNFf3TkkV+YrTEcu9+5UOhD/yVK0UYd0","key":"test_secret"}],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:13.953576Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "621"
+                - "639"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:40 GMT
+                - Wed, 27 Aug 2025 15:05:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1ef4d963-4661-4cc6-831a-dcdcfb86b733
+                - b5cbb0e3-5009-4aa4-9555-37afc05d0dd4
         status: 200 OK
         code: 200
-        duration: 42.384833ms
+        duration: 47.448688ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -116,8 +116,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e62f7ceb-0adf-46b6-b311-506202abf05c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b93c01af-e1e0-4c65-9c67-b0aa96481775
         method: GET
       response:
         proto: HTTP/2.0
@@ -125,20 +125,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 699
+        content_length: 639
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:22:40.790655Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"e62f7ceb-0adf-46b6-b311-506202abf05c","name":"tf-env-test","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtesttldyxtc9","registry_namespace_id":"8420ad41-936d-4377-acda-bffa89309827","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$YRIgmAtqAHq2gkmxCQXljw$UKT6Ye9rq/aP5pzT5IH+eTnoAxo8x6mnCaYubw5ufZo","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2025-04-28T09:22:43.817711Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.953576Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"b93c01af-e1e0-4c65-9c67-b0aa96481775","name":"tf-env-test","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$tmc1gTzeHbqhnyAeItKijw$fsDAC0QZSNEwNFf3TkkV+YrTEcu9+5UOhD/yVK0UYd0","key":"test_secret"}],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:17.776067Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "699"
+                - "639"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:45 GMT
+                - Wed, 27 Aug 2025 15:05:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -146,10 +146,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5802ac9a-4361-42dc-96bf-cfacfb7bc35b
+                - 26d4abe5-412e-4c21-a6a2-61844d32bd5a
         status: 200 OK
         code: 200
-        duration: 42.063791ms
+        duration: 347.339604ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -165,8 +165,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e62f7ceb-0adf-46b6-b311-506202abf05c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b93c01af-e1e0-4c65-9c67-b0aa96481775
         method: GET
       response:
         proto: HTTP/2.0
@@ -174,20 +174,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 699
+        content_length: 717
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:22:40.790655Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"e62f7ceb-0adf-46b6-b311-506202abf05c","name":"tf-env-test","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtesttldyxtc9","registry_namespace_id":"8420ad41-936d-4377-acda-bffa89309827","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$YRIgmAtqAHq2gkmxCQXljw$UKT6Ye9rq/aP5pzT5IH+eTnoAxo8x6mnCaYubw5ufZo","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2025-04-28T09:22:43.817711Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.953576Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"b93c01af-e1e0-4c65-9c67-b0aa96481775","name":"tf-env-test","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestypt4dsq9","registry_namespace_id":"c85db154-0af2-4b0c-9478-91d977381783","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$tmc1gTzeHbqhnyAeItKijw$fsDAC0QZSNEwNFf3TkkV+YrTEcu9+5UOhD/yVK0UYd0","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:21.942838Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "699"
+                - "717"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:46 GMT
+                - Wed, 27 Aug 2025 15:05:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -195,10 +195,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 596204e2-ffe2-4183-b6e3-e05c5326e79c
+                - 1ab4ce9c-6ffc-490e-a208-8091a062ece5
         status: 200 OK
         code: 200
-        duration: 40.739333ms
+        duration: 43.486686ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -214,8 +214,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e62f7ceb-0adf-46b6-b311-506202abf05c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b93c01af-e1e0-4c65-9c67-b0aa96481775
         method: GET
       response:
         proto: HTTP/2.0
@@ -223,20 +223,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 699
+        content_length: 717
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:22:40.790655Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"e62f7ceb-0adf-46b6-b311-506202abf05c","name":"tf-env-test","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtesttldyxtc9","registry_namespace_id":"8420ad41-936d-4377-acda-bffa89309827","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$YRIgmAtqAHq2gkmxCQXljw$UKT6Ye9rq/aP5pzT5IH+eTnoAxo8x6mnCaYubw5ufZo","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2025-04-28T09:22:43.817711Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.953576Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"b93c01af-e1e0-4c65-9c67-b0aa96481775","name":"tf-env-test","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestypt4dsq9","registry_namespace_id":"c85db154-0af2-4b0c-9478-91d977381783","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$tmc1gTzeHbqhnyAeItKijw$fsDAC0QZSNEwNFf3TkkV+YrTEcu9+5UOhD/yVK0UYd0","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:21.942838Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "699"
+                - "717"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:46 GMT
+                - Wed, 27 Aug 2025 15:05:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -244,10 +244,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 64bf449a-f097-48eb-8e54-ea1cd9b7f2a7
+                - 937e9ba1-2510-4258-9da5-505aa387e37e
         status: 200 OK
         code: 200
-        duration: 44.064667ms
+        duration: 49.083899ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -263,8 +263,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e62f7ceb-0adf-46b6-b311-506202abf05c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b93c01af-e1e0-4c65-9c67-b0aa96481775
         method: GET
       response:
         proto: HTTP/2.0
@@ -272,20 +272,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 699
+        content_length: 717
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:22:40.790655Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"e62f7ceb-0adf-46b6-b311-506202abf05c","name":"tf-env-test","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtesttldyxtc9","registry_namespace_id":"8420ad41-936d-4377-acda-bffa89309827","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$YRIgmAtqAHq2gkmxCQXljw$UKT6Ye9rq/aP5pzT5IH+eTnoAxo8x6mnCaYubw5ufZo","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2025-04-28T09:22:43.817711Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.953576Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"b93c01af-e1e0-4c65-9c67-b0aa96481775","name":"tf-env-test","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestypt4dsq9","registry_namespace_id":"c85db154-0af2-4b0c-9478-91d977381783","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$tmc1gTzeHbqhnyAeItKijw$fsDAC0QZSNEwNFf3TkkV+YrTEcu9+5UOhD/yVK0UYd0","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:21.942838Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "699"
+                - "717"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:46 GMT
+                - Wed, 27 Aug 2025 15:05:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -293,10 +293,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c3091853-a6e8-41c6-8b97-54aa0823874a
+                - 466a117b-353e-43c8-91ec-8c5f6b57b7df
         status: 200 OK
         code: 200
-        duration: 43.051625ms
+        duration: 56.568843ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -312,8 +312,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e62f7ceb-0adf-46b6-b311-506202abf05c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b93c01af-e1e0-4c65-9c67-b0aa96481775
         method: GET
       response:
         proto: HTTP/2.0
@@ -321,20 +321,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 699
+        content_length: 717
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:22:40.790655Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"e62f7ceb-0adf-46b6-b311-506202abf05c","name":"tf-env-test","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtesttldyxtc9","registry_namespace_id":"8420ad41-936d-4377-acda-bffa89309827","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$YRIgmAtqAHq2gkmxCQXljw$UKT6Ye9rq/aP5pzT5IH+eTnoAxo8x6mnCaYubw5ufZo","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2025-04-28T09:22:43.817711Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.953576Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"b93c01af-e1e0-4c65-9c67-b0aa96481775","name":"tf-env-test","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestypt4dsq9","registry_namespace_id":"c85db154-0af2-4b0c-9478-91d977381783","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$tmc1gTzeHbqhnyAeItKijw$fsDAC0QZSNEwNFf3TkkV+YrTEcu9+5UOhD/yVK0UYd0","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:21.942838Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "699"
+                - "717"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:46 GMT
+                - Wed, 27 Aug 2025 15:05:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -342,10 +342,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2c6b719a-90cc-419d-99bc-6da97de0f9cd
+                - 53f6369f-822f-4807-b985-f622a3043eb7
         status: 200 OK
         code: 200
-        duration: 49.291958ms
+        duration: 43.382079ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -361,8 +361,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e62f7ceb-0adf-46b6-b311-506202abf05c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b93c01af-e1e0-4c65-9c67-b0aa96481775
         method: GET
       response:
         proto: HTTP/2.0
@@ -370,20 +370,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 699
+        content_length: 717
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:22:40.790655Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"e62f7ceb-0adf-46b6-b311-506202abf05c","name":"tf-env-test","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtesttldyxtc9","registry_namespace_id":"8420ad41-936d-4377-acda-bffa89309827","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$YRIgmAtqAHq2gkmxCQXljw$UKT6Ye9rq/aP5pzT5IH+eTnoAxo8x6mnCaYubw5ufZo","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2025-04-28T09:22:43.817711Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.953576Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"b93c01af-e1e0-4c65-9c67-b0aa96481775","name":"tf-env-test","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestypt4dsq9","registry_namespace_id":"c85db154-0af2-4b0c-9478-91d977381783","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$tmc1gTzeHbqhnyAeItKijw$fsDAC0QZSNEwNFf3TkkV+YrTEcu9+5UOhD/yVK0UYd0","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:21.942838Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "699"
+                - "717"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:46 GMT
+                - Wed, 27 Aug 2025 15:05:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -391,11 +391,60 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2b1210c5-4fc4-4b14-836b-e2ff20aa84f7
+                - 0fa140c5-ae79-4646-9b21-00883b0e73a4
         status: 200 OK
         code: 200
-        duration: 38.575209ms
+        duration: 119.703857ms
     - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b93c01af-e1e0-4c65-9c67-b0aa96481775
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 717
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:13.953576Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"b93c01af-e1e0-4c65-9c67-b0aa96481775","name":"tf-env-test","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestypt4dsq9","registry_namespace_id":"c85db154-0af2-4b0c-9478-91d977381783","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$tmc1gTzeHbqhnyAeItKijw$fsDAC0QZSNEwNFf3TkkV+YrTEcu9+5UOhD/yVK0UYd0","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:21.942838Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "717"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:05:26 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - cdc36686-4819-415b-ae45-6b8d4cfe0a95
+        status: 200 OK
+        code: 200
+        duration: 46.733008ms
+    - id: 9
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -412,8 +461,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e62f7ceb-0adf-46b6-b311-506202abf05c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b93c01af-e1e0-4c65-9c67-b0aa96481775
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -421,20 +470,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 702
+        content_length: 720
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:22:40.790655Z","description":"","environment_variables":{"foo":"bar"},"error_message":null,"id":"e62f7ceb-0adf-46b6-b311-506202abf05c","name":"tf-env-test","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtesttldyxtc9","registry_namespace_id":"8420ad41-936d-4377-acda-bffa89309827","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$ABb+w+CD8Pme8B0qJ2bD3A$fh05pxjA/q35YWmVwzTxSqz3Jnw7BFfhEKrty5VMzbY","key":"test_secret"}],"status":"pending","tags":[],"updated_at":"2025-04-28T09:22:47.408367732Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.953576Z","description":"","environment_variables":{"foo":"bar"},"error_message":null,"id":"b93c01af-e1e0-4c65-9c67-b0aa96481775","name":"tf-env-test","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestypt4dsq9","registry_namespace_id":"c85db154-0af2-4b0c-9478-91d977381783","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$F6YoDr1TSZkSq2FfiRI0/w$nDR3udZIQIcPx53va8Q3EprMMAzN04GOmDifJzo3zTc","key":"test_secret"}],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:26.347847101Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "702"
+                - "720"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:47 GMT
+                - Wed, 27 Aug 2025 15:05:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -442,59 +491,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - eed77f98-fe90-4721-afd4-44e247fc878a
+                - 43f5b659-2eda-4334-bfbc-9690f6180b68
         status: 200 OK
         code: 200
-        duration: 554.10725ms
-    - id: 9
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e62f7ceb-0adf-46b6-b311-506202abf05c
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 699
-        uncompressed: false
-        body: '{"created_at":"2025-04-28T09:22:40.790655Z","description":"","environment_variables":{"foo":"bar"},"error_message":null,"id":"e62f7ceb-0adf-46b6-b311-506202abf05c","name":"tf-env-test","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtesttldyxtc9","registry_namespace_id":"8420ad41-936d-4377-acda-bffa89309827","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$ABb+w+CD8Pme8B0qJ2bD3A$fh05pxjA/q35YWmVwzTxSqz3Jnw7BFfhEKrty5VMzbY","key":"test_secret"}],"status":"pending","tags":[],"updated_at":"2025-04-28T09:22:47.408368Z"}'
-        headers:
-            Content-Length:
-                - "699"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 28 Apr 2025 09:22:47 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - f70d0e64-82f9-4e1f-9139-9d8fe647cdaf
-        status: 200 OK
-        code: 200
-        duration: 37.512792ms
+        duration: 328.699467ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -510,8 +510,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e62f7ceb-0adf-46b6-b311-506202abf05c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b93c01af-e1e0-4c65-9c67-b0aa96481775
         method: GET
       response:
         proto: HTTP/2.0
@@ -519,20 +519,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 697
+        content_length: 717
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:22:40.790655Z","description":"","environment_variables":{"foo":"bar"},"error_message":null,"id":"e62f7ceb-0adf-46b6-b311-506202abf05c","name":"tf-env-test","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtesttldyxtc9","registry_namespace_id":"8420ad41-936d-4377-acda-bffa89309827","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$ABb+w+CD8Pme8B0qJ2bD3A$fh05pxjA/q35YWmVwzTxSqz3Jnw7BFfhEKrty5VMzbY","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2025-04-28T09:22:47.805011Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.953576Z","description":"","environment_variables":{"foo":"bar"},"error_message":null,"id":"b93c01af-e1e0-4c65-9c67-b0aa96481775","name":"tf-env-test","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestypt4dsq9","registry_namespace_id":"c85db154-0af2-4b0c-9478-91d977381783","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$F6YoDr1TSZkSq2FfiRI0/w$nDR3udZIQIcPx53va8Q3EprMMAzN04GOmDifJzo3zTc","key":"test_secret"}],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:26.347847Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "697"
+                - "717"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:52 GMT
+                - Wed, 27 Aug 2025 15:05:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -540,10 +540,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a922e386-29cc-418e-92cb-d64a7e7f03c4
+                - 5343e3b1-e9d6-40a8-8229-f9ed36b1bf12
         status: 200 OK
         code: 200
-        duration: 43.154125ms
+        duration: 43.773235ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -559,8 +559,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e62f7ceb-0adf-46b6-b311-506202abf05c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b93c01af-e1e0-4c65-9c67-b0aa96481775
         method: GET
       response:
         proto: HTTP/2.0
@@ -568,20 +568,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 697
+        content_length: 715
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:22:40.790655Z","description":"","environment_variables":{"foo":"bar"},"error_message":null,"id":"e62f7ceb-0adf-46b6-b311-506202abf05c","name":"tf-env-test","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtesttldyxtc9","registry_namespace_id":"8420ad41-936d-4377-acda-bffa89309827","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$ABb+w+CD8Pme8B0qJ2bD3A$fh05pxjA/q35YWmVwzTxSqz3Jnw7BFfhEKrty5VMzbY","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2025-04-28T09:22:47.805011Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.953576Z","description":"","environment_variables":{"foo":"bar"},"error_message":null,"id":"b93c01af-e1e0-4c65-9c67-b0aa96481775","name":"tf-env-test","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestypt4dsq9","registry_namespace_id":"c85db154-0af2-4b0c-9478-91d977381783","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$F6YoDr1TSZkSq2FfiRI0/w$nDR3udZIQIcPx53va8Q3EprMMAzN04GOmDifJzo3zTc","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:27.176241Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "697"
+                - "715"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:52 GMT
+                - Wed, 27 Aug 2025 15:05:31 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -589,10 +589,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ff7293b9-876f-4512-8b0c-d468931bbaa4
+                - 70830dd5-1fc5-44d0-aa65-6fe8676034b2
         status: 200 OK
         code: 200
-        duration: 40.821083ms
+        duration: 45.652041ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -608,8 +608,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e62f7ceb-0adf-46b6-b311-506202abf05c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b93c01af-e1e0-4c65-9c67-b0aa96481775
         method: GET
       response:
         proto: HTTP/2.0
@@ -617,20 +617,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 697
+        content_length: 715
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:22:40.790655Z","description":"","environment_variables":{"foo":"bar"},"error_message":null,"id":"e62f7ceb-0adf-46b6-b311-506202abf05c","name":"tf-env-test","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtesttldyxtc9","registry_namespace_id":"8420ad41-936d-4377-acda-bffa89309827","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$ABb+w+CD8Pme8B0qJ2bD3A$fh05pxjA/q35YWmVwzTxSqz3Jnw7BFfhEKrty5VMzbY","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2025-04-28T09:22:47.805011Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.953576Z","description":"","environment_variables":{"foo":"bar"},"error_message":null,"id":"b93c01af-e1e0-4c65-9c67-b0aa96481775","name":"tf-env-test","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestypt4dsq9","registry_namespace_id":"c85db154-0af2-4b0c-9478-91d977381783","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$F6YoDr1TSZkSq2FfiRI0/w$nDR3udZIQIcPx53va8Q3EprMMAzN04GOmDifJzo3zTc","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:27.176241Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "697"
+                - "715"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:52 GMT
+                - Wed, 27 Aug 2025 15:05:31 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -638,10 +638,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b78fe63b-8c28-4bc4-87b0-2f9c929c8555
+                - a795bfc5-64c3-4fd7-8401-86d93dafa69c
         status: 200 OK
         code: 200
-        duration: 109.537959ms
+        duration: 43.437756ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -657,8 +657,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e62f7ceb-0adf-46b6-b311-506202abf05c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b93c01af-e1e0-4c65-9c67-b0aa96481775
         method: GET
       response:
         proto: HTTP/2.0
@@ -666,20 +666,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 697
+        content_length: 715
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:22:40.790655Z","description":"","environment_variables":{"foo":"bar"},"error_message":null,"id":"e62f7ceb-0adf-46b6-b311-506202abf05c","name":"tf-env-test","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtesttldyxtc9","registry_namespace_id":"8420ad41-936d-4377-acda-bffa89309827","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$ABb+w+CD8Pme8B0qJ2bD3A$fh05pxjA/q35YWmVwzTxSqz3Jnw7BFfhEKrty5VMzbY","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2025-04-28T09:22:47.805011Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.953576Z","description":"","environment_variables":{"foo":"bar"},"error_message":null,"id":"b93c01af-e1e0-4c65-9c67-b0aa96481775","name":"tf-env-test","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestypt4dsq9","registry_namespace_id":"c85db154-0af2-4b0c-9478-91d977381783","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$F6YoDr1TSZkSq2FfiRI0/w$nDR3udZIQIcPx53va8Q3EprMMAzN04GOmDifJzo3zTc","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:27.176241Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "697"
+                - "715"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:53 GMT
+                - Wed, 27 Aug 2025 15:05:32 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -687,10 +687,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5e0fdb1e-ef2b-46b9-9764-2ce1b258fe78
+                - b34a83c5-f1a1-4975-a9cf-8a5ec01f6acc
         status: 200 OK
         code: 200
-        duration: 44.97075ms
+        duration: 53.082333ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -706,29 +706,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e62f7ceb-0adf-46b6-b311-506202abf05c
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b93c01af-e1e0-4c65-9c67-b0aa96481775
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 703
+        content_length: 715
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:22:40.790655Z","description":"","environment_variables":{"foo":"bar"},"error_message":null,"id":"e62f7ceb-0adf-46b6-b311-506202abf05c","name":"tf-env-test","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtesttldyxtc9","registry_namespace_id":"8420ad41-936d-4377-acda-bffa89309827","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$ABb+w+CD8Pme8B0qJ2bD3A$fh05pxjA/q35YWmVwzTxSqz3Jnw7BFfhEKrty5VMzbY","key":"test_secret"}],"status":"deleting","tags":[],"updated_at":"2025-04-28T09:22:53.380425502Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.953576Z","description":"","environment_variables":{"foo":"bar"},"error_message":null,"id":"b93c01af-e1e0-4c65-9c67-b0aa96481775","name":"tf-env-test","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestypt4dsq9","registry_namespace_id":"c85db154-0af2-4b0c-9478-91d977381783","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$F6YoDr1TSZkSq2FfiRI0/w$nDR3udZIQIcPx53va8Q3EprMMAzN04GOmDifJzo3zTc","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:27.176241Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "703"
+                - "715"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:53 GMT
+                - Wed, 27 Aug 2025 15:05:32 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -736,10 +736,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7910de3a-9b70-4190-936a-95847768096f
+                - f3d29d02-5401-4ad1-9f7f-53346b1eeeda
         status: 200 OK
         code: 200
-        duration: 251.885292ms
+        duration: 41.252125ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -755,29 +755,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e62f7ceb-0adf-46b6-b311-506202abf05c
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b93c01af-e1e0-4c65-9c67-b0aa96481775
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 700
+        content_length: 721
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:22:40.790655Z","description":"","environment_variables":{"foo":"bar"},"error_message":null,"id":"e62f7ceb-0adf-46b6-b311-506202abf05c","name":"tf-env-test","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtesttldyxtc9","registry_namespace_id":"8420ad41-936d-4377-acda-bffa89309827","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$ABb+w+CD8Pme8B0qJ2bD3A$fh05pxjA/q35YWmVwzTxSqz3Jnw7BFfhEKrty5VMzbY","key":"test_secret"}],"status":"deleting","tags":[],"updated_at":"2025-04-28T09:22:53.380426Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.953576Z","description":"","environment_variables":{"foo":"bar"},"error_message":null,"id":"b93c01af-e1e0-4c65-9c67-b0aa96481775","name":"tf-env-test","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestypt4dsq9","registry_namespace_id":"c85db154-0af2-4b0c-9478-91d977381783","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$F6YoDr1TSZkSq2FfiRI0/w$nDR3udZIQIcPx53va8Q3EprMMAzN04GOmDifJzo3zTc","key":"test_secret"}],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:32.618680286Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "700"
+                - "721"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:53 GMT
+                - Wed, 27 Aug 2025 15:05:32 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -785,10 +785,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ce549792-aff1-4756-846f-14fad5b978c2
+                - 0759d908-1c7c-4d48-9f01-8b68654df01e
         status: 200 OK
         code: 200
-        duration: 42.811375ms
+        duration: 207.292027ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -804,8 +804,57 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e62f7ceb-0adf-46b6-b311-506202abf05c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b93c01af-e1e0-4c65-9c67-b0aa96481775
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 718
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:13.953576Z","description":"","environment_variables":{"foo":"bar"},"error_message":null,"id":"b93c01af-e1e0-4c65-9c67-b0aa96481775","name":"tf-env-test","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestypt4dsq9","registry_namespace_id":"c85db154-0af2-4b0c-9478-91d977381783","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$F6YoDr1TSZkSq2FfiRI0/w$nDR3udZIQIcPx53va8Q3EprMMAzN04GOmDifJzo3zTc","key":"test_secret"}],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:32.618680Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "718"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:05:32 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 9b19cef9-b7d0-4029-a603-f5c88848a940
+        status: 200 OK
+        code: 200
+        duration: 42.215572ms
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b93c01af-e1e0-4c65-9c67-b0aa96481775
         method: GET
       response:
         proto: HTTP/2.0
@@ -824,9 +873,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:58 GMT
+                - Wed, 27 Aug 2025 15:05:38 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -834,11 +883,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a9e97043-48a1-4d8c-a5d6-ad4d74ce2dbe
+                - ce749ea1-1ae6-47d2-9f7c-bc2b272fa109
         status: 404 Not Found
         code: 404
-        duration: 31.475291ms
-    - id: 17
+        duration: 247.138649ms
+    - id: 18
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -853,8 +902,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e62f7ceb-0adf-46b6-b311-506202abf05c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b93c01af-e1e0-4c65-9c67-b0aa96481775
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -873,9 +922,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:58 GMT
+                - Wed, 27 Aug 2025 15:05:38 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -883,7 +932,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a2136ba1-c776-46db-a77f-2ef79d53cede
+                - 3bca8e86-1bc9-4564-8a5a-5f4198e18faf
         status: 404 Not Found
         code: 404
-        duration: 72.553583ms
+        duration: 21.440882ms

--- a/internal/services/function/testdata/function-namespace-no-name.cassette.yaml
+++ b/internal/services/function/testdata/function-namespace-no-name.cassette.yaml
@@ -6,19 +6,19 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 166
+        content_length: 193
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-func-ecstatic-chandrasekhar","environment_variables":{},"project_id":"6867048b-fe12-4e96-835e-41c79a39604b","secret_environment_variables":[],"tags":null}'
+        body: '{"name":"tf-func-magical-engelbart","environment_variables":{},"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","secret_environment_variables":[],"tags":null,"activate_vpc_integration":true}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces
         method: POST
       response:
@@ -27,20 +27,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 496
+        content_length: 510
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:22:39.584003800Z","description":"","environment_variables":{},"error_message":null,"id":"c2d67483-b8ac-4638-9aed-7b40d8e757ab","name":"tf-func-ecstatic-chandrasekhar","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-04-28T09:22:39.584003800Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.317002519Z","description":"","environment_variables":{},"error_message":null,"id":"8978659a-23b4-4fb0-b592-c644d3125ead","name":"tf-func-magical-engelbart","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:13.317002519Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "496"
+                - "510"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:39 GMT
+                - Wed, 27 Aug 2025 15:05:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0b1641f7-605e-47c7-8aaa-9c07a8036cd5
+                - a4420438-018b-49ce-8af8-4f175b70b9e3
         status: 200 OK
         code: 200
-        duration: 1.609896917s
+        duration: 5.217142722s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -67,8 +67,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/c2d67483-b8ac-4638-9aed-7b40d8e757ab
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8978659a-23b4-4fb0-b592-c644d3125ead
         method: GET
       response:
         proto: HTTP/2.0
@@ -76,20 +76,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 490
+        content_length: 504
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:22:39.584004Z","description":"","environment_variables":{},"error_message":null,"id":"c2d67483-b8ac-4638-9aed-7b40d8e757ab","name":"tf-func-ecstatic-chandrasekhar","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-04-28T09:22:39.584004Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.317003Z","description":"","environment_variables":{},"error_message":null,"id":"8978659a-23b4-4fb0-b592-c644d3125ead","name":"tf-func-magical-engelbart","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:13.317003Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "490"
+                - "504"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:39 GMT
+                - Wed, 27 Aug 2025 15:05:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c0c115bc-d3d7-481b-bf7b-dc2fb37207b2
+                - 02218c6f-ff0f-47b8-9379-68f8a1e341ee
         status: 200 OK
         code: 200
-        duration: 40.272084ms
+        duration: 42.971407ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -116,8 +116,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/c2d67483-b8ac-4638-9aed-7b40d8e757ab
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8978659a-23b4-4fb0-b592-c644d3125ead
         method: GET
       response:
         proto: HTTP/2.0
@@ -125,20 +125,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 579
+        content_length: 593
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:22:39.584004Z","description":"","environment_variables":{},"error_message":null,"id":"c2d67483-b8ac-4638-9aed-7b40d8e757ab","name":"tf-func-ecstatic-chandrasekhar","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncecstaticchandrfauujmza","registry_namespace_id":"d0f5c7db-7ab3-475b-ada9-f0be61f99c60","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-28T09:22:43.043307Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.317003Z","description":"","environment_variables":{},"error_message":null,"id":"8978659a-23b4-4fb0-b592-c644d3125ead","name":"tf-func-magical-engelbart","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncmagicalengelbatq5njero","registry_namespace_id":"f48cf3ee-e182-46da-baff-ba6130b38160","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:18.274854Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "579"
+                - "593"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:44 GMT
+                - Wed, 27 Aug 2025 15:05:18 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -146,10 +146,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 550070b4-f98a-4813-9908-7f9852772f56
+                - 3d89449c-8e4f-422a-b291-f159e64df436
         status: 200 OK
         code: 200
-        duration: 41.477125ms
+        duration: 56.654732ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -165,8 +165,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/c2d67483-b8ac-4638-9aed-7b40d8e757ab
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8978659a-23b4-4fb0-b592-c644d3125ead
         method: GET
       response:
         proto: HTTP/2.0
@@ -174,20 +174,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 579
+        content_length: 593
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:22:39.584004Z","description":"","environment_variables":{},"error_message":null,"id":"c2d67483-b8ac-4638-9aed-7b40d8e757ab","name":"tf-func-ecstatic-chandrasekhar","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncecstaticchandrfauujmza","registry_namespace_id":"d0f5c7db-7ab3-475b-ada9-f0be61f99c60","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-28T09:22:43.043307Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.317003Z","description":"","environment_variables":{},"error_message":null,"id":"8978659a-23b4-4fb0-b592-c644d3125ead","name":"tf-func-magical-engelbart","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncmagicalengelbatq5njero","registry_namespace_id":"f48cf3ee-e182-46da-baff-ba6130b38160","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:18.274854Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "579"
+                - "593"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:44 GMT
+                - Wed, 27 Aug 2025 15:05:18 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -195,10 +195,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 10386eb8-bf1b-4f12-9677-afe78f7810ef
+                - 869352d7-1d21-4273-ba11-f0dfe884ae4d
         status: 200 OK
         code: 200
-        duration: 41.562542ms
+        duration: 39.903793ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -214,8 +214,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/c2d67483-b8ac-4638-9aed-7b40d8e757ab
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8978659a-23b4-4fb0-b592-c644d3125ead
         method: GET
       response:
         proto: HTTP/2.0
@@ -223,20 +223,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 579
+        content_length: 593
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:22:39.584004Z","description":"","environment_variables":{},"error_message":null,"id":"c2d67483-b8ac-4638-9aed-7b40d8e757ab","name":"tf-func-ecstatic-chandrasekhar","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncecstaticchandrfauujmza","registry_namespace_id":"d0f5c7db-7ab3-475b-ada9-f0be61f99c60","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-28T09:22:43.043307Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.317003Z","description":"","environment_variables":{},"error_message":null,"id":"8978659a-23b4-4fb0-b592-c644d3125ead","name":"tf-func-magical-engelbart","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncmagicalengelbatq5njero","registry_namespace_id":"f48cf3ee-e182-46da-baff-ba6130b38160","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:18.274854Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "579"
+                - "593"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:44 GMT
+                - Wed, 27 Aug 2025 15:05:18 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -244,10 +244,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9e23e672-2f91-4d26-a9df-226ea5c466cd
+                - e1d8db48-2cb2-4d96-9849-8cb09d2a2837
         status: 200 OK
         code: 200
-        duration: 89.818375ms
+        duration: 567.96072ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -263,8 +263,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/c2d67483-b8ac-4638-9aed-7b40d8e757ab
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8978659a-23b4-4fb0-b592-c644d3125ead
         method: GET
       response:
         proto: HTTP/2.0
@@ -272,20 +272,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 579
+        content_length: 593
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:22:39.584004Z","description":"","environment_variables":{},"error_message":null,"id":"c2d67483-b8ac-4638-9aed-7b40d8e757ab","name":"tf-func-ecstatic-chandrasekhar","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncecstaticchandrfauujmza","registry_namespace_id":"d0f5c7db-7ab3-475b-ada9-f0be61f99c60","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-28T09:22:43.043307Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.317003Z","description":"","environment_variables":{},"error_message":null,"id":"8978659a-23b4-4fb0-b592-c644d3125ead","name":"tf-func-magical-engelbart","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncmagicalengelbatq5njero","registry_namespace_id":"f48cf3ee-e182-46da-baff-ba6130b38160","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:18.274854Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "579"
+                - "593"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:45 GMT
+                - Wed, 27 Aug 2025 15:05:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -293,10 +293,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0ad927e5-ef78-4364-8a07-e55f3ff6e685
+                - ff012491-c581-4565-80d6-9c12f0ac72dd
         status: 200 OK
         code: 200
-        duration: 36.166417ms
+        duration: 41.233858ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -312,8 +312,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/c2d67483-b8ac-4638-9aed-7b40d8e757ab
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8978659a-23b4-4fb0-b592-c644d3125ead
         method: GET
       response:
         proto: HTTP/2.0
@@ -321,20 +321,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 579
+        content_length: 593
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:22:39.584004Z","description":"","environment_variables":{},"error_message":null,"id":"c2d67483-b8ac-4638-9aed-7b40d8e757ab","name":"tf-func-ecstatic-chandrasekhar","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncecstaticchandrfauujmza","registry_namespace_id":"d0f5c7db-7ab3-475b-ada9-f0be61f99c60","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-04-28T09:22:43.043307Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.317003Z","description":"","environment_variables":{},"error_message":null,"id":"8978659a-23b4-4fb0-b592-c644d3125ead","name":"tf-func-magical-engelbart","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncmagicalengelbatq5njero","registry_namespace_id":"f48cf3ee-e182-46da-baff-ba6130b38160","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:18.274854Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "579"
+                - "593"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:45 GMT
+                - Wed, 27 Aug 2025 15:05:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -342,10 +342,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5464e0f6-642b-4067-af42-c74bec1fec45
+                - 83c440c7-4e74-4fdf-ae72-4c7e7bac665b
         status: 200 OK
         code: 200
-        duration: 44.402292ms
+        duration: 46.818798ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -361,8 +361,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/c2d67483-b8ac-4638-9aed-7b40d8e757ab
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8978659a-23b4-4fb0-b592-c644d3125ead
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -370,20 +370,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 585
+        content_length: 599
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:22:39.584004Z","description":"","environment_variables":{},"error_message":null,"id":"c2d67483-b8ac-4638-9aed-7b40d8e757ab","name":"tf-func-ecstatic-chandrasekhar","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncecstaticchandrfauujmza","registry_namespace_id":"d0f5c7db-7ab3-475b-ada9-f0be61f99c60","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-04-28T09:22:45.303450246Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.317003Z","description":"","environment_variables":{},"error_message":null,"id":"8978659a-23b4-4fb0-b592-c644d3125ead","name":"tf-func-magical-engelbart","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncmagicalengelbatq5njero","registry_namespace_id":"f48cf3ee-e182-46da-baff-ba6130b38160","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:20.134409415Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "585"
+                - "599"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:45 GMT
+                - Wed, 27 Aug 2025 15:05:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -391,10 +391,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 888e33ae-2bab-40a3-b95a-ac163205c67a
+                - d7655593-0c8d-4e9e-90bf-7af4f9629c16
         status: 200 OK
         code: 200
-        duration: 189.039083ms
+        duration: 246.697366ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -410,8 +410,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/c2d67483-b8ac-4638-9aed-7b40d8e757ab
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8978659a-23b4-4fb0-b592-c644d3125ead
         method: GET
       response:
         proto: HTTP/2.0
@@ -419,20 +419,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 582
+        content_length: 596
         uncompressed: false
-        body: '{"created_at":"2025-04-28T09:22:39.584004Z","description":"","environment_variables":{},"error_message":null,"id":"c2d67483-b8ac-4638-9aed-7b40d8e757ab","name":"tf-func-ecstatic-chandrasekhar","organization_id":"6867048b-fe12-4e96-835e-41c79a39604b","project_id":"6867048b-fe12-4e96-835e-41c79a39604b","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncecstaticchandrfauujmza","registry_namespace_id":"d0f5c7db-7ab3-475b-ada9-f0be61f99c60","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-04-28T09:22:45.303450Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.317003Z","description":"","environment_variables":{},"error_message":null,"id":"8978659a-23b4-4fb0-b592-c644d3125ead","name":"tf-func-magical-engelbart","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncmagicalengelbatq5njero","registry_namespace_id":"f48cf3ee-e182-46da-baff-ba6130b38160","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:20.134409Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "582"
+                - "596"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:45 GMT
+                - Wed, 27 Aug 2025 15:05:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -440,10 +440,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d025061f-60f8-414b-80ef-9c81d723a005
+                - b5de5b12-3972-48d8-be04-eb32d4a00dfc
         status: 200 OK
         code: 200
-        duration: 88.775666ms
+        duration: 53.474967ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -459,8 +459,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/c2d67483-b8ac-4638-9aed-7b40d8e757ab
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8978659a-23b4-4fb0-b592-c644d3125ead
         method: GET
       response:
         proto: HTTP/2.0
@@ -479,9 +479,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:50 GMT
+                - Wed, 27 Aug 2025 15:05:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -489,10 +489,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d6680139-1c9f-4e4f-baf0-4fc1062c0596
+                - 8ba2a601-15b2-470d-be16-50a54e6bb320
         status: 404 Not Found
         code: 404
-        duration: 26.924334ms
+        duration: 24.620066ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -508,8 +508,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/c2d67483-b8ac-4638-9aed-7b40d8e757ab
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8978659a-23b4-4fb0-b592-c644d3125ead
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -528,9 +528,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 28 Apr 2025 09:22:50 GMT
+                - Wed, 27 Aug 2025 15:05:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -538,7 +538,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a02caeaf-e932-4dd7-a5ff-eb36a2c09d94
+                - c49fc923-5c6d-4abd-9dcc-59d123b19165
         status: 404 Not Found
         code: 404
-        duration: 27.039666ms
+        duration: 28.561201ms

--- a/internal/services/function/testdata/function-namespace-vpc-integration.cassette.yaml
+++ b/internal/services/function/testdata/function-namespace-vpc-integration.cassette.yaml
@@ -6,13 +6,13 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 191
+        content_length: 193
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-func-musing-leavitt","environment_variables":{},"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","secret_environment_variables":[],"tags":null,"activate_vpc_integration":false}'
+        body: '{"name":"tf-func-serene-lichterman","environment_variables":{},"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","secret_environment_variables":[],"tags":null,"activate_vpc_integration":true}'
         form: {}
         headers:
             Content-Type:
@@ -27,20 +27,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 508
+        content_length: 510
         uncompressed: false
-        body: '{"created_at":"2025-06-16T11:30:24.069127732Z","description":"","environment_variables":{},"error_message":null,"id":"a3a62ba2-9c10-4956-bc64-7890ea34c61c","name":"tf-func-musing-leavitt","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-06-16T11:30:24.069127732Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2025-08-27T14:01:44.917309032Z","description":"","environment_variables":{},"error_message":null,"id":"11f3af4d-e013-445f-8b22-156fc3c1f49c","name":"tf-func-serene-lichterman","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T14:01:44.917309032Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "508"
+                - "510"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 11:30:24 GMT
+                - Wed, 27 Aug 2025 14:01:44 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fb7690f3-5253-4527-ae0f-43e65e168250
+                - 9db72674-3220-417b-9111-33f938d2f387
         status: 200 OK
         code: 200
-        duration: 677.762471ms
+        duration: 825.58715ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -68,7 +68,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a3a62ba2-9c10-4956-bc64-7890ea34c61c
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/11f3af4d-e013-445f-8b22-156fc3c1f49c
         method: GET
       response:
         proto: HTTP/2.0
@@ -76,20 +76,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 502
+        content_length: 504
         uncompressed: false
-        body: '{"created_at":"2025-06-16T11:30:24.069128Z","description":"","environment_variables":{},"error_message":null,"id":"a3a62ba2-9c10-4956-bc64-7890ea34c61c","name":"tf-func-musing-leavitt","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-06-16T11:30:24.069128Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2025-08-27T14:01:44.917309Z","description":"","environment_variables":{},"error_message":null,"id":"11f3af4d-e013-445f-8b22-156fc3c1f49c","name":"tf-func-serene-lichterman","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T14:01:44.917309Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "502"
+                - "504"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 11:30:24 GMT
+                - Wed, 27 Aug 2025 14:01:44 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,22 +97,22 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - be86184e-3c1b-4cf2-b692-68a2c1f16afa
+                - 31d03ba1-fb19-4dcf-922c-1241d705a4a7
         status: 200 OK
         code: 200
-        duration: 49.597251ms
+        duration: 44.964823ms
     - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 152
+        content_length: 153
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-pn-gifted-engelbart","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"subnets":null,"default_route_propagation_enabled":false}'
+        body: '{"name":"tf-pn-stoic-stonebraker","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"subnets":null,"default_route_propagation_enabled":false}'
         form: {}
         headers:
             Content-Type:
@@ -127,20 +127,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1068
+        content_length: 1069
         uncompressed: false
-        body: '{"created_at":"2025-06-16T11:30:23.630403Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"238100f6-0246-441a-ae44-2c77af88ac9c","name":"tf-pn-gifted-engelbart","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-06-16T11:30:23.630403Z","id":"07330e73-1eac-4664-8601-56a0732618e2","private_network_id":"238100f6-0246-441a-ae44-2c77af88ac9c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.40.0/22","updated_at":"2025-06-16T11:30:23.630403Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-06-16T11:30:23.630403Z","id":"e86e1991-fbae-49a2-83ac-d8ac13f1d8e6","private_network_id":"238100f6-0246-441a-ae44-2c77af88ac9c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:d325::/64","updated_at":"2025-06-16T11:30:23.630403Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-06-16T11:30:23.630403Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+        body: '{"created_at":"2025-08-27T14:01:44.210929Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"c06c7ffa-e6c1-42e3-98d1-fd3da73d4253","name":"tf-pn-stoic-stonebraker","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-08-27T14:01:44.210929Z","id":"5873ffe4-f3f9-4933-88fe-71c893b7a8cf","private_network_id":"c06c7ffa-e6c1-42e3-98d1-fd3da73d4253","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.24.0/22","updated_at":"2025-08-27T14:01:44.210929Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-08-27T14:01:44.210929Z","id":"d77237aa-0dbe-4f17-9af4-31c6b6c7d6f5","private_network_id":"c06c7ffa-e6c1-42e3-98d1-fd3da73d4253","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:751f::/64","updated_at":"2025-08-27T14:01:44.210929Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-08-27T14:01:44.210929Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
         headers:
             Content-Length:
-                - "1068"
+                - "1069"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 11:30:24 GMT
+                - Wed, 27 Aug 2025 14:01:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -148,10 +148,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8a461cdf-c2e8-4de9-aafc-2a6b0042c345
+                - 6687e229-c1d7-4a36-b95a-2f0a53c2f20f
         status: 200 OK
         code: 200
-        duration: 768.861354ms
+        duration: 947.929346ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -168,7 +168,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/238100f6-0246-441a-ae44-2c77af88ac9c
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c06c7ffa-e6c1-42e3-98d1-fd3da73d4253
         method: GET
       response:
         proto: HTTP/2.0
@@ -176,20 +176,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1068
+        content_length: 1069
         uncompressed: false
-        body: '{"created_at":"2025-06-16T11:30:23.630403Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"238100f6-0246-441a-ae44-2c77af88ac9c","name":"tf-pn-gifted-engelbart","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-06-16T11:30:23.630403Z","id":"07330e73-1eac-4664-8601-56a0732618e2","private_network_id":"238100f6-0246-441a-ae44-2c77af88ac9c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.40.0/22","updated_at":"2025-06-16T11:30:23.630403Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-06-16T11:30:23.630403Z","id":"e86e1991-fbae-49a2-83ac-d8ac13f1d8e6","private_network_id":"238100f6-0246-441a-ae44-2c77af88ac9c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:d325::/64","updated_at":"2025-06-16T11:30:23.630403Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-06-16T11:30:23.630403Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+        body: '{"created_at":"2025-08-27T14:01:44.210929Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"c06c7ffa-e6c1-42e3-98d1-fd3da73d4253","name":"tf-pn-stoic-stonebraker","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-08-27T14:01:44.210929Z","id":"5873ffe4-f3f9-4933-88fe-71c893b7a8cf","private_network_id":"c06c7ffa-e6c1-42e3-98d1-fd3da73d4253","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.24.0/22","updated_at":"2025-08-27T14:01:44.210929Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-08-27T14:01:44.210929Z","id":"d77237aa-0dbe-4f17-9af4-31c6b6c7d6f5","private_network_id":"c06c7ffa-e6c1-42e3-98d1-fd3da73d4253","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:751f::/64","updated_at":"2025-08-27T14:01:44.210929Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-08-27T14:01:44.210929Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
         headers:
             Content-Length:
-                - "1068"
+                - "1069"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 11:30:24 GMT
+                - Wed, 27 Aug 2025 14:01:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -197,10 +197,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 635c6bab-137e-4b71-8fe6-ac4ed0394aee
+                - 2322b3aa-5fb2-449a-95cc-54519e207889
         status: 200 OK
         code: 200
-        duration: 36.694997ms
+        duration: 35.145608ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -217,7 +217,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a3a62ba2-9c10-4956-bc64-7890ea34c61c
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/11f3af4d-e013-445f-8b22-156fc3c1f49c
         method: GET
       response:
         proto: HTTP/2.0
@@ -225,20 +225,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 592
+        content_length: 593
         uncompressed: false
-        body: '{"created_at":"2025-06-16T11:30:24.069128Z","description":"","environment_variables":{},"error_message":null,"id":"a3a62ba2-9c10-4956-bc64-7890ea34c61c","name":"tf-func-musing-leavitt","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncmusingleavitt8rgde362","registry_namespace_id":"e4c8054f-7929-4f22-aa11-ff1b77c32d6c","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-06-16T11:30:27.312773Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2025-08-27T14:01:44.917309Z","description":"","environment_variables":{},"error_message":null,"id":"11f3af4d-e013-445f-8b22-156fc3c1f49c","name":"tf-func-serene-lichterman","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncserenelichtermytdhxbxc","registry_namespace_id":"a1317d92-e1bb-4bb1-b13d-b074295e69d1","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T14:01:48.786476Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "592"
+                - "593"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 11:30:29 GMT
+                - Wed, 27 Aug 2025 14:01:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -246,10 +246,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4b0cda1c-e72d-4025-a769-db8c59a27bbe
+                - f6e6d824-513c-46d1-94d9-f620e2bdc243
         status: 200 OK
         code: 200
-        duration: 51.563167ms
+        duration: 148.741845ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -266,7 +266,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a3a62ba2-9c10-4956-bc64-7890ea34c61c
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/11f3af4d-e013-445f-8b22-156fc3c1f49c
         method: GET
       response:
         proto: HTTP/2.0
@@ -274,20 +274,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 592
+        content_length: 593
         uncompressed: false
-        body: '{"created_at":"2025-06-16T11:30:24.069128Z","description":"","environment_variables":{},"error_message":null,"id":"a3a62ba2-9c10-4956-bc64-7890ea34c61c","name":"tf-func-musing-leavitt","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncmusingleavitt8rgde362","registry_namespace_id":"e4c8054f-7929-4f22-aa11-ff1b77c32d6c","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-06-16T11:30:27.312773Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2025-08-27T14:01:44.917309Z","description":"","environment_variables":{},"error_message":null,"id":"11f3af4d-e013-445f-8b22-156fc3c1f49c","name":"tf-func-serene-lichterman","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncserenelichtermytdhxbxc","registry_namespace_id":"a1317d92-e1bb-4bb1-b13d-b074295e69d1","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T14:01:48.786476Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "592"
+                - "593"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 11:30:34 GMT
+                - Wed, 27 Aug 2025 14:01:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -295,48 +295,50 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f58d0d54-3182-40b9-875e-4a8a8043526b
+                - be13d547-4ca1-44b2-879c-fd1aa6bc1c56
         status: 200 OK
         code: 200
-        duration: 53.378452ms
+        duration: 43.879533ms
     - id: 6
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 310
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"name":"tf-func-unruffled-montalcini","namespace_id":"11f3af4d-e013-445f-8b22-156fc3c1f49c","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"go123","memory_limit":256,"handler":"Handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"v1","tags":null}'
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a3a62ba2-9c10-4956-bc64-7890ea34c61c
-        method: GET
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 592
+        content_length: 741
         uncompressed: false
-        body: '{"created_at":"2025-06-16T11:30:24.069128Z","description":"","environment_variables":{},"error_message":null,"id":"a3a62ba2-9c10-4956-bc64-7890ea34c61c","name":"tf-func-musing-leavitt","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncmusingleavitt8rgde362","registry_namespace_id":"e4c8054f-7929-4f22-aa11-ff1b77c32d6c","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-06-16T11:30:27.312773Z","vpc_integration_activated":false}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T14:01:50.615081055Z","description":"","domain_name":"tffuncserenelichtermytdhxbxc-tf-func-unruffled-montalcini.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"87c2d675-77b9-4574-8c01-2f4f756a0fc4","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-unruffled-montalcini","namespace_id":"11f3af4d-e013-445f-8b22-156fc3c1f49c","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T14:01:50.615081055Z"}'
         headers:
             Content-Length:
-                - "592"
+                - "741"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 11:30:39 GMT
+                - Wed, 27 Aug 2025 14:01:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -344,10 +346,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d62ee746-2948-460d-960a-30b25bdd46da
+                - ac448401-4116-429b-97ac-48f33c9fbc34
         status: 200 OK
         code: 200
-        duration: 44.511101ms
+        duration: 464.214884ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -364,7 +366,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a3a62ba2-9c10-4956-bc64-7890ea34c61c
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/87c2d675-77b9-4574-8c01-2f4f756a0fc4
         method: GET
       response:
         proto: HTTP/2.0
@@ -372,20 +374,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 592
+        content_length: 735
         uncompressed: false
-        body: '{"created_at":"2025-06-16T11:30:24.069128Z","description":"","environment_variables":{},"error_message":null,"id":"a3a62ba2-9c10-4956-bc64-7890ea34c61c","name":"tf-func-musing-leavitt","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncmusingleavitt8rgde362","registry_namespace_id":"e4c8054f-7929-4f22-aa11-ff1b77c32d6c","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-06-16T11:30:27.312773Z","vpc_integration_activated":false}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T14:01:50.615081Z","description":"","domain_name":"tffuncserenelichtermytdhxbxc-tf-func-unruffled-montalcini.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"87c2d675-77b9-4574-8c01-2f4f756a0fc4","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-unruffled-montalcini","namespace_id":"11f3af4d-e013-445f-8b22-156fc3c1f49c","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T14:01:50.615081Z"}'
         headers:
             Content-Length:
-                - "592"
+                - "735"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 11:30:44 GMT
+                - Wed, 27 Aug 2025 14:01:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -393,10 +395,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 049961f3-845b-4231-951b-c7e7533f1dbe
+                - e8709008-7b80-4d10-9df1-99ef6f1c5371
         status: 200 OK
         code: 200
-        duration: 45.087121ms
+        duration: 60.958709ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -413,7 +415,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a3a62ba2-9c10-4956-bc64-7890ea34c61c
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/87c2d675-77b9-4574-8c01-2f4f756a0fc4
         method: GET
       response:
         proto: HTTP/2.0
@@ -421,20 +423,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 592
+        content_length: 735
         uncompressed: false
-        body: '{"created_at":"2025-06-16T11:30:24.069128Z","description":"","environment_variables":{},"error_message":null,"id":"a3a62ba2-9c10-4956-bc64-7890ea34c61c","name":"tf-func-musing-leavitt","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncmusingleavitt8rgde362","registry_namespace_id":"e4c8054f-7929-4f22-aa11-ff1b77c32d6c","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-06-16T11:30:27.312773Z","vpc_integration_activated":false}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T14:01:50.615081Z","description":"","domain_name":"tffuncserenelichtermytdhxbxc-tf-func-unruffled-montalcini.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"87c2d675-77b9-4574-8c01-2f4f756a0fc4","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-unruffled-montalcini","namespace_id":"11f3af4d-e013-445f-8b22-156fc3c1f49c","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T14:01:50.615081Z"}'
         headers:
             Content-Length:
-                - "592"
+                - "735"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 11:30:49 GMT
+                - Wed, 27 Aug 2025 14:01:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -442,10 +444,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - dd9c9382-3daf-4ba2-8f84-a83defb452e9
+                - 9cd84dee-356f-4e3d-815d-af6739b3f5dc
         status: 200 OK
         code: 200
-        duration: 461.79683ms
+        duration: 59.584183ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -462,7 +464,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a3a62ba2-9c10-4956-bc64-7890ea34c61c
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/11f3af4d-e013-445f-8b22-156fc3c1f49c
         method: GET
       response:
         proto: HTTP/2.0
@@ -470,20 +472,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 590
+        content_length: 593
         uncompressed: false
-        body: '{"created_at":"2025-06-16T11:30:24.069128Z","description":"","environment_variables":{},"error_message":null,"id":"a3a62ba2-9c10-4956-bc64-7890ea34c61c","name":"tf-func-musing-leavitt","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncmusingleavitt8rgde362","registry_namespace_id":"e4c8054f-7929-4f22-aa11-ff1b77c32d6c","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-16T11:30:53.930494Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2025-08-27T14:01:44.917309Z","description":"","environment_variables":{},"error_message":null,"id":"11f3af4d-e013-445f-8b22-156fc3c1f49c","name":"tf-func-serene-lichterman","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncserenelichtermytdhxbxc","registry_namespace_id":"a1317d92-e1bb-4bb1-b13d-b074295e69d1","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T14:01:48.786476Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "590"
+                - "593"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 11:30:54 GMT
+                - Wed, 27 Aug 2025 14:01:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -491,10 +493,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8f8e6fd1-cdb5-4f62-8a63-f8dfc59c5df0
+                - 71335984-7f56-46c8-bee0-59c57797023e
         status: 200 OK
         code: 200
-        duration: 48.620508ms
+        duration: 39.812544ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -511,7 +513,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a3a62ba2-9c10-4956-bc64-7890ea34c61c
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c06c7ffa-e6c1-42e3-98d1-fd3da73d4253
         method: GET
       response:
         proto: HTTP/2.0
@@ -519,20 +521,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 590
+        content_length: 1069
         uncompressed: false
-        body: '{"created_at":"2025-06-16T11:30:24.069128Z","description":"","environment_variables":{},"error_message":null,"id":"a3a62ba2-9c10-4956-bc64-7890ea34c61c","name":"tf-func-musing-leavitt","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncmusingleavitt8rgde362","registry_namespace_id":"e4c8054f-7929-4f22-aa11-ff1b77c32d6c","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-16T11:30:53.930494Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2025-08-27T14:01:44.210929Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"c06c7ffa-e6c1-42e3-98d1-fd3da73d4253","name":"tf-pn-stoic-stonebraker","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-08-27T14:01:44.210929Z","id":"5873ffe4-f3f9-4933-88fe-71c893b7a8cf","private_network_id":"c06c7ffa-e6c1-42e3-98d1-fd3da73d4253","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.24.0/22","updated_at":"2025-08-27T14:01:44.210929Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-08-27T14:01:44.210929Z","id":"d77237aa-0dbe-4f17-9af4-31c6b6c7d6f5","private_network_id":"c06c7ffa-e6c1-42e3-98d1-fd3da73d4253","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:751f::/64","updated_at":"2025-08-27T14:01:44.210929Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-08-27T14:01:44.210929Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
         headers:
             Content-Length:
-                - "590"
+                - "1069"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 11:30:54 GMT
+                - Wed, 27 Aug 2025 14:01:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -540,50 +542,48 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7d7378a4-b9e0-4ec8-85d4-1d7362853f71
+                - 8b0cc1e5-1344-40a2-9dc6-7ea13c9f1032
         status: 200 OK
         code: 200
-        duration: 51.14758ms
+        duration: 26.121168ms
     - id: 11
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 307
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-func-crazy-brahmagupta","namespace_id":"a3a62ba2-9c10-4956-bc64-7890ea34c61c","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"go123","memory_limit":256,"handler":"Handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"v1","tags":null}'
+        body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions
-        method: POST
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/11f3af4d-e013-445f-8b22-156fc3c1f49c
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 734
+        content_length: 593
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-16T11:30:55.173382401Z","description":"","domain_name":"tffuncmusingleavitt8rgde362-tf-func-crazy-brahmagupta.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"8b7ffd77-ab03-4783-9eb9-d0576bc19785","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-crazy-brahmagupta","namespace_id":"a3a62ba2-9c10-4956-bc64-7890ea34c61c","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-16T11:30:55.173382401Z"}'
+        body: '{"created_at":"2025-08-27T14:01:44.917309Z","description":"","environment_variables":{},"error_message":null,"id":"11f3af4d-e013-445f-8b22-156fc3c1f49c","name":"tf-func-serene-lichterman","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncserenelichtermytdhxbxc","registry_namespace_id":"a1317d92-e1bb-4bb1-b13d-b074295e69d1","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T14:01:48.786476Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "734"
+                - "593"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 11:30:55 GMT
+                - Wed, 27 Aug 2025 14:01:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -591,10 +591,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a0dcb67b-b8fc-4868-821d-d4481fd9dd12
+                - ef916180-5591-44ba-b561-472b89081679
         status: 200 OK
         code: 200
-        duration: 287.88431ms
+        duration: 39.548207ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -611,7 +611,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/8b7ffd77-ab03-4783-9eb9-d0576bc19785
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/87c2d675-77b9-4574-8c01-2f4f756a0fc4
         method: GET
       response:
         proto: HTTP/2.0
@@ -619,20 +619,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 728
+        content_length: 735
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-16T11:30:55.173382Z","description":"","domain_name":"tffuncmusingleavitt8rgde362-tf-func-crazy-brahmagupta.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"8b7ffd77-ab03-4783-9eb9-d0576bc19785","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-crazy-brahmagupta","namespace_id":"a3a62ba2-9c10-4956-bc64-7890ea34c61c","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-16T11:30:55.173382Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T14:01:50.615081Z","description":"","domain_name":"tffuncserenelichtermytdhxbxc-tf-func-unruffled-montalcini.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"87c2d675-77b9-4574-8c01-2f4f756a0fc4","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-unruffled-montalcini","namespace_id":"11f3af4d-e013-445f-8b22-156fc3c1f49c","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T14:01:50.615081Z"}'
         headers:
             Content-Length:
-                - "728"
+                - "735"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 11:30:55 GMT
+                - Wed, 27 Aug 2025 14:01:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -640,10 +640,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 64a2d2bc-9ade-4be3-9262-0e84deef441b
+                - 23c89e72-2185-43c1-9d3d-b9b9d4332791
         status: 200 OK
         code: 200
-        duration: 44.042593ms
+        duration: 43.619652ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -660,7 +660,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/8b7ffd77-ab03-4783-9eb9-d0576bc19785
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c06c7ffa-e6c1-42e3-98d1-fd3da73d4253
         method: GET
       response:
         proto: HTTP/2.0
@@ -668,20 +668,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 728
+        content_length: 1069
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-16T11:30:55.173382Z","description":"","domain_name":"tffuncmusingleavitt8rgde362-tf-func-crazy-brahmagupta.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"8b7ffd77-ab03-4783-9eb9-d0576bc19785","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-crazy-brahmagupta","namespace_id":"a3a62ba2-9c10-4956-bc64-7890ea34c61c","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-16T11:30:55.173382Z"}'
+        body: '{"created_at":"2025-08-27T14:01:44.210929Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"c06c7ffa-e6c1-42e3-98d1-fd3da73d4253","name":"tf-pn-stoic-stonebraker","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-08-27T14:01:44.210929Z","id":"5873ffe4-f3f9-4933-88fe-71c893b7a8cf","private_network_id":"c06c7ffa-e6c1-42e3-98d1-fd3da73d4253","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.24.0/22","updated_at":"2025-08-27T14:01:44.210929Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-08-27T14:01:44.210929Z","id":"d77237aa-0dbe-4f17-9af4-31c6b6c7d6f5","private_network_id":"c06c7ffa-e6c1-42e3-98d1-fd3da73d4253","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:751f::/64","updated_at":"2025-08-27T14:01:44.210929Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-08-27T14:01:44.210929Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
         headers:
             Content-Length:
-                - "728"
+                - "1069"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 11:30:55 GMT
+                - Wed, 27 Aug 2025 14:01:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -689,10 +689,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1723d974-e800-4080-adb5-761962ee2217
+                - 81dd80f6-8bdb-42ae-8f78-7cd2ddc75d79
         status: 200 OK
         code: 200
-        duration: 121.787712ms
+        duration: 53.8712ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -709,7 +709,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a3a62ba2-9c10-4956-bc64-7890ea34c61c
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/11f3af4d-e013-445f-8b22-156fc3c1f49c
         method: GET
       response:
         proto: HTTP/2.0
@@ -717,20 +717,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 590
+        content_length: 593
         uncompressed: false
-        body: '{"created_at":"2025-06-16T11:30:24.069128Z","description":"","environment_variables":{},"error_message":null,"id":"a3a62ba2-9c10-4956-bc64-7890ea34c61c","name":"tf-func-musing-leavitt","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncmusingleavitt8rgde362","registry_namespace_id":"e4c8054f-7929-4f22-aa11-ff1b77c32d6c","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-16T11:30:53.930494Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2025-08-27T14:01:44.917309Z","description":"","environment_variables":{},"error_message":null,"id":"11f3af4d-e013-445f-8b22-156fc3c1f49c","name":"tf-func-serene-lichterman","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncserenelichtermytdhxbxc","registry_namespace_id":"a1317d92-e1bb-4bb1-b13d-b074295e69d1","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T14:01:48.786476Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "590"
+                - "593"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 11:30:55 GMT
+                - Wed, 27 Aug 2025 14:01:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -738,10 +738,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f8185839-3033-4314-8631-c796228f3d18
+                - e509dacb-57e4-4e9d-b95b-ce8eed320f55
         status: 200 OK
         code: 200
-        duration: 34.737761ms
+        duration: 55.320445ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -758,7 +758,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a3a62ba2-9c10-4956-bc64-7890ea34c61c
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/87c2d675-77b9-4574-8c01-2f4f756a0fc4
         method: GET
       response:
         proto: HTTP/2.0
@@ -766,20 +766,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 590
+        content_length: 735
         uncompressed: false
-        body: '{"created_at":"2025-06-16T11:30:24.069128Z","description":"","environment_variables":{},"error_message":null,"id":"a3a62ba2-9c10-4956-bc64-7890ea34c61c","name":"tf-func-musing-leavitt","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncmusingleavitt8rgde362","registry_namespace_id":"e4c8054f-7929-4f22-aa11-ff1b77c32d6c","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-16T11:30:53.930494Z","vpc_integration_activated":false}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T14:01:50.615081Z","description":"","domain_name":"tffuncserenelichtermytdhxbxc-tf-func-unruffled-montalcini.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"87c2d675-77b9-4574-8c01-2f4f756a0fc4","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-unruffled-montalcini","namespace_id":"11f3af4d-e013-445f-8b22-156fc3c1f49c","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T14:01:50.615081Z"}'
         headers:
             Content-Length:
-                - "590"
+                - "735"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 11:30:56 GMT
+                - Wed, 27 Aug 2025 14:01:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -787,10 +787,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2af2e928-2977-446e-8b0c-5ada248fecf2
+                - bce59cdc-5b15-4130-8fa2-cdb252d80374
         status: 200 OK
         code: 200
-        duration: 42.596422ms
+        duration: 56.900757ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -807,7 +807,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/238100f6-0246-441a-ae44-2c77af88ac9c
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/87c2d675-77b9-4574-8c01-2f4f756a0fc4
         method: GET
       response:
         proto: HTTP/2.0
@@ -815,20 +815,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1068
+        content_length: 735
         uncompressed: false
-        body: '{"created_at":"2025-06-16T11:30:23.630403Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"238100f6-0246-441a-ae44-2c77af88ac9c","name":"tf-pn-gifted-engelbart","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-06-16T11:30:23.630403Z","id":"07330e73-1eac-4664-8601-56a0732618e2","private_network_id":"238100f6-0246-441a-ae44-2c77af88ac9c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.40.0/22","updated_at":"2025-06-16T11:30:23.630403Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-06-16T11:30:23.630403Z","id":"e86e1991-fbae-49a2-83ac-d8ac13f1d8e6","private_network_id":"238100f6-0246-441a-ae44-2c77af88ac9c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:d325::/64","updated_at":"2025-06-16T11:30:23.630403Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-06-16T11:30:23.630403Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T14:01:50.615081Z","description":"","domain_name":"tffuncserenelichtermytdhxbxc-tf-func-unruffled-montalcini.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"87c2d675-77b9-4574-8c01-2f4f756a0fc4","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-unruffled-montalcini","namespace_id":"11f3af4d-e013-445f-8b22-156fc3c1f49c","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T14:01:50.615081Z"}'
         headers:
             Content-Length:
-                - "1068"
+                - "735"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 11:30:56 GMT
+                - Wed, 27 Aug 2025 14:01:52 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -836,48 +836,50 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f0498bd9-f75f-40bd-b16c-8d8adc1428f5
+                - 1708bf8a-da13-4840-ada6-12d7405d7c8a
         status: 200 OK
         code: 200
-        duration: 84.631185ms
+        duration: 69.955154ms
     - id: 17
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 217
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"runtime":"unknown_runtime","privacy":"unknown_privacy","secret_environment_variables":null,"http_option":"unknown_http_option","sandbox":"unknown_sandbox","private_network_id":"c06c7ffa-e6c1-42e3-98d1-fd3da73d4253"}'
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/8b7ffd77-ab03-4783-9eb9-d0576bc19785
-        method: GET
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/87c2d675-77b9-4574-8c01-2f4f756a0fc4
+        method: PATCH
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 728
+        content_length: 772
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-16T11:30:55.173382Z","description":"","domain_name":"tffuncmusingleavitt8rgde362-tf-func-crazy-brahmagupta.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"8b7ffd77-ab03-4783-9eb9-d0576bc19785","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-crazy-brahmagupta","namespace_id":"a3a62ba2-9c10-4956-bc64-7890ea34c61c","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-16T11:30:55.173382Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T14:01:50.615081Z","description":"","domain_name":"tffuncserenelichtermytdhxbxc-tf-func-unruffled-montalcini.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"87c2d675-77b9-4574-8c01-2f4f756a0fc4","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-unruffled-montalcini","namespace_id":"11f3af4d-e013-445f-8b22-156fc3c1f49c","privacy":"private","private_network_id":"c06c7ffa-e6c1-42e3-98d1-fd3da73d4253","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T14:01:52.410733960Z"}'
         headers:
             Content-Length:
-                - "728"
+                - "772"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 11:30:56 GMT
+                - Wed, 27 Aug 2025 14:01:52 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -885,10 +887,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 26d77f7c-c033-4b0e-b2a3-ca793ba993bc
+                - 91d09e39-ba89-4e1c-b7b1-459972c5c66e
         status: 200 OK
         code: 200
-        duration: 95.415663ms
+        duration: 317.607149ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -905,7 +907,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a3a62ba2-9c10-4956-bc64-7890ea34c61c
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/87c2d675-77b9-4574-8c01-2f4f756a0fc4
         method: GET
       response:
         proto: HTTP/2.0
@@ -913,20 +915,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 590
+        content_length: 769
         uncompressed: false
-        body: '{"created_at":"2025-06-16T11:30:24.069128Z","description":"","environment_variables":{},"error_message":null,"id":"a3a62ba2-9c10-4956-bc64-7890ea34c61c","name":"tf-func-musing-leavitt","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncmusingleavitt8rgde362","registry_namespace_id":"e4c8054f-7929-4f22-aa11-ff1b77c32d6c","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-16T11:30:53.930494Z","vpc_integration_activated":false}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T14:01:50.615081Z","description":"","domain_name":"tffuncserenelichtermytdhxbxc-tf-func-unruffled-montalcini.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"87c2d675-77b9-4574-8c01-2f4f756a0fc4","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-unruffled-montalcini","namespace_id":"11f3af4d-e013-445f-8b22-156fc3c1f49c","privacy":"private","private_network_id":"c06c7ffa-e6c1-42e3-98d1-fd3da73d4253","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T14:01:52.410734Z"}'
         headers:
             Content-Length:
-                - "590"
+                - "769"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 11:30:57 GMT
+                - Wed, 27 Aug 2025 14:01:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -934,10 +936,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cebebc38-8cfa-414a-b111-b9c38ed3ef88
+                - b51fb0d2-b236-4f81-8ade-940bf7abc8eb
         status: 200 OK
         code: 200
-        duration: 130.859501ms
+        duration: 53.815053ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -954,7 +956,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/238100f6-0246-441a-ae44-2c77af88ac9c
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/87c2d675-77b9-4574-8c01-2f4f756a0fc4
         method: GET
       response:
         proto: HTTP/2.0
@@ -962,20 +964,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1068
+        content_length: 779
         uncompressed: false
-        body: '{"created_at":"2025-06-16T11:30:23.630403Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"238100f6-0246-441a-ae44-2c77af88ac9c","name":"tf-pn-gifted-engelbart","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-06-16T11:30:23.630403Z","id":"07330e73-1eac-4664-8601-56a0732618e2","private_network_id":"238100f6-0246-441a-ae44-2c77af88ac9c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.40.0/22","updated_at":"2025-06-16T11:30:23.630403Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-06-16T11:30:23.630403Z","id":"e86e1991-fbae-49a2-83ac-d8ac13f1d8e6","private_network_id":"238100f6-0246-441a-ae44-2c77af88ac9c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:d325::/64","updated_at":"2025-06-16T11:30:23.630403Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-06-16T11:30:23.630403Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T14:01:50.615081Z","description":"","domain_name":"tffuncserenelichtermytdhxbxc-tf-func-unruffled-montalcini.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"Handle","http_option":"enabled","id":"87c2d675-77b9-4574-8c01-2f4f756a0fc4","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-unruffled-montalcini","namespace_id":"11f3af4d-e013-445f-8b22-156fc3c1f49c","privacy":"private","private_network_id":"c06c7ffa-e6c1-42e3-98d1-fd3da73d4253","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T14:01:58.281774Z"}'
         headers:
             Content-Length:
-                - "1068"
+                - "779"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 11:30:57 GMT
+                - Wed, 27 Aug 2025 14:01:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -983,10 +985,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d32a89cd-e608-4737-bad9-8e6fd3ede1dc
+                - 794e0243-3c4e-4e5d-ab44-d316e9f3b1a0
         status: 200 OK
         code: 200
-        duration: 148.007566ms
+        duration: 68.921539ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1003,7 +1005,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/8b7ffd77-ab03-4783-9eb9-d0576bc19785
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/11f3af4d-e013-445f-8b22-156fc3c1f49c
         method: GET
       response:
         proto: HTTP/2.0
@@ -1011,20 +1013,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 728
+        content_length: 593
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-16T11:30:55.173382Z","description":"","domain_name":"tffuncmusingleavitt8rgde362-tf-func-crazy-brahmagupta.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"8b7ffd77-ab03-4783-9eb9-d0576bc19785","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-crazy-brahmagupta","namespace_id":"a3a62ba2-9c10-4956-bc64-7890ea34c61c","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-16T11:30:55.173382Z"}'
+        body: '{"created_at":"2025-08-27T14:01:44.917309Z","description":"","environment_variables":{},"error_message":null,"id":"11f3af4d-e013-445f-8b22-156fc3c1f49c","name":"tf-func-serene-lichterman","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncserenelichtermytdhxbxc","registry_namespace_id":"a1317d92-e1bb-4bb1-b13d-b074295e69d1","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T14:01:48.786476Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "728"
+                - "593"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 11:30:57 GMT
+                - Wed, 27 Aug 2025 14:01:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1032,10 +1034,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e48a7faf-5dc3-4cd5-aaac-ccacfacd12f8
+                - bc2c1fd9-8e21-47f8-b25c-8380c18fd07c
         status: 200 OK
         code: 200
-        duration: 44.866788ms
+        duration: 48.169748ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1052,7 +1054,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/8b7ffd77-ab03-4783-9eb9-d0576bc19785
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/87c2d675-77b9-4574-8c01-2f4f756a0fc4
         method: GET
       response:
         proto: HTTP/2.0
@@ -1060,20 +1062,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 728
+        content_length: 779
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-16T11:30:55.173382Z","description":"","domain_name":"tffuncmusingleavitt8rgde362-tf-func-crazy-brahmagupta.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"8b7ffd77-ab03-4783-9eb9-d0576bc19785","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-crazy-brahmagupta","namespace_id":"a3a62ba2-9c10-4956-bc64-7890ea34c61c","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-16T11:30:55.173382Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T14:01:50.615081Z","description":"","domain_name":"tffuncserenelichtermytdhxbxc-tf-func-unruffled-montalcini.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"Handle","http_option":"enabled","id":"87c2d675-77b9-4574-8c01-2f4f756a0fc4","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-unruffled-montalcini","namespace_id":"11f3af4d-e013-445f-8b22-156fc3c1f49c","privacy":"private","private_network_id":"c06c7ffa-e6c1-42e3-98d1-fd3da73d4253","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T14:01:58.281774Z"}'
         headers:
             Content-Length:
-                - "728"
+                - "779"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 11:30:58 GMT
+                - Wed, 27 Aug 2025 14:01:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1081,50 +1083,48 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - aec4827e-50b6-44a6-b495-0bda0bf3b617
+                - f2810d72-cd30-4d4a-9704-dba6136f9085
         status: 200 OK
         code: 200
-        duration: 65.069285ms
+        duration: 44.370053ms
     - id: 22
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 217
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"runtime":"unknown_runtime","privacy":"unknown_privacy","secret_environment_variables":null,"http_option":"unknown_http_option","sandbox":"unknown_sandbox","private_network_id":"238100f6-0246-441a-ae44-2c77af88ac9c"}'
+        body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/8b7ffd77-ab03-4783-9eb9-d0576bc19785
-        method: PATCH
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c06c7ffa-e6c1-42e3-98d1-fd3da73d4253
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 121
+        content_length: 1069
         uncompressed: false
-        body: '{"message":"Application can''t be attached to private network, vpc integration must be activated on its parent namespace"}'
+        body: '{"created_at":"2025-08-27T14:01:44.210929Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"c06c7ffa-e6c1-42e3-98d1-fd3da73d4253","name":"tf-pn-stoic-stonebraker","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-08-27T14:01:44.210929Z","id":"5873ffe4-f3f9-4933-88fe-71c893b7a8cf","private_network_id":"c06c7ffa-e6c1-42e3-98d1-fd3da73d4253","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.24.0/22","updated_at":"2025-08-27T14:01:44.210929Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-08-27T14:01:44.210929Z","id":"d77237aa-0dbe-4f17-9af4-31c6b6c7d6f5","private_network_id":"c06c7ffa-e6c1-42e3-98d1-fd3da73d4253","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:751f::/64","updated_at":"2025-08-27T14:01:44.210929Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-08-27T14:01:44.210929Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
         headers:
             Content-Length:
-                - "121"
+                - "1069"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 11:30:58 GMT
+                - Wed, 27 Aug 2025 14:01:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1132,10 +1132,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - de7f23b5-6a57-4b20-ae67-e329b161e02d
-        status: 400 Bad Request
-        code: 400
-        duration: 41.274475ms
+                - 28870d93-c2a0-4c3a-811d-965493f870f3
+        status: 200 OK
+        code: 200
+        duration: 19.136174ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1152,7 +1152,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a3a62ba2-9c10-4956-bc64-7890ea34c61c
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/11f3af4d-e013-445f-8b22-156fc3c1f49c
         method: GET
       response:
         proto: HTTP/2.0
@@ -1160,20 +1160,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 590
+        content_length: 593
         uncompressed: false
-        body: '{"created_at":"2025-06-16T11:30:24.069128Z","description":"","environment_variables":{},"error_message":null,"id":"a3a62ba2-9c10-4956-bc64-7890ea34c61c","name":"tf-func-musing-leavitt","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncmusingleavitt8rgde362","registry_namespace_id":"e4c8054f-7929-4f22-aa11-ff1b77c32d6c","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-16T11:30:53.930494Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2025-08-27T14:01:44.917309Z","description":"","environment_variables":{},"error_message":null,"id":"11f3af4d-e013-445f-8b22-156fc3c1f49c","name":"tf-func-serene-lichterman","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncserenelichtermytdhxbxc","registry_namespace_id":"a1317d92-e1bb-4bb1-b13d-b074295e69d1","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T14:01:48.786476Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "590"
+                - "593"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 11:30:58 GMT
+                - Wed, 27 Aug 2025 14:01:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1181,10 +1181,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1ef925be-4358-4d3c-ac89-f51984e07694
+                - 9c4d12a0-4a83-4120-a332-3b09720abcd9
         status: 200 OK
         code: 200
-        duration: 43.825524ms
+        duration: 50.16044ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1201,7 +1201,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/238100f6-0246-441a-ae44-2c77af88ac9c
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/87c2d675-77b9-4574-8c01-2f4f756a0fc4
         method: GET
       response:
         proto: HTTP/2.0
@@ -1209,20 +1209,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1068
+        content_length: 779
         uncompressed: false
-        body: '{"created_at":"2025-06-16T11:30:23.630403Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"238100f6-0246-441a-ae44-2c77af88ac9c","name":"tf-pn-gifted-engelbart","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-06-16T11:30:23.630403Z","id":"07330e73-1eac-4664-8601-56a0732618e2","private_network_id":"238100f6-0246-441a-ae44-2c77af88ac9c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.40.0/22","updated_at":"2025-06-16T11:30:23.630403Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-06-16T11:30:23.630403Z","id":"e86e1991-fbae-49a2-83ac-d8ac13f1d8e6","private_network_id":"238100f6-0246-441a-ae44-2c77af88ac9c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:d325::/64","updated_at":"2025-06-16T11:30:23.630403Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-06-16T11:30:23.630403Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T14:01:50.615081Z","description":"","domain_name":"tffuncserenelichtermytdhxbxc-tf-func-unruffled-montalcini.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"Handle","http_option":"enabled","id":"87c2d675-77b9-4574-8c01-2f4f756a0fc4","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-unruffled-montalcini","namespace_id":"11f3af4d-e013-445f-8b22-156fc3c1f49c","privacy":"private","private_network_id":"c06c7ffa-e6c1-42e3-98d1-fd3da73d4253","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T14:01:58.281774Z"}'
         headers:
             Content-Length:
-                - "1068"
+                - "779"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 11:30:58 GMT
+                - Wed, 27 Aug 2025 14:01:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1230,10 +1230,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 95968cb6-0c39-48b4-bbf7-3975a6b36052
+                - d690677f-0ef2-42b9-b6d6-855f0c4595f7
         status: 200 OK
         code: 200
-        duration: 91.853985ms
+        duration: 48.552446ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1250,7 +1250,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/8b7ffd77-ab03-4783-9eb9-d0576bc19785
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/87c2d675-77b9-4574-8c01-2f4f756a0fc4
         method: GET
       response:
         proto: HTTP/2.0
@@ -1258,20 +1258,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 728
+        content_length: 779
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-16T11:30:55.173382Z","description":"","domain_name":"tffuncmusingleavitt8rgde362-tf-func-crazy-brahmagupta.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"8b7ffd77-ab03-4783-9eb9-d0576bc19785","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-crazy-brahmagupta","namespace_id":"a3a62ba2-9c10-4956-bc64-7890ea34c61c","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-16T11:30:55.173382Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T14:01:50.615081Z","description":"","domain_name":"tffuncserenelichtermytdhxbxc-tf-func-unruffled-montalcini.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"Handle","http_option":"enabled","id":"87c2d675-77b9-4574-8c01-2f4f756a0fc4","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-unruffled-montalcini","namespace_id":"11f3af4d-e013-445f-8b22-156fc3c1f49c","privacy":"private","private_network_id":"c06c7ffa-e6c1-42e3-98d1-fd3da73d4253","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T14:01:58.281774Z"}'
         headers:
             Content-Length:
-                - "728"
+                - "779"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 11:30:58 GMT
+                - Wed, 27 Aug 2025 14:01:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1279,10 +1279,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c3cf9fef-0131-47a8-ab45-e6003802d95d
+                - a90f1257-539c-4a5f-8352-e783dc640502
         status: 200 OK
         code: 200
-        duration: 98.614252ms
+        duration: 53.628822ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1299,28 +1299,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/8b7ffd77-ab03-4783-9eb9-d0576bc19785
-        method: GET
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/87c2d675-77b9-4574-8c01-2f4f756a0fc4
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 728
+        content_length: 773
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-16T11:30:55.173382Z","description":"","domain_name":"tffuncmusingleavitt8rgde362-tf-func-crazy-brahmagupta.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"8b7ffd77-ab03-4783-9eb9-d0576bc19785","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-crazy-brahmagupta","namespace_id":"a3a62ba2-9c10-4956-bc64-7890ea34c61c","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-16T11:30:55.173382Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T14:01:50.615081Z","description":"","domain_name":"tffuncserenelichtermytdhxbxc-tf-func-unruffled-montalcini.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"87c2d675-77b9-4574-8c01-2f4f756a0fc4","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-unruffled-montalcini","namespace_id":"11f3af4d-e013-445f-8b22-156fc3c1f49c","privacy":"private","private_network_id":"c06c7ffa-e6c1-42e3-98d1-fd3da73d4253","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2025-08-27T14:01:59.601876398Z"}'
         headers:
             Content-Length:
-                - "728"
+                - "773"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 11:30:59 GMT
+                - Wed, 27 Aug 2025 14:01:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1328,10 +1328,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ca3b17bf-c27e-427a-8846-d8d769b97497
+                - e8f254d0-a7b9-4632-b2b7-295cfc373cf8
         status: 200 OK
         code: 200
-        duration: 54.619554ms
+        duration: 114.652651ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1348,28 +1348,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/8b7ffd77-ab03-4783-9eb9-d0576bc19785
-        method: DELETE
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/11f3af4d-e013-445f-8b22-156fc3c1f49c
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 732
+        content_length: 593
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-16T11:30:55.173382Z","description":"","domain_name":"tffuncmusingleavitt8rgde362-tf-func-crazy-brahmagupta.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"8b7ffd77-ab03-4783-9eb9-d0576bc19785","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-crazy-brahmagupta","namespace_id":"a3a62ba2-9c10-4956-bc64-7890ea34c61c","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2025-06-16T11:30:59.923814407Z"}'
+        body: '{"created_at":"2025-08-27T14:01:44.917309Z","description":"","environment_variables":{},"error_message":null,"id":"11f3af4d-e013-445f-8b22-156fc3c1f49c","name":"tf-func-serene-lichterman","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncserenelichtermytdhxbxc","registry_namespace_id":"a1317d92-e1bb-4bb1-b13d-b074295e69d1","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T14:01:48.786476Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "732"
+                - "593"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 11:31:00 GMT
+                - Wed, 27 Aug 2025 14:01:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1377,10 +1377,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9ff7e9c1-cdd9-4437-b20d-76f51b453fee
+                - 889197ba-6d89-4c77-b1fc-80db3ad2f5b8
         status: 200 OK
         code: 200
-        duration: 150.969589ms
+        duration: 40.410807ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1397,28 +1397,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a3a62ba2-9c10-4956-bc64-7890ea34c61c
-        method: GET
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/11f3af4d-e013-445f-8b22-156fc3c1f49c
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 590
+        content_length: 599
         uncompressed: false
-        body: '{"created_at":"2025-06-16T11:30:24.069128Z","description":"","environment_variables":{},"error_message":null,"id":"a3a62ba2-9c10-4956-bc64-7890ea34c61c","name":"tf-func-musing-leavitt","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncmusingleavitt8rgde362","registry_namespace_id":"e4c8054f-7929-4f22-aa11-ff1b77c32d6c","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-16T11:30:53.930494Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2025-08-27T14:01:44.917309Z","description":"","environment_variables":{},"error_message":null,"id":"11f3af4d-e013-445f-8b22-156fc3c1f49c","name":"tf-func-serene-lichterman","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncserenelichtermytdhxbxc","registry_namespace_id":"a1317d92-e1bb-4bb1-b13d-b074295e69d1","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T14:01:59.759410734Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "590"
+                - "599"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 11:31:00 GMT
+                - Wed, 27 Aug 2025 14:01:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1426,10 +1426,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8dec9b61-94ae-4cc8-a373-37505604ba26
+                - 51407f71-f4c9-4e41-b8ac-66d22a1f0aab
         status: 200 OK
         code: 200
-        duration: 56.836511ms
+        duration: 192.511955ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1446,8 +1446,8 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a3a62ba2-9c10-4956-bc64-7890ea34c61c
-        method: DELETE
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/11f3af4d-e013-445f-8b22-156fc3c1f49c
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
@@ -1456,7 +1456,7 @@ interactions:
         trailer: {}
         content_length: 596
         uncompressed: false
-        body: '{"created_at":"2025-06-16T11:30:24.069128Z","description":"","environment_variables":{},"error_message":null,"id":"a3a62ba2-9c10-4956-bc64-7890ea34c61c","name":"tf-func-musing-leavitt","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncmusingleavitt8rgde362","registry_namespace_id":"e4c8054f-7929-4f22-aa11-ff1b77c32d6c","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-06-16T11:31:00.126077874Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2025-08-27T14:01:44.917309Z","description":"","environment_variables":{},"error_message":null,"id":"11f3af4d-e013-445f-8b22-156fc3c1f49c","name":"tf-func-serene-lichterman","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncserenelichtermytdhxbxc","registry_namespace_id":"a1317d92-e1bb-4bb1-b13d-b074295e69d1","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T14:01:59.759411Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
                 - "596"
@@ -1465,9 +1465,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 11:31:00 GMT
+                - Wed, 27 Aug 2025 14:01:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1475,10 +1475,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0b2b9ab6-551c-41ee-bc05-b8e76c55ffe4
+                - e05af8d2-41a8-4cb6-ba0c-ec3f1a0acfa7
         status: 200 OK
         code: 200
-        duration: 166.158952ms
+        duration: 41.287586ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1495,28 +1495,26 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a3a62ba2-9c10-4956-bc64-7890ea34c61c
-        method: GET
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c06c7ffa-e6c1-42e3-98d1-fd3da73d4253
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 593
+        content_length: 0
         uncompressed: false
-        body: '{"created_at":"2025-06-16T11:30:24.069128Z","description":"","environment_variables":{},"error_message":null,"id":"a3a62ba2-9c10-4956-bc64-7890ea34c61c","name":"tf-func-musing-leavitt","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncmusingleavitt8rgde362","registry_namespace_id":"e4c8054f-7929-4f22-aa11-ff1b77c32d6c","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-06-16T11:31:00.126078Z","vpc_integration_activated":false}'
+        body: ""
         headers:
-            Content-Length:
-                - "593"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 11:31:00 GMT
+                - Wed, 27 Aug 2025 14:02:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1524,10 +1522,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 49d30e5f-1c22-46e6-9117-fcd7e93bbd52
-        status: 200 OK
-        code: 200
-        duration: 48.353143ms
+                - 904540a1-c3c6-4b79-877b-40a361e849c4
+        status: 204 No Content
+        code: 204
+        duration: 1.543081992s
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1544,7 +1542,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a3a62ba2-9c10-4956-bc64-7890ea34c61c
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/11f3af4d-e013-445f-8b22-156fc3c1f49c
         method: GET
       response:
         proto: HTTP/2.0
@@ -1552,20 +1550,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 37
+        content_length: 596
         uncompressed: false
-        body: '{"message":"Namespace was not found"}'
+        body: '{"created_at":"2025-08-27T14:01:44.917309Z","description":"","environment_variables":{},"error_message":null,"id":"11f3af4d-e013-445f-8b22-156fc3c1f49c","name":"tf-func-serene-lichterman","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncserenelichtermytdhxbxc","registry_namespace_id":"a1317d92-e1bb-4bb1-b13d-b074295e69d1","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T14:01:59.759411Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "37"
+                - "596"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 11:31:30 GMT
+                - Wed, 27 Aug 2025 14:02:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1573,50 +1571,48 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6ae152f2-3bb8-40b7-84cb-2a794b15c33d
-        status: 404 Not Found
-        code: 404
-        duration: 24.435295ms
+                - 39c1235c-496f-4ed4-a597-562228667963
+        status: 200 OK
+        code: 200
+        duration: 46.785794ms
     - id: 32
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 188
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-func-sleepy-hugle","environment_variables":{},"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","secret_environment_variables":[],"tags":null,"activate_vpc_integration":true}'
+        body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces
-        method: POST
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/11f3af4d-e013-445f-8b22-156fc3c1f49c
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 505
+        content_length: 596
         uncompressed: false
-        body: '{"created_at":"2025-06-16T11:31:30.799505775Z","description":"","environment_variables":{},"error_message":null,"id":"1c7ae062-389f-4da9-9a4c-6e79cb932275","name":"tf-func-sleepy-hugle","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-06-16T11:31:30.799505775Z","vpc_integration_activated":true}'
+        body: '{"created_at":"2025-08-27T14:01:44.917309Z","description":"","environment_variables":{},"error_message":null,"id":"11f3af4d-e013-445f-8b22-156fc3c1f49c","name":"tf-func-serene-lichterman","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncserenelichtermytdhxbxc","registry_namespace_id":"a1317d92-e1bb-4bb1-b13d-b074295e69d1","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T14:01:59.759411Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "505"
+                - "596"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 11:31:30 GMT
+                - Wed, 27 Aug 2025 14:02:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1624,10 +1620,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cc22bdf7-9b2f-47fa-b37c-f32976f9854d
+                - cdecbfa3-fcdf-440b-952e-1858ddd26163
         status: 200 OK
         code: 200
-        duration: 219.151852ms
+        duration: 41.478644ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1644,7 +1640,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/1c7ae062-389f-4da9-9a4c-6e79cb932275
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/11f3af4d-e013-445f-8b22-156fc3c1f49c
         method: GET
       response:
         proto: HTTP/2.0
@@ -1652,20 +1648,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 499
+        content_length: 596
         uncompressed: false
-        body: '{"created_at":"2025-06-16T11:31:30.799506Z","description":"","environment_variables":{},"error_message":null,"id":"1c7ae062-389f-4da9-9a4c-6e79cb932275","name":"tf-func-sleepy-hugle","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-06-16T11:31:30.799506Z","vpc_integration_activated":true}'
+        body: '{"created_at":"2025-08-27T14:01:44.917309Z","description":"","environment_variables":{},"error_message":null,"id":"11f3af4d-e013-445f-8b22-156fc3c1f49c","name":"tf-func-serene-lichterman","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncserenelichtermytdhxbxc","registry_namespace_id":"a1317d92-e1bb-4bb1-b13d-b074295e69d1","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T14:01:59.759411Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "499"
+                - "596"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 11:31:30 GMT
+                - Wed, 27 Aug 2025 14:02:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1673,10 +1669,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5140774b-44ea-4e73-941e-39278006eec7
+                - c8eaadb7-aba8-45da-a2d3-f89545b36938
         status: 200 OK
         code: 200
-        duration: 54.997513ms
+        duration: 57.721194ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1693,7 +1689,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/1c7ae062-389f-4da9-9a4c-6e79cb932275
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/11f3af4d-e013-445f-8b22-156fc3c1f49c
         method: GET
       response:
         proto: HTTP/2.0
@@ -1701,20 +1697,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 585
+        content_length: 596
         uncompressed: false
-        body: '{"created_at":"2025-06-16T11:31:30.799506Z","description":"","environment_variables":{},"error_message":null,"id":"1c7ae062-389f-4da9-9a4c-6e79cb932275","name":"tf-func-sleepy-hugle","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncsleepyhugletrrejwtv","registry_namespace_id":"b5d3216d-beee-4dea-970c-5413a1943dd7","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-16T11:31:32.550112Z","vpc_integration_activated":true}'
+        body: '{"created_at":"2025-08-27T14:01:44.917309Z","description":"","environment_variables":{},"error_message":null,"id":"11f3af4d-e013-445f-8b22-156fc3c1f49c","name":"tf-func-serene-lichterman","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncserenelichtermytdhxbxc","registry_namespace_id":"a1317d92-e1bb-4bb1-b13d-b074295e69d1","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T14:01:59.759411Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "585"
+                - "596"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 11:31:35 GMT
+                - Wed, 27 Aug 2025 14:02:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1722,10 +1718,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - af16b16f-ec29-4b24-91cd-28a0567bd56b
+                - 835c9071-767a-46d2-a517-e6b7cf724e7b
         status: 200 OK
         code: 200
-        duration: 53.228475ms
+        duration: 38.666555ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1742,7 +1738,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/1c7ae062-389f-4da9-9a4c-6e79cb932275
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/11f3af4d-e013-445f-8b22-156fc3c1f49c
         method: GET
       response:
         proto: HTTP/2.0
@@ -1750,20 +1746,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 585
+        content_length: 596
         uncompressed: false
-        body: '{"created_at":"2025-06-16T11:31:30.799506Z","description":"","environment_variables":{},"error_message":null,"id":"1c7ae062-389f-4da9-9a4c-6e79cb932275","name":"tf-func-sleepy-hugle","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncsleepyhugletrrejwtv","registry_namespace_id":"b5d3216d-beee-4dea-970c-5413a1943dd7","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-16T11:31:32.550112Z","vpc_integration_activated":true}'
+        body: '{"created_at":"2025-08-27T14:01:44.917309Z","description":"","environment_variables":{},"error_message":null,"id":"11f3af4d-e013-445f-8b22-156fc3c1f49c","name":"tf-func-serene-lichterman","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncserenelichtermytdhxbxc","registry_namespace_id":"a1317d92-e1bb-4bb1-b13d-b074295e69d1","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T14:01:59.759411Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "585"
+                - "596"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 11:31:35 GMT
+                - Wed, 27 Aug 2025 14:02:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1771,50 +1767,48 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3892e617-a510-49d6-b81b-468642fb2bc2
+                - 804706e8-0d03-4013-8126-426c3d3fdbdf
         status: 200 OK
         code: 200
-        duration: 55.32049ms
+        duration: 41.33931ms
     - id: 36
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 360
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-func-lucid-pare","namespace_id":"1c7ae062-389f-4da9-9a4c-6e79cb932275","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"go123","memory_limit":256,"handler":"Handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"v1","tags":null,"private_network_id":"238100f6-0246-441a-ae44-2c77af88ac9c"}'
+        body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions
-        method: POST
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/11f3af4d-e013-445f-8b22-156fc3c1f49c
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 752
+        content_length: 37
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-16T11:31:36.302087682Z","description":"","domain_name":"tffuncsleepyhugletrrejwtv-tf-func-lucid-pare.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"cb2d93e7-79fd-4d69-b867-26ab4b0b5d1a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-lucid-pare","namespace_id":"1c7ae062-389f-4da9-9a4c-6e79cb932275","privacy":"private","private_network_id":"238100f6-0246-441a-ae44-2c77af88ac9c","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-16T11:31:36.302087682Z"}'
+        body: '{"message":"Namespace was not found"}'
         headers:
             Content-Length:
-                - "752"
+                - "37"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 11:31:36 GMT
+                - Wed, 27 Aug 2025 14:02:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1822,10 +1816,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8d4691cf-ca92-4791-bc02-cb2564706c42
-        status: 200 OK
-        code: 200
-        duration: 322.175461ms
+                - 638c4832-130a-4532-81de-432ce54e4365
+        status: 404 Not Found
+        code: 404
+        duration: 33.377539ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1842,28 +1836,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/cb2d93e7-79fd-4d69-b867-26ab4b0b5d1a
-        method: GET
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/11f3af4d-e013-445f-8b22-156fc3c1f49c
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 746
+        content_length: 37
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-16T11:31:36.302088Z","description":"","domain_name":"tffuncsleepyhugletrrejwtv-tf-func-lucid-pare.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"cb2d93e7-79fd-4d69-b867-26ab4b0b5d1a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-lucid-pare","namespace_id":"1c7ae062-389f-4da9-9a4c-6e79cb932275","privacy":"private","private_network_id":"238100f6-0246-441a-ae44-2c77af88ac9c","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-16T11:31:36.302088Z"}'
+        body: '{"message":"Namespace was not found"}'
         headers:
             Content-Length:
-                - "746"
+                - "37"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 11:31:36 GMT
+                - Wed, 27 Aug 2025 14:02:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1871,10 +1865,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c4cd1fda-3db7-4da4-972b-923ae4acf52f
-        status: 200 OK
-        code: 200
-        duration: 49.693453ms
+                - 8de7828c-241e-497a-8206-098e565a6fc5
+        status: 404 Not Found
+        code: 404
+        duration: 22.30507ms
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1891,740 +1885,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/cb2d93e7-79fd-4d69-b867-26ab4b0b5d1a
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 746
-        uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-16T11:31:36.302088Z","description":"","domain_name":"tffuncsleepyhugletrrejwtv-tf-func-lucid-pare.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"cb2d93e7-79fd-4d69-b867-26ab4b0b5d1a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-lucid-pare","namespace_id":"1c7ae062-389f-4da9-9a4c-6e79cb932275","privacy":"private","private_network_id":"238100f6-0246-441a-ae44-2c77af88ac9c","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-16T11:31:36.302088Z"}'
-        headers:
-            Content-Length:
-                - "746"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 16 Jun 2025 11:31:36 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 4800167c-aa74-4a7a-906b-a2e1e0ac661d
-        status: 200 OK
-        code: 200
-        duration: 54.52832ms
-    - id: 39
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/1c7ae062-389f-4da9-9a4c-6e79cb932275
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 585
-        uncompressed: false
-        body: '{"created_at":"2025-06-16T11:31:30.799506Z","description":"","environment_variables":{},"error_message":null,"id":"1c7ae062-389f-4da9-9a4c-6e79cb932275","name":"tf-func-sleepy-hugle","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncsleepyhugletrrejwtv","registry_namespace_id":"b5d3216d-beee-4dea-970c-5413a1943dd7","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-16T11:31:32.550112Z","vpc_integration_activated":true}'
-        headers:
-            Content-Length:
-                - "585"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 16 Jun 2025 11:31:36 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - da31e1cc-bdb6-417f-9939-bb2313505463
-        status: 200 OK
-        code: 200
-        duration: 43.870858ms
-    - id: 40
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/cb2d93e7-79fd-4d69-b867-26ab4b0b5d1a
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 746
-        uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-16T11:31:36.302088Z","description":"","domain_name":"tffuncsleepyhugletrrejwtv-tf-func-lucid-pare.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"cb2d93e7-79fd-4d69-b867-26ab4b0b5d1a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-lucid-pare","namespace_id":"1c7ae062-389f-4da9-9a4c-6e79cb932275","privacy":"private","private_network_id":"238100f6-0246-441a-ae44-2c77af88ac9c","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-16T11:31:36.302088Z"}'
-        headers:
-            Content-Length:
-                - "746"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 16 Jun 2025 11:31:36 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 7d57c901-4cc0-4823-baad-ae4cb466b20f
-        status: 200 OK
-        code: 200
-        duration: 48.448574ms
-    - id: 41
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/238100f6-0246-441a-ae44-2c77af88ac9c
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 1068
-        uncompressed: false
-        body: '{"created_at":"2025-06-16T11:30:23.630403Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"238100f6-0246-441a-ae44-2c77af88ac9c","name":"tf-pn-gifted-engelbart","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-06-16T11:30:23.630403Z","id":"07330e73-1eac-4664-8601-56a0732618e2","private_network_id":"238100f6-0246-441a-ae44-2c77af88ac9c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.40.0/22","updated_at":"2025-06-16T11:30:23.630403Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-06-16T11:30:23.630403Z","id":"e86e1991-fbae-49a2-83ac-d8ac13f1d8e6","private_network_id":"238100f6-0246-441a-ae44-2c77af88ac9c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:d325::/64","updated_at":"2025-06-16T11:30:23.630403Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-06-16T11:30:23.630403Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
-        headers:
-            Content-Length:
-                - "1068"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 16 Jun 2025 11:31:37 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 656d9b17-fb39-40a4-b52e-8c0f91ef3b7f
-        status: 200 OK
-        code: 200
-        duration: 29.277043ms
-    - id: 42
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/1c7ae062-389f-4da9-9a4c-6e79cb932275
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 585
-        uncompressed: false
-        body: '{"created_at":"2025-06-16T11:31:30.799506Z","description":"","environment_variables":{},"error_message":null,"id":"1c7ae062-389f-4da9-9a4c-6e79cb932275","name":"tf-func-sleepy-hugle","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncsleepyhugletrrejwtv","registry_namespace_id":"b5d3216d-beee-4dea-970c-5413a1943dd7","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-16T11:31:32.550112Z","vpc_integration_activated":true}'
-        headers:
-            Content-Length:
-                - "585"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 16 Jun 2025 11:31:37 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 497d3c07-2818-476c-ace7-1bb732503fb5
-        status: 200 OK
-        code: 200
-        duration: 70.994974ms
-    - id: 43
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/cb2d93e7-79fd-4d69-b867-26ab4b0b5d1a
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 746
-        uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-16T11:31:36.302088Z","description":"","domain_name":"tffuncsleepyhugletrrejwtv-tf-func-lucid-pare.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"cb2d93e7-79fd-4d69-b867-26ab4b0b5d1a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-lucid-pare","namespace_id":"1c7ae062-389f-4da9-9a4c-6e79cb932275","privacy":"private","private_network_id":"238100f6-0246-441a-ae44-2c77af88ac9c","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-16T11:31:36.302088Z"}'
-        headers:
-            Content-Length:
-                - "746"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 16 Jun 2025 11:31:37 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 425757d5-3687-413b-82a0-24c97e0a05e8
-        status: 200 OK
-        code: 200
-        duration: 59.844209ms
-    - id: 44
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/cb2d93e7-79fd-4d69-b867-26ab4b0b5d1a
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 746
-        uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-16T11:31:36.302088Z","description":"","domain_name":"tffuncsleepyhugletrrejwtv-tf-func-lucid-pare.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"cb2d93e7-79fd-4d69-b867-26ab4b0b5d1a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-lucid-pare","namespace_id":"1c7ae062-389f-4da9-9a4c-6e79cb932275","privacy":"private","private_network_id":"238100f6-0246-441a-ae44-2c77af88ac9c","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-16T11:31:36.302088Z"}'
-        headers:
-            Content-Length:
-                - "746"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 16 Jun 2025 11:31:38 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - e7a9ce7b-780f-4ead-89fc-63423468b13f
-        status: 200 OK
-        code: 200
-        duration: 56.100616ms
-    - id: 45
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/cb2d93e7-79fd-4d69-b867-26ab4b0b5d1a
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 750
-        uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-16T11:31:36.302088Z","description":"","domain_name":"tffuncsleepyhugletrrejwtv-tf-func-lucid-pare.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"cb2d93e7-79fd-4d69-b867-26ab4b0b5d1a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-lucid-pare","namespace_id":"1c7ae062-389f-4da9-9a4c-6e79cb932275","privacy":"private","private_network_id":"238100f6-0246-441a-ae44-2c77af88ac9c","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2025-06-16T11:31:38.632097496Z"}'
-        headers:
-            Content-Length:
-                - "750"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 16 Jun 2025 11:31:38 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 534dde57-8093-42b8-b740-75e92bef3105
-        status: 200 OK
-        code: 200
-        duration: 174.557325ms
-    - id: 46
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/1c7ae062-389f-4da9-9a4c-6e79cb932275
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 585
-        uncompressed: false
-        body: '{"created_at":"2025-06-16T11:31:30.799506Z","description":"","environment_variables":{},"error_message":null,"id":"1c7ae062-389f-4da9-9a4c-6e79cb932275","name":"tf-func-sleepy-hugle","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncsleepyhugletrrejwtv","registry_namespace_id":"b5d3216d-beee-4dea-970c-5413a1943dd7","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-16T11:31:32.550112Z","vpc_integration_activated":true}'
-        headers:
-            Content-Length:
-                - "585"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 16 Jun 2025 11:31:38 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 51c0f871-8596-45c8-b0fb-d339adcf0c58
-        status: 200 OK
-        code: 200
-        duration: 49.164107ms
-    - id: 47
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/1c7ae062-389f-4da9-9a4c-6e79cb932275
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 591
-        uncompressed: false
-        body: '{"created_at":"2025-06-16T11:31:30.799506Z","description":"","environment_variables":{},"error_message":null,"id":"1c7ae062-389f-4da9-9a4c-6e79cb932275","name":"tf-func-sleepy-hugle","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncsleepyhugletrrejwtv","registry_namespace_id":"b5d3216d-beee-4dea-970c-5413a1943dd7","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-06-16T11:31:38.845421842Z","vpc_integration_activated":true}'
-        headers:
-            Content-Length:
-                - "591"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 16 Jun 2025 11:31:39 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 89a35560-e5e6-43fb-bb29-d8f2ee281208
-        status: 200 OK
-        code: 200
-        duration: 230.798585ms
-    - id: 48
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/1c7ae062-389f-4da9-9a4c-6e79cb932275
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 588
-        uncompressed: false
-        body: '{"created_at":"2025-06-16T11:31:30.799506Z","description":"","environment_variables":{},"error_message":null,"id":"1c7ae062-389f-4da9-9a4c-6e79cb932275","name":"tf-func-sleepy-hugle","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncsleepyhugletrrejwtv","registry_namespace_id":"b5d3216d-beee-4dea-970c-5413a1943dd7","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-06-16T11:31:38.845422Z","vpc_integration_activated":true}'
-        headers:
-            Content-Length:
-                - "588"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 16 Jun 2025 11:31:39 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - fb604293-7cd4-4293-ae9a-74bf64fe6edf
-        status: 200 OK
-        code: 200
-        duration: 44.700516ms
-    - id: 49
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/238100f6-0246-441a-ae44-2c77af88ac9c
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 0
-        uncompressed: false
-        body: ""
-        headers:
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 16 Jun 2025 11:31:39 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - a22bf63b-5e4d-44bf-ab6e-3ce9ae67e378
-        status: 204 No Content
-        code: 204
-        duration: 1.242246725s
-    - id: 50
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/1c7ae062-389f-4da9-9a4c-6e79cb932275
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 588
-        uncompressed: false
-        body: '{"created_at":"2025-06-16T11:31:30.799506Z","description":"","environment_variables":{},"error_message":null,"id":"1c7ae062-389f-4da9-9a4c-6e79cb932275","name":"tf-func-sleepy-hugle","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncsleepyhugletrrejwtv","registry_namespace_id":"b5d3216d-beee-4dea-970c-5413a1943dd7","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-06-16T11:31:38.845422Z","vpc_integration_activated":true}'
-        headers:
-            Content-Length:
-                - "588"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 16 Jun 2025 11:31:44 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 6bb42c1a-ac05-46f9-aee2-f97b184ae239
-        status: 200 OK
-        code: 200
-        duration: 45.869023ms
-    - id: 51
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/1c7ae062-389f-4da9-9a4c-6e79cb932275
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 37
-        uncompressed: false
-        body: '{"message":"Namespace was not found"}'
-        headers:
-            Content-Length:
-                - "37"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 16 Jun 2025 11:32:09 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - bcafd6ec-9f57-4927-b110-385d1b8611fe
-        status: 404 Not Found
-        code: 404
-        duration: 23.842054ms
-    - id: 52
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/1c7ae062-389f-4da9-9a4c-6e79cb932275
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 37
-        uncompressed: false
-        body: '{"message":"Namespace was not found"}'
-        headers:
-            Content-Length:
-                - "37"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 16 Jun 2025 11:32:09 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 23475c5f-fcaf-4e3f-8baf-05f1abdcfe55
-        status: 404 Not Found
-        code: 404
-        duration: 29.204495ms
-    - id: 53
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/cb2d93e7-79fd-4d69-b867-26ab4b0b5d1a
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/87c2d675-77b9-4574-8c01-2f4f756a0fc4
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -2643,9 +1904,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 11:32:09 GMT
+                - Wed, 27 Aug 2025 14:02:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2653,11 +1914,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7fdd6fbd-2954-417b-9a16-9f71afd02b84
+                - ec18a055-bdec-4d36-a78b-62183f122fa5
         status: 404 Not Found
         code: 404
-        duration: 103.053737ms
-    - id: 54
+        duration: 23.335688ms
+    - id: 39
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2673,7 +1934,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/238100f6-0246-441a-ae44-2c77af88ac9c
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c06c7ffa-e6c1-42e3-98d1-fd3da73d4253
         method: GET
       response:
         proto: HTTP/2.0
@@ -2683,7 +1944,7 @@ interactions:
         trailer: {}
         content_length: 136
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"private_network","resource_id":"238100f6-0246-441a-ae44-2c77af88ac9c","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"private_network","resource_id":"c06c7ffa-e6c1-42e3-98d1-fd3da73d4253","type":"not_found"}'
         headers:
             Content-Length:
                 - "136"
@@ -2692,9 +1953,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 11:32:09 GMT
+                - Wed, 27 Aug 2025 14:02:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2702,7 +1963,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f18590e5-b293-4412-86c9-aae812d952c8
+                - 26733972-d0ec-4e8a-b7c9-58acf83a5874
         status: 404 Not Found
         code: 404
-        duration: 28.964255ms
+        duration: 25.992163ms

--- a/internal/services/function/testdata/function-namespace-vpc-integration.cassette.yaml
+++ b/internal/services/function/testdata/function-namespace-vpc-integration.cassette.yaml
@@ -6,20 +6,20 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 193
+        content_length: 146
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-func-serene-lichterman","environment_variables":{},"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","secret_environment_variables":[],"tags":null,"activate_vpc_integration":true}'
+        body: '{"name":"tf-pn-eager-kare","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"subnets":null,"default_route_propagation_enabled":false}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
         method: POST
       response:
         proto: HTTP/2.0
@@ -27,20 +27,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 510
+        content_length: 1062
         uncompressed: false
-        body: '{"created_at":"2025-08-27T14:01:44.917309032Z","description":"","environment_variables":{},"error_message":null,"id":"11f3af4d-e013-445f-8b22-156fc3c1f49c","name":"tf-func-serene-lichterman","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T14:01:44.917309032Z","vpc_integration_activated":true}'
+        body: '{"created_at":"2025-08-27T15:05:08.250116Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"e67b56bb-a68b-4b30-852e-9d4a8023f6bb","name":"tf-pn-eager-kare","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-08-27T15:05:08.250116Z","id":"48309e13-53e3-406d-848e-69c9214e4f9b","private_network_id":"e67b56bb-a68b-4b30-852e-9d4a8023f6bb","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.20.0/22","updated_at":"2025-08-27T15:05:08.250116Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-08-27T15:05:08.250116Z","id":"2a929e16-dd46-4882-a714-f4c0988ba89d","private_network_id":"e67b56bb-a68b-4b30-852e-9d4a8023f6bb","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:c09b::/64","updated_at":"2025-08-27T15:05:08.250116Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-08-27T15:05:08.250116Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
         headers:
             Content-Length:
-                - "510"
+                - "1062"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:01:44 GMT
+                - Wed, 27 Aug 2025 15:05:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9db72674-3220-417b-9111-33f938d2f387
+                - 4db6715d-872e-42d7-ad2c-4814f84c69e4
         status: 200 OK
         code: 200
-        duration: 825.58715ms
+        duration: 898.147657ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -68,7 +68,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/11f3af4d-e013-445f-8b22-156fc3c1f49c
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e67b56bb-a68b-4b30-852e-9d4a8023f6bb
         method: GET
       response:
         proto: HTTP/2.0
@@ -76,20 +76,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 504
+        content_length: 1062
         uncompressed: false
-        body: '{"created_at":"2025-08-27T14:01:44.917309Z","description":"","environment_variables":{},"error_message":null,"id":"11f3af4d-e013-445f-8b22-156fc3c1f49c","name":"tf-func-serene-lichterman","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T14:01:44.917309Z","vpc_integration_activated":true}'
+        body: '{"created_at":"2025-08-27T15:05:08.250116Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"e67b56bb-a68b-4b30-852e-9d4a8023f6bb","name":"tf-pn-eager-kare","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-08-27T15:05:08.250116Z","id":"48309e13-53e3-406d-848e-69c9214e4f9b","private_network_id":"e67b56bb-a68b-4b30-852e-9d4a8023f6bb","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.20.0/22","updated_at":"2025-08-27T15:05:08.250116Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-08-27T15:05:08.250116Z","id":"2a929e16-dd46-4882-a714-f4c0988ba89d","private_network_id":"e67b56bb-a68b-4b30-852e-9d4a8023f6bb","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:c09b::/64","updated_at":"2025-08-27T15:05:08.250116Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-08-27T15:05:08.250116Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
         headers:
             Content-Length:
-                - "504"
+                - "1062"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:01:44 GMT
+                - Wed, 27 Aug 2025 15:05:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,29 +97,29 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 31d03ba1-fb19-4dcf-922c-1241d705a4a7
+                - 20414b30-ee30-4a78-bea9-cad06ae60f15
         status: 200 OK
         code: 200
-        duration: 44.964823ms
+        duration: 55.863977ms
     - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 153
+        content_length: 190
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-pn-stoic-stonebraker","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"subnets":null,"default_route_propagation_enabled":false}'
+        body: '{"name":"tf-func-frosty-shirley","environment_variables":{},"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","secret_environment_variables":[],"tags":null,"activate_vpc_integration":true}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces
         method: POST
       response:
         proto: HTTP/2.0
@@ -127,20 +127,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1069
+        content_length: 507
         uncompressed: false
-        body: '{"created_at":"2025-08-27T14:01:44.210929Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"c06c7ffa-e6c1-42e3-98d1-fd3da73d4253","name":"tf-pn-stoic-stonebraker","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-08-27T14:01:44.210929Z","id":"5873ffe4-f3f9-4933-88fe-71c893b7a8cf","private_network_id":"c06c7ffa-e6c1-42e3-98d1-fd3da73d4253","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.24.0/22","updated_at":"2025-08-27T14:01:44.210929Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-08-27T14:01:44.210929Z","id":"d77237aa-0dbe-4f17-9af4-31c6b6c7d6f5","private_network_id":"c06c7ffa-e6c1-42e3-98d1-fd3da73d4253","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:751f::/64","updated_at":"2025-08-27T14:01:44.210929Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-08-27T14:01:44.210929Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+        body: '{"created_at":"2025-08-27T15:05:13.710923308Z","description":"","environment_variables":{},"error_message":null,"id":"9bb9a723-46a2-4697-b364-147f375ce8fe","name":"tf-func-frosty-shirley","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:13.710923308Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "1069"
+                - "507"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:01:45 GMT
+                - Wed, 27 Aug 2025 15:05:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -148,10 +148,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6687e229-c1d7-4a36-b95a-2f0a53c2f20f
+                - 4844bc58-0f4d-4431-a62f-76e957499063
         status: 200 OK
         code: 200
-        duration: 947.929346ms
+        duration: 5.535048883s
     - id: 3
       request:
         proto: HTTP/1.1
@@ -168,7 +168,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c06c7ffa-e6c1-42e3-98d1-fd3da73d4253
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/9bb9a723-46a2-4697-b364-147f375ce8fe
         method: GET
       response:
         proto: HTTP/2.0
@@ -176,20 +176,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1069
+        content_length: 501
         uncompressed: false
-        body: '{"created_at":"2025-08-27T14:01:44.210929Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"c06c7ffa-e6c1-42e3-98d1-fd3da73d4253","name":"tf-pn-stoic-stonebraker","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-08-27T14:01:44.210929Z","id":"5873ffe4-f3f9-4933-88fe-71c893b7a8cf","private_network_id":"c06c7ffa-e6c1-42e3-98d1-fd3da73d4253","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.24.0/22","updated_at":"2025-08-27T14:01:44.210929Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-08-27T14:01:44.210929Z","id":"d77237aa-0dbe-4f17-9af4-31c6b6c7d6f5","private_network_id":"c06c7ffa-e6c1-42e3-98d1-fd3da73d4253","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:751f::/64","updated_at":"2025-08-27T14:01:44.210929Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-08-27T14:01:44.210929Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+        body: '{"created_at":"2025-08-27T15:05:13.710923Z","description":"","environment_variables":{},"error_message":null,"id":"9bb9a723-46a2-4697-b364-147f375ce8fe","name":"tf-func-frosty-shirley","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:13.710923Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "1069"
+                - "501"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:01:45 GMT
+                - Wed, 27 Aug 2025 15:05:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -197,10 +197,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2322b3aa-5fb2-449a-95cc-54519e207889
+                - 3092b329-fbf1-4ddd-8ad5-ce7fcfd75953
         status: 200 OK
         code: 200
-        duration: 35.145608ms
+        duration: 43.350228ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -217,7 +217,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/11f3af4d-e013-445f-8b22-156fc3c1f49c
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/9bb9a723-46a2-4697-b364-147f375ce8fe
         method: GET
       response:
         proto: HTTP/2.0
@@ -225,20 +225,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 593
+        content_length: 501
         uncompressed: false
-        body: '{"created_at":"2025-08-27T14:01:44.917309Z","description":"","environment_variables":{},"error_message":null,"id":"11f3af4d-e013-445f-8b22-156fc3c1f49c","name":"tf-func-serene-lichterman","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncserenelichtermytdhxbxc","registry_namespace_id":"a1317d92-e1bb-4bb1-b13d-b074295e69d1","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T14:01:48.786476Z","vpc_integration_activated":true}'
+        body: '{"created_at":"2025-08-27T15:05:13.710923Z","description":"","environment_variables":{},"error_message":null,"id":"9bb9a723-46a2-4697-b364-147f375ce8fe","name":"tf-func-frosty-shirley","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:15.137890Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "593"
+                - "501"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:01:50 GMT
+                - Wed, 27 Aug 2025 15:05:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -246,10 +246,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f6e6d824-513c-46d1-94d9-f620e2bdc243
+                - 5d77d8e3-9aea-4fd6-a60d-5ea0eae5a4a9
         status: 200 OK
         code: 200
-        duration: 148.741845ms
+        duration: 544.834649ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -266,7 +266,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/11f3af4d-e013-445f-8b22-156fc3c1f49c
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/9bb9a723-46a2-4697-b364-147f375ce8fe
         method: GET
       response:
         proto: HTTP/2.0
@@ -274,20 +274,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 593
+        content_length: 589
         uncompressed: false
-        body: '{"created_at":"2025-08-27T14:01:44.917309Z","description":"","environment_variables":{},"error_message":null,"id":"11f3af4d-e013-445f-8b22-156fc3c1f49c","name":"tf-func-serene-lichterman","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncserenelichtermytdhxbxc","registry_namespace_id":"a1317d92-e1bb-4bb1-b13d-b074295e69d1","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T14:01:48.786476Z","vpc_integration_activated":true}'
+        body: '{"created_at":"2025-08-27T15:05:13.710923Z","description":"","environment_variables":{},"error_message":null,"id":"9bb9a723-46a2-4697-b364-147f375ce8fe","name":"tf-func-frosty-shirley","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncfrostyshirleymwpev43g","registry_namespace_id":"cf2dce01-8b8c-4bb4-81ec-f345c84ae4c5","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:21.320300Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "593"
+                - "589"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:01:50 GMT
+                - Wed, 27 Aug 2025 15:05:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -295,62 +295,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - be13d547-4ca1-44b2-879c-fd1aa6bc1c56
+                - 09f1faa9-220e-4ee9-9c46-524c4a5036de
         status: 200 OK
         code: 200
-        duration: 43.879533ms
+        duration: 35.256353ms
     - id: 6
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 310
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"name":"tf-func-unruffled-montalcini","namespace_id":"11f3af4d-e013-445f-8b22-156fc3c1f49c","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"go123","memory_limit":256,"handler":"Handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"v1","tags":null}'
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 741
-        uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T14:01:50.615081055Z","description":"","domain_name":"tffuncserenelichtermytdhxbxc-tf-func-unruffled-montalcini.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"87c2d675-77b9-4574-8c01-2f4f756a0fc4","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-unruffled-montalcini","namespace_id":"11f3af4d-e013-445f-8b22-156fc3c1f49c","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T14:01:50.615081055Z"}'
-        headers:
-            Content-Length:
-                - "741"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 27 Aug 2025 14:01:50 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - ac448401-4116-429b-97ac-48f33c9fbc34
-        status: 200 OK
-        code: 200
-        duration: 464.214884ms
-    - id: 7
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -366,7 +315,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/87c2d675-77b9-4574-8c01-2f4f756a0fc4
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/9bb9a723-46a2-4697-b364-147f375ce8fe
         method: GET
       response:
         proto: HTTP/2.0
@@ -374,20 +323,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 735
+        content_length: 589
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T14:01:50.615081Z","description":"","domain_name":"tffuncserenelichtermytdhxbxc-tf-func-unruffled-montalcini.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"87c2d675-77b9-4574-8c01-2f4f756a0fc4","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-unruffled-montalcini","namespace_id":"11f3af4d-e013-445f-8b22-156fc3c1f49c","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T14:01:50.615081Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.710923Z","description":"","environment_variables":{},"error_message":null,"id":"9bb9a723-46a2-4697-b364-147f375ce8fe","name":"tf-func-frosty-shirley","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncfrostyshirleymwpev43g","registry_namespace_id":"cf2dce01-8b8c-4bb4-81ec-f345c84ae4c5","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:21.320300Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "735"
+                - "589"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:01:50 GMT
+                - Wed, 27 Aug 2025 15:05:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -395,10 +344,61 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e8709008-7b80-4d10-9df1-99ef6f1c5371
+                - 8179decc-8be2-4c77-afe3-1ae3a96dce7e
         status: 200 OK
         code: 200
-        duration: 60.958709ms
+        duration: 51.287534ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 301
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"name":"tf-func-tender-bell","namespace_id":"9bb9a723-46a2-4697-b364-147f375ce8fe","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"go123","memory_limit":256,"handler":"Handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"v1","tags":null}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 722
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:26.081451316Z","description":"","domain_name":"tffuncfrostyshirleymwpev43g-tf-func-tender-bell.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de06479-d5c8-4de0-93f8-223db9c6bcd7","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-tender-bell","namespace_id":"9bb9a723-46a2-4697-b364-147f375ce8fe","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:26.081451316Z"}'
+        headers:
+            Content-Length:
+                - "722"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:05:26 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3f908df9-a880-4875-b03c-49cef7c5b56e
+        status: 200 OK
+        code: 200
+        duration: 1.692134266s
     - id: 8
       request:
         proto: HTTP/1.1
@@ -415,7 +415,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/87c2d675-77b9-4574-8c01-2f4f756a0fc4
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de06479-d5c8-4de0-93f8-223db9c6bcd7
         method: GET
       response:
         proto: HTTP/2.0
@@ -423,20 +423,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 735
+        content_length: 716
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T14:01:50.615081Z","description":"","domain_name":"tffuncserenelichtermytdhxbxc-tf-func-unruffled-montalcini.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"87c2d675-77b9-4574-8c01-2f4f756a0fc4","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-unruffled-montalcini","namespace_id":"11f3af4d-e013-445f-8b22-156fc3c1f49c","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T14:01:50.615081Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:26.081451Z","description":"","domain_name":"tffuncfrostyshirleymwpev43g-tf-func-tender-bell.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de06479-d5c8-4de0-93f8-223db9c6bcd7","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-tender-bell","namespace_id":"9bb9a723-46a2-4697-b364-147f375ce8fe","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:26.081451Z"}'
         headers:
             Content-Length:
-                - "735"
+                - "716"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:01:50 GMT
+                - Wed, 27 Aug 2025 15:05:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -444,10 +444,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9cd84dee-356f-4e3d-815d-af6739b3f5dc
+                - fbd0bae1-a7c5-48cd-8f40-f91b6d39934b
         status: 200 OK
         code: 200
-        duration: 59.584183ms
+        duration: 57.795074ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -464,7 +464,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/11f3af4d-e013-445f-8b22-156fc3c1f49c
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de06479-d5c8-4de0-93f8-223db9c6bcd7
         method: GET
       response:
         proto: HTTP/2.0
@@ -472,20 +472,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 593
+        content_length: 716
         uncompressed: false
-        body: '{"created_at":"2025-08-27T14:01:44.917309Z","description":"","environment_variables":{},"error_message":null,"id":"11f3af4d-e013-445f-8b22-156fc3c1f49c","name":"tf-func-serene-lichterman","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncserenelichtermytdhxbxc","registry_namespace_id":"a1317d92-e1bb-4bb1-b13d-b074295e69d1","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T14:01:48.786476Z","vpc_integration_activated":true}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:26.081451Z","description":"","domain_name":"tffuncfrostyshirleymwpev43g-tf-func-tender-bell.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de06479-d5c8-4de0-93f8-223db9c6bcd7","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-tender-bell","namespace_id":"9bb9a723-46a2-4697-b364-147f375ce8fe","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:26.081451Z"}'
         headers:
             Content-Length:
-                - "593"
+                - "716"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:01:50 GMT
+                - Wed, 27 Aug 2025 15:05:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -493,10 +493,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 71335984-7f56-46c8-bee0-59c57797023e
+                - 7a7c7cad-d996-419a-b06d-c1f7a25e9c21
         status: 200 OK
         code: 200
-        duration: 39.812544ms
+        duration: 177.920482ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -513,7 +513,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c06c7ffa-e6c1-42e3-98d1-fd3da73d4253
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/9bb9a723-46a2-4697-b364-147f375ce8fe
         method: GET
       response:
         proto: HTTP/2.0
@@ -521,20 +521,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1069
+        content_length: 589
         uncompressed: false
-        body: '{"created_at":"2025-08-27T14:01:44.210929Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"c06c7ffa-e6c1-42e3-98d1-fd3da73d4253","name":"tf-pn-stoic-stonebraker","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-08-27T14:01:44.210929Z","id":"5873ffe4-f3f9-4933-88fe-71c893b7a8cf","private_network_id":"c06c7ffa-e6c1-42e3-98d1-fd3da73d4253","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.24.0/22","updated_at":"2025-08-27T14:01:44.210929Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-08-27T14:01:44.210929Z","id":"d77237aa-0dbe-4f17-9af4-31c6b6c7d6f5","private_network_id":"c06c7ffa-e6c1-42e3-98d1-fd3da73d4253","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:751f::/64","updated_at":"2025-08-27T14:01:44.210929Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-08-27T14:01:44.210929Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+        body: '{"created_at":"2025-08-27T15:05:13.710923Z","description":"","environment_variables":{},"error_message":null,"id":"9bb9a723-46a2-4697-b364-147f375ce8fe","name":"tf-func-frosty-shirley","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncfrostyshirleymwpev43g","registry_namespace_id":"cf2dce01-8b8c-4bb4-81ec-f345c84ae4c5","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:21.320300Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "1069"
+                - "589"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:01:51 GMT
+                - Wed, 27 Aug 2025 15:05:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -542,10 +542,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8b0cc1e5-1344-40a2-9dc6-7ea13c9f1032
+                - 592e5aec-6975-45bc-9b43-2e08fa0b4260
         status: 200 OK
         code: 200
-        duration: 26.121168ms
+        duration: 48.837597ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -562,7 +562,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/11f3af4d-e013-445f-8b22-156fc3c1f49c
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e67b56bb-a68b-4b30-852e-9d4a8023f6bb
         method: GET
       response:
         proto: HTTP/2.0
@@ -570,20 +570,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 593
+        content_length: 1062
         uncompressed: false
-        body: '{"created_at":"2025-08-27T14:01:44.917309Z","description":"","environment_variables":{},"error_message":null,"id":"11f3af4d-e013-445f-8b22-156fc3c1f49c","name":"tf-func-serene-lichterman","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncserenelichtermytdhxbxc","registry_namespace_id":"a1317d92-e1bb-4bb1-b13d-b074295e69d1","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T14:01:48.786476Z","vpc_integration_activated":true}'
+        body: '{"created_at":"2025-08-27T15:05:08.250116Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"e67b56bb-a68b-4b30-852e-9d4a8023f6bb","name":"tf-pn-eager-kare","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-08-27T15:05:08.250116Z","id":"48309e13-53e3-406d-848e-69c9214e4f9b","private_network_id":"e67b56bb-a68b-4b30-852e-9d4a8023f6bb","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.20.0/22","updated_at":"2025-08-27T15:05:08.250116Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-08-27T15:05:08.250116Z","id":"2a929e16-dd46-4882-a714-f4c0988ba89d","private_network_id":"e67b56bb-a68b-4b30-852e-9d4a8023f6bb","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:c09b::/64","updated_at":"2025-08-27T15:05:08.250116Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-08-27T15:05:08.250116Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
         headers:
             Content-Length:
-                - "593"
+                - "1062"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:01:51 GMT
+                - Wed, 27 Aug 2025 15:05:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -591,10 +591,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ef916180-5591-44ba-b561-472b89081679
+                - 621da1fe-b938-4646-83b8-617ee53aabb1
         status: 200 OK
         code: 200
-        duration: 39.548207ms
+        duration: 21.022486ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -611,7 +611,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/87c2d675-77b9-4574-8c01-2f4f756a0fc4
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/9bb9a723-46a2-4697-b364-147f375ce8fe
         method: GET
       response:
         proto: HTTP/2.0
@@ -619,20 +619,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 735
+        content_length: 589
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T14:01:50.615081Z","description":"","domain_name":"tffuncserenelichtermytdhxbxc-tf-func-unruffled-montalcini.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"87c2d675-77b9-4574-8c01-2f4f756a0fc4","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-unruffled-montalcini","namespace_id":"11f3af4d-e013-445f-8b22-156fc3c1f49c","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T14:01:50.615081Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.710923Z","description":"","environment_variables":{},"error_message":null,"id":"9bb9a723-46a2-4697-b364-147f375ce8fe","name":"tf-func-frosty-shirley","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncfrostyshirleymwpev43g","registry_namespace_id":"cf2dce01-8b8c-4bb4-81ec-f345c84ae4c5","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:21.320300Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "735"
+                - "589"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:01:51 GMT
+                - Wed, 27 Aug 2025 15:05:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -640,10 +640,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 23c89e72-2185-43c1-9d3d-b9b9d4332791
+                - ba4de87b-e48a-4510-b548-6deddf8defc1
         status: 200 OK
         code: 200
-        duration: 43.619652ms
+        duration: 42.585646ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -660,7 +660,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c06c7ffa-e6c1-42e3-98d1-fd3da73d4253
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de06479-d5c8-4de0-93f8-223db9c6bcd7
         method: GET
       response:
         proto: HTTP/2.0
@@ -668,20 +668,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1069
+        content_length: 716
         uncompressed: false
-        body: '{"created_at":"2025-08-27T14:01:44.210929Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"c06c7ffa-e6c1-42e3-98d1-fd3da73d4253","name":"tf-pn-stoic-stonebraker","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-08-27T14:01:44.210929Z","id":"5873ffe4-f3f9-4933-88fe-71c893b7a8cf","private_network_id":"c06c7ffa-e6c1-42e3-98d1-fd3da73d4253","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.24.0/22","updated_at":"2025-08-27T14:01:44.210929Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-08-27T14:01:44.210929Z","id":"d77237aa-0dbe-4f17-9af4-31c6b6c7d6f5","private_network_id":"c06c7ffa-e6c1-42e3-98d1-fd3da73d4253","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:751f::/64","updated_at":"2025-08-27T14:01:44.210929Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-08-27T14:01:44.210929Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:26.081451Z","description":"","domain_name":"tffuncfrostyshirleymwpev43g-tf-func-tender-bell.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de06479-d5c8-4de0-93f8-223db9c6bcd7","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-tender-bell","namespace_id":"9bb9a723-46a2-4697-b364-147f375ce8fe","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:26.081451Z"}'
         headers:
             Content-Length:
-                - "1069"
+                - "716"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:01:51 GMT
+                - Wed, 27 Aug 2025 15:05:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -689,10 +689,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 81dd80f6-8bdb-42ae-8f78-7cd2ddc75d79
+                - d6c6e1a8-4d54-45f2-91a4-8bddce5a44ec
         status: 200 OK
         code: 200
-        duration: 53.8712ms
+        duration: 81.619327ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -709,7 +709,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/11f3af4d-e013-445f-8b22-156fc3c1f49c
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/9bb9a723-46a2-4697-b364-147f375ce8fe
         method: GET
       response:
         proto: HTTP/2.0
@@ -717,20 +717,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 593
+        content_length: 589
         uncompressed: false
-        body: '{"created_at":"2025-08-27T14:01:44.917309Z","description":"","environment_variables":{},"error_message":null,"id":"11f3af4d-e013-445f-8b22-156fc3c1f49c","name":"tf-func-serene-lichterman","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncserenelichtermytdhxbxc","registry_namespace_id":"a1317d92-e1bb-4bb1-b13d-b074295e69d1","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T14:01:48.786476Z","vpc_integration_activated":true}'
+        body: '{"created_at":"2025-08-27T15:05:13.710923Z","description":"","environment_variables":{},"error_message":null,"id":"9bb9a723-46a2-4697-b364-147f375ce8fe","name":"tf-func-frosty-shirley","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncfrostyshirleymwpev43g","registry_namespace_id":"cf2dce01-8b8c-4bb4-81ec-f345c84ae4c5","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:21.320300Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "593"
+                - "589"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:01:51 GMT
+                - Wed, 27 Aug 2025 15:05:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -738,10 +738,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e509dacb-57e4-4e9d-b95b-ce8eed320f55
+                - b92572c9-4c8f-4cf6-9d13-0791e9c3df9f
         status: 200 OK
         code: 200
-        duration: 55.320445ms
+        duration: 39.755255ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -758,7 +758,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/87c2d675-77b9-4574-8c01-2f4f756a0fc4
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e67b56bb-a68b-4b30-852e-9d4a8023f6bb
         method: GET
       response:
         proto: HTTP/2.0
@@ -766,20 +766,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 735
+        content_length: 1062
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T14:01:50.615081Z","description":"","domain_name":"tffuncserenelichtermytdhxbxc-tf-func-unruffled-montalcini.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"87c2d675-77b9-4574-8c01-2f4f756a0fc4","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-unruffled-montalcini","namespace_id":"11f3af4d-e013-445f-8b22-156fc3c1f49c","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T14:01:50.615081Z"}'
+        body: '{"created_at":"2025-08-27T15:05:08.250116Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"e67b56bb-a68b-4b30-852e-9d4a8023f6bb","name":"tf-pn-eager-kare","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-08-27T15:05:08.250116Z","id":"48309e13-53e3-406d-848e-69c9214e4f9b","private_network_id":"e67b56bb-a68b-4b30-852e-9d4a8023f6bb","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.20.0/22","updated_at":"2025-08-27T15:05:08.250116Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-08-27T15:05:08.250116Z","id":"2a929e16-dd46-4882-a714-f4c0988ba89d","private_network_id":"e67b56bb-a68b-4b30-852e-9d4a8023f6bb","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:c09b::/64","updated_at":"2025-08-27T15:05:08.250116Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-08-27T15:05:08.250116Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
         headers:
             Content-Length:
-                - "735"
+                - "1062"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:01:51 GMT
+                - Wed, 27 Aug 2025 15:05:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -787,10 +787,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bce59cdc-5b15-4130-8fa2-cdb252d80374
+                - ebd2422e-9779-43e6-8a32-079ec3b203a5
         status: 200 OK
         code: 200
-        duration: 56.900757ms
+        duration: 48.934418ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -807,7 +807,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/87c2d675-77b9-4574-8c01-2f4f756a0fc4
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de06479-d5c8-4de0-93f8-223db9c6bcd7
         method: GET
       response:
         proto: HTTP/2.0
@@ -815,20 +815,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 735
+        content_length: 716
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T14:01:50.615081Z","description":"","domain_name":"tffuncserenelichtermytdhxbxc-tf-func-unruffled-montalcini.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"87c2d675-77b9-4574-8c01-2f4f756a0fc4","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-unruffled-montalcini","namespace_id":"11f3af4d-e013-445f-8b22-156fc3c1f49c","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T14:01:50.615081Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:26.081451Z","description":"","domain_name":"tffuncfrostyshirleymwpev43g-tf-func-tender-bell.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de06479-d5c8-4de0-93f8-223db9c6bcd7","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-tender-bell","namespace_id":"9bb9a723-46a2-4697-b364-147f375ce8fe","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:26.081451Z"}'
         headers:
             Content-Length:
-                - "735"
+                - "716"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:01:52 GMT
+                - Wed, 27 Aug 2025 15:05:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -836,62 +836,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1708bf8a-da13-4840-ada6-12d7405d7c8a
+                - 5f25a8a4-bcfd-4f3e-a4bc-a9545d9f7946
         status: 200 OK
         code: 200
-        duration: 69.955154ms
+        duration: 100.001969ms
     - id: 17
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 217
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"runtime":"unknown_runtime","privacy":"unknown_privacy","secret_environment_variables":null,"http_option":"unknown_http_option","sandbox":"unknown_sandbox","private_network_id":"c06c7ffa-e6c1-42e3-98d1-fd3da73d4253"}'
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/87c2d675-77b9-4574-8c01-2f4f756a0fc4
-        method: PATCH
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 772
-        uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T14:01:50.615081Z","description":"","domain_name":"tffuncserenelichtermytdhxbxc-tf-func-unruffled-montalcini.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"87c2d675-77b9-4574-8c01-2f4f756a0fc4","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-unruffled-montalcini","namespace_id":"11f3af4d-e013-445f-8b22-156fc3c1f49c","privacy":"private","private_network_id":"c06c7ffa-e6c1-42e3-98d1-fd3da73d4253","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T14:01:52.410733960Z"}'
-        headers:
-            Content-Length:
-                - "772"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 27 Aug 2025 14:01:52 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 91d09e39-ba89-4e1c-b7b1-459972c5c66e
-        status: 200 OK
-        code: 200
-        duration: 317.607149ms
-    - id: 18
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -907,7 +856,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/87c2d675-77b9-4574-8c01-2f4f756a0fc4
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de06479-d5c8-4de0-93f8-223db9c6bcd7
         method: GET
       response:
         proto: HTTP/2.0
@@ -915,20 +864,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 769
+        content_length: 716
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T14:01:50.615081Z","description":"","domain_name":"tffuncserenelichtermytdhxbxc-tf-func-unruffled-montalcini.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"87c2d675-77b9-4574-8c01-2f4f756a0fc4","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-unruffled-montalcini","namespace_id":"11f3af4d-e013-445f-8b22-156fc3c1f49c","privacy":"private","private_network_id":"c06c7ffa-e6c1-42e3-98d1-fd3da73d4253","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T14:01:52.410734Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:26.081451Z","description":"","domain_name":"tffuncfrostyshirleymwpev43g-tf-func-tender-bell.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de06479-d5c8-4de0-93f8-223db9c6bcd7","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-tender-bell","namespace_id":"9bb9a723-46a2-4697-b364-147f375ce8fe","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:26.081451Z"}'
         headers:
             Content-Length:
-                - "769"
+                - "716"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:01:53 GMT
+                - Wed, 27 Aug 2025 15:05:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -936,10 +885,61 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b51fb0d2-b236-4f81-8ade-940bf7abc8eb
+                - 290c576e-6c42-4a33-98bb-8f3ec039ad1a
         status: 200 OK
         code: 200
-        duration: 53.815053ms
+        duration: 42.310931ms
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 217
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"runtime":"unknown_runtime","privacy":"unknown_privacy","secret_environment_variables":null,"http_option":"unknown_http_option","sandbox":"unknown_sandbox","private_network_id":"e67b56bb-a68b-4b30-852e-9d4a8023f6bb"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de06479-d5c8-4de0-93f8-223db9c6bcd7
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 753
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:26.081451Z","description":"","domain_name":"tffuncfrostyshirleymwpev43g-tf-func-tender-bell.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de06479-d5c8-4de0-93f8-223db9c6bcd7","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-tender-bell","namespace_id":"9bb9a723-46a2-4697-b364-147f375ce8fe","privacy":"private","private_network_id":"e67b56bb-a68b-4b30-852e-9d4a8023f6bb","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:28.324480534Z"}'
+        headers:
+            Content-Length:
+                - "753"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:05:28 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 11564cb1-75de-4f04-bf66-13cf28838ac9
+        status: 200 OK
+        code: 200
+        duration: 490.548636ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -956,7 +956,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/87c2d675-77b9-4574-8c01-2f4f756a0fc4
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de06479-d5c8-4de0-93f8-223db9c6bcd7
         method: GET
       response:
         proto: HTTP/2.0
@@ -964,20 +964,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 779
+        content_length: 760
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T14:01:50.615081Z","description":"","domain_name":"tffuncserenelichtermytdhxbxc-tf-func-unruffled-montalcini.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"Handle","http_option":"enabled","id":"87c2d675-77b9-4574-8c01-2f4f756a0fc4","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-unruffled-montalcini","namespace_id":"11f3af4d-e013-445f-8b22-156fc3c1f49c","privacy":"private","private_network_id":"c06c7ffa-e6c1-42e3-98d1-fd3da73d4253","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T14:01:58.281774Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:26.081451Z","description":"","domain_name":"tffuncfrostyshirleymwpev43g-tf-func-tender-bell.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"Handle","http_option":"enabled","id":"0de06479-d5c8-4de0-93f8-223db9c6bcd7","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-tender-bell","namespace_id":"9bb9a723-46a2-4697-b364-147f375ce8fe","privacy":"private","private_network_id":"e67b56bb-a68b-4b30-852e-9d4a8023f6bb","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:29.163328Z"}'
         headers:
             Content-Length:
-                - "779"
+                - "760"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:01:58 GMT
+                - Wed, 27 Aug 2025 15:05:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -985,10 +985,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 794e0243-3c4e-4e5d-ab44-d316e9f3b1a0
+                - 8c3a41a8-fbe0-4b19-8cd1-ad88d3b36e09
         status: 200 OK
         code: 200
-        duration: 68.921539ms
+        duration: 64.254795ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1005,7 +1005,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/11f3af4d-e013-445f-8b22-156fc3c1f49c
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/9bb9a723-46a2-4697-b364-147f375ce8fe
         method: GET
       response:
         proto: HTTP/2.0
@@ -1013,20 +1013,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 593
+        content_length: 589
         uncompressed: false
-        body: '{"created_at":"2025-08-27T14:01:44.917309Z","description":"","environment_variables":{},"error_message":null,"id":"11f3af4d-e013-445f-8b22-156fc3c1f49c","name":"tf-func-serene-lichterman","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncserenelichtermytdhxbxc","registry_namespace_id":"a1317d92-e1bb-4bb1-b13d-b074295e69d1","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T14:01:48.786476Z","vpc_integration_activated":true}'
+        body: '{"created_at":"2025-08-27T15:05:13.710923Z","description":"","environment_variables":{},"error_message":null,"id":"9bb9a723-46a2-4697-b364-147f375ce8fe","name":"tf-func-frosty-shirley","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncfrostyshirleymwpev43g","registry_namespace_id":"cf2dce01-8b8c-4bb4-81ec-f345c84ae4c5","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:21.320300Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "593"
+                - "589"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:01:58 GMT
+                - Wed, 27 Aug 2025 15:05:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1034,10 +1034,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bc2c1fd9-8e21-47f8-b25c-8380c18fd07c
+                - 76414192-063e-4261-896c-cf8a938ebfe4
         status: 200 OK
         code: 200
-        duration: 48.169748ms
+        duration: 46.491425ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1054,7 +1054,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/87c2d675-77b9-4574-8c01-2f4f756a0fc4
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de06479-d5c8-4de0-93f8-223db9c6bcd7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1062,20 +1062,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 779
+        content_length: 760
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T14:01:50.615081Z","description":"","domain_name":"tffuncserenelichtermytdhxbxc-tf-func-unruffled-montalcini.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"Handle","http_option":"enabled","id":"87c2d675-77b9-4574-8c01-2f4f756a0fc4","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-unruffled-montalcini","namespace_id":"11f3af4d-e013-445f-8b22-156fc3c1f49c","privacy":"private","private_network_id":"c06c7ffa-e6c1-42e3-98d1-fd3da73d4253","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T14:01:58.281774Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:26.081451Z","description":"","domain_name":"tffuncfrostyshirleymwpev43g-tf-func-tender-bell.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"Handle","http_option":"enabled","id":"0de06479-d5c8-4de0-93f8-223db9c6bcd7","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-tender-bell","namespace_id":"9bb9a723-46a2-4697-b364-147f375ce8fe","privacy":"private","private_network_id":"e67b56bb-a68b-4b30-852e-9d4a8023f6bb","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:29.163328Z"}'
         headers:
             Content-Length:
-                - "779"
+                - "760"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:01:58 GMT
+                - Wed, 27 Aug 2025 15:05:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1083,10 +1083,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f2810d72-cd30-4d4a-9704-dba6136f9085
+                - 500f6cb0-6915-472b-a85a-09382721577c
         status: 200 OK
         code: 200
-        duration: 44.370053ms
+        duration: 56.871452ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1103,7 +1103,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c06c7ffa-e6c1-42e3-98d1-fd3da73d4253
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e67b56bb-a68b-4b30-852e-9d4a8023f6bb
         method: GET
       response:
         proto: HTTP/2.0
@@ -1111,20 +1111,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1069
+        content_length: 1062
         uncompressed: false
-        body: '{"created_at":"2025-08-27T14:01:44.210929Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"c06c7ffa-e6c1-42e3-98d1-fd3da73d4253","name":"tf-pn-stoic-stonebraker","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-08-27T14:01:44.210929Z","id":"5873ffe4-f3f9-4933-88fe-71c893b7a8cf","private_network_id":"c06c7ffa-e6c1-42e3-98d1-fd3da73d4253","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.24.0/22","updated_at":"2025-08-27T14:01:44.210929Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-08-27T14:01:44.210929Z","id":"d77237aa-0dbe-4f17-9af4-31c6b6c7d6f5","private_network_id":"c06c7ffa-e6c1-42e3-98d1-fd3da73d4253","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:751f::/64","updated_at":"2025-08-27T14:01:44.210929Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-08-27T14:01:44.210929Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+        body: '{"created_at":"2025-08-27T15:05:08.250116Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"e67b56bb-a68b-4b30-852e-9d4a8023f6bb","name":"tf-pn-eager-kare","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-08-27T15:05:08.250116Z","id":"48309e13-53e3-406d-848e-69c9214e4f9b","private_network_id":"e67b56bb-a68b-4b30-852e-9d4a8023f6bb","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.20.0/22","updated_at":"2025-08-27T15:05:08.250116Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-08-27T15:05:08.250116Z","id":"2a929e16-dd46-4882-a714-f4c0988ba89d","private_network_id":"e67b56bb-a68b-4b30-852e-9d4a8023f6bb","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:c09b::/64","updated_at":"2025-08-27T15:05:08.250116Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-08-27T15:05:08.250116Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
         headers:
             Content-Length:
-                - "1069"
+                - "1062"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:01:59 GMT
+                - Wed, 27 Aug 2025 15:05:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1132,10 +1132,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 28870d93-c2a0-4c3a-811d-965493f870f3
+                - c5dafde8-c3d1-442f-9b06-f5df30db5401
         status: 200 OK
         code: 200
-        duration: 19.136174ms
+        duration: 26.192526ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1152,7 +1152,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/11f3af4d-e013-445f-8b22-156fc3c1f49c
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/9bb9a723-46a2-4697-b364-147f375ce8fe
         method: GET
       response:
         proto: HTTP/2.0
@@ -1160,20 +1160,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 593
+        content_length: 589
         uncompressed: false
-        body: '{"created_at":"2025-08-27T14:01:44.917309Z","description":"","environment_variables":{},"error_message":null,"id":"11f3af4d-e013-445f-8b22-156fc3c1f49c","name":"tf-func-serene-lichterman","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncserenelichtermytdhxbxc","registry_namespace_id":"a1317d92-e1bb-4bb1-b13d-b074295e69d1","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T14:01:48.786476Z","vpc_integration_activated":true}'
+        body: '{"created_at":"2025-08-27T15:05:13.710923Z","description":"","environment_variables":{},"error_message":null,"id":"9bb9a723-46a2-4697-b364-147f375ce8fe","name":"tf-func-frosty-shirley","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncfrostyshirleymwpev43g","registry_namespace_id":"cf2dce01-8b8c-4bb4-81ec-f345c84ae4c5","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:21.320300Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "593"
+                - "589"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:01:59 GMT
+                - Wed, 27 Aug 2025 15:05:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1181,10 +1181,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9c4d12a0-4a83-4120-a332-3b09720abcd9
+                - b2450234-1243-4967-b221-a9cf17a60d66
         status: 200 OK
         code: 200
-        duration: 50.16044ms
+        duration: 55.613822ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1201,7 +1201,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/87c2d675-77b9-4574-8c01-2f4f756a0fc4
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de06479-d5c8-4de0-93f8-223db9c6bcd7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1209,20 +1209,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 779
+        content_length: 760
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T14:01:50.615081Z","description":"","domain_name":"tffuncserenelichtermytdhxbxc-tf-func-unruffled-montalcini.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"Handle","http_option":"enabled","id":"87c2d675-77b9-4574-8c01-2f4f756a0fc4","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-unruffled-montalcini","namespace_id":"11f3af4d-e013-445f-8b22-156fc3c1f49c","privacy":"private","private_network_id":"c06c7ffa-e6c1-42e3-98d1-fd3da73d4253","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T14:01:58.281774Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:26.081451Z","description":"","domain_name":"tffuncfrostyshirleymwpev43g-tf-func-tender-bell.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"Handle","http_option":"enabled","id":"0de06479-d5c8-4de0-93f8-223db9c6bcd7","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-tender-bell","namespace_id":"9bb9a723-46a2-4697-b364-147f375ce8fe","privacy":"private","private_network_id":"e67b56bb-a68b-4b30-852e-9d4a8023f6bb","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:29.163328Z"}'
         headers:
             Content-Length:
-                - "779"
+                - "760"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:01:59 GMT
+                - Wed, 27 Aug 2025 15:05:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1230,10 +1230,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d690677f-0ef2-42b9-b6d6-855f0c4595f7
+                - c5972ede-1bcb-435f-923e-6d41d3b4c9a0
         status: 200 OK
         code: 200
-        duration: 48.552446ms
+        duration: 48.698897ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1250,7 +1250,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/87c2d675-77b9-4574-8c01-2f4f756a0fc4
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de06479-d5c8-4de0-93f8-223db9c6bcd7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1258,20 +1258,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 779
+        content_length: 760
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T14:01:50.615081Z","description":"","domain_name":"tffuncserenelichtermytdhxbxc-tf-func-unruffled-montalcini.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"Handle","http_option":"enabled","id":"87c2d675-77b9-4574-8c01-2f4f756a0fc4","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-unruffled-montalcini","namespace_id":"11f3af4d-e013-445f-8b22-156fc3c1f49c","privacy":"private","private_network_id":"c06c7ffa-e6c1-42e3-98d1-fd3da73d4253","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T14:01:58.281774Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:26.081451Z","description":"","domain_name":"tffuncfrostyshirleymwpev43g-tf-func-tender-bell.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"Handle","http_option":"enabled","id":"0de06479-d5c8-4de0-93f8-223db9c6bcd7","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-tender-bell","namespace_id":"9bb9a723-46a2-4697-b364-147f375ce8fe","privacy":"private","private_network_id":"e67b56bb-a68b-4b30-852e-9d4a8023f6bb","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:29.163328Z"}'
         headers:
             Content-Length:
-                - "779"
+                - "760"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:01:59 GMT
+                - Wed, 27 Aug 2025 15:05:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1279,10 +1279,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a90f1257-539c-4a5f-8352-e783dc640502
+                - e7ddc729-bbdc-4da7-b5ea-1fb39c198021
         status: 200 OK
         code: 200
-        duration: 53.628822ms
+        duration: 47.824696ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1299,7 +1299,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/87c2d675-77b9-4574-8c01-2f4f756a0fc4
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de06479-d5c8-4de0-93f8-223db9c6bcd7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1307,20 +1307,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 773
+        content_length: 754
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T14:01:50.615081Z","description":"","domain_name":"tffuncserenelichtermytdhxbxc-tf-func-unruffled-montalcini.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"87c2d675-77b9-4574-8c01-2f4f756a0fc4","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-unruffled-montalcini","namespace_id":"11f3af4d-e013-445f-8b22-156fc3c1f49c","privacy":"private","private_network_id":"c06c7ffa-e6c1-42e3-98d1-fd3da73d4253","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2025-08-27T14:01:59.601876398Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:26.081451Z","description":"","domain_name":"tffuncfrostyshirleymwpev43g-tf-func-tender-bell.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0de06479-d5c8-4de0-93f8-223db9c6bcd7","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-tender-bell","namespace_id":"9bb9a723-46a2-4697-b364-147f375ce8fe","privacy":"private","private_network_id":"e67b56bb-a68b-4b30-852e-9d4a8023f6bb","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:30.452724812Z"}'
         headers:
             Content-Length:
-                - "773"
+                - "754"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:01:59 GMT
+                - Wed, 27 Aug 2025 15:05:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1328,10 +1328,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e8f254d0-a7b9-4632-b2b7-295cfc373cf8
+                - 3e775e97-2cff-44d0-bc0d-90e7df1a77aa
         status: 200 OK
         code: 200
-        duration: 114.652651ms
+        duration: 146.496351ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1348,7 +1348,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/11f3af4d-e013-445f-8b22-156fc3c1f49c
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/9bb9a723-46a2-4697-b364-147f375ce8fe
         method: GET
       response:
         proto: HTTP/2.0
@@ -1356,20 +1356,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 593
+        content_length: 589
         uncompressed: false
-        body: '{"created_at":"2025-08-27T14:01:44.917309Z","description":"","environment_variables":{},"error_message":null,"id":"11f3af4d-e013-445f-8b22-156fc3c1f49c","name":"tf-func-serene-lichterman","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncserenelichtermytdhxbxc","registry_namespace_id":"a1317d92-e1bb-4bb1-b13d-b074295e69d1","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T14:01:48.786476Z","vpc_integration_activated":true}'
+        body: '{"created_at":"2025-08-27T15:05:13.710923Z","description":"","environment_variables":{},"error_message":null,"id":"9bb9a723-46a2-4697-b364-147f375ce8fe","name":"tf-func-frosty-shirley","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncfrostyshirleymwpev43g","registry_namespace_id":"cf2dce01-8b8c-4bb4-81ec-f345c84ae4c5","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:21.320300Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "593"
+                - "589"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:01:59 GMT
+                - Wed, 27 Aug 2025 15:05:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1377,10 +1377,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 889197ba-6d89-4c77-b1fc-80db3ad2f5b8
+                - 9bd4b060-2881-4bf6-a058-e3306e398774
         status: 200 OK
         code: 200
-        duration: 40.410807ms
+        duration: 43.021334ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1397,7 +1397,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/11f3af4d-e013-445f-8b22-156fc3c1f49c
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/9bb9a723-46a2-4697-b364-147f375ce8fe
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1405,20 +1405,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 599
+        content_length: 595
         uncompressed: false
-        body: '{"created_at":"2025-08-27T14:01:44.917309Z","description":"","environment_variables":{},"error_message":null,"id":"11f3af4d-e013-445f-8b22-156fc3c1f49c","name":"tf-func-serene-lichterman","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncserenelichtermytdhxbxc","registry_namespace_id":"a1317d92-e1bb-4bb1-b13d-b074295e69d1","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T14:01:59.759410734Z","vpc_integration_activated":true}'
+        body: '{"created_at":"2025-08-27T15:05:13.710923Z","description":"","environment_variables":{},"error_message":null,"id":"9bb9a723-46a2-4697-b364-147f375ce8fe","name":"tf-func-frosty-shirley","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncfrostyshirleymwpev43g","registry_namespace_id":"cf2dce01-8b8c-4bb4-81ec-f345c84ae4c5","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:30.635431759Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "599"
+                - "595"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:01:59 GMT
+                - Wed, 27 Aug 2025 15:05:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1426,10 +1426,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 51407f71-f4c9-4e41-b8ac-66d22a1f0aab
+                - d518e612-05b4-4133-a9a7-a3232538bb21
         status: 200 OK
         code: 200
-        duration: 192.511955ms
+        duration: 231.293311ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1446,7 +1446,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/11f3af4d-e013-445f-8b22-156fc3c1f49c
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/9bb9a723-46a2-4697-b364-147f375ce8fe
         method: GET
       response:
         proto: HTTP/2.0
@@ -1454,20 +1454,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 596
+        content_length: 592
         uncompressed: false
-        body: '{"created_at":"2025-08-27T14:01:44.917309Z","description":"","environment_variables":{},"error_message":null,"id":"11f3af4d-e013-445f-8b22-156fc3c1f49c","name":"tf-func-serene-lichterman","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncserenelichtermytdhxbxc","registry_namespace_id":"a1317d92-e1bb-4bb1-b13d-b074295e69d1","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T14:01:59.759411Z","vpc_integration_activated":true}'
+        body: '{"created_at":"2025-08-27T15:05:13.710923Z","description":"","environment_variables":{},"error_message":null,"id":"9bb9a723-46a2-4697-b364-147f375ce8fe","name":"tf-func-frosty-shirley","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncfrostyshirleymwpev43g","registry_namespace_id":"cf2dce01-8b8c-4bb4-81ec-f345c84ae4c5","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:30.635432Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "596"
+                - "592"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:01:59 GMT
+                - Wed, 27 Aug 2025 15:05:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1475,10 +1475,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e05af8d2-41a8-4cb6-ba0c-ec3f1a0acfa7
+                - 0e6df2f8-d40d-4c67-a05b-70eb16ee1e41
         status: 200 OK
         code: 200
-        duration: 41.287586ms
+        duration: 45.763238ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1495,7 +1495,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c06c7ffa-e6c1-42e3-98d1-fd3da73d4253
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e67b56bb-a68b-4b30-852e-9d4a8023f6bb
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1512,9 +1512,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:02:01 GMT
+                - Wed, 27 Aug 2025 15:05:31 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1522,10 +1522,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 904540a1-c3c6-4b79-877b-40a361e849c4
+                - e40ac98f-45e5-42a5-b64f-9f38c94580e2
         status: 204 No Content
         code: 204
-        duration: 1.543081992s
+        duration: 1.285701211s
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1542,7 +1542,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/11f3af4d-e013-445f-8b22-156fc3c1f49c
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/9bb9a723-46a2-4697-b364-147f375ce8fe
         method: GET
       response:
         proto: HTTP/2.0
@@ -1550,20 +1550,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 596
+        content_length: 592
         uncompressed: false
-        body: '{"created_at":"2025-08-27T14:01:44.917309Z","description":"","environment_variables":{},"error_message":null,"id":"11f3af4d-e013-445f-8b22-156fc3c1f49c","name":"tf-func-serene-lichterman","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncserenelichtermytdhxbxc","registry_namespace_id":"a1317d92-e1bb-4bb1-b13d-b074295e69d1","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T14:01:59.759411Z","vpc_integration_activated":true}'
+        body: '{"created_at":"2025-08-27T15:05:13.710923Z","description":"","environment_variables":{},"error_message":null,"id":"9bb9a723-46a2-4697-b364-147f375ce8fe","name":"tf-func-frosty-shirley","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncfrostyshirleymwpev43g","registry_namespace_id":"cf2dce01-8b8c-4bb4-81ec-f345c84ae4c5","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:30.635432Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "596"
+                - "592"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:02:04 GMT
+                - Wed, 27 Aug 2025 15:05:35 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1571,10 +1571,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 39c1235c-496f-4ed4-a597-562228667963
+                - bee51ea7-9fad-4e0c-a008-340af722dadc
         status: 200 OK
         code: 200
-        duration: 46.785794ms
+        duration: 47.225112ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1591,7 +1591,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/11f3af4d-e013-445f-8b22-156fc3c1f49c
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/9bb9a723-46a2-4697-b364-147f375ce8fe
         method: GET
       response:
         proto: HTTP/2.0
@@ -1599,20 +1599,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 596
+        content_length: 592
         uncompressed: false
-        body: '{"created_at":"2025-08-27T14:01:44.917309Z","description":"","environment_variables":{},"error_message":null,"id":"11f3af4d-e013-445f-8b22-156fc3c1f49c","name":"tf-func-serene-lichterman","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncserenelichtermytdhxbxc","registry_namespace_id":"a1317d92-e1bb-4bb1-b13d-b074295e69d1","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T14:01:59.759411Z","vpc_integration_activated":true}'
+        body: '{"created_at":"2025-08-27T15:05:13.710923Z","description":"","environment_variables":{},"error_message":null,"id":"9bb9a723-46a2-4697-b364-147f375ce8fe","name":"tf-func-frosty-shirley","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncfrostyshirleymwpev43g","registry_namespace_id":"cf2dce01-8b8c-4bb4-81ec-f345c84ae4c5","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:30.635432Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "596"
+                - "592"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:02:10 GMT
+                - Wed, 27 Aug 2025 15:05:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1620,10 +1620,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cdecbfa3-fcdf-440b-952e-1858ddd26163
+                - 4cc0cfe2-2694-46fc-a9b4-e849ae590b6d
         status: 200 OK
         code: 200
-        duration: 41.478644ms
+        duration: 54.025534ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1640,7 +1640,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/11f3af4d-e013-445f-8b22-156fc3c1f49c
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/9bb9a723-46a2-4697-b364-147f375ce8fe
         method: GET
       response:
         proto: HTTP/2.0
@@ -1648,20 +1648,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 596
+        content_length: 592
         uncompressed: false
-        body: '{"created_at":"2025-08-27T14:01:44.917309Z","description":"","environment_variables":{},"error_message":null,"id":"11f3af4d-e013-445f-8b22-156fc3c1f49c","name":"tf-func-serene-lichterman","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncserenelichtermytdhxbxc","registry_namespace_id":"a1317d92-e1bb-4bb1-b13d-b074295e69d1","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T14:01:59.759411Z","vpc_integration_activated":true}'
+        body: '{"created_at":"2025-08-27T15:05:13.710923Z","description":"","environment_variables":{},"error_message":null,"id":"9bb9a723-46a2-4697-b364-147f375ce8fe","name":"tf-func-frosty-shirley","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncfrostyshirleymwpev43g","registry_namespace_id":"cf2dce01-8b8c-4bb4-81ec-f345c84ae4c5","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:30.635432Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "596"
+                - "592"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:02:15 GMT
+                - Wed, 27 Aug 2025 15:05:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1669,10 +1669,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c8eaadb7-aba8-45da-a2d3-f89545b36938
+                - a50399b3-dadd-4c61-ae29-ae6ff94a7566
         status: 200 OK
         code: 200
-        duration: 57.721194ms
+        duration: 46.345333ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1689,7 +1689,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/11f3af4d-e013-445f-8b22-156fc3c1f49c
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/9bb9a723-46a2-4697-b364-147f375ce8fe
         method: GET
       response:
         proto: HTTP/2.0
@@ -1697,20 +1697,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 596
+        content_length: 592
         uncompressed: false
-        body: '{"created_at":"2025-08-27T14:01:44.917309Z","description":"","environment_variables":{},"error_message":null,"id":"11f3af4d-e013-445f-8b22-156fc3c1f49c","name":"tf-func-serene-lichterman","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncserenelichtermytdhxbxc","registry_namespace_id":"a1317d92-e1bb-4bb1-b13d-b074295e69d1","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T14:01:59.759411Z","vpc_integration_activated":true}'
+        body: '{"created_at":"2025-08-27T15:05:13.710923Z","description":"","environment_variables":{},"error_message":null,"id":"9bb9a723-46a2-4697-b364-147f375ce8fe","name":"tf-func-frosty-shirley","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncfrostyshirleymwpev43g","registry_namespace_id":"cf2dce01-8b8c-4bb4-81ec-f345c84ae4c5","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:30.635432Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "596"
+                - "592"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:02:20 GMT
+                - Wed, 27 Aug 2025 15:05:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1718,10 +1718,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 835c9071-767a-46d2-a517-e6b7cf724e7b
+                - 9a83e8d4-fe1c-451f-891a-be6dda074075
         status: 200 OK
         code: 200
-        duration: 38.666555ms
+        duration: 43.55069ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1738,7 +1738,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/11f3af4d-e013-445f-8b22-156fc3c1f49c
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/9bb9a723-46a2-4697-b364-147f375ce8fe
         method: GET
       response:
         proto: HTTP/2.0
@@ -1746,20 +1746,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 596
+        content_length: 592
         uncompressed: false
-        body: '{"created_at":"2025-08-27T14:01:44.917309Z","description":"","environment_variables":{},"error_message":null,"id":"11f3af4d-e013-445f-8b22-156fc3c1f49c","name":"tf-func-serene-lichterman","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncserenelichtermytdhxbxc","registry_namespace_id":"a1317d92-e1bb-4bb1-b13d-b074295e69d1","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T14:01:59.759411Z","vpc_integration_activated":true}'
+        body: '{"created_at":"2025-08-27T15:05:13.710923Z","description":"","environment_variables":{},"error_message":null,"id":"9bb9a723-46a2-4697-b364-147f375ce8fe","name":"tf-func-frosty-shirley","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncfrostyshirleymwpev43g","registry_namespace_id":"cf2dce01-8b8c-4bb4-81ec-f345c84ae4c5","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:30.635432Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "596"
+                - "592"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:02:25 GMT
+                - Wed, 27 Aug 2025 15:05:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1767,10 +1767,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 804706e8-0d03-4013-8126-426c3d3fdbdf
+                - 6de637cf-80d6-4b1b-96d6-0597fd6f9530
         status: 200 OK
         code: 200
-        duration: 41.33931ms
+        duration: 37.094977ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1787,7 +1787,56 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/11f3af4d-e013-445f-8b22-156fc3c1f49c
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/9bb9a723-46a2-4697-b364-147f375ce8fe
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 592
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:13.710923Z","description":"","environment_variables":{},"error_message":null,"id":"9bb9a723-46a2-4697-b364-147f375ce8fe","name":"tf-func-frosty-shirley","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncfrostyshirleymwpev43g","registry_namespace_id":"cf2dce01-8b8c-4bb4-81ec-f345c84ae4c5","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:30.635432Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "592"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:01 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b827998f-5e79-48e5-a8bb-b3b0bde50bf4
+        status: 200 OK
+        code: 200
+        duration: 47.879474ms
+    - id: 37
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/9bb9a723-46a2-4697-b364-147f375ce8fe
         method: GET
       response:
         proto: HTTP/2.0
@@ -1806,9 +1855,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:02:30 GMT
+                - Wed, 27 Aug 2025 15:06:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1816,11 +1865,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 638c4832-130a-4532-81de-432ce54e4365
+                - 4257c3a3-f413-4f7c-acb2-11d36d69a6db
         status: 404 Not Found
         code: 404
-        duration: 33.377539ms
-    - id: 37
+        duration: 28.099739ms
+    - id: 38
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1836,7 +1885,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/11f3af4d-e013-445f-8b22-156fc3c1f49c
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/9bb9a723-46a2-4697-b364-147f375ce8fe
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1855,9 +1904,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:02:30 GMT
+                - Wed, 27 Aug 2025 15:06:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1865,11 +1914,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8de7828c-241e-497a-8206-098e565a6fc5
+                - 3a6d5370-b491-43b0-ae4a-d2112717ab96
         status: 404 Not Found
         code: 404
-        duration: 22.30507ms
-    - id: 38
+        duration: 25.74476ms
+    - id: 39
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1885,7 +1934,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/87c2d675-77b9-4574-8c01-2f4f756a0fc4
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0de06479-d5c8-4de0-93f8-223db9c6bcd7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1904,9 +1953,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:02:30 GMT
+                - Wed, 27 Aug 2025 15:06:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1914,11 +1963,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ec18a055-bdec-4d36-a78b-62183f122fa5
+                - e9a1ec27-9ca0-4348-9761-bbba4967f099
         status: 404 Not Found
         code: 404
-        duration: 23.335688ms
-    - id: 39
+        duration: 25.095051ms
+    - id: 40
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1934,7 +1983,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c06c7ffa-e6c1-42e3-98d1-fd3da73d4253
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e67b56bb-a68b-4b30-852e-9d4a8023f6bb
         method: GET
       response:
         proto: HTTP/2.0
@@ -1944,7 +1993,7 @@ interactions:
         trailer: {}
         content_length: 136
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"private_network","resource_id":"c06c7ffa-e6c1-42e3-98d1-fd3da73d4253","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"private_network","resource_id":"e67b56bb-a68b-4b30-852e-9d4a8023f6bb","type":"not_found"}'
         headers:
             Content-Length:
                 - "136"
@@ -1953,9 +2002,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 27 Aug 2025 14:02:30 GMT
+                - Wed, 27 Aug 2025 15:06:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1963,7 +2012,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 26733972-d0ec-4e8a-b7c9-58acf83a5874
+                - 95357610-12ca-4031-9ab9-facf026d31f4
         status: 404 Not Found
         code: 404
-        duration: 25.992163ms
+        duration: 20.795874ms

--- a/internal/services/function/testdata/function-no-name.cassette.yaml
+++ b/internal/services/function/testdata/function-no-name.cassette.yaml
@@ -6,19 +6,19 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 159
+        content_length: 192
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-func-sharp-ramanujan","environment_variables":{},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","secret_environment_variables":[],"tags":null}'
+        body: '{"name":"tf-func-admiring-dewdney","environment_variables":{},"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","secret_environment_variables":[],"tags":null,"activate_vpc_integration":true}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces
         method: POST
       response:
@@ -27,20 +27,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 475
+        content_length: 509
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.352599485Z","description":"","environment_variables":{},"error_message":null,"id":"b11ef392-64fb-415c-ac8e-a52db9a89acd","name":"tf-func-sharp-ramanujan","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:44:07.352599485Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.558072935Z","description":"","environment_variables":{},"error_message":null,"id":"e5193db2-75c1-42af-a0ae-baf7888e274b","name":"tf-func-admiring-dewdney","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:13.558072935Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "475"
+                - "509"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:07 GMT
+                - Wed, 27 Aug 2025 15:05:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a34b41f1-9b1b-413c-a276-3c2fcea3b1b2
+                - 5cb46f79-fd61-4854-842e-940115463e53
         status: 200 OK
         code: 200
-        duration: 721.315125ms
+        duration: 5.40427917s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -67,8 +67,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b11ef392-64fb-415c-ac8e-a52db9a89acd
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e5193db2-75c1-42af-a0ae-baf7888e274b
         method: GET
       response:
         proto: HTTP/2.0
@@ -76,20 +76,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 469
+        content_length: 503
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.352599Z","description":"","environment_variables":{},"error_message":null,"id":"b11ef392-64fb-415c-ac8e-a52db9a89acd","name":"tf-func-sharp-ramanujan","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:44:07.352599Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.558073Z","description":"","environment_variables":{},"error_message":null,"id":"e5193db2-75c1-42af-a0ae-baf7888e274b","name":"tf-func-admiring-dewdney","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:13.558073Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "469"
+                - "503"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:07 GMT
+                - Wed, 27 Aug 2025 15:05:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c6e31379-c9ac-433d-8ae7-89eabf07d2ba
+                - 72b3edc2-7ddb-412e-b75e-49b722c946d5
         status: 200 OK
         code: 200
-        duration: 112.270666ms
+        duration: 52.810519ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -116,8 +116,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b11ef392-64fb-415c-ac8e-a52db9a89acd
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e5193db2-75c1-42af-a0ae-baf7888e274b
         method: GET
       response:
         proto: HTTP/2.0
@@ -125,20 +125,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 560
+        content_length: 503
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.352599Z","description":"","environment_variables":{},"error_message":null,"id":"b11ef392-64fb-415c-ac8e-a52db9a89acd","name":"tf-func-sharp-ramanujan","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncsharpramanujanlces7dof","registry_namespace_id":"122883f4-6deb-4c39-8daf-6e0f89258f61","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:44:09.631801Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.558073Z","description":"","environment_variables":{},"error_message":null,"id":"e5193db2-75c1-42af-a0ae-baf7888e274b","name":"tf-func-admiring-dewdney","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:13.959326Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "560"
+                - "503"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:12 GMT
+                - Wed, 27 Aug 2025 15:05:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -146,10 +146,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2e36b6db-01d5-4b1f-bdc3-c5016556f813
+                - bb942e4a-d178-4678-b10b-d0ba8e7345c4
         status: 200 OK
         code: 200
-        duration: 73.913375ms
+        duration: 547.110448ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -165,8 +165,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b11ef392-64fb-415c-ac8e-a52db9a89acd
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e5193db2-75c1-42af-a0ae-baf7888e274b
         method: GET
       response:
         proto: HTTP/2.0
@@ -174,20 +174,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 558
+        content_length: 592
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.352599Z","description":"","environment_variables":{},"error_message":null,"id":"b11ef392-64fb-415c-ac8e-a52db9a89acd","name":"tf-func-sharp-ramanujan","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncsharpramanujanlces7dof","registry_namespace_id":"122883f4-6deb-4c39-8daf-6e0f89258f61","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:44:12.824488Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.558073Z","description":"","environment_variables":{},"error_message":null,"id":"e5193db2-75c1-42af-a0ae-baf7888e274b","name":"tf-func-admiring-dewdney","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncadmiringdewdneqy1zjw8c","registry_namespace_id":"72204338-7600-455d-bc12-2b46d81873d1","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:21.078305Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "558"
+                - "592"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:17 GMT
+                - Wed, 27 Aug 2025 15:05:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -195,10 +195,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - eb458cb8-7be4-4578-98dd-0a53a6a502e1
+                - 9e55eed3-a842-49b9-b1fe-47a2fb544978
         status: 200 OK
         code: 200
-        duration: 76.328667ms
+        duration: 42.392764ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -214,8 +214,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b11ef392-64fb-415c-ac8e-a52db9a89acd
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e5193db2-75c1-42af-a0ae-baf7888e274b
         method: GET
       response:
         proto: HTTP/2.0
@@ -223,20 +223,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 558
+        content_length: 592
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.352599Z","description":"","environment_variables":{},"error_message":null,"id":"b11ef392-64fb-415c-ac8e-a52db9a89acd","name":"tf-func-sharp-ramanujan","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncsharpramanujanlces7dof","registry_namespace_id":"122883f4-6deb-4c39-8daf-6e0f89258f61","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:44:12.824488Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.558073Z","description":"","environment_variables":{},"error_message":null,"id":"e5193db2-75c1-42af-a0ae-baf7888e274b","name":"tf-func-admiring-dewdney","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncadmiringdewdneqy1zjw8c","registry_namespace_id":"72204338-7600-455d-bc12-2b46d81873d1","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:21.078305Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "558"
+                - "592"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:17 GMT
+                - Wed, 27 Aug 2025 15:05:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -244,28 +244,28 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e40d7f2a-28ee-4f1f-85ed-2714a2473c1b
+                - 3a181d34-c9cf-4197-8b15-8412ac01e7ee
         status: 200 OK
         code: 200
-        duration: 63.420791ms
+        duration: 42.274862ms
     - id: 5
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 315
+        content_length: 331
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-func-awesome-meitner","namespace_id":"b11ef392-64fb-415c-ac8e-a52db9a89acd","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"node22","memory_limit":256,"handler":"handler.handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox"}'
+        body: '{"name":"tf-func-sleepy-grothendieck","namespace_id":"e5193db2-75c1-42af-a0ae-baf7888e274b","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"node22","memory_limit":256,"handler":"handler.handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox","tags":null}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions
         method: POST
       response:
@@ -274,20 +274,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 704
+        content_length: 748
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:17.971714457Z","description":"","domain_name":"tffuncsharpramanujanlces7dof-tf-func-awesome-meitner.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"1852a6b0-1bcd-4c11-b570-7ffbb81f3155","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-awesome-meitner","namespace_id":"b11ef392-64fb-415c-ac8e-a52db9a89acd","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:17.971714457Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:25.283163467Z","description":"","domain_name":"tffuncadmiringdewdneqy1zjw8c-tf-func-sleepy-grothendieck.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"e3d2b809-db8b-45a2-bd70-a3e96b3d481d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-sleepy-grothendieck","namespace_id":"e5193db2-75c1-42af-a0ae-baf7888e274b","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:25.283163467Z"}'
         headers:
             Content-Length:
-                - "704"
+                - "748"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:17 GMT
+                - Wed, 27 Aug 2025 15:05:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -295,10 +295,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1a8c7066-fa2b-40c9-a3c1-b8f869a328db
+                - 7fd2686f-3b2e-46fd-94c2-6f633d92aa07
         status: 200 OK
         code: 200
-        duration: 281.210458ms
+        duration: 1.050940361s
     - id: 6
       request:
         proto: HTTP/1.1
@@ -314,8 +314,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/1852a6b0-1bcd-4c11-b570-7ffbb81f3155
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e3d2b809-db8b-45a2-bd70-a3e96b3d481d
         method: GET
       response:
         proto: HTTP/2.0
@@ -323,20 +323,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 698
+        content_length: 742
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:17.971714Z","description":"","domain_name":"tffuncsharpramanujanlces7dof-tf-func-awesome-meitner.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"1852a6b0-1bcd-4c11-b570-7ffbb81f3155","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-awesome-meitner","namespace_id":"b11ef392-64fb-415c-ac8e-a52db9a89acd","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:17.971714Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:25.283163Z","description":"","domain_name":"tffuncadmiringdewdneqy1zjw8c-tf-func-sleepy-grothendieck.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"e3d2b809-db8b-45a2-bd70-a3e96b3d481d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-sleepy-grothendieck","namespace_id":"e5193db2-75c1-42af-a0ae-baf7888e274b","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:25.283163Z"}'
         headers:
             Content-Length:
-                - "698"
+                - "742"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:18 GMT
+                - Wed, 27 Aug 2025 15:05:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -344,10 +344,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f729a69e-5476-4b4c-a7d7-913a2e44f959
+                - a5111740-fd01-4869-8c22-13242cf6437f
         status: 200 OK
         code: 200
-        duration: 111.030916ms
+        duration: 67.426576ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -363,8 +363,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/1852a6b0-1bcd-4c11-b570-7ffbb81f3155
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e3d2b809-db8b-45a2-bd70-a3e96b3d481d
         method: GET
       response:
         proto: HTTP/2.0
@@ -372,20 +372,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 698
+        content_length: 742
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:17.971714Z","description":"","domain_name":"tffuncsharpramanujanlces7dof-tf-func-awesome-meitner.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"1852a6b0-1bcd-4c11-b570-7ffbb81f3155","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-awesome-meitner","namespace_id":"b11ef392-64fb-415c-ac8e-a52db9a89acd","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:17.971714Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:25.283163Z","description":"","domain_name":"tffuncadmiringdewdneqy1zjw8c-tf-func-sleepy-grothendieck.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"e3d2b809-db8b-45a2-bd70-a3e96b3d481d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-sleepy-grothendieck","namespace_id":"e5193db2-75c1-42af-a0ae-baf7888e274b","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:25.283163Z"}'
         headers:
             Content-Length:
-                - "698"
+                - "742"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:18 GMT
+                - Wed, 27 Aug 2025 15:05:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -393,10 +393,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b302696c-9fb2-45fd-98fa-c93cbb43fe9f
+                - e03d377e-9e5b-4c50-ad0e-eae1907a807d
         status: 200 OK
         code: 200
-        duration: 80.622167ms
+        duration: 83.453868ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -412,8 +412,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/1852a6b0-1bcd-4c11-b570-7ffbb81f3155
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e3d2b809-db8b-45a2-bd70-a3e96b3d481d
         method: GET
       response:
         proto: HTTP/2.0
@@ -421,20 +421,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 698
+        content_length: 742
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:17.971714Z","description":"","domain_name":"tffuncsharpramanujanlces7dof-tf-func-awesome-meitner.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"1852a6b0-1bcd-4c11-b570-7ffbb81f3155","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-awesome-meitner","namespace_id":"b11ef392-64fb-415c-ac8e-a52db9a89acd","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:17.971714Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:25.283163Z","description":"","domain_name":"tffuncadmiringdewdneqy1zjw8c-tf-func-sleepy-grothendieck.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"e3d2b809-db8b-45a2-bd70-a3e96b3d481d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-sleepy-grothendieck","namespace_id":"e5193db2-75c1-42af-a0ae-baf7888e274b","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:25.283163Z"}'
         headers:
             Content-Length:
-                - "698"
+                - "742"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:18 GMT
+                - Wed, 27 Aug 2025 15:05:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -442,10 +442,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ac713b7b-59c0-45bc-a45b-7f56d2499f0b
+                - 45a03df4-643e-47bc-b5c8-ba9f6fec051f
         status: 200 OK
         code: 200
-        duration: 67.701459ms
+        duration: 77.603762ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -461,8 +461,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b11ef392-64fb-415c-ac8e-a52db9a89acd
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e5193db2-75c1-42af-a0ae-baf7888e274b
         method: GET
       response:
         proto: HTTP/2.0
@@ -470,20 +470,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 558
+        content_length: 592
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.352599Z","description":"","environment_variables":{},"error_message":null,"id":"b11ef392-64fb-415c-ac8e-a52db9a89acd","name":"tf-func-sharp-ramanujan","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncsharpramanujanlces7dof","registry_namespace_id":"122883f4-6deb-4c39-8daf-6e0f89258f61","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:44:12.824488Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.558073Z","description":"","environment_variables":{},"error_message":null,"id":"e5193db2-75c1-42af-a0ae-baf7888e274b","name":"tf-func-admiring-dewdney","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncadmiringdewdneqy1zjw8c","registry_namespace_id":"72204338-7600-455d-bc12-2b46d81873d1","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:21.078305Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "558"
+                - "592"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:19 GMT
+                - Wed, 27 Aug 2025 15:05:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -491,10 +491,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e6ded258-97ec-48d2-b781-40fea18a048d
+                - cddc678b-a2aa-4ac8-baad-8cd6c9f6756c
         status: 200 OK
         code: 200
-        duration: 66.795584ms
+        duration: 38.31381ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -510,8 +510,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/1852a6b0-1bcd-4c11-b570-7ffbb81f3155
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e3d2b809-db8b-45a2-bd70-a3e96b3d481d
         method: GET
       response:
         proto: HTTP/2.0
@@ -519,20 +519,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 698
+        content_length: 742
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:17.971714Z","description":"","domain_name":"tffuncsharpramanujanlces7dof-tf-func-awesome-meitner.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"1852a6b0-1bcd-4c11-b570-7ffbb81f3155","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-awesome-meitner","namespace_id":"b11ef392-64fb-415c-ac8e-a52db9a89acd","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:17.971714Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:25.283163Z","description":"","domain_name":"tffuncadmiringdewdneqy1zjw8c-tf-func-sleepy-grothendieck.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"e3d2b809-db8b-45a2-bd70-a3e96b3d481d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-sleepy-grothendieck","namespace_id":"e5193db2-75c1-42af-a0ae-baf7888e274b","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:25.283163Z"}'
         headers:
             Content-Length:
-                - "698"
+                - "742"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:19 GMT
+                - Wed, 27 Aug 2025 15:05:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -540,10 +540,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9b8eb46d-a933-4f76-8e81-bc0f75bafa78
+                - 0aca5a12-3843-420d-aa5e-d97b939b525b
         status: 200 OK
         code: 200
-        duration: 86.48175ms
+        duration: 61.077052ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -559,8 +559,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/1852a6b0-1bcd-4c11-b570-7ffbb81f3155
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e3d2b809-db8b-45a2-bd70-a3e96b3d481d
         method: GET
       response:
         proto: HTTP/2.0
@@ -568,20 +568,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 698
+        content_length: 742
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:17.971714Z","description":"","domain_name":"tffuncsharpramanujanlces7dof-tf-func-awesome-meitner.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"1852a6b0-1bcd-4c11-b570-7ffbb81f3155","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-awesome-meitner","namespace_id":"b11ef392-64fb-415c-ac8e-a52db9a89acd","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:17.971714Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:25.283163Z","description":"","domain_name":"tffuncadmiringdewdneqy1zjw8c-tf-func-sleepy-grothendieck.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"e3d2b809-db8b-45a2-bd70-a3e96b3d481d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-sleepy-grothendieck","namespace_id":"e5193db2-75c1-42af-a0ae-baf7888e274b","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:25.283163Z"}'
         headers:
             Content-Length:
-                - "698"
+                - "742"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:20 GMT
+                - Wed, 27 Aug 2025 15:05:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -589,10 +589,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1496fa1c-332b-416b-88f6-929ddb30667f
+                - 06201a1d-1587-4b78-8403-275f00b0e240
         status: 200 OK
         code: 200
-        duration: 66.353292ms
+        duration: 54.679158ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -608,8 +608,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/1852a6b0-1bcd-4c11-b570-7ffbb81f3155
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e3d2b809-db8b-45a2-bd70-a3e96b3d481d
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -617,20 +617,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 702
+        content_length: 746
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:17.971714Z","description":"","domain_name":"tffuncsharpramanujanlces7dof-tf-func-awesome-meitner.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"1852a6b0-1bcd-4c11-b570-7ffbb81f3155","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-awesome-meitner","namespace_id":"b11ef392-64fb-415c-ac8e-a52db9a89acd","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"deleting","timeout":"300s","updated_at":"2025-01-24T15:44:20.333467004Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:25.283163Z","description":"","domain_name":"tffuncadmiringdewdneqy1zjw8c-tf-func-sleepy-grothendieck.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"e3d2b809-db8b-45a2-bd70-a3e96b3d481d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-sleepy-grothendieck","namespace_id":"e5193db2-75c1-42af-a0ae-baf7888e274b","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:26.543336703Z"}'
         headers:
             Content-Length:
-                - "702"
+                - "746"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:20 GMT
+                - Wed, 27 Aug 2025 15:05:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -638,10 +638,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7a2086e8-e75d-4445-8431-56bb8f859b91
+                - 644e01b7-231a-43f7-a1c6-7c4603c19e45
         status: 200 OK
         code: 200
-        duration: 132.294916ms
+        duration: 189.64993ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -657,8 +657,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b11ef392-64fb-415c-ac8e-a52db9a89acd
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e5193db2-75c1-42af-a0ae-baf7888e274b
         method: GET
       response:
         proto: HTTP/2.0
@@ -666,20 +666,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 558
+        content_length: 592
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.352599Z","description":"","environment_variables":{},"error_message":null,"id":"b11ef392-64fb-415c-ac8e-a52db9a89acd","name":"tf-func-sharp-ramanujan","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncsharpramanujanlces7dof","registry_namespace_id":"122883f4-6deb-4c39-8daf-6e0f89258f61","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:44:12.824488Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.558073Z","description":"","environment_variables":{},"error_message":null,"id":"e5193db2-75c1-42af-a0ae-baf7888e274b","name":"tf-func-admiring-dewdney","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncadmiringdewdneqy1zjw8c","registry_namespace_id":"72204338-7600-455d-bc12-2b46d81873d1","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:21.078305Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "558"
+                - "592"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:20 GMT
+                - Wed, 27 Aug 2025 15:05:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -687,10 +687,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 553869fe-fc72-479f-b21a-3ccd558e128f
+                - 5ff116bb-357c-4b93-9b57-3541b782ef03
         status: 200 OK
         code: 200
-        duration: 62.840833ms
+        duration: 53.914522ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -706,8 +706,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b11ef392-64fb-415c-ac8e-a52db9a89acd
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e5193db2-75c1-42af-a0ae-baf7888e274b
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -715,20 +715,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 564
+        content_length: 598
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.352599Z","description":"","environment_variables":{},"error_message":null,"id":"b11ef392-64fb-415c-ac8e-a52db9a89acd","name":"tf-func-sharp-ramanujan","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncsharpramanujanlces7dof","registry_namespace_id":"122883f4-6deb-4c39-8daf-6e0f89258f61","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:44:20.549306217Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.558073Z","description":"","environment_variables":{},"error_message":null,"id":"e5193db2-75c1-42af-a0ae-baf7888e274b","name":"tf-func-admiring-dewdney","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncadmiringdewdneqy1zjw8c","registry_namespace_id":"72204338-7600-455d-bc12-2b46d81873d1","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:26.870788209Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "564"
+                - "598"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:20 GMT
+                - Wed, 27 Aug 2025 15:05:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -736,10 +736,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 56359bd4-44c8-4dd7-a6a8-740ea0231abf
+                - d0001d40-dd01-4b69-8d77-398b336642a5
         status: 200 OK
         code: 200
-        duration: 253.677166ms
+        duration: 379.741711ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -755,8 +755,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b11ef392-64fb-415c-ac8e-a52db9a89acd
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e5193db2-75c1-42af-a0ae-baf7888e274b
         method: GET
       response:
         proto: HTTP/2.0
@@ -764,20 +764,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 561
+        content_length: 595
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.352599Z","description":"","environment_variables":{},"error_message":null,"id":"b11ef392-64fb-415c-ac8e-a52db9a89acd","name":"tf-func-sharp-ramanujan","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncsharpramanujanlces7dof","registry_namespace_id":"122883f4-6deb-4c39-8daf-6e0f89258f61","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:44:20.549306Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.558073Z","description":"","environment_variables":{},"error_message":null,"id":"e5193db2-75c1-42af-a0ae-baf7888e274b","name":"tf-func-admiring-dewdney","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncadmiringdewdneqy1zjw8c","registry_namespace_id":"72204338-7600-455d-bc12-2b46d81873d1","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:26.870788Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "561"
+                - "595"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:20 GMT
+                - Wed, 27 Aug 2025 15:05:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -785,10 +785,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6728cade-31f8-41e7-8a09-36e16515845f
+                - 0e07e597-ae9f-4d9e-b758-ed765eed962f
         status: 200 OK
         code: 200
-        duration: 133.297333ms
+        duration: 48.953163ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -804,8 +804,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b11ef392-64fb-415c-ac8e-a52db9a89acd
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e5193db2-75c1-42af-a0ae-baf7888e274b
         method: GET
       response:
         proto: HTTP/2.0
@@ -824,9 +824,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:25 GMT
+                - Wed, 27 Aug 2025 15:05:32 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -834,10 +834,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8660b1b6-3094-42a9-bb28-c888996ab45b
+                - da43f39e-7952-4e30-be72-52262b013cf6
         status: 404 Not Found
         code: 404
-        duration: 26.064791ms
+        duration: 20.898253ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -853,8 +853,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b11ef392-64fb-415c-ac8e-a52db9a89acd
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e5193db2-75c1-42af-a0ae-baf7888e274b
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -873,9 +873,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:25 GMT
+                - Wed, 27 Aug 2025 15:05:32 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -883,7 +883,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 125de54f-6906-417e-a7f4-46bde273f220
+                - cd450d22-d20d-44db-b985-2003277afb5a
         status: 404 Not Found
         code: 404
-        duration: 23.149959ms
+        duration: 27.374695ms

--- a/internal/services/function/testdata/function-private-network.cassette.yaml
+++ b/internal/services/function/testdata/function-private-network.cassette.yaml
@@ -6,20 +6,20 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 185
+        content_length: 155
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-func-kind-buck","environment_variables":{},"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","secret_environment_variables":[],"tags":null,"activate_vpc_integration":true}'
+        body: '{"name":"test-acc-function-pn-pn00","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"subnets":null,"default_route_propagation_enabled":false}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
         method: POST
       response:
         proto: HTTP/2.0
@@ -27,20 +27,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 502
+        content_length: 1071
         uncompressed: false
-        body: '{"created_at":"2025-06-16T16:32:29.224353568Z","description":"","environment_variables":{},"error_message":null,"id":"0aa68856-5a7c-460e-a304-96399c647807","name":"tf-func-kind-buck","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-06-16T16:32:29.224353568Z","vpc_integration_activated":true}'
+        body: '{"created_at":"2025-08-27T15:05:08.450070Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"d2582989-54df-4e6a-b43d-6cc6fc8370e1","name":"test-acc-function-pn-pn00","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-08-27T15:05:08.450070Z","id":"c5f17ea2-1cf9-459a-9529-9e91992fe302","private_network_id":"d2582989-54df-4e6a-b43d-6cc6fc8370e1","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.28.0/22","updated_at":"2025-08-27T15:05:08.450070Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-08-27T15:05:08.450070Z","id":"dab15e62-9a15-48ba-8f7c-b73e9a4bc41a","private_network_id":"d2582989-54df-4e6a-b43d-6cc6fc8370e1","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:a9d4::/64","updated_at":"2025-08-27T15:05:08.450070Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-08-27T15:05:08.450070Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
         headers:
             Content-Length:
-                - "502"
+                - "1071"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:29 GMT
+                - Wed, 27 Aug 2025 15:05:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 78b0c751-8cf0-45f0-8148-79580747022a
+                - 8fcc6c7a-81d2-4f0f-9c4b-a001a9e2e3f2
         status: 200 OK
         code: 200
-        duration: 382.726304ms
+        duration: 924.009202ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -68,7 +68,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/0aa68856-5a7c-460e-a304-96399c647807
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/d2582989-54df-4e6a-b43d-6cc6fc8370e1
         method: GET
       response:
         proto: HTTP/2.0
@@ -76,20 +76,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 496
+        content_length: 1071
         uncompressed: false
-        body: '{"created_at":"2025-06-16T16:32:29.224354Z","description":"","environment_variables":{},"error_message":null,"id":"0aa68856-5a7c-460e-a304-96399c647807","name":"tf-func-kind-buck","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-06-16T16:32:29.224354Z","vpc_integration_activated":true}'
+        body: '{"created_at":"2025-08-27T15:05:08.450070Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"d2582989-54df-4e6a-b43d-6cc6fc8370e1","name":"test-acc-function-pn-pn00","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-08-27T15:05:08.450070Z","id":"c5f17ea2-1cf9-459a-9529-9e91992fe302","private_network_id":"d2582989-54df-4e6a-b43d-6cc6fc8370e1","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.28.0/22","updated_at":"2025-08-27T15:05:08.450070Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-08-27T15:05:08.450070Z","id":"dab15e62-9a15-48ba-8f7c-b73e9a4bc41a","private_network_id":"d2582989-54df-4e6a-b43d-6cc6fc8370e1","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:a9d4::/64","updated_at":"2025-08-27T15:05:08.450070Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-08-27T15:05:08.450070Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
         headers:
             Content-Length:
-                - "496"
+                - "1071"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:29 GMT
+                - Wed, 27 Aug 2025 15:05:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3a79e36d-96cc-436c-a79b-1f2a69035cad
+                - de2a9978-f781-4d61-b99b-7df284c91a18
         status: 200 OK
         code: 200
-        duration: 53.41771ms
+        duration: 39.627432ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -129,7 +129,7 @@ interactions:
         trailer: {}
         content_length: 1070
         uncompressed: false
-        body: '{"created_at":"2025-06-16T16:32:29.056273Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"c5b3c2f5-3a1b-4241-805e-c9aa9f7a4432","name":"test-acc-function-pn-pn01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-06-16T16:32:29.056273Z","id":"81747cba-53fd-4399-828c-fbadd1b1faf3","private_network_id":"c5b3c2f5-3a1b-4241-805e-c9aa9f7a4432","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.4.0/22","updated_at":"2025-06-16T16:32:29.056273Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-06-16T16:32:29.056273Z","id":"e1a95737-170c-4783-9297-8710b1350a1a","private_network_id":"c5b3c2f5-3a1b-4241-805e-c9aa9f7a4432","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:d0b8::/64","updated_at":"2025-06-16T16:32:29.056273Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-06-16T16:32:29.056273Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+        body: '{"created_at":"2025-08-27T15:05:08.378389Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"8f30733d-b898-4a49-9ac7-97e32bc94122","name":"test-acc-function-pn-pn01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-08-27T15:05:08.378389Z","id":"574b8d66-42ef-45b3-b04d-f4957a41304c","private_network_id":"8f30733d-b898-4a49-9ac7-97e32bc94122","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.4.0/22","updated_at":"2025-08-27T15:05:08.378389Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-08-27T15:05:08.378389Z","id":"39e3c40e-042a-4454-9a15-3371cea11bb8","private_network_id":"8f30733d-b898-4a49-9ac7-97e32bc94122","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:8fab::/64","updated_at":"2025-08-27T15:05:08.378389Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-08-27T15:05:08.378389Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
         headers:
             Content-Length:
                 - "1070"
@@ -138,9 +138,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:29 GMT
+                - Wed, 27 Aug 2025 15:05:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -148,10 +148,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 575c3393-95a7-420b-9207-e5e3afa0e44d
+                - a31aac29-9403-40e4-b321-108782c78fb6
         status: 200 OK
         code: 200
-        duration: 747.666056ms
+        duration: 1.007937947s
     - id: 3
       request:
         proto: HTTP/1.1
@@ -168,7 +168,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c5b3c2f5-3a1b-4241-805e-c9aa9f7a4432
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/8f30733d-b898-4a49-9ac7-97e32bc94122
         method: GET
       response:
         proto: HTTP/2.0
@@ -178,7 +178,7 @@ interactions:
         trailer: {}
         content_length: 1070
         uncompressed: false
-        body: '{"created_at":"2025-06-16T16:32:29.056273Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"c5b3c2f5-3a1b-4241-805e-c9aa9f7a4432","name":"test-acc-function-pn-pn01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-06-16T16:32:29.056273Z","id":"81747cba-53fd-4399-828c-fbadd1b1faf3","private_network_id":"c5b3c2f5-3a1b-4241-805e-c9aa9f7a4432","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.4.0/22","updated_at":"2025-06-16T16:32:29.056273Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-06-16T16:32:29.056273Z","id":"e1a95737-170c-4783-9297-8710b1350a1a","private_network_id":"c5b3c2f5-3a1b-4241-805e-c9aa9f7a4432","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:d0b8::/64","updated_at":"2025-06-16T16:32:29.056273Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-06-16T16:32:29.056273Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+        body: '{"created_at":"2025-08-27T15:05:08.378389Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"8f30733d-b898-4a49-9ac7-97e32bc94122","name":"test-acc-function-pn-pn01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-08-27T15:05:08.378389Z","id":"574b8d66-42ef-45b3-b04d-f4957a41304c","private_network_id":"8f30733d-b898-4a49-9ac7-97e32bc94122","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.4.0/22","updated_at":"2025-08-27T15:05:08.378389Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-08-27T15:05:08.378389Z","id":"39e3c40e-042a-4454-9a15-3371cea11bb8","private_network_id":"8f30733d-b898-4a49-9ac7-97e32bc94122","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:8fab::/64","updated_at":"2025-08-27T15:05:08.378389Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-08-27T15:05:08.378389Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
         headers:
             Content-Length:
                 - "1070"
@@ -187,9 +187,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:29 GMT
+                - Wed, 27 Aug 2025 15:05:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -197,29 +197,29 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - dbf47ba2-7a7b-40d6-92b7-caa8f4f9361d
+                - 353ad410-056b-4fc8-b69d-b4dd57503dff
         status: 200 OK
         code: 200
-        duration: 28.662889ms
+        duration: 48.657586ms
     - id: 4
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 155
+        content_length: 190
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"test-acc-function-pn-pn00","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"subnets":null,"default_route_propagation_enabled":false}'
+        body: '{"name":"tf-func-nifty-goldberg","environment_variables":{},"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","secret_environment_variables":[],"tags":null,"activate_vpc_integration":true}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces
         method: POST
       response:
         proto: HTTP/2.0
@@ -227,20 +227,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1071
+        content_length: 507
         uncompressed: false
-        body: '{"created_at":"2025-06-16T16:32:29.135893Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"d4a00f5a-5222-43fb-9fd2-7dae459ef2a0","name":"test-acc-function-pn-pn00","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-06-16T16:32:29.135893Z","id":"9b81f242-1f9d-48b8-b259-99aa33f49cea","private_network_id":"d4a00f5a-5222-43fb-9fd2-7dae459ef2a0","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.40.0/22","updated_at":"2025-06-16T16:32:29.135893Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-06-16T16:32:29.135893Z","id":"61b2717f-432b-4be8-9795-cef5602bdf3c","private_network_id":"d4a00f5a-5222-43fb-9fd2-7dae459ef2a0","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:411f::/64","updated_at":"2025-06-16T16:32:29.135893Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-06-16T16:32:29.135893Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+        body: '{"created_at":"2025-08-27T15:05:13.795514264Z","description":"","environment_variables":{},"error_message":null,"id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","name":"tf-func-nifty-goldberg","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:13.795514264Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "1071"
+                - "507"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:29 GMT
+                - Wed, 27 Aug 2025 15:05:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -248,10 +248,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e1f72830-04a5-4a04-bcd3-e086b8256d38
+                - ce632507-80cf-4d78-bac9-7b4e09d40dfd
         status: 200 OK
         code: 200
-        duration: 821.945346ms
+        duration: 5.586494402s
     - id: 5
       request:
         proto: HTTP/1.1
@@ -268,7 +268,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/d4a00f5a-5222-43fb-9fd2-7dae459ef2a0
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/74fb790d-1104-4b78-bce7-39372f9f9ffc
         method: GET
       response:
         proto: HTTP/2.0
@@ -276,20 +276,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1071
+        content_length: 501
         uncompressed: false
-        body: '{"created_at":"2025-06-16T16:32:29.135893Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"d4a00f5a-5222-43fb-9fd2-7dae459ef2a0","name":"test-acc-function-pn-pn00","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-06-16T16:32:29.135893Z","id":"9b81f242-1f9d-48b8-b259-99aa33f49cea","private_network_id":"d4a00f5a-5222-43fb-9fd2-7dae459ef2a0","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.40.0/22","updated_at":"2025-06-16T16:32:29.135893Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-06-16T16:32:29.135893Z","id":"61b2717f-432b-4be8-9795-cef5602bdf3c","private_network_id":"d4a00f5a-5222-43fb-9fd2-7dae459ef2a0","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:411f::/64","updated_at":"2025-06-16T16:32:29.135893Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-06-16T16:32:29.135893Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+        body: '{"created_at":"2025-08-27T15:05:13.795514Z","description":"","environment_variables":{},"error_message":null,"id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","name":"tf-func-nifty-goldberg","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:13.795514Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "1071"
+                - "501"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:29 GMT
+                - Wed, 27 Aug 2025 15:05:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -297,10 +297,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7e06dfcf-5913-485c-a0a1-804a60b9a987
+                - c4c6b4c0-6f0e-476d-af96-c03866a2f6a1
         status: 200 OK
         code: 200
-        duration: 76.937514ms
+        duration: 50.057554ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -317,7 +317,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/0aa68856-5a7c-460e-a304-96399c647807
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/74fb790d-1104-4b78-bce7-39372f9f9ffc
         method: GET
       response:
         proto: HTTP/2.0
@@ -325,20 +325,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 579
+        content_length: 591
         uncompressed: false
-        body: '{"created_at":"2025-06-16T16:32:29.224354Z","description":"","environment_variables":{},"error_message":null,"id":"0aa68856-5a7c-460e-a304-96399c647807","name":"tf-func-kind-buck","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunckindbuckzikb0q7x","registry_namespace_id":"5ce9f5db-16c5-4cca-bd16-b8187a1f2784","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-16T16:32:32.884625Z","vpc_integration_activated":true}'
+        body: '{"created_at":"2025-08-27T15:05:13.795514Z","description":"","environment_variables":{},"error_message":null,"id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","name":"tf-func-nifty-goldberg","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncniftygoldbergp8m2adll","registry_namespace_id":"ac24eb9f-5629-420c-b895-b8737c0e1243","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:17.926869Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "579"
+                - "591"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:34 GMT
+                - Wed, 27 Aug 2025 15:05:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -346,10 +346,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d5b43d37-ee6c-4774-8963-6dba2d7fb390
+                - 1c328e3c-3e03-4161-9681-6b1aefb852df
         status: 200 OK
         code: 200
-        duration: 47.30149ms
+        duration: 443.919924ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -366,7 +366,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/0aa68856-5a7c-460e-a304-96399c647807
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/74fb790d-1104-4b78-bce7-39372f9f9ffc
         method: GET
       response:
         proto: HTTP/2.0
@@ -374,20 +374,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 579
+        content_length: 589
         uncompressed: false
-        body: '{"created_at":"2025-06-16T16:32:29.224354Z","description":"","environment_variables":{},"error_message":null,"id":"0aa68856-5a7c-460e-a304-96399c647807","name":"tf-func-kind-buck","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunckindbuckzikb0q7x","registry_namespace_id":"5ce9f5db-16c5-4cca-bd16-b8187a1f2784","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-16T16:32:32.884625Z","vpc_integration_activated":true}'
+        body: '{"created_at":"2025-08-27T15:05:13.795514Z","description":"","environment_variables":{},"error_message":null,"id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","name":"tf-func-nifty-goldberg","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncniftygoldbergp8m2adll","registry_namespace_id":"ac24eb9f-5629-420c-b895-b8737c0e1243","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:19.286578Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "579"
+                - "589"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:34 GMT
+                - Wed, 27 Aug 2025 15:05:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -395,62 +395,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f0bfb9bc-4792-4f82-99b6-b77d03b4250f
+                - 8eaf2243-5b4a-47d0-881a-05cf9d2d304b
         status: 200 OK
         code: 200
-        duration: 46.283151ms
+        duration: 56.24752ms
     - id: 8
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 365
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"name":"test-acc-function-pn-00","namespace_id":"0aa68856-5a7c-460e-a304-96399c647807","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"go123","memory_limit":256,"handler":"Handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"v1","tags":null,"private_network_id":"d4a00f5a-5222-43fb-9fd2-7dae459ef2a0"}'
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 759
-        uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-16T16:32:34.739489328Z","description":"","domain_name":"tffunckindbuckzikb0q7x-test-acc-function-pn-00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0ddfbecf-40c1-49e3-b00f-9f23194ed112","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-00","namespace_id":"0aa68856-5a7c-460e-a304-96399c647807","privacy":"private","private_network_id":"d4a00f5a-5222-43fb-9fd2-7dae459ef2a0","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:32:34.739489328Z"}'
-        headers:
-            Content-Length:
-                - "759"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 16 Jun 2025 16:32:34 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - ab9f44c2-ca88-4c0d-90fe-f3ca003d3b27
-        status: 200 OK
-        code: 200
-        duration: 363.58077ms
-    - id: 9
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -466,7 +415,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0ddfbecf-40c1-49e3-b00f-9f23194ed112
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/74fb790d-1104-4b78-bce7-39372f9f9ffc
         method: GET
       response:
         proto: HTTP/2.0
@@ -474,20 +423,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 753
+        content_length: 589
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-16T16:32:34.739489Z","description":"","domain_name":"tffunckindbuckzikb0q7x-test-acc-function-pn-00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0ddfbecf-40c1-49e3-b00f-9f23194ed112","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-00","namespace_id":"0aa68856-5a7c-460e-a304-96399c647807","privacy":"private","private_network_id":"d4a00f5a-5222-43fb-9fd2-7dae459ef2a0","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:32:34.739489Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.795514Z","description":"","environment_variables":{},"error_message":null,"id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","name":"tf-func-nifty-goldberg","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncniftygoldbergp8m2adll","registry_namespace_id":"ac24eb9f-5629-420c-b895-b8737c0e1243","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:19.286578Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "753"
+                - "589"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:34 GMT
+                - Wed, 27 Aug 2025 15:05:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -495,10 +444,61 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 96eedc08-fcc0-406e-a881-d06628b49edb
+                - 320df768-fd1b-46c3-a479-20fd093d6fc7
         status: 200 OK
         code: 200
-        duration: 58.583146ms
+        duration: 42.12455ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 365
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"name":"test-acc-function-pn-00","namespace_id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"go123","memory_limit":256,"handler":"Handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"v1","tags":null,"private_network_id":"d2582989-54df-4e6a-b43d-6cc6fc8370e1"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 764
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:26.696895091Z","description":"","domain_name":"tffuncniftygoldbergp8m2adll-test-acc-function-pn-00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"14e1e31c-547a-4350-9ac4-8366c71c2473","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-00","namespace_id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","privacy":"private","private_network_id":"d2582989-54df-4e6a-b43d-6cc6fc8370e1","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:26.696895091Z"}'
+        headers:
+            Content-Length:
+                - "764"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:05:26 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - c1d8d308-f39b-49ea-965b-a45f7f43ed79
+        status: 200 OK
+        code: 200
+        duration: 2.391911697s
     - id: 10
       request:
         proto: HTTP/1.1
@@ -515,7 +515,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0ddfbecf-40c1-49e3-b00f-9f23194ed112
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/14e1e31c-547a-4350-9ac4-8366c71c2473
         method: GET
       response:
         proto: HTTP/2.0
@@ -523,20 +523,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 753
+        content_length: 758
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-16T16:32:34.739489Z","description":"","domain_name":"tffunckindbuckzikb0q7x-test-acc-function-pn-00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0ddfbecf-40c1-49e3-b00f-9f23194ed112","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-00","namespace_id":"0aa68856-5a7c-460e-a304-96399c647807","privacy":"private","private_network_id":"d4a00f5a-5222-43fb-9fd2-7dae459ef2a0","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:32:34.739489Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:26.696895Z","description":"","domain_name":"tffuncniftygoldbergp8m2adll-test-acc-function-pn-00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"14e1e31c-547a-4350-9ac4-8366c71c2473","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-00","namespace_id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","privacy":"private","private_network_id":"d2582989-54df-4e6a-b43d-6cc6fc8370e1","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:26.696895Z"}'
         headers:
             Content-Length:
-                - "753"
+                - "758"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:34 GMT
+                - Wed, 27 Aug 2025 15:05:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -544,10 +544,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7c8dde9e-bc2d-43e9-9eff-eb1ac08d7fc0
+                - a773227f-9f1f-408a-8d6a-c9e3ba4b1f0a
         status: 200 OK
         code: 200
-        duration: 61.063225ms
+        duration: 63.881033ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -564,7 +564,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0ddfbecf-40c1-49e3-b00f-9f23194ed112
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/14e1e31c-547a-4350-9ac4-8366c71c2473
         method: GET
       response:
         proto: HTTP/2.0
@@ -572,20 +572,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 753
+        content_length: 758
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-16T16:32:34.739489Z","description":"","domain_name":"tffunckindbuckzikb0q7x-test-acc-function-pn-00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0ddfbecf-40c1-49e3-b00f-9f23194ed112","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-00","namespace_id":"0aa68856-5a7c-460e-a304-96399c647807","privacy":"private","private_network_id":"d4a00f5a-5222-43fb-9fd2-7dae459ef2a0","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:32:34.739489Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:26.696895Z","description":"","domain_name":"tffuncniftygoldbergp8m2adll-test-acc-function-pn-00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"14e1e31c-547a-4350-9ac4-8366c71c2473","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-00","namespace_id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","privacy":"private","private_network_id":"d2582989-54df-4e6a-b43d-6cc6fc8370e1","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:26.696895Z"}'
         headers:
             Content-Length:
-                - "753"
+                - "758"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:35 GMT
+                - Wed, 27 Aug 2025 15:05:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -593,10 +593,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4ebc4ee2-2fa3-4965-8677-545c65ee6d2d
+                - dd61ebfa-ff69-441d-a2d9-d754fb7cd021
         status: 200 OK
         code: 200
-        duration: 51.138496ms
+        duration: 67.888011ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -613,7 +613,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/0aa68856-5a7c-460e-a304-96399c647807
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/14e1e31c-547a-4350-9ac4-8366c71c2473
         method: GET
       response:
         proto: HTTP/2.0
@@ -621,20 +621,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 579
+        content_length: 758
         uncompressed: false
-        body: '{"created_at":"2025-06-16T16:32:29.224354Z","description":"","environment_variables":{},"error_message":null,"id":"0aa68856-5a7c-460e-a304-96399c647807","name":"tf-func-kind-buck","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunckindbuckzikb0q7x","registry_namespace_id":"5ce9f5db-16c5-4cca-bd16-b8187a1f2784","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-16T16:32:32.884625Z","vpc_integration_activated":true}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:26.696895Z","description":"","domain_name":"tffuncniftygoldbergp8m2adll-test-acc-function-pn-00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"14e1e31c-547a-4350-9ac4-8366c71c2473","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-00","namespace_id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","privacy":"private","private_network_id":"d2582989-54df-4e6a-b43d-6cc6fc8370e1","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:26.696895Z"}'
         headers:
             Content-Length:
-                - "579"
+                - "758"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:35 GMT
+                - Wed, 27 Aug 2025 15:05:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -642,10 +642,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 40e9cc67-60e5-43e4-ac64-439a4b98d3ea
+                - 468c3c86-cf16-465f-997b-40bb2aec6460
         status: 200 OK
         code: 200
-        duration: 46.248264ms
+        duration: 46.723119ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -662,7 +662,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/d4a00f5a-5222-43fb-9fd2-7dae459ef2a0
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/d2582989-54df-4e6a-b43d-6cc6fc8370e1
         method: GET
       response:
         proto: HTTP/2.0
@@ -672,7 +672,7 @@ interactions:
         trailer: {}
         content_length: 1071
         uncompressed: false
-        body: '{"created_at":"2025-06-16T16:32:29.135893Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"d4a00f5a-5222-43fb-9fd2-7dae459ef2a0","name":"test-acc-function-pn-pn00","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-06-16T16:32:29.135893Z","id":"9b81f242-1f9d-48b8-b259-99aa33f49cea","private_network_id":"d4a00f5a-5222-43fb-9fd2-7dae459ef2a0","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.40.0/22","updated_at":"2025-06-16T16:32:29.135893Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-06-16T16:32:29.135893Z","id":"61b2717f-432b-4be8-9795-cef5602bdf3c","private_network_id":"d4a00f5a-5222-43fb-9fd2-7dae459ef2a0","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:411f::/64","updated_at":"2025-06-16T16:32:29.135893Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-06-16T16:32:29.135893Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+        body: '{"created_at":"2025-08-27T15:05:08.450070Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"d2582989-54df-4e6a-b43d-6cc6fc8370e1","name":"test-acc-function-pn-pn00","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-08-27T15:05:08.450070Z","id":"c5f17ea2-1cf9-459a-9529-9e91992fe302","private_network_id":"d2582989-54df-4e6a-b43d-6cc6fc8370e1","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.28.0/22","updated_at":"2025-08-27T15:05:08.450070Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-08-27T15:05:08.450070Z","id":"dab15e62-9a15-48ba-8f7c-b73e9a4bc41a","private_network_id":"d2582989-54df-4e6a-b43d-6cc6fc8370e1","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:a9d4::/64","updated_at":"2025-08-27T15:05:08.450070Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-08-27T15:05:08.450070Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
         headers:
             Content-Length:
                 - "1071"
@@ -681,9 +681,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:35 GMT
+                - Wed, 27 Aug 2025 15:05:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -691,10 +691,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5a05674d-c144-46d2-b4e7-96cf623d4857
+                - 681ecae0-17ba-406e-9254-25f1a0b90255
         status: 200 OK
         code: 200
-        duration: 69.667912ms
+        duration: 26.585033ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -711,7 +711,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c5b3c2f5-3a1b-4241-805e-c9aa9f7a4432
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/74fb790d-1104-4b78-bce7-39372f9f9ffc
         method: GET
       response:
         proto: HTTP/2.0
@@ -719,20 +719,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1070
+        content_length: 589
         uncompressed: false
-        body: '{"created_at":"2025-06-16T16:32:29.056273Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"c5b3c2f5-3a1b-4241-805e-c9aa9f7a4432","name":"test-acc-function-pn-pn01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-06-16T16:32:29.056273Z","id":"81747cba-53fd-4399-828c-fbadd1b1faf3","private_network_id":"c5b3c2f5-3a1b-4241-805e-c9aa9f7a4432","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.4.0/22","updated_at":"2025-06-16T16:32:29.056273Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-06-16T16:32:29.056273Z","id":"e1a95737-170c-4783-9297-8710b1350a1a","private_network_id":"c5b3c2f5-3a1b-4241-805e-c9aa9f7a4432","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:d0b8::/64","updated_at":"2025-06-16T16:32:29.056273Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-06-16T16:32:29.056273Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+        body: '{"created_at":"2025-08-27T15:05:13.795514Z","description":"","environment_variables":{},"error_message":null,"id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","name":"tf-func-nifty-goldberg","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncniftygoldbergp8m2adll","registry_namespace_id":"ac24eb9f-5629-420c-b895-b8737c0e1243","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:19.286578Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "1070"
+                - "589"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:35 GMT
+                - Wed, 27 Aug 2025 15:05:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -740,10 +740,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b48e9b82-42de-4e85-9afa-b5bc6acbcfce
+                - 09747ef4-0127-47d6-8db5-87d411a7ed0e
         status: 200 OK
         code: 200
-        duration: 72.740844ms
+        duration: 45.222273ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -760,7 +760,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0ddfbecf-40c1-49e3-b00f-9f23194ed112
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/8f30733d-b898-4a49-9ac7-97e32bc94122
         method: GET
       response:
         proto: HTTP/2.0
@@ -768,20 +768,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 753
+        content_length: 1070
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-16T16:32:34.739489Z","description":"","domain_name":"tffunckindbuckzikb0q7x-test-acc-function-pn-00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0ddfbecf-40c1-49e3-b00f-9f23194ed112","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-00","namespace_id":"0aa68856-5a7c-460e-a304-96399c647807","privacy":"private","private_network_id":"d4a00f5a-5222-43fb-9fd2-7dae459ef2a0","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:32:34.739489Z"}'
+        body: '{"created_at":"2025-08-27T15:05:08.378389Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"8f30733d-b898-4a49-9ac7-97e32bc94122","name":"test-acc-function-pn-pn01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-08-27T15:05:08.378389Z","id":"574b8d66-42ef-45b3-b04d-f4957a41304c","private_network_id":"8f30733d-b898-4a49-9ac7-97e32bc94122","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.4.0/22","updated_at":"2025-08-27T15:05:08.378389Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-08-27T15:05:08.378389Z","id":"39e3c40e-042a-4454-9a15-3371cea11bb8","private_network_id":"8f30733d-b898-4a49-9ac7-97e32bc94122","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:8fab::/64","updated_at":"2025-08-27T15:05:08.378389Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-08-27T15:05:08.378389Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
         headers:
             Content-Length:
-                - "753"
+                - "1070"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:35 GMT
+                - Wed, 27 Aug 2025 15:05:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -789,10 +789,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9b14411b-067b-4968-855a-da5d9ab5f8ec
+                - bc9ea6a2-6f56-4509-90b0-4ed1da0bede1
         status: 200 OK
         code: 200
-        duration: 47.769508ms
+        duration: 60.831011ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -809,7 +809,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c5b3c2f5-3a1b-4241-805e-c9aa9f7a4432
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/14e1e31c-547a-4350-9ac4-8366c71c2473
         method: GET
       response:
         proto: HTTP/2.0
@@ -817,20 +817,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1070
+        content_length: 758
         uncompressed: false
-        body: '{"created_at":"2025-06-16T16:32:29.056273Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"c5b3c2f5-3a1b-4241-805e-c9aa9f7a4432","name":"test-acc-function-pn-pn01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-06-16T16:32:29.056273Z","id":"81747cba-53fd-4399-828c-fbadd1b1faf3","private_network_id":"c5b3c2f5-3a1b-4241-805e-c9aa9f7a4432","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.4.0/22","updated_at":"2025-06-16T16:32:29.056273Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-06-16T16:32:29.056273Z","id":"e1a95737-170c-4783-9297-8710b1350a1a","private_network_id":"c5b3c2f5-3a1b-4241-805e-c9aa9f7a4432","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:d0b8::/64","updated_at":"2025-06-16T16:32:29.056273Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-06-16T16:32:29.056273Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:26.696895Z","description":"","domain_name":"tffuncniftygoldbergp8m2adll-test-acc-function-pn-00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"14e1e31c-547a-4350-9ac4-8366c71c2473","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-00","namespace_id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","privacy":"private","private_network_id":"d2582989-54df-4e6a-b43d-6cc6fc8370e1","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:26.696895Z"}'
         headers:
             Content-Length:
-                - "1070"
+                - "758"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:36 GMT
+                - Wed, 27 Aug 2025 15:05:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -838,10 +838,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 26586706-7ad4-410d-8246-e3a93d68b705
+                - 6cd5a6e0-4d25-4d31-830b-7336ba966236
         status: 200 OK
         code: 200
-        duration: 38.257601ms
+        duration: 43.831794ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -858,7 +858,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/d4a00f5a-5222-43fb-9fd2-7dae459ef2a0
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/d2582989-54df-4e6a-b43d-6cc6fc8370e1
         method: GET
       response:
         proto: HTTP/2.0
@@ -868,7 +868,7 @@ interactions:
         trailer: {}
         content_length: 1071
         uncompressed: false
-        body: '{"created_at":"2025-06-16T16:32:29.135893Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"d4a00f5a-5222-43fb-9fd2-7dae459ef2a0","name":"test-acc-function-pn-pn00","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-06-16T16:32:29.135893Z","id":"9b81f242-1f9d-48b8-b259-99aa33f49cea","private_network_id":"d4a00f5a-5222-43fb-9fd2-7dae459ef2a0","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.40.0/22","updated_at":"2025-06-16T16:32:29.135893Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-06-16T16:32:29.135893Z","id":"61b2717f-432b-4be8-9795-cef5602bdf3c","private_network_id":"d4a00f5a-5222-43fb-9fd2-7dae459ef2a0","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:411f::/64","updated_at":"2025-06-16T16:32:29.135893Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-06-16T16:32:29.135893Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+        body: '{"created_at":"2025-08-27T15:05:08.450070Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"d2582989-54df-4e6a-b43d-6cc6fc8370e1","name":"test-acc-function-pn-pn00","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-08-27T15:05:08.450070Z","id":"c5f17ea2-1cf9-459a-9529-9e91992fe302","private_network_id":"d2582989-54df-4e6a-b43d-6cc6fc8370e1","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.28.0/22","updated_at":"2025-08-27T15:05:08.450070Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-08-27T15:05:08.450070Z","id":"dab15e62-9a15-48ba-8f7c-b73e9a4bc41a","private_network_id":"d2582989-54df-4e6a-b43d-6cc6fc8370e1","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:a9d4::/64","updated_at":"2025-08-27T15:05:08.450070Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-08-27T15:05:08.450070Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
         headers:
             Content-Length:
                 - "1071"
@@ -877,9 +877,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:36 GMT
+                - Wed, 27 Aug 2025 15:05:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -887,10 +887,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c0a68b17-dbad-412f-9fc3-806c3deefbba
+                - 6b028873-c829-49b0-9470-12b5362f7d9e
         status: 200 OK
         code: 200
-        duration: 37.410953ms
+        duration: 23.946792ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -907,7 +907,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/0aa68856-5a7c-460e-a304-96399c647807
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/8f30733d-b898-4a49-9ac7-97e32bc94122
         method: GET
       response:
         proto: HTTP/2.0
@@ -915,20 +915,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 579
+        content_length: 1070
         uncompressed: false
-        body: '{"created_at":"2025-06-16T16:32:29.224354Z","description":"","environment_variables":{},"error_message":null,"id":"0aa68856-5a7c-460e-a304-96399c647807","name":"tf-func-kind-buck","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunckindbuckzikb0q7x","registry_namespace_id":"5ce9f5db-16c5-4cca-bd16-b8187a1f2784","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-16T16:32:32.884625Z","vpc_integration_activated":true}'
+        body: '{"created_at":"2025-08-27T15:05:08.378389Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"8f30733d-b898-4a49-9ac7-97e32bc94122","name":"test-acc-function-pn-pn01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-08-27T15:05:08.378389Z","id":"574b8d66-42ef-45b3-b04d-f4957a41304c","private_network_id":"8f30733d-b898-4a49-9ac7-97e32bc94122","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.4.0/22","updated_at":"2025-08-27T15:05:08.378389Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-08-27T15:05:08.378389Z","id":"39e3c40e-042a-4454-9a15-3371cea11bb8","private_network_id":"8f30733d-b898-4a49-9ac7-97e32bc94122","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:8fab::/64","updated_at":"2025-08-27T15:05:08.378389Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-08-27T15:05:08.378389Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
         headers:
             Content-Length:
-                - "579"
+                - "1070"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:36 GMT
+                - Wed, 27 Aug 2025 15:05:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -936,10 +936,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1743d862-cf61-4b14-a82b-d582e30c6760
+                - aa9e8124-d974-4199-a69b-01d779cc337f
         status: 200 OK
         code: 200
-        duration: 49.335354ms
+        duration: 28.447036ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -956,7 +956,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0ddfbecf-40c1-49e3-b00f-9f23194ed112
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/74fb790d-1104-4b78-bce7-39372f9f9ffc
         method: GET
       response:
         proto: HTTP/2.0
@@ -964,20 +964,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 753
+        content_length: 589
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-16T16:32:34.739489Z","description":"","domain_name":"tffunckindbuckzikb0q7x-test-acc-function-pn-00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0ddfbecf-40c1-49e3-b00f-9f23194ed112","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-00","namespace_id":"0aa68856-5a7c-460e-a304-96399c647807","privacy":"private","private_network_id":"d4a00f5a-5222-43fb-9fd2-7dae459ef2a0","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:32:34.739489Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.795514Z","description":"","environment_variables":{},"error_message":null,"id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","name":"tf-func-nifty-goldberg","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncniftygoldbergp8m2adll","registry_namespace_id":"ac24eb9f-5629-420c-b895-b8737c0e1243","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:19.286578Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "753"
+                - "589"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:36 GMT
+                - Wed, 27 Aug 2025 15:05:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -985,10 +985,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fd5f2533-e3da-4285-a56b-ad9077a8f900
+                - 6d3c8149-d754-45e7-9a80-d1907e37a421
         status: 200 OK
         code: 200
-        duration: 55.178492ms
+        duration: 49.522752ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1005,7 +1005,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0ddfbecf-40c1-49e3-b00f-9f23194ed112
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/14e1e31c-547a-4350-9ac4-8366c71c2473
         method: GET
       response:
         proto: HTTP/2.0
@@ -1013,20 +1013,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 753
+        content_length: 758
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-16T16:32:34.739489Z","description":"","domain_name":"tffunckindbuckzikb0q7x-test-acc-function-pn-00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0ddfbecf-40c1-49e3-b00f-9f23194ed112","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-00","namespace_id":"0aa68856-5a7c-460e-a304-96399c647807","privacy":"private","private_network_id":"d4a00f5a-5222-43fb-9fd2-7dae459ef2a0","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:32:34.739489Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:26.696895Z","description":"","domain_name":"tffuncniftygoldbergp8m2adll-test-acc-function-pn-00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"14e1e31c-547a-4350-9ac4-8366c71c2473","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-00","namespace_id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","privacy":"private","private_network_id":"d2582989-54df-4e6a-b43d-6cc6fc8370e1","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:26.696895Z"}'
         headers:
             Content-Length:
-                - "753"
+                - "758"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:37 GMT
+                - Wed, 27 Aug 2025 15:05:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1034,10 +1034,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a957dea8-50da-40b2-8cce-4be2e839d12f
+                - 03eabe39-795b-42ec-9d91-ebe79761ce76
         status: 200 OK
         code: 200
-        duration: 49.762645ms
+        duration: 62.143063ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1054,28 +1054,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0ddfbecf-40c1-49e3-b00f-9f23194ed112
-        method: DELETE
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/14e1e31c-547a-4350-9ac4-8366c71c2473
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 757
+        content_length: 758
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-16T16:32:34.739489Z","description":"","domain_name":"tffunckindbuckzikb0q7x-test-acc-function-pn-00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"0ddfbecf-40c1-49e3-b00f-9f23194ed112","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-00","namespace_id":"0aa68856-5a7c-460e-a304-96399c647807","privacy":"private","private_network_id":"d4a00f5a-5222-43fb-9fd2-7dae459ef2a0","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:32:37.718823709Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:26.696895Z","description":"","domain_name":"tffuncniftygoldbergp8m2adll-test-acc-function-pn-00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"14e1e31c-547a-4350-9ac4-8366c71c2473","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-00","namespace_id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","privacy":"private","private_network_id":"d2582989-54df-4e6a-b43d-6cc6fc8370e1","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:26.696895Z"}'
         headers:
             Content-Length:
-                - "757"
+                - "758"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:37 GMT
+                - Wed, 27 Aug 2025 15:05:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1083,113 +1083,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a399d664-467e-4079-8985-859d00e69318
+                - 8429c2d8-18c4-43fb-bd27-ba3cfb0653d5
         status: 200 OK
         code: 200
-        duration: 217.402825ms
+        duration: 63.188865ms
     - id: 22
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 366
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"name":"test-acc-function-pn-f02","namespace_id":"0aa68856-5a7c-460e-a304-96399c647807","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"go123","memory_limit":256,"handler":"Handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"v1","tags":null,"private_network_id":"d4a00f5a-5222-43fb-9fd2-7dae459ef2a0"}'
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 761
-        uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-16T16:32:38.119280717Z","description":"","domain_name":"tffunckindbuckzikb0q7x-test-acc-function-pn-f02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"7686b60e-d807-40ab-a415-e70edcf09bc2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f02","namespace_id":"0aa68856-5a7c-460e-a304-96399c647807","privacy":"private","private_network_id":"d4a00f5a-5222-43fb-9fd2-7dae459ef2a0","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:32:38.119280717Z"}'
-        headers:
-            Content-Length:
-                - "761"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 16 Jun 2025 16:32:38 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 8bef7307-fd6d-4391-aa03-a08000c6ad7d
-        status: 200 OK
-        code: 200
-        duration: 587.828569ms
-    - id: 23
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 366
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"name":"test-acc-function-pn-f01","namespace_id":"0aa68856-5a7c-460e-a304-96399c647807","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"go123","memory_limit":256,"handler":"Handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"v1","tags":null,"private_network_id":"d4a00f5a-5222-43fb-9fd2-7dae459ef2a0"}'
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 761
-        uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-16T16:32:38.121174792Z","description":"","domain_name":"tffunckindbuckzikb0q7x-test-acc-function-pn-f01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"e81349b1-4ad1-4599-871f-0e3057bf3de7","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f01","namespace_id":"0aa68856-5a7c-460e-a304-96399c647807","privacy":"private","private_network_id":"d4a00f5a-5222-43fb-9fd2-7dae459ef2a0","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:32:38.121174792Z"}'
-        headers:
-            Content-Length:
-                - "761"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 16 Jun 2025 16:32:38 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 0b2c9259-dc67-4ee7-8c60-e27a98c01792
-        status: 200 OK
-        code: 200
-        duration: 596.681631ms
-    - id: 24
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1205,28 +1103,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/7686b60e-d807-40ab-a415-e70edcf09bc2
-        method: GET
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/14e1e31c-547a-4350-9ac4-8366c71c2473
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 755
+        content_length: 762
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-16T16:32:38.119281Z","description":"","domain_name":"tffunckindbuckzikb0q7x-test-acc-function-pn-f02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"7686b60e-d807-40ab-a415-e70edcf09bc2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f02","namespace_id":"0aa68856-5a7c-460e-a304-96399c647807","privacy":"private","private_network_id":"d4a00f5a-5222-43fb-9fd2-7dae459ef2a0","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:32:38.119281Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:26.696895Z","description":"","domain_name":"tffuncniftygoldbergp8m2adll-test-acc-function-pn-00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"14e1e31c-547a-4350-9ac4-8366c71c2473","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-00","namespace_id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","privacy":"private","private_network_id":"d2582989-54df-4e6a-b43d-6cc6fc8370e1","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:28.458304115Z"}'
         headers:
             Content-Length:
-                - "755"
+                - "762"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:38 GMT
+                - Wed, 27 Aug 2025 15:05:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1234,10 +1132,112 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 951f1b4e-5078-49e1-9e64-a81aa2069df7
+                - 0af8d229-f74b-4943-9e69-749d775fb050
         status: 200 OK
         code: 200
-        duration: 52.23953ms
+        duration: 266.240273ms
+    - id: 23
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 366
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"name":"test-acc-function-pn-f02","namespace_id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"go123","memory_limit":256,"handler":"Handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"v1","tags":null,"private_network_id":"d2582989-54df-4e6a-b43d-6cc6fc8370e1"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 766
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:29.599704943Z","description":"","domain_name":"tffuncniftygoldbergp8m2adll-test-acc-function-pn-f02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"176091e3-d6e4-4c48-8cc8-44c15d81395d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f02","namespace_id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","privacy":"private","private_network_id":"d2582989-54df-4e6a-b43d-6cc6fc8370e1","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:29.599704943Z"}'
+        headers:
+            Content-Length:
+                - "766"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:05:29 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - fe2805c4-fbab-4b55-9b2f-245c2bb001c2
+        status: 200 OK
+        code: 200
+        duration: 1.274144297s
+    - id: 24
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 366
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"name":"test-acc-function-pn-f01","namespace_id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"go123","memory_limit":256,"handler":"Handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"v1","tags":null,"private_network_id":"d2582989-54df-4e6a-b43d-6cc6fc8370e1"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 766
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:29.568099744Z","description":"","domain_name":"tffuncniftygoldbergp8m2adll-test-acc-function-pn-f01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"a00ddf4b-26e3-4342-8794-e4b96bdf9c1f","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f01","namespace_id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","privacy":"private","private_network_id":"d2582989-54df-4e6a-b43d-6cc6fc8370e1","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:29.568099744Z"}'
+        headers:
+            Content-Length:
+                - "766"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:05:29 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 42785826-5ab8-4815-b044-92e3b0a4e3ef
+        status: 200 OK
+        code: 200
+        duration: 1.306286988s
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1254,7 +1254,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e81349b1-4ad1-4599-871f-0e3057bf3de7
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/176091e3-d6e4-4c48-8cc8-44c15d81395d
         method: GET
       response:
         proto: HTTP/2.0
@@ -1262,20 +1262,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 755
+        content_length: 760
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-16T16:32:38.121175Z","description":"","domain_name":"tffunckindbuckzikb0q7x-test-acc-function-pn-f01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"e81349b1-4ad1-4599-871f-0e3057bf3de7","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f01","namespace_id":"0aa68856-5a7c-460e-a304-96399c647807","privacy":"private","private_network_id":"d4a00f5a-5222-43fb-9fd2-7dae459ef2a0","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:32:38.121175Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:29.599705Z","description":"","domain_name":"tffuncniftygoldbergp8m2adll-test-acc-function-pn-f02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"176091e3-d6e4-4c48-8cc8-44c15d81395d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f02","namespace_id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","privacy":"private","private_network_id":"d2582989-54df-4e6a-b43d-6cc6fc8370e1","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:29.599705Z"}'
         headers:
             Content-Length:
-                - "755"
+                - "760"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:38 GMT
+                - Wed, 27 Aug 2025 15:05:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1283,10 +1283,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 742608c2-f006-495f-9394-04404c78a06b
+                - 26b5d632-0a64-4987-8bc1-3685ee3b1bce
         status: 200 OK
         code: 200
-        duration: 46.781836ms
+        duration: 41.230102ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1303,7 +1303,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/7686b60e-d807-40ab-a415-e70edcf09bc2
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/a00ddf4b-26e3-4342-8794-e4b96bdf9c1f
         method: GET
       response:
         proto: HTTP/2.0
@@ -1311,20 +1311,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 755
+        content_length: 760
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-16T16:32:38.119281Z","description":"","domain_name":"tffunckindbuckzikb0q7x-test-acc-function-pn-f02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"7686b60e-d807-40ab-a415-e70edcf09bc2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f02","namespace_id":"0aa68856-5a7c-460e-a304-96399c647807","privacy":"private","private_network_id":"d4a00f5a-5222-43fb-9fd2-7dae459ef2a0","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:32:38.119281Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:29.568100Z","description":"","domain_name":"tffuncniftygoldbergp8m2adll-test-acc-function-pn-f01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"a00ddf4b-26e3-4342-8794-e4b96bdf9c1f","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f01","namespace_id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","privacy":"private","private_network_id":"d2582989-54df-4e6a-b43d-6cc6fc8370e1","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:29.568100Z"}'
         headers:
             Content-Length:
-                - "755"
+                - "760"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:38 GMT
+                - Wed, 27 Aug 2025 15:05:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1332,50 +1332,48 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7f2c41d8-8e52-4a40-b7ae-547c9b906f6f
+                - 93e99c08-a98d-4c9f-81e9-9230b13de88b
         status: 200 OK
         code: 200
-        duration: 55.72167ms
+        duration: 55.596729ms
     - id: 27
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 366
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"test-acc-function-pn-f00","namespace_id":"0aa68856-5a7c-460e-a304-96399c647807","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"go123","memory_limit":256,"handler":"Handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"v1","tags":null,"private_network_id":"d4a00f5a-5222-43fb-9fd2-7dae459ef2a0"}'
+        body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions
-        method: POST
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/176091e3-d6e4-4c48-8cc8-44c15d81395d
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 761
+        content_length: 760
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-16T16:32:38.239982578Z","description":"","domain_name":"tffunckindbuckzikb0q7x-test-acc-function-pn-f00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"f187ffcd-e01a-4018-9669-38b3c7e3e8ef","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f00","namespace_id":"0aa68856-5a7c-460e-a304-96399c647807","privacy":"private","private_network_id":"d4a00f5a-5222-43fb-9fd2-7dae459ef2a0","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:32:38.239982578Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:29.599705Z","description":"","domain_name":"tffuncniftygoldbergp8m2adll-test-acc-function-pn-f02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"176091e3-d6e4-4c48-8cc8-44c15d81395d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f02","namespace_id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","privacy":"private","private_network_id":"d2582989-54df-4e6a-b43d-6cc6fc8370e1","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:29.599705Z"}'
         headers:
             Content-Length:
-                - "761"
+                - "760"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:38 GMT
+                - Wed, 27 Aug 2025 15:05:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1383,10 +1381,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b77811f3-721a-4c06-ace2-6580f8685ca7
+                - 12fc289d-22a1-4cd5-b998-4a55acd75d0c
         status: 200 OK
         code: 200
-        duration: 430.300752ms
+        duration: 55.93789ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1403,7 +1401,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e81349b1-4ad1-4599-871f-0e3057bf3de7
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/a00ddf4b-26e3-4342-8794-e4b96bdf9c1f
         method: GET
       response:
         proto: HTTP/2.0
@@ -1411,20 +1409,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 755
+        content_length: 760
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-16T16:32:38.121175Z","description":"","domain_name":"tffunckindbuckzikb0q7x-test-acc-function-pn-f01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"e81349b1-4ad1-4599-871f-0e3057bf3de7","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f01","namespace_id":"0aa68856-5a7c-460e-a304-96399c647807","privacy":"private","private_network_id":"d4a00f5a-5222-43fb-9fd2-7dae459ef2a0","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:32:38.121175Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:29.568100Z","description":"","domain_name":"tffuncniftygoldbergp8m2adll-test-acc-function-pn-f01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"a00ddf4b-26e3-4342-8794-e4b96bdf9c1f","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f01","namespace_id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","privacy":"private","private_network_id":"d2582989-54df-4e6a-b43d-6cc6fc8370e1","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:29.568100Z"}'
         headers:
             Content-Length:
-                - "755"
+                - "760"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:38 GMT
+                - Wed, 27 Aug 2025 15:05:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1432,48 +1430,50 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 92a94601-b58c-4c5b-ab29-b0e49d23554b
+                - 79cc8a35-9382-4500-b856-8c0e2a982dae
         status: 200 OK
         code: 200
-        duration: 91.248039ms
+        duration: 46.122382ms
     - id: 29
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 366
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"name":"test-acc-function-pn-f00","namespace_id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"go123","memory_limit":256,"handler":"Handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"v1","tags":null,"private_network_id":"d2582989-54df-4e6a-b43d-6cc6fc8370e1"}'
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/f187ffcd-e01a-4018-9669-38b3c7e3e8ef
-        method: GET
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 755
+        content_length: 766
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-16T16:32:38.239983Z","description":"","domain_name":"tffunckindbuckzikb0q7x-test-acc-function-pn-f00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"f187ffcd-e01a-4018-9669-38b3c7e3e8ef","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f00","namespace_id":"0aa68856-5a7c-460e-a304-96399c647807","privacy":"private","private_network_id":"d4a00f5a-5222-43fb-9fd2-7dae459ef2a0","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:32:38.239983Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:29.832555876Z","description":"","domain_name":"tffuncniftygoldbergp8m2adll-test-acc-function-pn-f00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"f7365af3-31a3-4fbe-b12b-2c11aa863a3d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f00","namespace_id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","privacy":"private","private_network_id":"d2582989-54df-4e6a-b43d-6cc6fc8370e1","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:29.832555876Z"}'
         headers:
             Content-Length:
-                - "755"
+                - "766"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:38 GMT
+                - Wed, 27 Aug 2025 15:05:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1481,10 +1481,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e2a92832-1bf1-4176-b070-a0efd56b2fc4
+                - 1ccc0538-8f2e-43f5-b238-cf69f08c0d3f
         status: 200 OK
         code: 200
-        duration: 48.721453ms
+        duration: 1.166947477s
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1501,7 +1501,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/f187ffcd-e01a-4018-9669-38b3c7e3e8ef
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/f7365af3-31a3-4fbe-b12b-2c11aa863a3d
         method: GET
       response:
         proto: HTTP/2.0
@@ -1509,20 +1509,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 755
+        content_length: 760
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-16T16:32:38.239983Z","description":"","domain_name":"tffunckindbuckzikb0q7x-test-acc-function-pn-f00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"f187ffcd-e01a-4018-9669-38b3c7e3e8ef","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f00","namespace_id":"0aa68856-5a7c-460e-a304-96399c647807","privacy":"private","private_network_id":"d4a00f5a-5222-43fb-9fd2-7dae459ef2a0","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:32:38.239983Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:29.832556Z","description":"","domain_name":"tffuncniftygoldbergp8m2adll-test-acc-function-pn-f00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"f7365af3-31a3-4fbe-b12b-2c11aa863a3d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f00","namespace_id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","privacy":"private","private_network_id":"d2582989-54df-4e6a-b43d-6cc6fc8370e1","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:29.832556Z"}'
         headers:
             Content-Length:
-                - "755"
+                - "760"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:38 GMT
+                - Wed, 27 Aug 2025 15:05:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1530,10 +1530,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0458faa6-3651-4563-9b9e-3a861c39863e
+                - b98ba6cf-08d2-46ac-be05-127946608407
         status: 200 OK
         code: 200
-        duration: 151.497199ms
+        duration: 44.856768ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1550,7 +1550,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/f187ffcd-e01a-4018-9669-38b3c7e3e8ef
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/f7365af3-31a3-4fbe-b12b-2c11aa863a3d
         method: GET
       response:
         proto: HTTP/2.0
@@ -1558,20 +1558,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 755
+        content_length: 760
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-16T16:32:38.239983Z","description":"","domain_name":"tffunckindbuckzikb0q7x-test-acc-function-pn-f00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"f187ffcd-e01a-4018-9669-38b3c7e3e8ef","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f00","namespace_id":"0aa68856-5a7c-460e-a304-96399c647807","privacy":"private","private_network_id":"d4a00f5a-5222-43fb-9fd2-7dae459ef2a0","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:32:38.239983Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:29.832556Z","description":"","domain_name":"tffuncniftygoldbergp8m2adll-test-acc-function-pn-f00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"f7365af3-31a3-4fbe-b12b-2c11aa863a3d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f00","namespace_id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","privacy":"private","private_network_id":"d2582989-54df-4e6a-b43d-6cc6fc8370e1","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:29.832556Z"}'
         headers:
             Content-Length:
-                - "755"
+                - "760"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:38 GMT
+                - Wed, 27 Aug 2025 15:05:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1579,10 +1579,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a4535fa3-8308-478b-8a26-67997a937405
+                - 7066eafd-a308-470c-8f89-be1dbf65a6df
         status: 200 OK
         code: 200
-        duration: 44.859781ms
+        duration: 48.995683ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1599,7 +1599,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e81349b1-4ad1-4599-871f-0e3057bf3de7
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/f7365af3-31a3-4fbe-b12b-2c11aa863a3d
         method: GET
       response:
         proto: HTTP/2.0
@@ -1607,20 +1607,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 755
+        content_length: 760
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-16T16:32:38.121175Z","description":"","domain_name":"tffunckindbuckzikb0q7x-test-acc-function-pn-f01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"e81349b1-4ad1-4599-871f-0e3057bf3de7","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f01","namespace_id":"0aa68856-5a7c-460e-a304-96399c647807","privacy":"private","private_network_id":"d4a00f5a-5222-43fb-9fd2-7dae459ef2a0","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:32:38.121175Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:29.832556Z","description":"","domain_name":"tffuncniftygoldbergp8m2adll-test-acc-function-pn-f00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"f7365af3-31a3-4fbe-b12b-2c11aa863a3d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f00","namespace_id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","privacy":"private","private_network_id":"d2582989-54df-4e6a-b43d-6cc6fc8370e1","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:29.832556Z"}'
         headers:
             Content-Length:
-                - "755"
+                - "760"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:38 GMT
+                - Wed, 27 Aug 2025 15:05:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1628,10 +1628,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e3a54dc0-e429-4c8a-bf13-7e03a3680658
+                - c00814da-f1e8-47e0-b01f-a253841305c6
         status: 200 OK
         code: 200
-        duration: 62.557578ms
+        duration: 48.778937ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1648,7 +1648,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/7686b60e-d807-40ab-a415-e70edcf09bc2
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/a00ddf4b-26e3-4342-8794-e4b96bdf9c1f
         method: GET
       response:
         proto: HTTP/2.0
@@ -1656,20 +1656,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 755
+        content_length: 760
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-16T16:32:38.119281Z","description":"","domain_name":"tffunckindbuckzikb0q7x-test-acc-function-pn-f02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"7686b60e-d807-40ab-a415-e70edcf09bc2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f02","namespace_id":"0aa68856-5a7c-460e-a304-96399c647807","privacy":"private","private_network_id":"d4a00f5a-5222-43fb-9fd2-7dae459ef2a0","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:32:38.119281Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:29.568100Z","description":"","domain_name":"tffuncniftygoldbergp8m2adll-test-acc-function-pn-f01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"a00ddf4b-26e3-4342-8794-e4b96bdf9c1f","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f01","namespace_id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","privacy":"private","private_network_id":"d2582989-54df-4e6a-b43d-6cc6fc8370e1","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:29.568100Z"}'
         headers:
             Content-Length:
-                - "755"
+                - "760"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:38 GMT
+                - Wed, 27 Aug 2025 15:05:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1677,10 +1677,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 39e384a3-fad5-4a59-a86b-86dec1d72a01
+                - 36c372e6-9d21-4567-b441-013607443684
         status: 200 OK
         code: 200
-        duration: 93.237199ms
+        duration: 55.786967ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1697,7 +1697,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/d4a00f5a-5222-43fb-9fd2-7dae459ef2a0
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/176091e3-d6e4-4c48-8cc8-44c15d81395d
         method: GET
       response:
         proto: HTTP/2.0
@@ -1705,20 +1705,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1071
+        content_length: 760
         uncompressed: false
-        body: '{"created_at":"2025-06-16T16:32:29.135893Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"d4a00f5a-5222-43fb-9fd2-7dae459ef2a0","name":"test-acc-function-pn-pn00","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-06-16T16:32:29.135893Z","id":"9b81f242-1f9d-48b8-b259-99aa33f49cea","private_network_id":"d4a00f5a-5222-43fb-9fd2-7dae459ef2a0","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.40.0/22","updated_at":"2025-06-16T16:32:29.135893Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-06-16T16:32:29.135893Z","id":"61b2717f-432b-4be8-9795-cef5602bdf3c","private_network_id":"d4a00f5a-5222-43fb-9fd2-7dae459ef2a0","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:411f::/64","updated_at":"2025-06-16T16:32:29.135893Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-06-16T16:32:29.135893Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:29.599705Z","description":"","domain_name":"tffuncniftygoldbergp8m2adll-test-acc-function-pn-f02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"176091e3-d6e4-4c48-8cc8-44c15d81395d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f02","namespace_id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","privacy":"private","private_network_id":"d2582989-54df-4e6a-b43d-6cc6fc8370e1","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:29.599705Z"}'
         headers:
             Content-Length:
-                - "1071"
+                - "760"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:39 GMT
+                - Wed, 27 Aug 2025 15:05:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1726,10 +1726,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9bd80484-6044-4990-8d96-8f3470624486
+                - 023ad2ea-e02f-485d-8849-8ef39a20ba27
         status: 200 OK
         code: 200
-        duration: 29.897133ms
+        duration: 52.629232ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1746,7 +1746,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c5b3c2f5-3a1b-4241-805e-c9aa9f7a4432
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/d2582989-54df-4e6a-b43d-6cc6fc8370e1
         method: GET
       response:
         proto: HTTP/2.0
@@ -1754,20 +1754,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1070
+        content_length: 1071
         uncompressed: false
-        body: '{"created_at":"2025-06-16T16:32:29.056273Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"c5b3c2f5-3a1b-4241-805e-c9aa9f7a4432","name":"test-acc-function-pn-pn01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-06-16T16:32:29.056273Z","id":"81747cba-53fd-4399-828c-fbadd1b1faf3","private_network_id":"c5b3c2f5-3a1b-4241-805e-c9aa9f7a4432","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.4.0/22","updated_at":"2025-06-16T16:32:29.056273Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-06-16T16:32:29.056273Z","id":"e1a95737-170c-4783-9297-8710b1350a1a","private_network_id":"c5b3c2f5-3a1b-4241-805e-c9aa9f7a4432","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:d0b8::/64","updated_at":"2025-06-16T16:32:29.056273Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-06-16T16:32:29.056273Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+        body: '{"created_at":"2025-08-27T15:05:08.450070Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"d2582989-54df-4e6a-b43d-6cc6fc8370e1","name":"test-acc-function-pn-pn00","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-08-27T15:05:08.450070Z","id":"c5f17ea2-1cf9-459a-9529-9e91992fe302","private_network_id":"d2582989-54df-4e6a-b43d-6cc6fc8370e1","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.28.0/22","updated_at":"2025-08-27T15:05:08.450070Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-08-27T15:05:08.450070Z","id":"dab15e62-9a15-48ba-8f7c-b73e9a4bc41a","private_network_id":"d2582989-54df-4e6a-b43d-6cc6fc8370e1","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:a9d4::/64","updated_at":"2025-08-27T15:05:08.450070Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-08-27T15:05:08.450070Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
         headers:
             Content-Length:
-                - "1070"
+                - "1071"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:39 GMT
+                - Wed, 27 Aug 2025 15:05:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1775,10 +1775,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - afc105df-1add-44a7-bb2e-088d1fa62775
+                - 4fc3a8fc-0527-44b2-8f26-2c86c20ef904
         status: 200 OK
         code: 200
-        duration: 31.928713ms
+        duration: 26.486397ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1795,7 +1795,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/0aa68856-5a7c-460e-a304-96399c647807
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/74fb790d-1104-4b78-bce7-39372f9f9ffc
         method: GET
       response:
         proto: HTTP/2.0
@@ -1803,20 +1803,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 579
+        content_length: 589
         uncompressed: false
-        body: '{"created_at":"2025-06-16T16:32:29.224354Z","description":"","environment_variables":{},"error_message":null,"id":"0aa68856-5a7c-460e-a304-96399c647807","name":"tf-func-kind-buck","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunckindbuckzikb0q7x","registry_namespace_id":"5ce9f5db-16c5-4cca-bd16-b8187a1f2784","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-16T16:32:32.884625Z","vpc_integration_activated":true}'
+        body: '{"created_at":"2025-08-27T15:05:13.795514Z","description":"","environment_variables":{},"error_message":null,"id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","name":"tf-func-nifty-goldberg","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncniftygoldbergp8m2adll","registry_namespace_id":"ac24eb9f-5629-420c-b895-b8737c0e1243","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:19.286578Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "579"
+                - "589"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:39 GMT
+                - Wed, 27 Aug 2025 15:05:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1824,10 +1824,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1e795516-3ed3-4a78-8628-1cb52037a9f9
+                - 5f245607-037b-421c-a931-f848073baf98
         status: 200 OK
         code: 200
-        duration: 46.680466ms
+        duration: 44.709882ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1844,7 +1844,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/f187ffcd-e01a-4018-9669-38b3c7e3e8ef
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/8f30733d-b898-4a49-9ac7-97e32bc94122
         method: GET
       response:
         proto: HTTP/2.0
@@ -1852,20 +1852,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 755
+        content_length: 1070
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-16T16:32:38.239983Z","description":"","domain_name":"tffunckindbuckzikb0q7x-test-acc-function-pn-f00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"f187ffcd-e01a-4018-9669-38b3c7e3e8ef","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f00","namespace_id":"0aa68856-5a7c-460e-a304-96399c647807","privacy":"private","private_network_id":"d4a00f5a-5222-43fb-9fd2-7dae459ef2a0","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:32:38.239983Z"}'
+        body: '{"created_at":"2025-08-27T15:05:08.378389Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"8f30733d-b898-4a49-9ac7-97e32bc94122","name":"test-acc-function-pn-pn01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-08-27T15:05:08.378389Z","id":"574b8d66-42ef-45b3-b04d-f4957a41304c","private_network_id":"8f30733d-b898-4a49-9ac7-97e32bc94122","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.4.0/22","updated_at":"2025-08-27T15:05:08.378389Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-08-27T15:05:08.378389Z","id":"39e3c40e-042a-4454-9a15-3371cea11bb8","private_network_id":"8f30733d-b898-4a49-9ac7-97e32bc94122","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:8fab::/64","updated_at":"2025-08-27T15:05:08.378389Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-08-27T15:05:08.378389Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
         headers:
             Content-Length:
-                - "755"
+                - "1070"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:39 GMT
+                - Wed, 27 Aug 2025 15:05:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1873,10 +1873,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7f2905e2-6b54-45f6-949e-c1e54bdd715b
+                - dc49097f-2bbc-4fa5-9b6a-2aeeeb2db443
         status: 200 OK
         code: 200
-        duration: 56.492535ms
+        duration: 45.025524ms
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1893,7 +1893,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/7686b60e-d807-40ab-a415-e70edcf09bc2
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/f7365af3-31a3-4fbe-b12b-2c11aa863a3d
         method: GET
       response:
         proto: HTTP/2.0
@@ -1901,20 +1901,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 755
+        content_length: 760
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-16T16:32:38.119281Z","description":"","domain_name":"tffunckindbuckzikb0q7x-test-acc-function-pn-f02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"7686b60e-d807-40ab-a415-e70edcf09bc2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f02","namespace_id":"0aa68856-5a7c-460e-a304-96399c647807","privacy":"private","private_network_id":"d4a00f5a-5222-43fb-9fd2-7dae459ef2a0","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:32:38.119281Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:29.832556Z","description":"","domain_name":"tffuncniftygoldbergp8m2adll-test-acc-function-pn-f00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"f7365af3-31a3-4fbe-b12b-2c11aa863a3d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f00","namespace_id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","privacy":"private","private_network_id":"d2582989-54df-4e6a-b43d-6cc6fc8370e1","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:29.832556Z"}'
         headers:
             Content-Length:
-                - "755"
+                - "760"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:39 GMT
+                - Wed, 27 Aug 2025 15:05:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1922,10 +1922,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0d52d1f8-1af0-4b03-a7fe-5503a902fe83
+                - 3f236c47-d3e4-43bb-a908-323eb363eb84
         status: 200 OK
         code: 200
-        duration: 90.533539ms
+        duration: 45.151591ms
     - id: 39
       request:
         proto: HTTP/1.1
@@ -1942,7 +1942,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e81349b1-4ad1-4599-871f-0e3057bf3de7
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/176091e3-d6e4-4c48-8cc8-44c15d81395d
         method: GET
       response:
         proto: HTTP/2.0
@@ -1950,20 +1950,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 755
+        content_length: 760
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-16T16:32:38.121175Z","description":"","domain_name":"tffunckindbuckzikb0q7x-test-acc-function-pn-f01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"e81349b1-4ad1-4599-871f-0e3057bf3de7","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f01","namespace_id":"0aa68856-5a7c-460e-a304-96399c647807","privacy":"private","private_network_id":"d4a00f5a-5222-43fb-9fd2-7dae459ef2a0","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:32:38.121175Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:29.599705Z","description":"","domain_name":"tffuncniftygoldbergp8m2adll-test-acc-function-pn-f02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"176091e3-d6e4-4c48-8cc8-44c15d81395d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f02","namespace_id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","privacy":"private","private_network_id":"d2582989-54df-4e6a-b43d-6cc6fc8370e1","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:29.599705Z"}'
         headers:
             Content-Length:
-                - "755"
+                - "760"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:39 GMT
+                - Wed, 27 Aug 2025 15:05:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1971,10 +1971,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6c383799-7126-413d-8b8a-4923604d7a30
+                - 9dc22c93-de3d-46bb-8483-8f3007848925
         status: 200 OK
         code: 200
-        duration: 130.576998ms
+        duration: 48.692535ms
     - id: 40
       request:
         proto: HTTP/1.1
@@ -1991,7 +1991,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/0aa68856-5a7c-460e-a304-96399c647807
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/a00ddf4b-26e3-4342-8794-e4b96bdf9c1f
         method: GET
       response:
         proto: HTTP/2.0
@@ -1999,20 +1999,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 579
+        content_length: 760
         uncompressed: false
-        body: '{"created_at":"2025-06-16T16:32:29.224354Z","description":"","environment_variables":{},"error_message":null,"id":"0aa68856-5a7c-460e-a304-96399c647807","name":"tf-func-kind-buck","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunckindbuckzikb0q7x","registry_namespace_id":"5ce9f5db-16c5-4cca-bd16-b8187a1f2784","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-16T16:32:32.884625Z","vpc_integration_activated":true}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:29.568100Z","description":"","domain_name":"tffuncniftygoldbergp8m2adll-test-acc-function-pn-f01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"a00ddf4b-26e3-4342-8794-e4b96bdf9c1f","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f01","namespace_id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","privacy":"private","private_network_id":"d2582989-54df-4e6a-b43d-6cc6fc8370e1","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:29.568100Z"}'
         headers:
             Content-Length:
-                - "579"
+                - "760"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:40 GMT
+                - Wed, 27 Aug 2025 15:05:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2020,10 +2020,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1564c858-6c0e-44a4-a8ce-cf3e0b59b6e0
+                - 6a18ccd3-8cea-4221-9f16-3aa716b4cd22
         status: 200 OK
         code: 200
-        duration: 40.767227ms
+        duration: 53.328023ms
     - id: 41
       request:
         proto: HTTP/1.1
@@ -2040,7 +2040,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/d4a00f5a-5222-43fb-9fd2-7dae459ef2a0
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/d2582989-54df-4e6a-b43d-6cc6fc8370e1
         method: GET
       response:
         proto: HTTP/2.0
@@ -2050,7 +2050,7 @@ interactions:
         trailer: {}
         content_length: 1071
         uncompressed: false
-        body: '{"created_at":"2025-06-16T16:32:29.135893Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"d4a00f5a-5222-43fb-9fd2-7dae459ef2a0","name":"test-acc-function-pn-pn00","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-06-16T16:32:29.135893Z","id":"9b81f242-1f9d-48b8-b259-99aa33f49cea","private_network_id":"d4a00f5a-5222-43fb-9fd2-7dae459ef2a0","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.40.0/22","updated_at":"2025-06-16T16:32:29.135893Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-06-16T16:32:29.135893Z","id":"61b2717f-432b-4be8-9795-cef5602bdf3c","private_network_id":"d4a00f5a-5222-43fb-9fd2-7dae459ef2a0","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:411f::/64","updated_at":"2025-06-16T16:32:29.135893Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-06-16T16:32:29.135893Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+        body: '{"created_at":"2025-08-27T15:05:08.450070Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"d2582989-54df-4e6a-b43d-6cc6fc8370e1","name":"test-acc-function-pn-pn00","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-08-27T15:05:08.450070Z","id":"c5f17ea2-1cf9-459a-9529-9e91992fe302","private_network_id":"d2582989-54df-4e6a-b43d-6cc6fc8370e1","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.28.0/22","updated_at":"2025-08-27T15:05:08.450070Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-08-27T15:05:08.450070Z","id":"dab15e62-9a15-48ba-8f7c-b73e9a4bc41a","private_network_id":"d2582989-54df-4e6a-b43d-6cc6fc8370e1","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:a9d4::/64","updated_at":"2025-08-27T15:05:08.450070Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-08-27T15:05:08.450070Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
         headers:
             Content-Length:
                 - "1071"
@@ -2059,9 +2059,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:40 GMT
+                - Wed, 27 Aug 2025 15:05:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2069,10 +2069,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d438faf4-8128-4a12-9207-045f21d1d04c
+                - 44c0df6e-a098-44f7-8c74-ca94d279d366
         status: 200 OK
         code: 200
-        duration: 62.210357ms
+        duration: 21.214596ms
     - id: 42
       request:
         proto: HTTP/1.1
@@ -2089,7 +2089,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c5b3c2f5-3a1b-4241-805e-c9aa9f7a4432
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/8f30733d-b898-4a49-9ac7-97e32bc94122
         method: GET
       response:
         proto: HTTP/2.0
@@ -2099,7 +2099,7 @@ interactions:
         trailer: {}
         content_length: 1070
         uncompressed: false
-        body: '{"created_at":"2025-06-16T16:32:29.056273Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"c5b3c2f5-3a1b-4241-805e-c9aa9f7a4432","name":"test-acc-function-pn-pn01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-06-16T16:32:29.056273Z","id":"81747cba-53fd-4399-828c-fbadd1b1faf3","private_network_id":"c5b3c2f5-3a1b-4241-805e-c9aa9f7a4432","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.4.0/22","updated_at":"2025-06-16T16:32:29.056273Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-06-16T16:32:29.056273Z","id":"e1a95737-170c-4783-9297-8710b1350a1a","private_network_id":"c5b3c2f5-3a1b-4241-805e-c9aa9f7a4432","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:d0b8::/64","updated_at":"2025-06-16T16:32:29.056273Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-06-16T16:32:29.056273Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+        body: '{"created_at":"2025-08-27T15:05:08.378389Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"8f30733d-b898-4a49-9ac7-97e32bc94122","name":"test-acc-function-pn-pn01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-08-27T15:05:08.378389Z","id":"574b8d66-42ef-45b3-b04d-f4957a41304c","private_network_id":"8f30733d-b898-4a49-9ac7-97e32bc94122","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.4.0/22","updated_at":"2025-08-27T15:05:08.378389Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-08-27T15:05:08.378389Z","id":"39e3c40e-042a-4454-9a15-3371cea11bb8","private_network_id":"8f30733d-b898-4a49-9ac7-97e32bc94122","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:8fab::/64","updated_at":"2025-08-27T15:05:08.378389Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-08-27T15:05:08.378389Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
         headers:
             Content-Length:
                 - "1070"
@@ -2108,9 +2108,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:40 GMT
+                - Wed, 27 Aug 2025 15:05:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2118,10 +2118,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 87e65a91-1f9d-4e67-8076-b968eeab5d4b
+                - 714ccc84-d83a-45ac-8be2-795ddacecafa
         status: 200 OK
         code: 200
-        duration: 71.054191ms
+        duration: 42.239688ms
     - id: 43
       request:
         proto: HTTP/1.1
@@ -2138,7 +2138,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/f187ffcd-e01a-4018-9669-38b3c7e3e8ef
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/74fb790d-1104-4b78-bce7-39372f9f9ffc
         method: GET
       response:
         proto: HTTP/2.0
@@ -2146,20 +2146,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 755
+        content_length: 589
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-16T16:32:38.239983Z","description":"","domain_name":"tffunckindbuckzikb0q7x-test-acc-function-pn-f00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"f187ffcd-e01a-4018-9669-38b3c7e3e8ef","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f00","namespace_id":"0aa68856-5a7c-460e-a304-96399c647807","privacy":"private","private_network_id":"d4a00f5a-5222-43fb-9fd2-7dae459ef2a0","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:32:38.239983Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.795514Z","description":"","environment_variables":{},"error_message":null,"id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","name":"tf-func-nifty-goldberg","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncniftygoldbergp8m2adll","registry_namespace_id":"ac24eb9f-5629-420c-b895-b8737c0e1243","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:19.286578Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "755"
+                - "589"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:40 GMT
+                - Wed, 27 Aug 2025 15:05:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2167,10 +2167,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b90c53b8-40fc-42ae-969f-0cb68ac622c1
+                - cecc6ad8-c01b-42e9-8967-256e5d1fa2dc
         status: 200 OK
         code: 200
-        duration: 57.233244ms
+        duration: 46.246846ms
     - id: 44
       request:
         proto: HTTP/1.1
@@ -2187,7 +2187,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/7686b60e-d807-40ab-a415-e70edcf09bc2
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/a00ddf4b-26e3-4342-8794-e4b96bdf9c1f
         method: GET
       response:
         proto: HTTP/2.0
@@ -2195,20 +2195,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 755
+        content_length: 760
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-16T16:32:38.119281Z","description":"","domain_name":"tffunckindbuckzikb0q7x-test-acc-function-pn-f02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"7686b60e-d807-40ab-a415-e70edcf09bc2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f02","namespace_id":"0aa68856-5a7c-460e-a304-96399c647807","privacy":"private","private_network_id":"d4a00f5a-5222-43fb-9fd2-7dae459ef2a0","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:32:38.119281Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:29.568100Z","description":"","domain_name":"tffuncniftygoldbergp8m2adll-test-acc-function-pn-f01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"a00ddf4b-26e3-4342-8794-e4b96bdf9c1f","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f01","namespace_id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","privacy":"private","private_network_id":"d2582989-54df-4e6a-b43d-6cc6fc8370e1","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:29.568100Z"}'
         headers:
             Content-Length:
-                - "755"
+                - "760"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:40 GMT
+                - Wed, 27 Aug 2025 15:05:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2216,10 +2216,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 369c8fe7-25f3-47c3-a5ca-11a44ac20988
+                - 3a80c1c1-74bf-4f6c-bec8-0e69814249fd
         status: 200 OK
         code: 200
-        duration: 79.445036ms
+        duration: 41.53749ms
     - id: 45
       request:
         proto: HTTP/1.1
@@ -2236,7 +2236,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e81349b1-4ad1-4599-871f-0e3057bf3de7
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/f7365af3-31a3-4fbe-b12b-2c11aa863a3d
         method: GET
       response:
         proto: HTTP/2.0
@@ -2244,20 +2244,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 755
+        content_length: 760
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-16T16:32:38.121175Z","description":"","domain_name":"tffunckindbuckzikb0q7x-test-acc-function-pn-f01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"e81349b1-4ad1-4599-871f-0e3057bf3de7","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f01","namespace_id":"0aa68856-5a7c-460e-a304-96399c647807","privacy":"private","private_network_id":"d4a00f5a-5222-43fb-9fd2-7dae459ef2a0","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:32:38.121175Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:29.832556Z","description":"","domain_name":"tffuncniftygoldbergp8m2adll-test-acc-function-pn-f00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"f7365af3-31a3-4fbe-b12b-2c11aa863a3d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f00","namespace_id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","privacy":"private","private_network_id":"d2582989-54df-4e6a-b43d-6cc6fc8370e1","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:29.832556Z"}'
         headers:
             Content-Length:
-                - "755"
+                - "760"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:40 GMT
+                - Wed, 27 Aug 2025 15:05:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2265,10 +2265,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e8ce577b-e3e9-4705-8419-f16191f047f2
+                - aa5bbc4a-4137-44c1-97ed-72ba8c849e5b
         status: 200 OK
         code: 200
-        duration: 76.421956ms
+        duration: 45.118208ms
     - id: 46
       request:
         proto: HTTP/1.1
@@ -2285,7 +2285,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/7686b60e-d807-40ab-a415-e70edcf09bc2
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/176091e3-d6e4-4c48-8cc8-44c15d81395d
         method: GET
       response:
         proto: HTTP/2.0
@@ -2293,20 +2293,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 755
+        content_length: 760
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-16T16:32:38.119281Z","description":"","domain_name":"tffunckindbuckzikb0q7x-test-acc-function-pn-f02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"7686b60e-d807-40ab-a415-e70edcf09bc2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f02","namespace_id":"0aa68856-5a7c-460e-a304-96399c647807","privacy":"private","private_network_id":"d4a00f5a-5222-43fb-9fd2-7dae459ef2a0","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:32:38.119281Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:29.599705Z","description":"","domain_name":"tffuncniftygoldbergp8m2adll-test-acc-function-pn-f02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"176091e3-d6e4-4c48-8cc8-44c15d81395d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f02","namespace_id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","privacy":"private","private_network_id":"d2582989-54df-4e6a-b43d-6cc6fc8370e1","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:29.599705Z"}'
         headers:
             Content-Length:
-                - "755"
+                - "760"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:41 GMT
+                - Wed, 27 Aug 2025 15:05:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2314,10 +2314,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0b694510-944d-4353-96d6-a8a6b81abb87
+                - 0d950533-8a84-45a3-85cc-4f057cff6873
         status: 200 OK
         code: 200
-        duration: 48.318016ms
+        duration: 55.84745ms
     - id: 47
       request:
         proto: HTTP/1.1
@@ -2334,7 +2334,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/f187ffcd-e01a-4018-9669-38b3c7e3e8ef
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/a00ddf4b-26e3-4342-8794-e4b96bdf9c1f
         method: GET
       response:
         proto: HTTP/2.0
@@ -2342,20 +2342,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 755
+        content_length: 760
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-16T16:32:38.239983Z","description":"","domain_name":"tffunckindbuckzikb0q7x-test-acc-function-pn-f00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"f187ffcd-e01a-4018-9669-38b3c7e3e8ef","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f00","namespace_id":"0aa68856-5a7c-460e-a304-96399c647807","privacy":"private","private_network_id":"d4a00f5a-5222-43fb-9fd2-7dae459ef2a0","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:32:38.239983Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:29.568100Z","description":"","domain_name":"tffuncniftygoldbergp8m2adll-test-acc-function-pn-f01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"a00ddf4b-26e3-4342-8794-e4b96bdf9c1f","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f01","namespace_id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","privacy":"private","private_network_id":"d2582989-54df-4e6a-b43d-6cc6fc8370e1","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:29.568100Z"}'
         headers:
             Content-Length:
-                - "755"
+                - "760"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:41 GMT
+                - Wed, 27 Aug 2025 15:05:31 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2363,10 +2363,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 109418f4-3691-4568-bd9a-ecc9e27fa062
+                - 0c997e8a-52ba-45d4-b7be-72705e4542e7
         status: 200 OK
         code: 200
-        duration: 91.886306ms
+        duration: 49.309594ms
     - id: 48
       request:
         proto: HTTP/1.1
@@ -2383,7 +2383,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e81349b1-4ad1-4599-871f-0e3057bf3de7
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/176091e3-d6e4-4c48-8cc8-44c15d81395d
         method: GET
       response:
         proto: HTTP/2.0
@@ -2391,20 +2391,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 755
+        content_length: 760
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-16T16:32:38.121175Z","description":"","domain_name":"tffunckindbuckzikb0q7x-test-acc-function-pn-f01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"e81349b1-4ad1-4599-871f-0e3057bf3de7","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f01","namespace_id":"0aa68856-5a7c-460e-a304-96399c647807","privacy":"private","private_network_id":"d4a00f5a-5222-43fb-9fd2-7dae459ef2a0","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:32:38.121175Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:29.599705Z","description":"","domain_name":"tffuncniftygoldbergp8m2adll-test-acc-function-pn-f02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"176091e3-d6e4-4c48-8cc8-44c15d81395d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f02","namespace_id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","privacy":"private","private_network_id":"d2582989-54df-4e6a-b43d-6cc6fc8370e1","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:29.599705Z"}'
         headers:
             Content-Length:
-                - "755"
+                - "760"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:41 GMT
+                - Wed, 27 Aug 2025 15:05:31 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2412,10 +2412,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7df590cd-db43-4f59-b2b8-ddb6d1908afb
+                - ad837a7d-05ca-485f-8ba8-27badbe2c981
         status: 200 OK
         code: 200
-        duration: 93.818248ms
+        duration: 57.548723ms
     - id: 49
       request:
         proto: HTTP/1.1
@@ -2432,28 +2432,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/7686b60e-d807-40ab-a415-e70edcf09bc2
-        method: DELETE
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/f7365af3-31a3-4fbe-b12b-2c11aa863a3d
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 759
+        content_length: 760
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-16T16:32:38.119281Z","description":"","domain_name":"tffunckindbuckzikb0q7x-test-acc-function-pn-f02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"7686b60e-d807-40ab-a415-e70edcf09bc2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f02","namespace_id":"0aa68856-5a7c-460e-a304-96399c647807","privacy":"private","private_network_id":"d4a00f5a-5222-43fb-9fd2-7dae459ef2a0","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:32:41.616339669Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:29.832556Z","description":"","domain_name":"tffuncniftygoldbergp8m2adll-test-acc-function-pn-f00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"f7365af3-31a3-4fbe-b12b-2c11aa863a3d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f00","namespace_id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","privacy":"private","private_network_id":"d2582989-54df-4e6a-b43d-6cc6fc8370e1","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:29.832556Z"}'
         headers:
             Content-Length:
-                - "759"
+                - "760"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:41 GMT
+                - Wed, 27 Aug 2025 15:05:31 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2461,11 +2461,60 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7ed8d0f2-53ed-46a5-aab2-5d88b4a00b7d
+                - 14154656-9d4c-4a4e-9a0f-5be9819f1bc6
         status: 200 OK
         code: 200
-        duration: 105.683538ms
+        duration: 59.746136ms
     - id: 50
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/176091e3-d6e4-4c48-8cc8-44c15d81395d
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 764
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:29.599705Z","description":"","domain_name":"tffuncniftygoldbergp8m2adll-test-acc-function-pn-f02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"176091e3-d6e4-4c48-8cc8-44c15d81395d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f02","namespace_id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","privacy":"private","private_network_id":"d2582989-54df-4e6a-b43d-6cc6fc8370e1","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:31.480760133Z"}'
+        headers:
+            Content-Length:
+                - "764"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:05:31 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 4fe5dd82-0307-48ce-a21d-3717e718c29a
+        status: 200 OK
+        code: 200
+        duration: 96.763544ms
+    - id: 51
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2483,7 +2532,7 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/f187ffcd-e01a-4018-9669-38b3c7e3e8ef
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/f7365af3-31a3-4fbe-b12b-2c11aa863a3d
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -2491,20 +2540,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 724
+        content_length: 729
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-16T16:32:38.239983Z","description":"","domain_name":"tffunckindbuckzikb0q7x-test-acc-function-pn-f00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"f187ffcd-e01a-4018-9669-38b3c7e3e8ef","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f00","namespace_id":"0aa68856-5a7c-460e-a304-96399c647807","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:32:41.695723795Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:29.832556Z","description":"","domain_name":"tffuncniftygoldbergp8m2adll-test-acc-function-pn-f00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"f7365af3-31a3-4fbe-b12b-2c11aa863a3d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f00","namespace_id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:31.453714400Z"}'
         headers:
             Content-Length:
-                - "724"
+                - "729"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:41 GMT
+                - Wed, 27 Aug 2025 15:05:31 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2512,11 +2561,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a6eb742f-71b6-44b8-8946-29c963c697eb
+                - f483b405-9fac-4793-a5df-adbefb224541
         status: 200 OK
         code: 200
-        duration: 96.252262ms
-    - id: 51
+        duration: 93.241636ms
+    - id: 52
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2527,14 +2576,14 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"runtime":"unknown_runtime","privacy":"unknown_privacy","secret_environment_variables":null,"http_option":"unknown_http_option","sandbox":"unknown_sandbox","private_network_id":"c5b3c2f5-3a1b-4241-805e-c9aa9f7a4432"}'
+        body: '{"runtime":"unknown_runtime","privacy":"unknown_privacy","secret_environment_variables":null,"http_option":"unknown_http_option","sandbox":"unknown_sandbox","private_network_id":"8f30733d-b898-4a49-9ac7-97e32bc94122"}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e81349b1-4ad1-4599-871f-0e3057bf3de7
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/a00ddf4b-26e3-4342-8794-e4b96bdf9c1f
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -2542,20 +2591,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 758
+        content_length: 763
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-16T16:32:38.121175Z","description":"","domain_name":"tffunckindbuckzikb0q7x-test-acc-function-pn-f01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"e81349b1-4ad1-4599-871f-0e3057bf3de7","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f01","namespace_id":"0aa68856-5a7c-460e-a304-96399c647807","privacy":"private","private_network_id":"c5b3c2f5-3a1b-4241-805e-c9aa9f7a4432","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:32:41.730833091Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:29.568100Z","description":"","domain_name":"tffuncniftygoldbergp8m2adll-test-acc-function-pn-f01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"a00ddf4b-26e3-4342-8794-e4b96bdf9c1f","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f01","namespace_id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","privacy":"private","private_network_id":"8f30733d-b898-4a49-9ac7-97e32bc94122","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:31.509836028Z"}'
         headers:
             Content-Length:
-                - "758"
+                - "763"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:41 GMT
+                - Wed, 27 Aug 2025 15:05:31 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2563,11 +2612,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e2ee0c7b-9f74-4081-bf3a-b0867655083a
+                - f95dd59f-a04b-4807-b01b-7acef7707277
         status: 200 OK
         code: 200
-        duration: 134.045463ms
-    - id: 52
+        duration: 155.829224ms
+    - id: 53
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2578,7 +2627,7 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"test-acc-function-pn-02","namespace_id":"0aa68856-5a7c-460e-a304-96399c647807","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"go123","memory_limit":256,"handler":"Handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"v1","tags":null,"private_network_id":"d4a00f5a-5222-43fb-9fd2-7dae459ef2a0"}'
+        body: '{"name":"test-acc-function-pn-02","namespace_id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"go123","memory_limit":256,"handler":"Handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"v1","tags":null,"private_network_id":"d2582989-54df-4e6a-b43d-6cc6fc8370e1"}'
         form: {}
         headers:
             Content-Type:
@@ -2593,20 +2642,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 759
+        content_length: 764
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-16T16:32:42.004093017Z","description":"","domain_name":"tffunckindbuckzikb0q7x-test-acc-function-pn-02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"462bb3a7-301e-44b9-8f69-207cfb9cb94c","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-02","namespace_id":"0aa68856-5a7c-460e-a304-96399c647807","privacy":"private","private_network_id":"d4a00f5a-5222-43fb-9fd2-7dae459ef2a0","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:32:42.004093017Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:32.162561612Z","description":"","domain_name":"tffuncniftygoldbergp8m2adll-test-acc-function-pn-02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"e433448e-b9f7-4034-bf83-c0d867b61e31","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-02","namespace_id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","privacy":"private","private_network_id":"d2582989-54df-4e6a-b43d-6cc6fc8370e1","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:32.162561612Z"}'
         headers:
             Content-Length:
-                - "759"
+                - "764"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:42 GMT
+                - Wed, 27 Aug 2025 15:05:32 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2614,59 +2663,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5a72c569-8b0c-4d97-9927-dcd3117ec2f0
+                - 139a5e58-5913-4d3d-85da-af59c9b4bab5
         status: 200 OK
         code: 200
-        duration: 349.175665ms
-    - id: 53
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/462bb3a7-301e-44b9-8f69-207cfb9cb94c
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 753
-        uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-16T16:32:42.004093Z","description":"","domain_name":"tffunckindbuckzikb0q7x-test-acc-function-pn-02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"462bb3a7-301e-44b9-8f69-207cfb9cb94c","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-02","namespace_id":"0aa68856-5a7c-460e-a304-96399c647807","privacy":"private","private_network_id":"d4a00f5a-5222-43fb-9fd2-7dae459ef2a0","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:32:42.004093Z"}'
-        headers:
-            Content-Length:
-                - "753"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 16 Jun 2025 16:32:42 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 0b9f23df-2e1c-43aa-a494-755e11730993
-        status: 200 OK
-        code: 200
-        duration: 65.892953ms
+        duration: 642.851549ms
     - id: 54
       request:
         proto: HTTP/1.1
@@ -2683,7 +2683,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/462bb3a7-301e-44b9-8f69-207cfb9cb94c
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e433448e-b9f7-4034-bf83-c0d867b61e31
         method: GET
       response:
         proto: HTTP/2.0
@@ -2691,20 +2691,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 753
+        content_length: 758
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-16T16:32:42.004093Z","description":"","domain_name":"tffunckindbuckzikb0q7x-test-acc-function-pn-02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"462bb3a7-301e-44b9-8f69-207cfb9cb94c","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-02","namespace_id":"0aa68856-5a7c-460e-a304-96399c647807","privacy":"private","private_network_id":"d4a00f5a-5222-43fb-9fd2-7dae459ef2a0","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:32:42.004093Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:32.162562Z","description":"","domain_name":"tffuncniftygoldbergp8m2adll-test-acc-function-pn-02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"e433448e-b9f7-4034-bf83-c0d867b61e31","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-02","namespace_id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","privacy":"private","private_network_id":"d2582989-54df-4e6a-b43d-6cc6fc8370e1","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:32.162562Z"}'
         headers:
             Content-Length:
-                - "753"
+                - "758"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:42 GMT
+                - Wed, 27 Aug 2025 15:05:32 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2712,10 +2712,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3de708bd-4890-4436-9ccc-7799574ee051
+                - 5ee52a7e-264f-41df-84c1-770973b51ec0
         status: 200 OK
         code: 200
-        duration: 54.455214ms
+        duration: 63.817035ms
     - id: 55
       request:
         proto: HTTP/1.1
@@ -2732,7 +2732,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/f187ffcd-e01a-4018-9669-38b3c7e3e8ef
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e433448e-b9f7-4034-bf83-c0d867b61e31
         method: GET
       response:
         proto: HTTP/2.0
@@ -2740,20 +2740,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 721
+        content_length: 758
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-16T16:32:38.239983Z","description":"","domain_name":"tffunckindbuckzikb0q7x-test-acc-function-pn-f00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"f187ffcd-e01a-4018-9669-38b3c7e3e8ef","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f00","namespace_id":"0aa68856-5a7c-460e-a304-96399c647807","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:32:41.695724Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:32.162562Z","description":"","domain_name":"tffuncniftygoldbergp8m2adll-test-acc-function-pn-02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"e433448e-b9f7-4034-bf83-c0d867b61e31","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-02","namespace_id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","privacy":"private","private_network_id":"d2582989-54df-4e6a-b43d-6cc6fc8370e1","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:32.162562Z"}'
         headers:
             Content-Length:
-                - "721"
+                - "758"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:42 GMT
+                - Wed, 27 Aug 2025 15:05:32 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2761,10 +2761,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d518b3db-3914-4712-a4ca-06ee0f237914
+                - 37e2f5f6-59f4-4de1-bd34-821f72758656
         status: 200 OK
         code: 200
-        duration: 55.377433ms
+        duration: 47.536697ms
     - id: 56
       request:
         proto: HTTP/1.1
@@ -2781,7 +2781,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e81349b1-4ad1-4599-871f-0e3057bf3de7
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/f7365af3-31a3-4fbe-b12b-2c11aa863a3d
         method: GET
       response:
         proto: HTTP/2.0
@@ -2789,20 +2789,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 755
+        content_length: 726
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-16T16:32:38.121175Z","description":"","domain_name":"tffunckindbuckzikb0q7x-test-acc-function-pn-f01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"e81349b1-4ad1-4599-871f-0e3057bf3de7","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f01","namespace_id":"0aa68856-5a7c-460e-a304-96399c647807","privacy":"private","private_network_id":"c5b3c2f5-3a1b-4241-805e-c9aa9f7a4432","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:32:41.730833Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:29.832556Z","description":"","domain_name":"tffuncniftygoldbergp8m2adll-test-acc-function-pn-f00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"f7365af3-31a3-4fbe-b12b-2c11aa863a3d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f00","namespace_id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:31.453714Z"}'
         headers:
             Content-Length:
-                - "755"
+                - "726"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:42 GMT
+                - Wed, 27 Aug 2025 15:05:32 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2810,10 +2810,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0a3d0933-f532-4d79-9882-29f78775171f
+                - e7b14456-39f0-4e99-88a5-7e0a6df0d1ca
         status: 200 OK
         code: 200
-        duration: 58.483989ms
+        duration: 49.313471ms
     - id: 57
       request:
         proto: HTTP/1.1
@@ -2830,7 +2830,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/f187ffcd-e01a-4018-9669-38b3c7e3e8ef
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/a00ddf4b-26e3-4342-8794-e4b96bdf9c1f
         method: GET
       response:
         proto: HTTP/2.0
@@ -2838,20 +2838,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 731
+        content_length: 760
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-16T16:32:38.239983Z","description":"","domain_name":"tffunckindbuckzikb0q7x-test-acc-function-pn-f00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"Handle","http_option":"enabled","id":"f187ffcd-e01a-4018-9669-38b3c7e3e8ef","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f00","namespace_id":"0aa68856-5a7c-460e-a304-96399c647807","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:32:47.501611Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:29.568100Z","description":"","domain_name":"tffuncniftygoldbergp8m2adll-test-acc-function-pn-f01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"a00ddf4b-26e3-4342-8794-e4b96bdf9c1f","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f01","namespace_id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","privacy":"private","private_network_id":"8f30733d-b898-4a49-9ac7-97e32bc94122","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:31.509836Z"}'
         headers:
             Content-Length:
-                - "731"
+                - "760"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:47 GMT
+                - Wed, 27 Aug 2025 15:05:32 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2859,10 +2859,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bd9b6164-2796-4a88-88fd-dd95cf0d8195
+                - be13d8fd-66e3-4cc7-88e2-51d0dfc40d5b
         status: 200 OK
         code: 200
-        duration: 48.551052ms
+        duration: 50.667631ms
     - id: 58
       request:
         proto: HTTP/1.1
@@ -2879,7 +2879,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e81349b1-4ad1-4599-871f-0e3057bf3de7
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/f7365af3-31a3-4fbe-b12b-2c11aa863a3d
         method: GET
       response:
         proto: HTTP/2.0
@@ -2887,20 +2887,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 765
+        content_length: 726
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-16T16:32:38.121175Z","description":"","domain_name":"tffunckindbuckzikb0q7x-test-acc-function-pn-f01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"Handle","http_option":"enabled","id":"e81349b1-4ad1-4599-871f-0e3057bf3de7","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f01","namespace_id":"0aa68856-5a7c-460e-a304-96399c647807","privacy":"private","private_network_id":"c5b3c2f5-3a1b-4241-805e-c9aa9f7a4432","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:32:47.671624Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:29.832556Z","description":"","domain_name":"tffuncniftygoldbergp8m2adll-test-acc-function-pn-f00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"f7365af3-31a3-4fbe-b12b-2c11aa863a3d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f00","namespace_id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:31.453714Z"}'
         headers:
             Content-Length:
-                - "765"
+                - "726"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:47 GMT
+                - Wed, 27 Aug 2025 15:05:37 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2908,10 +2908,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c201241b-5978-40ad-aa97-4ca1bd92e15e
+                - 94cd3931-6201-4049-802a-93d0080d30bb
         status: 200 OK
         code: 200
-        duration: 78.34392ms
+        duration: 66.75541ms
     - id: 59
       request:
         proto: HTTP/1.1
@@ -2928,7 +2928,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/f187ffcd-e01a-4018-9669-38b3c7e3e8ef
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/a00ddf4b-26e3-4342-8794-e4b96bdf9c1f
         method: GET
       response:
         proto: HTTP/2.0
@@ -2936,20 +2936,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 731
+        content_length: 770
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-16T16:32:38.239983Z","description":"","domain_name":"tffunckindbuckzikb0q7x-test-acc-function-pn-f00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"Handle","http_option":"enabled","id":"f187ffcd-e01a-4018-9669-38b3c7e3e8ef","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f00","namespace_id":"0aa68856-5a7c-460e-a304-96399c647807","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:32:47.501611Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:29.568100Z","description":"","domain_name":"tffuncniftygoldbergp8m2adll-test-acc-function-pn-f01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"Handle","http_option":"enabled","id":"a00ddf4b-26e3-4342-8794-e4b96bdf9c1f","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f01","namespace_id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","privacy":"private","private_network_id":"8f30733d-b898-4a49-9ac7-97e32bc94122","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:37.229676Z"}'
         headers:
             Content-Length:
-                - "731"
+                - "770"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:48 GMT
+                - Wed, 27 Aug 2025 15:05:37 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2957,10 +2957,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 80f27668-67a6-4279-b6ad-0ea5a1169829
+                - 4156cfa1-7b51-4dc7-8a35-d85fcef6eb23
         status: 200 OK
         code: 200
-        duration: 61.190174ms
+        duration: 46.969473ms
     - id: 60
       request:
         proto: HTTP/1.1
@@ -2977,7 +2977,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e81349b1-4ad1-4599-871f-0e3057bf3de7
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/f7365af3-31a3-4fbe-b12b-2c11aa863a3d
         method: GET
       response:
         proto: HTTP/2.0
@@ -2985,20 +2985,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 765
+        content_length: 726
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-16T16:32:38.121175Z","description":"","domain_name":"tffunckindbuckzikb0q7x-test-acc-function-pn-f01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"Handle","http_option":"enabled","id":"e81349b1-4ad1-4599-871f-0e3057bf3de7","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f01","namespace_id":"0aa68856-5a7c-460e-a304-96399c647807","privacy":"private","private_network_id":"c5b3c2f5-3a1b-4241-805e-c9aa9f7a4432","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:32:47.671624Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:29.832556Z","description":"","domain_name":"tffuncniftygoldbergp8m2adll-test-acc-function-pn-f00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"f7365af3-31a3-4fbe-b12b-2c11aa863a3d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f00","namespace_id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:31.453714Z"}'
         headers:
             Content-Length:
-                - "765"
+                - "726"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:48 GMT
+                - Wed, 27 Aug 2025 15:05:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3006,10 +3006,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cc83aa25-e886-416f-9873-0e2c72dda9d0
+                - b0452f20-c44e-4ed5-b0c2-659cfe73e5cb
         status: 200 OK
         code: 200
-        duration: 52.085801ms
+        duration: 46.35413ms
     - id: 61
       request:
         proto: HTTP/1.1
@@ -3026,7 +3026,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/462bb3a7-301e-44b9-8f69-207cfb9cb94c
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/f7365af3-31a3-4fbe-b12b-2c11aa863a3d
         method: GET
       response:
         proto: HTTP/2.0
@@ -3034,20 +3034,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 753
+        content_length: 726
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-16T16:32:42.004093Z","description":"","domain_name":"tffunckindbuckzikb0q7x-test-acc-function-pn-02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"462bb3a7-301e-44b9-8f69-207cfb9cb94c","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-02","namespace_id":"0aa68856-5a7c-460e-a304-96399c647807","privacy":"private","private_network_id":"d4a00f5a-5222-43fb-9fd2-7dae459ef2a0","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:32:42.004093Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:29.832556Z","description":"","domain_name":"tffuncniftygoldbergp8m2adll-test-acc-function-pn-f00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"f7365af3-31a3-4fbe-b12b-2c11aa863a3d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f00","namespace_id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:31.453714Z"}'
         headers:
             Content-Length:
-                - "753"
+                - "726"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:48 GMT
+                - Wed, 27 Aug 2025 15:05:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3055,10 +3055,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ab19d010-5af5-4e41-aec6-da7c1a96deca
+                - a608c6cc-4b5e-4716-b3bc-9e104a14547e
         status: 200 OK
         code: 200
-        duration: 68.684446ms
+        duration: 46.296252ms
     - id: 62
       request:
         proto: HTTP/1.1
@@ -3075,7 +3075,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c5b3c2f5-3a1b-4241-805e-c9aa9f7a4432
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/f7365af3-31a3-4fbe-b12b-2c11aa863a3d
         method: GET
       response:
         proto: HTTP/2.0
@@ -3083,20 +3083,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1070
+        content_length: 736
         uncompressed: false
-        body: '{"created_at":"2025-06-16T16:32:29.056273Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"c5b3c2f5-3a1b-4241-805e-c9aa9f7a4432","name":"test-acc-function-pn-pn01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-06-16T16:32:29.056273Z","id":"81747cba-53fd-4399-828c-fbadd1b1faf3","private_network_id":"c5b3c2f5-3a1b-4241-805e-c9aa9f7a4432","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.4.0/22","updated_at":"2025-06-16T16:32:29.056273Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-06-16T16:32:29.056273Z","id":"e1a95737-170c-4783-9297-8710b1350a1a","private_network_id":"c5b3c2f5-3a1b-4241-805e-c9aa9f7a4432","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:d0b8::/64","updated_at":"2025-06-16T16:32:29.056273Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-06-16T16:32:29.056273Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:29.832556Z","description":"","domain_name":"tffuncniftygoldbergp8m2adll-test-acc-function-pn-f00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"Handle","http_option":"enabled","id":"f7365af3-31a3-4fbe-b12b-2c11aa863a3d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f00","namespace_id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:52.318107Z"}'
         headers:
             Content-Length:
-                - "1070"
+                - "736"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:49 GMT
+                - Wed, 27 Aug 2025 15:05:52 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3104,10 +3104,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8480b176-581f-436f-8278-1d8800b43bc9
+                - fec3f559-2ef6-4adb-afdb-f6bcab670003
         status: 200 OK
         code: 200
-        duration: 27.262673ms
+        duration: 52.980225ms
     - id: 63
       request:
         proto: HTTP/1.1
@@ -3124,7 +3124,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/d4a00f5a-5222-43fb-9fd2-7dae459ef2a0
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/f7365af3-31a3-4fbe-b12b-2c11aa863a3d
         method: GET
       response:
         proto: HTTP/2.0
@@ -3132,20 +3132,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1071
+        content_length: 736
         uncompressed: false
-        body: '{"created_at":"2025-06-16T16:32:29.135893Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"d4a00f5a-5222-43fb-9fd2-7dae459ef2a0","name":"test-acc-function-pn-pn00","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-06-16T16:32:29.135893Z","id":"9b81f242-1f9d-48b8-b259-99aa33f49cea","private_network_id":"d4a00f5a-5222-43fb-9fd2-7dae459ef2a0","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.40.0/22","updated_at":"2025-06-16T16:32:29.135893Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-06-16T16:32:29.135893Z","id":"61b2717f-432b-4be8-9795-cef5602bdf3c","private_network_id":"d4a00f5a-5222-43fb-9fd2-7dae459ef2a0","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:411f::/64","updated_at":"2025-06-16T16:32:29.135893Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-06-16T16:32:29.135893Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:29.832556Z","description":"","domain_name":"tffuncniftygoldbergp8m2adll-test-acc-function-pn-f00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"Handle","http_option":"enabled","id":"f7365af3-31a3-4fbe-b12b-2c11aa863a3d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f00","namespace_id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:52.318107Z"}'
         headers:
             Content-Length:
-                - "1071"
+                - "736"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:49 GMT
+                - Wed, 27 Aug 2025 15:05:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3153,10 +3153,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d98e6993-39e0-49e8-bf25-c8beca849125
+                - aeed244a-63d8-4afe-ae7d-fc34816d0e07
         status: 200 OK
         code: 200
-        duration: 31.665799ms
+        duration: 162.688535ms
     - id: 64
       request:
         proto: HTTP/1.1
@@ -3173,7 +3173,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/0aa68856-5a7c-460e-a304-96399c647807
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/a00ddf4b-26e3-4342-8794-e4b96bdf9c1f
         method: GET
       response:
         proto: HTTP/2.0
@@ -3181,20 +3181,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 579
+        content_length: 770
         uncompressed: false
-        body: '{"created_at":"2025-06-16T16:32:29.224354Z","description":"","environment_variables":{},"error_message":null,"id":"0aa68856-5a7c-460e-a304-96399c647807","name":"tf-func-kind-buck","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunckindbuckzikb0q7x","registry_namespace_id":"5ce9f5db-16c5-4cca-bd16-b8187a1f2784","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-16T16:32:32.884625Z","vpc_integration_activated":true}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:29.568100Z","description":"","domain_name":"tffuncniftygoldbergp8m2adll-test-acc-function-pn-f01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"Handle","http_option":"enabled","id":"a00ddf4b-26e3-4342-8794-e4b96bdf9c1f","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f01","namespace_id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","privacy":"private","private_network_id":"8f30733d-b898-4a49-9ac7-97e32bc94122","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:37.229676Z"}'
         headers:
             Content-Length:
-                - "579"
+                - "770"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:49 GMT
+                - Wed, 27 Aug 2025 15:05:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3202,10 +3202,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 86b6b6e6-38f0-41d0-b64e-71f20cf716d8
+                - 77d8c0b1-1b3c-4c43-9b6d-be29a990f0d8
         status: 200 OK
         code: 200
-        duration: 40.80164ms
+        duration: 75.410003ms
     - id: 65
       request:
         proto: HTTP/1.1
@@ -3222,7 +3222,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/f187ffcd-e01a-4018-9669-38b3c7e3e8ef
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e433448e-b9f7-4034-bf83-c0d867b61e31
         method: GET
       response:
         proto: HTTP/2.0
@@ -3230,20 +3230,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 731
+        content_length: 758
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-16T16:32:38.239983Z","description":"","domain_name":"tffunckindbuckzikb0q7x-test-acc-function-pn-f00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"Handle","http_option":"enabled","id":"f187ffcd-e01a-4018-9669-38b3c7e3e8ef","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f00","namespace_id":"0aa68856-5a7c-460e-a304-96399c647807","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:32:47.501611Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:32.162562Z","description":"","domain_name":"tffuncniftygoldbergp8m2adll-test-acc-function-pn-02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"e433448e-b9f7-4034-bf83-c0d867b61e31","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-02","namespace_id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","privacy":"private","private_network_id":"d2582989-54df-4e6a-b43d-6cc6fc8370e1","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:32.162562Z"}'
         headers:
             Content-Length:
-                - "731"
+                - "758"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:49 GMT
+                - Wed, 27 Aug 2025 15:05:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3251,10 +3251,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3230de08-e269-4dbb-ac96-1321a144b4e8
+                - 4b21205a-59ae-4dfb-9947-6eb9e857ffef
         status: 200 OK
         code: 200
-        duration: 58.52745ms
+        duration: 41.867833ms
     - id: 66
       request:
         proto: HTTP/1.1
@@ -3271,7 +3271,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/462bb3a7-301e-44b9-8f69-207cfb9cb94c
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/8f30733d-b898-4a49-9ac7-97e32bc94122
         method: GET
       response:
         proto: HTTP/2.0
@@ -3279,20 +3279,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 753
+        content_length: 1070
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-16T16:32:42.004093Z","description":"","domain_name":"tffunckindbuckzikb0q7x-test-acc-function-pn-02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"462bb3a7-301e-44b9-8f69-207cfb9cb94c","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-02","namespace_id":"0aa68856-5a7c-460e-a304-96399c647807","privacy":"private","private_network_id":"d4a00f5a-5222-43fb-9fd2-7dae459ef2a0","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:32:42.004093Z"}'
+        body: '{"created_at":"2025-08-27T15:05:08.378389Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"8f30733d-b898-4a49-9ac7-97e32bc94122","name":"test-acc-function-pn-pn01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-08-27T15:05:08.378389Z","id":"574b8d66-42ef-45b3-b04d-f4957a41304c","private_network_id":"8f30733d-b898-4a49-9ac7-97e32bc94122","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.4.0/22","updated_at":"2025-08-27T15:05:08.378389Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-08-27T15:05:08.378389Z","id":"39e3c40e-042a-4454-9a15-3371cea11bb8","private_network_id":"8f30733d-b898-4a49-9ac7-97e32bc94122","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:8fab::/64","updated_at":"2025-08-27T15:05:08.378389Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-08-27T15:05:08.378389Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
         headers:
             Content-Length:
-                - "753"
+                - "1070"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:49 GMT
+                - Wed, 27 Aug 2025 15:05:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3300,10 +3300,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bb2df814-bbad-4f39-b1c8-1eb206106b07
+                - c1e5ceba-9135-4a98-80f0-7eb78d836185
         status: 200 OK
         code: 200
-        duration: 103.913397ms
+        duration: 27.406277ms
     - id: 67
       request:
         proto: HTTP/1.1
@@ -3320,7 +3320,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e81349b1-4ad1-4599-871f-0e3057bf3de7
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/d2582989-54df-4e6a-b43d-6cc6fc8370e1
         method: GET
       response:
         proto: HTTP/2.0
@@ -3328,20 +3328,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 765
+        content_length: 1071
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-16T16:32:38.121175Z","description":"","domain_name":"tffunckindbuckzikb0q7x-test-acc-function-pn-f01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"Handle","http_option":"enabled","id":"e81349b1-4ad1-4599-871f-0e3057bf3de7","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f01","namespace_id":"0aa68856-5a7c-460e-a304-96399c647807","privacy":"private","private_network_id":"c5b3c2f5-3a1b-4241-805e-c9aa9f7a4432","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:32:47.671624Z"}'
+        body: '{"created_at":"2025-08-27T15:05:08.450070Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"d2582989-54df-4e6a-b43d-6cc6fc8370e1","name":"test-acc-function-pn-pn00","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2025-08-27T15:05:08.450070Z","id":"c5f17ea2-1cf9-459a-9529-9e91992fe302","private_network_id":"d2582989-54df-4e6a-b43d-6cc6fc8370e1","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.28.0/22","updated_at":"2025-08-27T15:05:08.450070Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},{"created_at":"2025-08-27T15:05:08.450070Z","id":"dab15e62-9a15-48ba-8f7c-b73e9a4bc41a","private_network_id":"d2582989-54df-4e6a-b43d-6cc6fc8370e1","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:a9d4::/64","updated_at":"2025-08-27T15:05:08.450070Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}],"tags":[],"updated_at":"2025-08-27T15:05:08.450070Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
         headers:
             Content-Length:
-                - "765"
+                - "1071"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:49 GMT
+                - Wed, 27 Aug 2025 15:05:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3349,10 +3349,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a97d6eba-080b-4aa7-95fb-c0c73b2b3470
+                - bb8e36e4-1531-479d-8f72-f4ef70d08c80
         status: 200 OK
         code: 200
-        duration: 144.754412ms
+        duration: 29.948837ms
     - id: 68
       request:
         proto: HTTP/1.1
@@ -3369,7 +3369,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/462bb3a7-301e-44b9-8f69-207cfb9cb94c
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/74fb790d-1104-4b78-bce7-39372f9f9ffc
         method: GET
       response:
         proto: HTTP/2.0
@@ -3377,20 +3377,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 753
+        content_length: 589
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-16T16:32:42.004093Z","description":"","domain_name":"tffunckindbuckzikb0q7x-test-acc-function-pn-02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"462bb3a7-301e-44b9-8f69-207cfb9cb94c","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-02","namespace_id":"0aa68856-5a7c-460e-a304-96399c647807","privacy":"private","private_network_id":"d4a00f5a-5222-43fb-9fd2-7dae459ef2a0","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:32:42.004093Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.795514Z","description":"","environment_variables":{},"error_message":null,"id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","name":"tf-func-nifty-goldberg","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncniftygoldbergp8m2adll","registry_namespace_id":"ac24eb9f-5629-420c-b895-b8737c0e1243","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:19.286578Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "753"
+                - "589"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:50 GMT
+                - Wed, 27 Aug 2025 15:05:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3398,10 +3398,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - de13224a-c287-446f-9ad3-78bf53d5be10
+                - 508ef1a9-7f33-471b-b7f5-96f8ceb35a8e
         status: 200 OK
         code: 200
-        duration: 60.716385ms
+        duration: 52.19987ms
     - id: 69
       request:
         proto: HTTP/1.1
@@ -3418,7 +3418,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/f187ffcd-e01a-4018-9669-38b3c7e3e8ef
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/a00ddf4b-26e3-4342-8794-e4b96bdf9c1f
         method: GET
       response:
         proto: HTTP/2.0
@@ -3426,20 +3426,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 731
+        content_length: 770
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-16T16:32:38.239983Z","description":"","domain_name":"tffunckindbuckzikb0q7x-test-acc-function-pn-f00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"Handle","http_option":"enabled","id":"f187ffcd-e01a-4018-9669-38b3c7e3e8ef","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f00","namespace_id":"0aa68856-5a7c-460e-a304-96399c647807","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:32:47.501611Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:29.568100Z","description":"","domain_name":"tffuncniftygoldbergp8m2adll-test-acc-function-pn-f01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"Handle","http_option":"enabled","id":"a00ddf4b-26e3-4342-8794-e4b96bdf9c1f","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f01","namespace_id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","privacy":"private","private_network_id":"8f30733d-b898-4a49-9ac7-97e32bc94122","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:37.229676Z"}'
         headers:
             Content-Length:
-                - "731"
+                - "770"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:50 GMT
+                - Wed, 27 Aug 2025 15:05:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3447,10 +3447,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fac5d29a-bdc4-42d1-ae81-bb2831966956
+                - 1ce3a933-845e-4afc-9f45-9191b2c980d3
         status: 200 OK
         code: 200
-        duration: 111.725917ms
+        duration: 175.085718ms
     - id: 70
       request:
         proto: HTTP/1.1
@@ -3467,7 +3467,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e81349b1-4ad1-4599-871f-0e3057bf3de7
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/f7365af3-31a3-4fbe-b12b-2c11aa863a3d
         method: GET
       response:
         proto: HTTP/2.0
@@ -3475,20 +3475,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 765
+        content_length: 736
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-16T16:32:38.121175Z","description":"","domain_name":"tffunckindbuckzikb0q7x-test-acc-function-pn-f01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"Handle","http_option":"enabled","id":"e81349b1-4ad1-4599-871f-0e3057bf3de7","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f01","namespace_id":"0aa68856-5a7c-460e-a304-96399c647807","privacy":"private","private_network_id":"c5b3c2f5-3a1b-4241-805e-c9aa9f7a4432","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:32:47.671624Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:29.832556Z","description":"","domain_name":"tffuncniftygoldbergp8m2adll-test-acc-function-pn-f00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"Handle","http_option":"enabled","id":"f7365af3-31a3-4fbe-b12b-2c11aa863a3d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f00","namespace_id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:52.318107Z"}'
         headers:
             Content-Length:
-                - "765"
+                - "736"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:50 GMT
+                - Wed, 27 Aug 2025 15:05:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3496,10 +3496,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bcc7627d-83af-41e4-85c7-dc9e344bd652
+                - 72537b3a-7837-4b8c-ab65-ad644e41d829
         status: 200 OK
         code: 200
-        duration: 114.775425ms
+        duration: 179.754309ms
     - id: 71
       request:
         proto: HTTP/1.1
@@ -3516,28 +3516,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/462bb3a7-301e-44b9-8f69-207cfb9cb94c
-        method: DELETE
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e433448e-b9f7-4034-bf83-c0d867b61e31
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 757
+        content_length: 758
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-16T16:32:42.004093Z","description":"","domain_name":"tffunckindbuckzikb0q7x-test-acc-function-pn-02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"462bb3a7-301e-44b9-8f69-207cfb9cb94c","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-02","namespace_id":"0aa68856-5a7c-460e-a304-96399c647807","privacy":"private","private_network_id":"d4a00f5a-5222-43fb-9fd2-7dae459ef2a0","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:32:50.412790861Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:32.162562Z","description":"","domain_name":"tffuncniftygoldbergp8m2adll-test-acc-function-pn-02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"e433448e-b9f7-4034-bf83-c0d867b61e31","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-02","namespace_id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","privacy":"private","private_network_id":"d2582989-54df-4e6a-b43d-6cc6fc8370e1","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:32.162562Z"}'
         headers:
             Content-Length:
-                - "757"
+                - "758"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:50 GMT
+                - Wed, 27 Aug 2025 15:05:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3545,10 +3545,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0765dffa-052b-4b60-814a-3232567e4183
+                - a1b19252-9f7c-4c82-8c2c-6248b671191c
         status: 200 OK
         code: 200
-        duration: 84.103701ms
+        duration: 180.239038ms
     - id: 72
       request:
         proto: HTTP/1.1
@@ -3565,28 +3565,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/f187ffcd-e01a-4018-9669-38b3c7e3e8ef
-        method: DELETE
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/f7365af3-31a3-4fbe-b12b-2c11aa863a3d
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 725
+        content_length: 736
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-16T16:32:38.239983Z","description":"","domain_name":"tffunckindbuckzikb0q7x-test-acc-function-pn-f00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"f187ffcd-e01a-4018-9669-38b3c7e3e8ef","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f00","namespace_id":"0aa68856-5a7c-460e-a304-96399c647807","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:32:50.470422235Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:29.832556Z","description":"","domain_name":"tffuncniftygoldbergp8m2adll-test-acc-function-pn-f00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"Handle","http_option":"enabled","id":"f7365af3-31a3-4fbe-b12b-2c11aa863a3d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f00","namespace_id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:52.318107Z"}'
         headers:
             Content-Length:
-                - "725"
+                - "736"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:50 GMT
+                - Wed, 27 Aug 2025 15:05:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3594,10 +3594,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a4640955-62b5-403c-aab3-4d7cdf7ce40e
+                - 0bd20509-bd41-4711-8bdb-d385a1605d6d
         status: 200 OK
         code: 200
-        duration: 98.821779ms
+        duration: 43.239707ms
     - id: 73
       request:
         proto: HTTP/1.1
@@ -3614,28 +3614,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e81349b1-4ad1-4599-871f-0e3057bf3de7
-        method: DELETE
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e433448e-b9f7-4034-bf83-c0d867b61e31
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 759
+        content_length: 758
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-06-16T16:32:38.121175Z","description":"","domain_name":"tffunckindbuckzikb0q7x-test-acc-function-pn-f01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"e81349b1-4ad1-4599-871f-0e3057bf3de7","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f01","namespace_id":"0aa68856-5a7c-460e-a304-96399c647807","privacy":"private","private_network_id":"c5b3c2f5-3a1b-4241-805e-c9aa9f7a4432","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2025-06-16T16:32:50.485426036Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:32.162562Z","description":"","domain_name":"tffuncniftygoldbergp8m2adll-test-acc-function-pn-02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"e433448e-b9f7-4034-bf83-c0d867b61e31","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-02","namespace_id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","privacy":"private","private_network_id":"d2582989-54df-4e6a-b43d-6cc6fc8370e1","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:32.162562Z"}'
         headers:
             Content-Length:
-                - "759"
+                - "758"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:50 GMT
+                - Wed, 27 Aug 2025 15:05:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3643,10 +3643,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0f1e0715-23af-4ec6-bbc0-d059f78969bd
+                - 1dfc3010-df8a-44da-8548-2c4ecfb13b54
         status: 200 OK
         code: 200
-        duration: 137.487655ms
+        duration: 43.270084ms
     - id: 74
       request:
         proto: HTTP/1.1
@@ -3663,7 +3663,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/0aa68856-5a7c-460e-a304-96399c647807
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/a00ddf4b-26e3-4342-8794-e4b96bdf9c1f
         method: GET
       response:
         proto: HTTP/2.0
@@ -3671,20 +3671,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 579
+        content_length: 770
         uncompressed: false
-        body: '{"created_at":"2025-06-16T16:32:29.224354Z","description":"","environment_variables":{},"error_message":null,"id":"0aa68856-5a7c-460e-a304-96399c647807","name":"tf-func-kind-buck","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunckindbuckzikb0q7x","registry_namespace_id":"5ce9f5db-16c5-4cca-bd16-b8187a1f2784","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-06-16T16:32:32.884625Z","vpc_integration_activated":true}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:29.568100Z","description":"","domain_name":"tffuncniftygoldbergp8m2adll-test-acc-function-pn-f01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"Handle","http_option":"enabled","id":"a00ddf4b-26e3-4342-8794-e4b96bdf9c1f","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f01","namespace_id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","privacy":"private","private_network_id":"8f30733d-b898-4a49-9ac7-97e32bc94122","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:37.229676Z"}'
         headers:
             Content-Length:
-                - "579"
+                - "770"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:50 GMT
+                - Wed, 27 Aug 2025 15:05:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3692,10 +3692,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 019b7e24-c4ef-4704-bb87-5c5ee5e0faa8
+                - ae3c6752-734f-4c9e-ac5f-7701ed350b46
         status: 200 OK
         code: 200
-        duration: 47.35007ms
+        duration: 65.664215ms
     - id: 75
       request:
         proto: HTTP/1.1
@@ -3712,7 +3712,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/0aa68856-5a7c-460e-a304-96399c647807
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/f7365af3-31a3-4fbe-b12b-2c11aa863a3d
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -3720,20 +3720,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 585
+        content_length: 730
         uncompressed: false
-        body: '{"created_at":"2025-06-16T16:32:29.224354Z","description":"","environment_variables":{},"error_message":null,"id":"0aa68856-5a7c-460e-a304-96399c647807","name":"tf-func-kind-buck","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunckindbuckzikb0q7x","registry_namespace_id":"5ce9f5db-16c5-4cca-bd16-b8187a1f2784","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-06-16T16:32:50.704304065Z","vpc_integration_activated":true}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:29.832556Z","description":"","domain_name":"tffuncniftygoldbergp8m2adll-test-acc-function-pn-f00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"f7365af3-31a3-4fbe-b12b-2c11aa863a3d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f00","namespace_id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:54.257929457Z"}'
         headers:
             Content-Length:
-                - "585"
+                - "730"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:50 GMT
+                - Wed, 27 Aug 2025 15:05:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3741,10 +3741,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7848a2d5-66c3-46d4-a36c-e56edddb9d8b
+                - c2748a08-8a89-4b85-b0c7-4d22c2cdc66c
         status: 200 OK
         code: 200
-        duration: 316.62398ms
+        duration: 261.671422ms
     - id: 76
       request:
         proto: HTTP/1.1
@@ -3761,28 +3761,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/0aa68856-5a7c-460e-a304-96399c647807
-        method: GET
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/a00ddf4b-26e3-4342-8794-e4b96bdf9c1f
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 582
+        content_length: 764
         uncompressed: false
-        body: '{"created_at":"2025-06-16T16:32:29.224354Z","description":"","environment_variables":{},"error_message":null,"id":"0aa68856-5a7c-460e-a304-96399c647807","name":"tf-func-kind-buck","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunckindbuckzikb0q7x","registry_namespace_id":"5ce9f5db-16c5-4cca-bd16-b8187a1f2784","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-06-16T16:32:50.704304Z","vpc_integration_activated":true}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:29.568100Z","description":"","domain_name":"tffuncniftygoldbergp8m2adll-test-acc-function-pn-f01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"a00ddf4b-26e3-4342-8794-e4b96bdf9c1f","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f01","namespace_id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","privacy":"private","private_network_id":"8f30733d-b898-4a49-9ac7-97e32bc94122","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:54.258708804Z"}'
         headers:
             Content-Length:
-                - "582"
+                - "764"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:50 GMT
+                - Wed, 27 Aug 2025 15:05:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3790,10 +3790,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 386d4973-ed88-47e8-aa8f-d73b70e1362e
+                - b5ba8cff-cafa-48a1-b8c5-b5f1c8f5ad74
         status: 200 OK
         code: 200
-        duration: 44.194813ms
+        duration: 243.666677ms
     - id: 77
       request:
         proto: HTTP/1.1
@@ -3810,7 +3810,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/d4a00f5a-5222-43fb-9fd2-7dae459ef2a0
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e433448e-b9f7-4034-bf83-c0d867b61e31
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -3818,18 +3818,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 762
         uncompressed: false
-        body: ""
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:32.162562Z","description":"","domain_name":"tffuncniftygoldbergp8m2adll-test-acc-function-pn-02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"e433448e-b9f7-4034-bf83-c0d867b61e31","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-02","namespace_id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","privacy":"private","private_network_id":"d2582989-54df-4e6a-b43d-6cc6fc8370e1","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:54.239295305Z"}'
         headers:
+            Content-Length:
+                - "762"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:51 GMT
+                - Wed, 27 Aug 2025 15:05:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3837,10 +3839,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6a435b73-1439-494e-b6d3-2fec30d0d4af
-        status: 204 No Content
-        code: 204
-        duration: 1.383833819s
+                - fef64709-949d-4782-ab7c-b54f02e1543c
+        status: 200 OK
+        code: 200
+        duration: 286.916574ms
     - id: 78
       request:
         proto: HTTP/1.1
@@ -3857,26 +3859,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c5b3c2f5-3a1b-4241-805e-c9aa9f7a4432
-        method: DELETE
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/74fb790d-1104-4b78-bce7-39372f9f9ffc
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 589
         uncompressed: false
-        body: ""
+        body: '{"created_at":"2025-08-27T15:05:13.795514Z","description":"","environment_variables":{},"error_message":null,"id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","name":"tf-func-nifty-goldberg","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncniftygoldbergp8m2adll","registry_namespace_id":"ac24eb9f-5629-420c-b895-b8737c0e1243","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:19.286578Z","vpc_integration_activated":true}'
         headers:
+            Content-Length:
+                - "589"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:51 GMT
+                - Wed, 27 Aug 2025 15:05:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3884,10 +3888,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1c24f28f-0ff5-4bc2-9004-8fe7e7688184
-        status: 204 No Content
-        code: 204
-        duration: 1.387494533s
+                - bd18ecbc-2cff-4f2d-ab42-0563100dd01c
+        status: 200 OK
+        code: 200
+        duration: 39.424107ms
     - id: 79
       request:
         proto: HTTP/1.1
@@ -3904,28 +3908,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/0aa68856-5a7c-460e-a304-96399c647807
-        method: GET
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/74fb790d-1104-4b78-bce7-39372f9f9ffc
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 582
+        content_length: 595
         uncompressed: false
-        body: '{"created_at":"2025-06-16T16:32:29.224354Z","description":"","environment_variables":{},"error_message":null,"id":"0aa68856-5a7c-460e-a304-96399c647807","name":"tf-func-kind-buck","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunckindbuckzikb0q7x","registry_namespace_id":"5ce9f5db-16c5-4cca-bd16-b8187a1f2784","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-06-16T16:32:50.704304Z","vpc_integration_activated":true}'
+        body: '{"created_at":"2025-08-27T15:05:13.795514Z","description":"","environment_variables":{},"error_message":null,"id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","name":"tf-func-nifty-goldberg","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncniftygoldbergp8m2adll","registry_namespace_id":"ac24eb9f-5629-420c-b895-b8737c0e1243","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:54.541387210Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "582"
+                - "595"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:32:56 GMT
+                - Wed, 27 Aug 2025 15:05:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3933,10 +3937,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d2d56546-2a06-4926-aef9-6ee9d1462ada
+                - 2791807a-162f-4514-bb62-373894725d64
         status: 200 OK
         code: 200
-        duration: 49.366ms
+        duration: 578.313114ms
     - id: 80
       request:
         proto: HTTP/1.1
@@ -3953,7 +3957,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/0aa68856-5a7c-460e-a304-96399c647807
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/74fb790d-1104-4b78-bce7-39372f9f9ffc
         method: GET
       response:
         proto: HTTP/2.0
@@ -3961,20 +3965,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 582
+        content_length: 592
         uncompressed: false
-        body: '{"created_at":"2025-06-16T16:32:29.224354Z","description":"","environment_variables":{},"error_message":null,"id":"0aa68856-5a7c-460e-a304-96399c647807","name":"tf-func-kind-buck","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunckindbuckzikb0q7x","registry_namespace_id":"5ce9f5db-16c5-4cca-bd16-b8187a1f2784","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-06-16T16:32:50.704304Z","vpc_integration_activated":true}'
+        body: '{"created_at":"2025-08-27T15:05:13.795514Z","description":"","environment_variables":{},"error_message":null,"id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","name":"tf-func-nifty-goldberg","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncniftygoldbergp8m2adll","registry_namespace_id":"ac24eb9f-5629-420c-b895-b8737c0e1243","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:54.541387Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "582"
+                - "592"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:01 GMT
+                - Wed, 27 Aug 2025 15:05:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3982,10 +3986,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0a0ff14b-5bae-4065-81d4-4fb209d77d21
+                - d245831e-5f84-4e38-9ce3-501f9860e54b
         status: 200 OK
         code: 200
-        duration: 45.163099ms
+        duration: 44.897979ms
     - id: 81
       request:
         proto: HTTP/1.1
@@ -4002,28 +4006,26 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/0aa68856-5a7c-460e-a304-96399c647807
-        method: GET
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/8f30733d-b898-4a49-9ac7-97e32bc94122
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 582
+        content_length: 0
         uncompressed: false
-        body: '{"created_at":"2025-06-16T16:32:29.224354Z","description":"","environment_variables":{},"error_message":null,"id":"0aa68856-5a7c-460e-a304-96399c647807","name":"tf-func-kind-buck","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunckindbuckzikb0q7x","registry_namespace_id":"5ce9f5db-16c5-4cca-bd16-b8187a1f2784","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-06-16T16:32:50.704304Z","vpc_integration_activated":true}'
+        body: ""
         headers:
-            Content-Length:
-                - "582"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:06 GMT
+                - Wed, 27 Aug 2025 15:05:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4031,10 +4033,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4413a55e-6030-4eb8-86e6-dcf0a062cea1
-        status: 200 OK
-        code: 200
-        duration: 41.60648ms
+                - d0743984-796c-4578-820c-7800231788f3
+        status: 204 No Content
+        code: 204
+        duration: 1.83281214s
     - id: 82
       request:
         proto: HTTP/1.1
@@ -4051,28 +4053,26 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/0aa68856-5a7c-460e-a304-96399c647807
-        method: GET
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/d2582989-54df-4e6a-b43d-6cc6fc8370e1
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 582
+        content_length: 0
         uncompressed: false
-        body: '{"created_at":"2025-06-16T16:32:29.224354Z","description":"","environment_variables":{},"error_message":null,"id":"0aa68856-5a7c-460e-a304-96399c647807","name":"tf-func-kind-buck","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunckindbuckzikb0q7x","registry_namespace_id":"5ce9f5db-16c5-4cca-bd16-b8187a1f2784","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-06-16T16:32:50.704304Z","vpc_integration_activated":true}'
+        body: ""
         headers:
-            Content-Length:
-                - "582"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:11 GMT
+                - Wed, 27 Aug 2025 15:05:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4080,10 +4080,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e85ba935-492e-4f5c-97bb-36327a05bebc
-        status: 200 OK
-        code: 200
-        duration: 47.221699ms
+                - b5d98f45-9b9a-4145-b02d-b1a88705cf1b
+        status: 204 No Content
+        code: 204
+        duration: 2.123904461s
     - id: 83
       request:
         proto: HTTP/1.1
@@ -4100,7 +4100,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/0aa68856-5a7c-460e-a304-96399c647807
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/74fb790d-1104-4b78-bce7-39372f9f9ffc
         method: GET
       response:
         proto: HTTP/2.0
@@ -4108,20 +4108,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 582
+        content_length: 592
         uncompressed: false
-        body: '{"created_at":"2025-06-16T16:32:29.224354Z","description":"","environment_variables":{},"error_message":null,"id":"0aa68856-5a7c-460e-a304-96399c647807","name":"tf-func-kind-buck","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunckindbuckzikb0q7x","registry_namespace_id":"5ce9f5db-16c5-4cca-bd16-b8187a1f2784","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-06-16T16:32:50.704304Z","vpc_integration_activated":true}'
+        body: '{"created_at":"2025-08-27T15:05:13.795514Z","description":"","environment_variables":{},"error_message":null,"id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","name":"tf-func-nifty-goldberg","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncniftygoldbergp8m2adll","registry_namespace_id":"ac24eb9f-5629-420c-b895-b8737c0e1243","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:54.541387Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "582"
+                - "592"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:16 GMT
+                - Wed, 27 Aug 2025 15:06:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4129,10 +4129,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6f21a9ef-922e-4fa0-8dc1-77303babd679
+                - bce7c0db-f456-4c9c-8cc9-ea5baec7253a
         status: 200 OK
         code: 200
-        duration: 40.179924ms
+        duration: 44.514249ms
     - id: 84
       request:
         proto: HTTP/1.1
@@ -4149,7 +4149,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/0aa68856-5a7c-460e-a304-96399c647807
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/74fb790d-1104-4b78-bce7-39372f9f9ffc
         method: GET
       response:
         proto: HTTP/2.0
@@ -4157,20 +4157,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 37
+        content_length: 592
         uncompressed: false
-        body: '{"message":"Namespace was not found"}'
+        body: '{"created_at":"2025-08-27T15:05:13.795514Z","description":"","environment_variables":{},"error_message":null,"id":"74fb790d-1104-4b78-bce7-39372f9f9ffc","name":"tf-func-nifty-goldberg","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncniftygoldbergp8m2adll","registry_namespace_id":"ac24eb9f-5629-420c-b895-b8737c0e1243","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:54.541387Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "37"
+                - "592"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:21 GMT
+                - Wed, 27 Aug 2025 15:06:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4178,10 +4178,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bdfff8da-4c31-4484-9ec5-3671bd75639f
-        status: 404 Not Found
-        code: 404
-        duration: 21.348ms
+                - 7eb3ea44-c7c0-4236-bd99-1c573df126dc
+        status: 200 OK
+        code: 200
+        duration: 99.279215ms
     - id: 85
       request:
         proto: HTTP/1.1
@@ -4198,7 +4198,56 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/0aa68856-5a7c-460e-a304-96399c647807
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/74fb790d-1104-4b78-bce7-39372f9f9ffc
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 37
+        uncompressed: false
+        body: '{"message":"Namespace was not found"}'
+        headers:
+            Content-Length:
+                - "37"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:10 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e8364862-55bf-4c28-a8f3-97cbe1fae3da
+        status: 404 Not Found
+        code: 404
+        duration: 19.833417ms
+    - id: 86
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/74fb790d-1104-4b78-bce7-39372f9f9ffc
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -4217,9 +4266,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:21 GMT
+                - Wed, 27 Aug 2025 15:06:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4227,59 +4276,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d238295f-9a5d-4ff6-9c23-9d7b348248e6
+                - 051eb9d7-4063-42eb-9775-8de66e6e3768
         status: 404 Not Found
         code: 404
-        duration: 23.076522ms
-    - id: 86
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/f187ffcd-e01a-4018-9669-38b3c7e3e8ef
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 36
-        uncompressed: false
-        body: '{"message":"Function was not found"}'
-        headers:
-            Content-Length:
-                - "36"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 16 Jun 2025 16:33:21 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 8c676177-a761-4bac-abd2-03fd06c37469
-        status: 404 Not Found
-        code: 404
-        duration: 76.916771ms
+        duration: 23.06404ms
     - id: 87
       request:
         proto: HTTP/1.1
@@ -4296,7 +4296,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e81349b1-4ad1-4599-871f-0e3057bf3de7
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/a00ddf4b-26e3-4342-8794-e4b96bdf9c1f
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -4315,9 +4315,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:21 GMT
+                - Wed, 27 Aug 2025 15:06:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4325,10 +4325,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a86e8221-30bb-49dc-8c24-6db4c2ea9189
+                - 97b32fc2-941d-4d56-943e-416688e8bab7
         status: 404 Not Found
         code: 404
-        duration: 25.442909ms
+        duration: 23.230753ms
     - id: 88
       request:
         proto: HTTP/1.1
@@ -4345,7 +4345,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/462bb3a7-301e-44b9-8f69-207cfb9cb94c
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e433448e-b9f7-4034-bf83-c0d867b61e31
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -4364,9 +4364,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:21 GMT
+                - Wed, 27 Aug 2025 15:06:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4374,10 +4374,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a8798b2f-ef94-477c-8950-bf4c32d5cc2a
+                - f1f690b7-a895-4df2-b0af-9f2baf332645
         status: 404 Not Found
         code: 404
-        duration: 72.868589ms
+        duration: 22.245223ms
     - id: 89
       request:
         proto: HTTP/1.1
@@ -4394,28 +4394,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/d4a00f5a-5222-43fb-9fd2-7dae459ef2a0
-        method: GET
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/f7365af3-31a3-4fbe-b12b-2c11aa863a3d
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 136
+        content_length: 36
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"private_network","resource_id":"d4a00f5a-5222-43fb-9fd2-7dae459ef2a0","type":"not_found"}'
+        body: '{"message":"Function was not found"}'
         headers:
             Content-Length:
-                - "136"
+                - "36"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:21 GMT
+                - Wed, 27 Aug 2025 15:06:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4423,10 +4423,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 07eefb97-a13b-41a7-a24c-e27716984ddd
+                - 90d9857b-dc16-456f-846e-8d2aba7de6ff
         status: 404 Not Found
         code: 404
-        duration: 18.99034ms
+        duration: 26.247574ms
     - id: 90
       request:
         proto: HTTP/1.1
@@ -4443,7 +4443,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c5b3c2f5-3a1b-4241-805e-c9aa9f7a4432
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/d2582989-54df-4e6a-b43d-6cc6fc8370e1
         method: GET
       response:
         proto: HTTP/2.0
@@ -4453,7 +4453,7 @@ interactions:
         trailer: {}
         content_length: 136
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"private_network","resource_id":"c5b3c2f5-3a1b-4241-805e-c9aa9f7a4432","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"private_network","resource_id":"d2582989-54df-4e6a-b43d-6cc6fc8370e1","type":"not_found"}'
         headers:
             Content-Length:
                 - "136"
@@ -4462,9 +4462,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 16 Jun 2025 16:33:21 GMT
+                - Wed, 27 Aug 2025 15:06:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4472,7 +4472,56 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fe1b562b-63e1-4c80-8bad-9bcdd28ee218
+                - c1e3870c-e713-45b5-b451-7dc284b1e951
         status: 404 Not Found
         code: 404
-        duration: 66.347381ms
+        duration: 24.422188ms
+    - id: 91
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/8f30733d-b898-4a49-9ac7-97e32bc94122
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 136
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"private_network","resource_id":"8f30733d-b898-4a49-9ac7-97e32bc94122","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "136"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:10 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 25d7e332-9b1c-4df3-846c-b5eb2c96548c
+        status: 404 Not Found
+        code: 404
+        duration: 16.486257ms

--- a/internal/services/function/testdata/function-sandbox.cassette.yaml
+++ b/internal/services/function/testdata/function-sandbox.cassette.yaml
@@ -6,19 +6,19 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 159
+        content_length: 191
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-func-gallant-greider","environment_variables":{},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","secret_environment_variables":[],"tags":null}'
+        body: '{"name":"tf-func-gallant-dewdney","environment_variables":{},"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","secret_environment_variables":[],"tags":null,"activate_vpc_integration":true}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces
         method: POST
       response:
@@ -27,20 +27,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 475
+        content_length: 508
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:39.703167986Z","description":"","environment_variables":{},"error_message":null,"id":"eb76e881-c5b1-43b3-b1fe-f97f315d8b39","name":"tf-func-gallant-greider","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:44:39.703167986Z"}'
+        body: '{"created_at":"2025-08-27T15:05:29.106914736Z","description":"","environment_variables":{},"error_message":null,"id":"e20e7cde-edd8-4038-8c85-6031974a3346","name":"tf-func-gallant-dewdney","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:29.106914736Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "475"
+                - "508"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:39 GMT
+                - Wed, 27 Aug 2025 15:05:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0dee3565-ce0b-46eb-a45b-c36273e8b578
+                - c4e99296-b82f-49e7-a1f3-56bc1a66169d
         status: 200 OK
         code: 200
-        duration: 558.645667ms
+        duration: 3.100870182s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -67,8 +67,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/eb76e881-c5b1-43b3-b1fe-f97f315d8b39
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e20e7cde-edd8-4038-8c85-6031974a3346
         method: GET
       response:
         proto: HTTP/2.0
@@ -76,20 +76,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 469
+        content_length: 502
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:39.703168Z","description":"","environment_variables":{},"error_message":null,"id":"eb76e881-c5b1-43b3-b1fe-f97f315d8b39","name":"tf-func-gallant-greider","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:44:39.703168Z"}'
+        body: '{"created_at":"2025-08-27T15:05:29.106915Z","description":"","environment_variables":{},"error_message":null,"id":"e20e7cde-edd8-4038-8c85-6031974a3346","name":"tf-func-gallant-dewdney","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:29.106915Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "469"
+                - "502"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:40 GMT
+                - Wed, 27 Aug 2025 15:05:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8087e326-75d6-4b2e-be9f-db05de81d2b5
+                - 12b51971-0354-4d89-a333-eca32b47ad3f
         status: 200 OK
         code: 200
-        duration: 74.367834ms
+        duration: 51.059236ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -116,8 +116,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/eb76e881-c5b1-43b3-b1fe-f97f315d8b39
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e20e7cde-edd8-4038-8c85-6031974a3346
         method: GET
       response:
         proto: HTTP/2.0
@@ -125,20 +125,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 558
+        content_length: 591
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:39.703168Z","description":"","environment_variables":{},"error_message":null,"id":"eb76e881-c5b1-43b3-b1fe-f97f315d8b39","name":"tf-func-gallant-greider","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncgallantgreidereooqd604","registry_namespace_id":"afbcaee1-7a8c-46ff-8640-6032e4bb4491","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:44:42.698918Z"}'
+        body: '{"created_at":"2025-08-27T15:05:29.106915Z","description":"","environment_variables":{},"error_message":null,"id":"e20e7cde-edd8-4038-8c85-6031974a3346","name":"tf-func-gallant-dewdney","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncgallantdewdneycwkipree","registry_namespace_id":"4949f4b6-e60a-4c60-b7bd-521b69d1681f","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:32.181293Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "558"
+                - "591"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:45 GMT
+                - Wed, 27 Aug 2025 15:05:34 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -146,10 +146,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - def4a8e5-9437-4e25-ac14-c237dee72a90
+                - d8fa6d2e-3493-413e-8dfe-c6f6bfb1871c
         status: 200 OK
         code: 200
-        duration: 62.437542ms
+        duration: 52.432082ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -165,8 +165,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/eb76e881-c5b1-43b3-b1fe-f97f315d8b39
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e20e7cde-edd8-4038-8c85-6031974a3346
         method: GET
       response:
         proto: HTTP/2.0
@@ -174,20 +174,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 558
+        content_length: 591
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:39.703168Z","description":"","environment_variables":{},"error_message":null,"id":"eb76e881-c5b1-43b3-b1fe-f97f315d8b39","name":"tf-func-gallant-greider","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncgallantgreidereooqd604","registry_namespace_id":"afbcaee1-7a8c-46ff-8640-6032e4bb4491","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:44:42.698918Z"}'
+        body: '{"created_at":"2025-08-27T15:05:29.106915Z","description":"","environment_variables":{},"error_message":null,"id":"e20e7cde-edd8-4038-8c85-6031974a3346","name":"tf-func-gallant-dewdney","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncgallantdewdneycwkipree","registry_namespace_id":"4949f4b6-e60a-4c60-b7bd-521b69d1681f","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:32.181293Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "558"
+                - "591"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:45 GMT
+                - Wed, 27 Aug 2025 15:05:34 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -195,28 +195,28 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - eaa7bf34-d578-42ee-bb7e-1d1d100bc51d
+                - 4f9e86c5-d6e1-47f9-a1fb-e7a659dadda2
         status: 200 OK
         code: 200
-        duration: 65.249042ms
+        duration: 51.060749ms
     - id: 4
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 298
+        content_length: 310
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"foobar","namespace_id":"eb76e881-c5b1-43b3-b1fe-f97f315d8b39","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"node22","memory_limit":256,"handler":"handler.handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox"}'
+        body: '{"name":"foobar","namespace_id":"e20e7cde-edd8-4038-8c85-6031974a3346","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"node22","memory_limit":256,"handler":"handler.handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox","tags":null}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions
         method: POST
       response:
@@ -225,20 +225,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 670
+        content_length: 706
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:45.430155299Z","description":"","domain_name":"tffuncgallantgreidereooqd604-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"9013c4b2-a4bb-4b70-a7f0-d2850206369c","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"eb76e881-c5b1-43b3-b1fe-f97f315d8b39","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:45.430155299Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:34.793825360Z","description":"","domain_name":"tffuncgallantdewdneycwkipree-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"cf90e081-5268-4ba9-88fb-48173a71b144","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"e20e7cde-edd8-4038-8c85-6031974a3346","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:34.793825360Z"}'
         headers:
             Content-Length:
-                - "670"
+                - "706"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:45 GMT
+                - Wed, 27 Aug 2025 15:05:34 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -246,10 +246,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ab31cc76-d0a0-45a2-92be-3f5f77a0b124
+                - 431cefbb-2825-4340-896d-c301f7397f60
         status: 200 OK
         code: 200
-        duration: 250.897416ms
+        duration: 460.842366ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -265,8 +265,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/9013c4b2-a4bb-4b70-a7f0-d2850206369c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/cf90e081-5268-4ba9-88fb-48173a71b144
         method: GET
       response:
         proto: HTTP/2.0
@@ -274,20 +274,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 664
+        content_length: 700
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:45.430155Z","description":"","domain_name":"tffuncgallantgreidereooqd604-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"9013c4b2-a4bb-4b70-a7f0-d2850206369c","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"eb76e881-c5b1-43b3-b1fe-f97f315d8b39","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:45.430155Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:34.793825Z","description":"","domain_name":"tffuncgallantdewdneycwkipree-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"cf90e081-5268-4ba9-88fb-48173a71b144","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"e20e7cde-edd8-4038-8c85-6031974a3346","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:34.793825Z"}'
         headers:
             Content-Length:
-                - "664"
+                - "700"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:45 GMT
+                - Wed, 27 Aug 2025 15:05:34 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -295,10 +295,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0d76af6f-d6d1-4a18-9f7b-e6a21e5982ca
+                - e1f046dd-3077-4a42-a498-d99276be0424
         status: 200 OK
         code: 200
-        duration: 80.478459ms
+        duration: 40.061992ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -314,8 +314,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/9013c4b2-a4bb-4b70-a7f0-d2850206369c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/cf90e081-5268-4ba9-88fb-48173a71b144
         method: GET
       response:
         proto: HTTP/2.0
@@ -323,20 +323,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 664
+        content_length: 700
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:45.430155Z","description":"","domain_name":"tffuncgallantgreidereooqd604-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"9013c4b2-a4bb-4b70-a7f0-d2850206369c","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"eb76e881-c5b1-43b3-b1fe-f97f315d8b39","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:45.430155Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:34.793825Z","description":"","domain_name":"tffuncgallantdewdneycwkipree-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"cf90e081-5268-4ba9-88fb-48173a71b144","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"e20e7cde-edd8-4038-8c85-6031974a3346","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:34.793825Z"}'
         headers:
             Content-Length:
-                - "664"
+                - "700"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:45 GMT
+                - Wed, 27 Aug 2025 15:05:34 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -344,10 +344,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9285e947-4575-485d-813f-85a7ecc674ff
+                - b442905a-0242-4c7f-a66f-a5fb8faa22cf
         status: 200 OK
         code: 200
-        duration: 69.470667ms
+        duration: 44.220204ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -363,8 +363,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/9013c4b2-a4bb-4b70-a7f0-d2850206369c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/cf90e081-5268-4ba9-88fb-48173a71b144
         method: GET
       response:
         proto: HTTP/2.0
@@ -372,20 +372,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 664
+        content_length: 700
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:45.430155Z","description":"","domain_name":"tffuncgallantgreidereooqd604-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"9013c4b2-a4bb-4b70-a7f0-d2850206369c","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"eb76e881-c5b1-43b3-b1fe-f97f315d8b39","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:45.430155Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:34.793825Z","description":"","domain_name":"tffuncgallantdewdneycwkipree-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"cf90e081-5268-4ba9-88fb-48173a71b144","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"e20e7cde-edd8-4038-8c85-6031974a3346","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:34.793825Z"}'
         headers:
             Content-Length:
-                - "664"
+                - "700"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:45 GMT
+                - Wed, 27 Aug 2025 15:05:35 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -393,10 +393,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2b1c53a7-2e3d-462a-b54a-17858db4acbf
+                - ed22abab-25a2-4526-b4f6-d91f87e40853
         status: 200 OK
         code: 200
-        duration: 91.27175ms
+        duration: 57.777042ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -412,8 +412,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/eb76e881-c5b1-43b3-b1fe-f97f315d8b39
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e20e7cde-edd8-4038-8c85-6031974a3346
         method: GET
       response:
         proto: HTTP/2.0
@@ -421,20 +421,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 558
+        content_length: 591
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:39.703168Z","description":"","environment_variables":{},"error_message":null,"id":"eb76e881-c5b1-43b3-b1fe-f97f315d8b39","name":"tf-func-gallant-greider","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncgallantgreidereooqd604","registry_namespace_id":"afbcaee1-7a8c-46ff-8640-6032e4bb4491","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:44:42.698918Z"}'
+        body: '{"created_at":"2025-08-27T15:05:29.106915Z","description":"","environment_variables":{},"error_message":null,"id":"e20e7cde-edd8-4038-8c85-6031974a3346","name":"tf-func-gallant-dewdney","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncgallantdewdneycwkipree","registry_namespace_id":"4949f4b6-e60a-4c60-b7bd-521b69d1681f","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:32.181293Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "558"
+                - "591"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:46 GMT
+                - Wed, 27 Aug 2025 15:05:35 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -442,10 +442,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 323faedc-abdf-428c-9d96-c20ee33c1b31
+                - fab4e34e-de6e-441c-918c-a43e2a03a797
         status: 200 OK
         code: 200
-        duration: 78.598875ms
+        duration: 56.921728ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -461,8 +461,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/9013c4b2-a4bb-4b70-a7f0-d2850206369c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/cf90e081-5268-4ba9-88fb-48173a71b144
         method: GET
       response:
         proto: HTTP/2.0
@@ -470,20 +470,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 664
+        content_length: 700
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:45.430155Z","description":"","domain_name":"tffuncgallantgreidereooqd604-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"9013c4b2-a4bb-4b70-a7f0-d2850206369c","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"eb76e881-c5b1-43b3-b1fe-f97f315d8b39","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:45.430155Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:34.793825Z","description":"","domain_name":"tffuncgallantdewdneycwkipree-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"cf90e081-5268-4ba9-88fb-48173a71b144","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"e20e7cde-edd8-4038-8c85-6031974a3346","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:34.793825Z"}'
         headers:
             Content-Length:
-                - "664"
+                - "700"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:46 GMT
+                - Wed, 27 Aug 2025 15:05:35 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -491,10 +491,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 269bae43-6903-4da9-9d7f-fe4da22121cb
+                - a160c5ae-b926-41f9-9d11-433815fc3ae9
         status: 200 OK
         code: 200
-        duration: 88.721334ms
+        duration: 46.468824ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -510,8 +510,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/eb76e881-c5b1-43b3-b1fe-f97f315d8b39
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e20e7cde-edd8-4038-8c85-6031974a3346
         method: GET
       response:
         proto: HTTP/2.0
@@ -519,20 +519,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 558
+        content_length: 591
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:39.703168Z","description":"","environment_variables":{},"error_message":null,"id":"eb76e881-c5b1-43b3-b1fe-f97f315d8b39","name":"tf-func-gallant-greider","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncgallantgreidereooqd604","registry_namespace_id":"afbcaee1-7a8c-46ff-8640-6032e4bb4491","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:44:42.698918Z"}'
+        body: '{"created_at":"2025-08-27T15:05:29.106915Z","description":"","environment_variables":{},"error_message":null,"id":"e20e7cde-edd8-4038-8c85-6031974a3346","name":"tf-func-gallant-dewdney","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncgallantdewdneycwkipree","registry_namespace_id":"4949f4b6-e60a-4c60-b7bd-521b69d1681f","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:32.181293Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "558"
+                - "591"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:47 GMT
+                - Wed, 27 Aug 2025 15:05:36 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -540,10 +540,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 711c59f5-7d9b-4308-9735-305df850cae2
+                - fd4762fc-c7b7-46f6-9b91-14c2aff1028e
         status: 200 OK
         code: 200
-        duration: 75.9225ms
+        duration: 149.598104ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -559,8 +559,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/9013c4b2-a4bb-4b70-a7f0-d2850206369c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/cf90e081-5268-4ba9-88fb-48173a71b144
         method: GET
       response:
         proto: HTTP/2.0
@@ -568,20 +568,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 664
+        content_length: 700
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:45.430155Z","description":"","domain_name":"tffuncgallantgreidereooqd604-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"9013c4b2-a4bb-4b70-a7f0-d2850206369c","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"eb76e881-c5b1-43b3-b1fe-f97f315d8b39","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:45.430155Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:34.793825Z","description":"","domain_name":"tffuncgallantdewdneycwkipree-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"cf90e081-5268-4ba9-88fb-48173a71b144","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"e20e7cde-edd8-4038-8c85-6031974a3346","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:34.793825Z"}'
         headers:
             Content-Length:
-                - "664"
+                - "700"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:47 GMT
+                - Wed, 27 Aug 2025 15:05:36 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -589,10 +589,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 83cd2a97-067a-4763-939d-d5ecdd3cbdbd
+                - c8612002-4f0d-4df7-a581-79d9953038c2
         status: 200 OK
         code: 200
-        duration: 74.397917ms
+        duration: 88.888149ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -608,8 +608,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/9013c4b2-a4bb-4b70-a7f0-d2850206369c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/cf90e081-5268-4ba9-88fb-48173a71b144
         method: GET
       response:
         proto: HTTP/2.0
@@ -617,20 +617,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 664
+        content_length: 700
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:45.430155Z","description":"","domain_name":"tffuncgallantgreidereooqd604-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"9013c4b2-a4bb-4b70-a7f0-d2850206369c","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"eb76e881-c5b1-43b3-b1fe-f97f315d8b39","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:45.430155Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:34.793825Z","description":"","domain_name":"tffuncgallantdewdneycwkipree-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"cf90e081-5268-4ba9-88fb-48173a71b144","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"e20e7cde-edd8-4038-8c85-6031974a3346","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:34.793825Z"}'
         headers:
             Content-Length:
-                - "664"
+                - "700"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:48 GMT
+                - Wed, 27 Aug 2025 15:05:36 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -638,10 +638,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d918a9b7-4e35-40c6-b537-b2938a41a1e6
+                - a3ff8717-766c-47ad-836b-408dd68548ef
         status: 200 OK
         code: 200
-        duration: 263.812459ms
+        duration: 120.428741ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -657,8 +657,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/eb76e881-c5b1-43b3-b1fe-f97f315d8b39
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e20e7cde-edd8-4038-8c85-6031974a3346
         method: GET
       response:
         proto: HTTP/2.0
@@ -666,20 +666,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 558
+        content_length: 591
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:39.703168Z","description":"","environment_variables":{},"error_message":null,"id":"eb76e881-c5b1-43b3-b1fe-f97f315d8b39","name":"tf-func-gallant-greider","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncgallantgreidereooqd604","registry_namespace_id":"afbcaee1-7a8c-46ff-8640-6032e4bb4491","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:44:42.698918Z"}'
+        body: '{"created_at":"2025-08-27T15:05:29.106915Z","description":"","environment_variables":{},"error_message":null,"id":"e20e7cde-edd8-4038-8c85-6031974a3346","name":"tf-func-gallant-dewdney","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncgallantdewdneycwkipree","registry_namespace_id":"4949f4b6-e60a-4c60-b7bd-521b69d1681f","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:32.181293Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "558"
+                - "591"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:49 GMT
+                - Wed, 27 Aug 2025 15:05:37 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -687,10 +687,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b7137b78-afe7-4e29-962f-57b8ef6cdf1c
+                - 931cd736-b703-4d29-bb04-c9f911e68a91
         status: 200 OK
         code: 200
-        duration: 75.697208ms
+        duration: 41.366901ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -706,8 +706,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/9013c4b2-a4bb-4b70-a7f0-d2850206369c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/cf90e081-5268-4ba9-88fb-48173a71b144
         method: GET
       response:
         proto: HTTP/2.0
@@ -715,20 +715,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 664
+        content_length: 700
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:45.430155Z","description":"","domain_name":"tffuncgallantgreidereooqd604-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"9013c4b2-a4bb-4b70-a7f0-d2850206369c","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"eb76e881-c5b1-43b3-b1fe-f97f315d8b39","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:45.430155Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:34.793825Z","description":"","domain_name":"tffuncgallantdewdneycwkipree-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"cf90e081-5268-4ba9-88fb-48173a71b144","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"e20e7cde-edd8-4038-8c85-6031974a3346","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:34.793825Z"}'
         headers:
             Content-Length:
-                - "664"
+                - "700"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:49 GMT
+                - Wed, 27 Aug 2025 15:05:37 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -736,10 +736,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c63f8468-ceeb-4805-855b-349e00b534b7
+                - 7b6a4998-078f-4cd6-a474-2d711d91886e
         status: 200 OK
         code: 200
-        duration: 74.197791ms
+        duration: 52.772722ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -755,8 +755,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/eb76e881-c5b1-43b3-b1fe-f97f315d8b39
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e20e7cde-edd8-4038-8c85-6031974a3346
         method: GET
       response:
         proto: HTTP/2.0
@@ -764,20 +764,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 558
+        content_length: 591
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:39.703168Z","description":"","environment_variables":{},"error_message":null,"id":"eb76e881-c5b1-43b3-b1fe-f97f315d8b39","name":"tf-func-gallant-greider","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncgallantgreidereooqd604","registry_namespace_id":"afbcaee1-7a8c-46ff-8640-6032e4bb4491","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:44:42.698918Z"}'
+        body: '{"created_at":"2025-08-27T15:05:29.106915Z","description":"","environment_variables":{},"error_message":null,"id":"e20e7cde-edd8-4038-8c85-6031974a3346","name":"tf-func-gallant-dewdney","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncgallantdewdneycwkipree","registry_namespace_id":"4949f4b6-e60a-4c60-b7bd-521b69d1681f","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:32.181293Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "558"
+                - "591"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:50 GMT
+                - Wed, 27 Aug 2025 15:05:37 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -785,10 +785,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 38389264-4078-4854-a0f4-f2aec612379d
+                - be1e227d-b8a6-489b-ac8d-6304461c892b
         status: 200 OK
         code: 200
-        duration: 67.256833ms
+        duration: 61.524574ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -804,8 +804,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/9013c4b2-a4bb-4b70-a7f0-d2850206369c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/cf90e081-5268-4ba9-88fb-48173a71b144
         method: GET
       response:
         proto: HTTP/2.0
@@ -813,20 +813,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 664
+        content_length: 700
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:45.430155Z","description":"","domain_name":"tffuncgallantgreidereooqd604-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"9013c4b2-a4bb-4b70-a7f0-d2850206369c","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"eb76e881-c5b1-43b3-b1fe-f97f315d8b39","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:45.430155Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:34.793825Z","description":"","domain_name":"tffuncgallantdewdneycwkipree-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"cf90e081-5268-4ba9-88fb-48173a71b144","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"e20e7cde-edd8-4038-8c85-6031974a3346","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:34.793825Z"}'
         headers:
             Content-Length:
-                - "664"
+                - "700"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:50 GMT
+                - Wed, 27 Aug 2025 15:05:37 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -834,10 +834,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8d1c9c45-c23d-4311-9017-56dd44a153b3
+                - e70299f4-d219-48df-8840-5bac7b51e3d1
         status: 200 OK
         code: 200
-        duration: 80.603625ms
+        duration: 50.9117ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -853,8 +853,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/9013c4b2-a4bb-4b70-a7f0-d2850206369c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/cf90e081-5268-4ba9-88fb-48173a71b144
         method: GET
       response:
         proto: HTTP/2.0
@@ -862,20 +862,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 664
+        content_length: 700
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:45.430155Z","description":"","domain_name":"tffuncgallantgreidereooqd604-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"9013c4b2-a4bb-4b70-a7f0-d2850206369c","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"eb76e881-c5b1-43b3-b1fe-f97f315d8b39","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:45.430155Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:34.793825Z","description":"","domain_name":"tffuncgallantdewdneycwkipree-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"cf90e081-5268-4ba9-88fb-48173a71b144","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"e20e7cde-edd8-4038-8c85-6031974a3346","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:34.793825Z"}'
         headers:
             Content-Length:
-                - "664"
+                - "700"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:51 GMT
+                - Wed, 27 Aug 2025 15:05:38 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -883,10 +883,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6362d93f-b380-4dfb-ac96-ab1841897935
+                - 1b4c6d75-387d-4aa4-a193-31ca29ee1343
         status: 200 OK
         code: 200
-        duration: 83.173875ms
+        duration: 140.260104ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -904,8 +904,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/9013c4b2-a4bb-4b70-a7f0-d2850206369c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/cf90e081-5268-4ba9-88fb-48173a71b144
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -913,20 +913,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 667
+        content_length: 703
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:45.430155Z","description":"","domain_name":"tffuncgallantgreidereooqd604-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"9013c4b2-a4bb-4b70-a7f0-d2850206369c","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"eb76e881-c5b1-43b3-b1fe-f97f315d8b39","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s","updated_at":"2025-01-24T15:44:51.099826106Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:34.793825Z","description":"","domain_name":"tffuncgallantdewdneycwkipree-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"cf90e081-5268-4ba9-88fb-48173a71b144","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"e20e7cde-edd8-4038-8c85-6031974a3346","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:38.168359456Z"}'
         headers:
             Content-Length:
-                - "667"
+                - "703"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:51 GMT
+                - Wed, 27 Aug 2025 15:05:38 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -934,10 +934,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 60ca4b5b-6122-4797-8238-b8d73bd35b36
+                - fa2015a1-6fa8-45dc-9020-ce1bea5e0e75
         status: 200 OK
         code: 200
-        duration: 102.208ms
+        duration: 86.771728ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -953,8 +953,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/9013c4b2-a4bb-4b70-a7f0-d2850206369c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/cf90e081-5268-4ba9-88fb-48173a71b144
         method: GET
       response:
         proto: HTTP/2.0
@@ -962,20 +962,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 664
+        content_length: 700
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:45.430155Z","description":"","domain_name":"tffuncgallantgreidereooqd604-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"9013c4b2-a4bb-4b70-a7f0-d2850206369c","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"eb76e881-c5b1-43b3-b1fe-f97f315d8b39","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s","updated_at":"2025-01-24T15:44:51.099826Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:34.793825Z","description":"","domain_name":"tffuncgallantdewdneycwkipree-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"cf90e081-5268-4ba9-88fb-48173a71b144","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"e20e7cde-edd8-4038-8c85-6031974a3346","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:38.168359Z"}'
         headers:
             Content-Length:
-                - "664"
+                - "700"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:52 GMT
+                - Wed, 27 Aug 2025 15:05:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -983,10 +983,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a80c63aa-03f7-4a70-b187-247aa8e2347f
+                - 11289339-108b-446a-bd39-52267982c490
         status: 200 OK
         code: 200
-        duration: 74.452916ms
+        duration: 59.967032ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1002,8 +1002,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/9013c4b2-a4bb-4b70-a7f0-d2850206369c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/cf90e081-5268-4ba9-88fb-48173a71b144
         method: GET
       response:
         proto: HTTP/2.0
@@ -1011,20 +1011,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 664
+        content_length: 700
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:45.430155Z","description":"","domain_name":"tffuncgallantgreidereooqd604-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"9013c4b2-a4bb-4b70-a7f0-d2850206369c","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"eb76e881-c5b1-43b3-b1fe-f97f315d8b39","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","timeout":"300s","updated_at":"2025-01-24T15:44:51.099826Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:34.793825Z","description":"","domain_name":"tffuncgallantdewdneycwkipree-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"cf90e081-5268-4ba9-88fb-48173a71b144","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"e20e7cde-edd8-4038-8c85-6031974a3346","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:38.168359Z"}'
         headers:
             Content-Length:
-                - "664"
+                - "700"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:57 GMT
+                - Wed, 27 Aug 2025 15:05:44 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1032,10 +1032,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b1eb93b1-fb3b-4b61-8fe0-6ba78a56b424
+                - 0c7eb3ca-36a2-487b-bd4e-c56e6035a806
         status: 200 OK
         code: 200
-        duration: 73.800875ms
+        duration: 61.797658ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1051,8 +1051,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/9013c4b2-a4bb-4b70-a7f0-d2850206369c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/cf90e081-5268-4ba9-88fb-48173a71b144
         method: GET
       response:
         proto: HTTP/2.0
@@ -1060,20 +1060,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 674
+        content_length: 710
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:45.430155Z","description":"","domain_name":"tffuncgallantgreidereooqd604-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"9013c4b2-a4bb-4b70-a7f0-d2850206369c","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"eb76e881-c5b1-43b3-b1fe-f97f315d8b39","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-24T15:45:00.982197Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:34.793825Z","description":"","domain_name":"tffuncgallantdewdneycwkipree-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"cf90e081-5268-4ba9-88fb-48173a71b144","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"e20e7cde-edd8-4038-8c85-6031974a3346","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:46.455939Z"}'
         headers:
             Content-Length:
-                - "674"
+                - "710"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:02 GMT
+                - Wed, 27 Aug 2025 15:05:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1081,10 +1081,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fd53fb2a-1b36-4d0f-ba5d-26659b915e39
+                - e47e79cc-bbf8-4202-8188-6ba4d95904ae
         status: 200 OK
         code: 200
-        duration: 83.713ms
+        duration: 54.643946ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1100,8 +1100,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/9013c4b2-a4bb-4b70-a7f0-d2850206369c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/cf90e081-5268-4ba9-88fb-48173a71b144
         method: GET
       response:
         proto: HTTP/2.0
@@ -1109,20 +1109,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 674
+        content_length: 710
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:45.430155Z","description":"","domain_name":"tffuncgallantgreidereooqd604-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"9013c4b2-a4bb-4b70-a7f0-d2850206369c","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"eb76e881-c5b1-43b3-b1fe-f97f315d8b39","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-24T15:45:00.982197Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:34.793825Z","description":"","domain_name":"tffuncgallantdewdneycwkipree-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"cf90e081-5268-4ba9-88fb-48173a71b144","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"e20e7cde-edd8-4038-8c85-6031974a3346","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:46.455939Z"}'
         headers:
             Content-Length:
-                - "674"
+                - "710"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:02 GMT
+                - Wed, 27 Aug 2025 15:05:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1130,10 +1130,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0ac0242a-c08e-4442-a8c9-6b9208215b31
+                - c5242e16-6453-404b-a194-b9b6ef2ea7bd
         status: 200 OK
         code: 200
-        duration: 69.309583ms
+        duration: 56.180208ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1149,8 +1149,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/eb76e881-c5b1-43b3-b1fe-f97f315d8b39
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e20e7cde-edd8-4038-8c85-6031974a3346
         method: GET
       response:
         proto: HTTP/2.0
@@ -1158,20 +1158,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 558
+        content_length: 591
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:39.703168Z","description":"","environment_variables":{},"error_message":null,"id":"eb76e881-c5b1-43b3-b1fe-f97f315d8b39","name":"tf-func-gallant-greider","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncgallantgreidereooqd604","registry_namespace_id":"afbcaee1-7a8c-46ff-8640-6032e4bb4491","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:44:42.698918Z"}'
+        body: '{"created_at":"2025-08-27T15:05:29.106915Z","description":"","environment_variables":{},"error_message":null,"id":"e20e7cde-edd8-4038-8c85-6031974a3346","name":"tf-func-gallant-dewdney","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncgallantdewdneycwkipree","registry_namespace_id":"4949f4b6-e60a-4c60-b7bd-521b69d1681f","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:32.181293Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "558"
+                - "591"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:03 GMT
+                - Wed, 27 Aug 2025 15:05:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1179,10 +1179,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ae829f69-1171-40c9-b97f-69121523d99c
+                - 1d318cf3-66f6-470b-9300-a04b54591c11
         status: 200 OK
         code: 200
-        duration: 65.989625ms
+        duration: 56.19137ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1198,8 +1198,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/9013c4b2-a4bb-4b70-a7f0-d2850206369c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/cf90e081-5268-4ba9-88fb-48173a71b144
         method: GET
       response:
         proto: HTTP/2.0
@@ -1207,20 +1207,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 674
+        content_length: 710
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:45.430155Z","description":"","domain_name":"tffuncgallantgreidereooqd604-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"9013c4b2-a4bb-4b70-a7f0-d2850206369c","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"eb76e881-c5b1-43b3-b1fe-f97f315d8b39","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-24T15:45:00.982197Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:34.793825Z","description":"","domain_name":"tffuncgallantdewdneycwkipree-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"cf90e081-5268-4ba9-88fb-48173a71b144","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"e20e7cde-edd8-4038-8c85-6031974a3346","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:46.455939Z"}'
         headers:
             Content-Length:
-                - "674"
+                - "710"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:03 GMT
+                - Wed, 27 Aug 2025 15:05:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1228,10 +1228,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 08ddd80b-2d15-4e02-b5bd-ba3060bc149d
+                - 58965b30-e6d1-40e5-924e-9b22b3ad6f87
         status: 200 OK
         code: 200
-        duration: 84.195042ms
+        duration: 45.936537ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1247,8 +1247,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/eb76e881-c5b1-43b3-b1fe-f97f315d8b39
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e20e7cde-edd8-4038-8c85-6031974a3346
         method: GET
       response:
         proto: HTTP/2.0
@@ -1256,20 +1256,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 558
+        content_length: 591
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:39.703168Z","description":"","environment_variables":{},"error_message":null,"id":"eb76e881-c5b1-43b3-b1fe-f97f315d8b39","name":"tf-func-gallant-greider","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncgallantgreidereooqd604","registry_namespace_id":"afbcaee1-7a8c-46ff-8640-6032e4bb4491","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:44:42.698918Z"}'
+        body: '{"created_at":"2025-08-27T15:05:29.106915Z","description":"","environment_variables":{},"error_message":null,"id":"e20e7cde-edd8-4038-8c85-6031974a3346","name":"tf-func-gallant-dewdney","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncgallantdewdneycwkipree","registry_namespace_id":"4949f4b6-e60a-4c60-b7bd-521b69d1681f","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:32.181293Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "558"
+                - "591"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:04 GMT
+                - Wed, 27 Aug 2025 15:05:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1277,10 +1277,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e34ede7b-c40f-4993-a117-7f9d5ce24a60
+                - 4487a0ca-848b-48c3-8c53-2d6154182490
         status: 200 OK
         code: 200
-        duration: 80.807875ms
+        duration: 83.831465ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1296,8 +1296,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/9013c4b2-a4bb-4b70-a7f0-d2850206369c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/cf90e081-5268-4ba9-88fb-48173a71b144
         method: GET
       response:
         proto: HTTP/2.0
@@ -1305,20 +1305,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 674
+        content_length: 710
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:45.430155Z","description":"","domain_name":"tffuncgallantgreidereooqd604-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"9013c4b2-a4bb-4b70-a7f0-d2850206369c","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"eb76e881-c5b1-43b3-b1fe-f97f315d8b39","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-24T15:45:00.982197Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:34.793825Z","description":"","domain_name":"tffuncgallantdewdneycwkipree-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"cf90e081-5268-4ba9-88fb-48173a71b144","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"e20e7cde-edd8-4038-8c85-6031974a3346","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:46.455939Z"}'
         headers:
             Content-Length:
-                - "674"
+                - "710"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:04 GMT
+                - Wed, 27 Aug 2025 15:05:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1326,10 +1326,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e4c49872-1c0b-46f6-b77b-06071d379d87
+                - 32984380-b004-458d-9e61-05cae4c48270
         status: 200 OK
         code: 200
-        duration: 132.276625ms
+        duration: 57.377304ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1345,8 +1345,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/9013c4b2-a4bb-4b70-a7f0-d2850206369c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/cf90e081-5268-4ba9-88fb-48173a71b144
         method: GET
       response:
         proto: HTTP/2.0
@@ -1354,20 +1354,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 674
+        content_length: 710
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:45.430155Z","description":"","domain_name":"tffuncgallantgreidereooqd604-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"9013c4b2-a4bb-4b70-a7f0-d2850206369c","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"eb76e881-c5b1-43b3-b1fe-f97f315d8b39","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-24T15:45:00.982197Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:34.793825Z","description":"","domain_name":"tffuncgallantdewdneycwkipree-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"cf90e081-5268-4ba9-88fb-48173a71b144","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"e20e7cde-edd8-4038-8c85-6031974a3346","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:46.455939Z"}'
         headers:
             Content-Length:
-                - "674"
+                - "710"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:05 GMT
+                - Wed, 27 Aug 2025 15:05:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1375,10 +1375,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 173361a9-d534-4b5d-aa64-91ec3810d55d
+                - 0ee8be7f-c496-4d12-bcab-8eb3fba82980
         status: 200 OK
         code: 200
-        duration: 64.872ms
+        duration: 60.122697ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1396,8 +1396,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/9013c4b2-a4bb-4b70-a7f0-d2850206369c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/cf90e081-5268-4ba9-88fb-48173a71b144
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -1405,20 +1405,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 667
+        content_length: 703
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:45.430155Z","description":"","domain_name":"tffuncgallantgreidereooqd604-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"9013c4b2-a4bb-4b70-a7f0-d2850206369c","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"eb76e881-c5b1-43b3-b1fe-f97f315d8b39","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","timeout":"300s","updated_at":"2025-01-24T15:45:05.192222527Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:34.793825Z","description":"","domain_name":"tffuncgallantdewdneycwkipree-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"cf90e081-5268-4ba9-88fb-48173a71b144","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"e20e7cde-edd8-4038-8c85-6031974a3346","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:50.844107985Z"}'
         headers:
             Content-Length:
-                - "667"
+                - "703"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:05 GMT
+                - Wed, 27 Aug 2025 15:05:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1426,10 +1426,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 87523407-81da-48e8-8a78-a49a177892cf
+                - 497077a6-370d-4fd2-8caf-0914e1fd3d97
         status: 200 OK
         code: 200
-        duration: 117.098708ms
+        duration: 89.594578ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1445,8 +1445,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/9013c4b2-a4bb-4b70-a7f0-d2850206369c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/cf90e081-5268-4ba9-88fb-48173a71b144
         method: GET
       response:
         proto: HTTP/2.0
@@ -1454,20 +1454,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 664
+        content_length: 700
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:45.430155Z","description":"","domain_name":"tffuncgallantgreidereooqd604-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"9013c4b2-a4bb-4b70-a7f0-d2850206369c","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"eb76e881-c5b1-43b3-b1fe-f97f315d8b39","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","timeout":"300s","updated_at":"2025-01-24T15:45:05.192223Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:34.793825Z","description":"","domain_name":"tffuncgallantdewdneycwkipree-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"cf90e081-5268-4ba9-88fb-48173a71b144","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"e20e7cde-edd8-4038-8c85-6031974a3346","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:50.844108Z"}'
         headers:
             Content-Length:
-                - "664"
+                - "700"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:06 GMT
+                - Wed, 27 Aug 2025 15:05:52 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1475,10 +1475,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 427ecad0-5d98-411b-ba63-4155bcebd7c3
+                - fb2620d2-4ced-40af-8df7-d00e8e6c1682
         status: 200 OK
         code: 200
-        duration: 81.106458ms
+        duration: 205.941798ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1494,8 +1494,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/9013c4b2-a4bb-4b70-a7f0-d2850206369c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/cf90e081-5268-4ba9-88fb-48173a71b144
         method: GET
       response:
         proto: HTTP/2.0
@@ -1503,20 +1503,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 674
+        content_length: 700
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:45.430155Z","description":"","domain_name":"tffuncgallantgreidereooqd604-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"9013c4b2-a4bb-4b70-a7f0-d2850206369c","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"eb76e881-c5b1-43b3-b1fe-f97f315d8b39","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-24T15:45:10.661651Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:34.793825Z","description":"","domain_name":"tffuncgallantdewdneycwkipree-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"cf90e081-5268-4ba9-88fb-48173a71b144","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"e20e7cde-edd8-4038-8c85-6031974a3346","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:50.844108Z"}'
         headers:
             Content-Length:
-                - "674"
+                - "700"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:11 GMT
+                - Wed, 27 Aug 2025 15:05:57 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1524,10 +1524,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a1bfcfb8-9c45-4174-9409-5477b535abbb
+                - b52aa739-0ade-46de-8718-4736695f8295
         status: 200 OK
         code: 200
-        duration: 79.289834ms
+        duration: 213.31155ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1543,8 +1543,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/9013c4b2-a4bb-4b70-a7f0-d2850206369c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/cf90e081-5268-4ba9-88fb-48173a71b144
         method: GET
       response:
         proto: HTTP/2.0
@@ -1552,20 +1552,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 674
+        content_length: 700
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:45.430155Z","description":"","domain_name":"tffuncgallantgreidereooqd604-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"9013c4b2-a4bb-4b70-a7f0-d2850206369c","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"eb76e881-c5b1-43b3-b1fe-f97f315d8b39","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-24T15:45:10.661651Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:34.793825Z","description":"","domain_name":"tffuncgallantdewdneycwkipree-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"cf90e081-5268-4ba9-88fb-48173a71b144","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"e20e7cde-edd8-4038-8c85-6031974a3346","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:50.844108Z"}'
         headers:
             Content-Length:
-                - "674"
+                - "700"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:11 GMT
+                - Wed, 27 Aug 2025 15:06:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1573,10 +1573,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d2ffe9d3-a006-4c45-93a6-5ba976da7741
+                - 3b823002-1739-4ef7-ae38-79013623028e
         status: 200 OK
         code: 200
-        duration: 87.30525ms
+        duration: 102.454693ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1592,8 +1592,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/eb76e881-c5b1-43b3-b1fe-f97f315d8b39
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/cf90e081-5268-4ba9-88fb-48173a71b144
         method: GET
       response:
         proto: HTTP/2.0
@@ -1601,20 +1601,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 558
+        content_length: 710
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:39.703168Z","description":"","environment_variables":{},"error_message":null,"id":"eb76e881-c5b1-43b3-b1fe-f97f315d8b39","name":"tf-func-gallant-greider","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncgallantgreidereooqd604","registry_namespace_id":"afbcaee1-7a8c-46ff-8640-6032e4bb4491","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:44:42.698918Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:34.793825Z","description":"","domain_name":"tffuncgallantdewdneycwkipree-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"cf90e081-5268-4ba9-88fb-48173a71b144","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"e20e7cde-edd8-4038-8c85-6031974a3346","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:04.602029Z"}'
         headers:
             Content-Length:
-                - "558"
+                - "710"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:12 GMT
+                - Wed, 27 Aug 2025 15:06:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1622,10 +1622,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fc7a8e6f-21d0-454d-95ab-82a9e11f7310
+                - d3ee32cc-9c8f-4612-9a89-04077a72844a
         status: 200 OK
         code: 200
-        duration: 63.034666ms
+        duration: 40.307637ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1641,8 +1641,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/9013c4b2-a4bb-4b70-a7f0-d2850206369c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/cf90e081-5268-4ba9-88fb-48173a71b144
         method: GET
       response:
         proto: HTTP/2.0
@@ -1650,20 +1650,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 674
+        content_length: 710
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:45.430155Z","description":"","domain_name":"tffuncgallantgreidereooqd604-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"9013c4b2-a4bb-4b70-a7f0-d2850206369c","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"eb76e881-c5b1-43b3-b1fe-f97f315d8b39","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-24T15:45:10.661651Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:34.793825Z","description":"","domain_name":"tffuncgallantdewdneycwkipree-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"cf90e081-5268-4ba9-88fb-48173a71b144","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"e20e7cde-edd8-4038-8c85-6031974a3346","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:04.602029Z"}'
         headers:
             Content-Length:
-                - "674"
+                - "710"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:12 GMT
+                - Wed, 27 Aug 2025 15:06:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1671,10 +1671,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fe380bcf-372d-48e7-bedb-c92c381222e4
+                - 4f8982da-5d09-4b54-a7a4-c9b98113a69e
         status: 200 OK
         code: 200
-        duration: 156.586958ms
+        duration: 46.876153ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1690,8 +1690,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/9013c4b2-a4bb-4b70-a7f0-d2850206369c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e20e7cde-edd8-4038-8c85-6031974a3346
         method: GET
       response:
         proto: HTTP/2.0
@@ -1699,20 +1699,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 674
+        content_length: 591
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:45.430155Z","description":"","domain_name":"tffuncgallantgreidereooqd604-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"9013c4b2-a4bb-4b70-a7f0-d2850206369c","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"eb76e881-c5b1-43b3-b1fe-f97f315d8b39","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"error","timeout":"300s","updated_at":"2025-01-24T15:45:10.661651Z"}'
+        body: '{"created_at":"2025-08-27T15:05:29.106915Z","description":"","environment_variables":{},"error_message":null,"id":"e20e7cde-edd8-4038-8c85-6031974a3346","name":"tf-func-gallant-dewdney","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncgallantdewdneycwkipree","registry_namespace_id":"4949f4b6-e60a-4c60-b7bd-521b69d1681f","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:32.181293Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "674"
+                - "591"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:13 GMT
+                - Wed, 27 Aug 2025 15:06:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1720,10 +1720,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 84e9d2d6-e34a-461a-8837-83b61534b38d
+                - 13c81c12-e91a-458a-889d-ba8d8fb7d48e
         status: 200 OK
         code: 200
-        duration: 75.235083ms
+        duration: 54.888508ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1739,29 +1739,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/9013c4b2-a4bb-4b70-a7f0-d2850206369c
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/cf90e081-5268-4ba9-88fb-48173a71b144
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 668
+        content_length: 710
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:45.430155Z","description":"","domain_name":"tffuncgallantgreidereooqd604-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"9013c4b2-a4bb-4b70-a7f0-d2850206369c","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"eb76e881-c5b1-43b3-b1fe-f97f315d8b39","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"deleting","timeout":"300s","updated_at":"2025-01-24T15:45:13.477657671Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:34.793825Z","description":"","domain_name":"tffuncgallantdewdneycwkipree-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"cf90e081-5268-4ba9-88fb-48173a71b144","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"e20e7cde-edd8-4038-8c85-6031974a3346","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:04.602029Z"}'
         headers:
             Content-Length:
-                - "668"
+                - "710"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:13 GMT
+                - Wed, 27 Aug 2025 15:06:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1769,10 +1769,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 112e96e6-f100-4d87-9924-2fb612244777
+                - de81a848-b992-4cd4-a293-0b87b761b777
         status: 200 OK
         code: 200
-        duration: 153.903791ms
+        duration: 48.022434ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1788,8 +1788,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/eb76e881-c5b1-43b3-b1fe-f97f315d8b39
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/cf90e081-5268-4ba9-88fb-48173a71b144
         method: GET
       response:
         proto: HTTP/2.0
@@ -1797,20 +1797,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 558
+        content_length: 710
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:39.703168Z","description":"","environment_variables":{},"error_message":null,"id":"eb76e881-c5b1-43b3-b1fe-f97f315d8b39","name":"tf-func-gallant-greider","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncgallantgreidereooqd604","registry_namespace_id":"afbcaee1-7a8c-46ff-8640-6032e4bb4491","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:44:42.698918Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:34.793825Z","description":"","domain_name":"tffuncgallantdewdneycwkipree-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"cf90e081-5268-4ba9-88fb-48173a71b144","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"e20e7cde-edd8-4038-8c85-6031974a3346","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:04.602029Z"}'
         headers:
             Content-Length:
-                - "558"
+                - "710"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:13 GMT
+                - Wed, 27 Aug 2025 15:06:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1818,10 +1818,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4ac85583-0cf8-4d6b-9e13-3c8ee59f2f7b
+                - 94980c55-78c9-4c60-9ae1-396f8090f930
         status: 200 OK
         code: 200
-        duration: 63.329042ms
+        duration: 61.595012ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1837,8 +1837,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/eb76e881-c5b1-43b3-b1fe-f97f315d8b39
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/cf90e081-5268-4ba9-88fb-48173a71b144
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1846,20 +1846,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 564
+        content_length: 704
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:39.703168Z","description":"","environment_variables":{},"error_message":null,"id":"eb76e881-c5b1-43b3-b1fe-f97f315d8b39","name":"tf-func-gallant-greider","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncgallantgreidereooqd604","registry_namespace_id":"afbcaee1-7a8c-46ff-8640-6032e4bb4491","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:45:13.690732307Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:34.793825Z","description":"","domain_name":"tffuncgallantdewdneycwkipree-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"cf90e081-5268-4ba9-88fb-48173a71b144","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"e20e7cde-edd8-4038-8c85-6031974a3346","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:08.479099718Z"}'
         headers:
             Content-Length:
-                - "564"
+                - "704"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:13 GMT
+                - Wed, 27 Aug 2025 15:06:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1867,10 +1867,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9a8b7909-6b57-4088-8bba-2a84538fa213
+                - 550e3072-8eb3-405f-9cac-07e85283a9c9
         status: 200 OK
         code: 200
-        duration: 311.167291ms
+        duration: 118.346947ms
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1886,8 +1886,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/eb76e881-c5b1-43b3-b1fe-f97f315d8b39
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e20e7cde-edd8-4038-8c85-6031974a3346
         method: GET
       response:
         proto: HTTP/2.0
@@ -1895,20 +1895,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 561
+        content_length: 591
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:39.703168Z","description":"","environment_variables":{},"error_message":null,"id":"eb76e881-c5b1-43b3-b1fe-f97f315d8b39","name":"tf-func-gallant-greider","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncgallantgreidereooqd604","registry_namespace_id":"afbcaee1-7a8c-46ff-8640-6032e4bb4491","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:45:13.690732Z"}'
+        body: '{"created_at":"2025-08-27T15:05:29.106915Z","description":"","environment_variables":{},"error_message":null,"id":"e20e7cde-edd8-4038-8c85-6031974a3346","name":"tf-func-gallant-dewdney","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncgallantdewdneycwkipree","registry_namespace_id":"4949f4b6-e60a-4c60-b7bd-521b69d1681f","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:32.181293Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "561"
+                - "591"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:14 GMT
+                - Wed, 27 Aug 2025 15:06:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1916,10 +1916,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b0bfcd26-1daf-4495-890b-276c9c452fbc
+                - 3d72fb09-7676-4b6b-b0f4-15e1af466d0b
         status: 200 OK
         code: 200
-        duration: 108.033458ms
+        duration: 51.392518ms
     - id: 39
       request:
         proto: HTTP/1.1
@@ -1935,29 +1935,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/eb76e881-c5b1-43b3-b1fe-f97f315d8b39
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e20e7cde-edd8-4038-8c85-6031974a3346
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 561
+        content_length: 597
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:39.703168Z","description":"","environment_variables":{},"error_message":null,"id":"eb76e881-c5b1-43b3-b1fe-f97f315d8b39","name":"tf-func-gallant-greider","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncgallantgreidereooqd604","registry_namespace_id":"afbcaee1-7a8c-46ff-8640-6032e4bb4491","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:45:13.690732Z"}'
+        body: '{"created_at":"2025-08-27T15:05:29.106915Z","description":"","environment_variables":{},"error_message":null,"id":"e20e7cde-edd8-4038-8c85-6031974a3346","name":"tf-func-gallant-dewdney","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncgallantdewdneycwkipree","registry_namespace_id":"4949f4b6-e60a-4c60-b7bd-521b69d1681f","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:08.583280887Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "561"
+                - "597"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:19 GMT
+                - Wed, 27 Aug 2025 15:06:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1965,10 +1965,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 806183ac-aa2f-4697-81a6-bf94290338c6
+                - 76130dcd-1601-4887-82b2-6ac4855ef040
         status: 200 OK
         code: 200
-        duration: 65.250458ms
+        duration: 485.23512ms
     - id: 40
       request:
         proto: HTTP/1.1
@@ -1984,8 +1984,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/eb76e881-c5b1-43b3-b1fe-f97f315d8b39
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e20e7cde-edd8-4038-8c85-6031974a3346
         method: GET
       response:
         proto: HTTP/2.0
@@ -1993,20 +1993,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 561
+        content_length: 594
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:39.703168Z","description":"","environment_variables":{},"error_message":null,"id":"eb76e881-c5b1-43b3-b1fe-f97f315d8b39","name":"tf-func-gallant-greider","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncgallantgreidereooqd604","registry_namespace_id":"afbcaee1-7a8c-46ff-8640-6032e4bb4491","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:45:13.690732Z"}'
+        body: '{"created_at":"2025-08-27T15:05:29.106915Z","description":"","environment_variables":{},"error_message":null,"id":"e20e7cde-edd8-4038-8c85-6031974a3346","name":"tf-func-gallant-dewdney","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncgallantdewdneycwkipree","registry_namespace_id":"4949f4b6-e60a-4c60-b7bd-521b69d1681f","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:08.583281Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "561"
+                - "594"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:24 GMT
+                - Wed, 27 Aug 2025 15:06:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2014,10 +2014,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ad525352-d061-4679-bb22-77b43c83dbae
+                - e6a118da-2c8a-453e-b522-022e4ff05b12
         status: 200 OK
         code: 200
-        duration: 58.343042ms
+        duration: 49.805139ms
     - id: 41
       request:
         proto: HTTP/1.1
@@ -2033,8 +2033,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/eb76e881-c5b1-43b3-b1fe-f97f315d8b39
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e20e7cde-edd8-4038-8c85-6031974a3346
         method: GET
       response:
         proto: HTTP/2.0
@@ -2042,20 +2042,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 561
+        content_length: 594
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:39.703168Z","description":"","environment_variables":{},"error_message":null,"id":"eb76e881-c5b1-43b3-b1fe-f97f315d8b39","name":"tf-func-gallant-greider","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncgallantgreidereooqd604","registry_namespace_id":"afbcaee1-7a8c-46ff-8640-6032e4bb4491","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:45:13.690732Z"}'
+        body: '{"created_at":"2025-08-27T15:05:29.106915Z","description":"","environment_variables":{},"error_message":null,"id":"e20e7cde-edd8-4038-8c85-6031974a3346","name":"tf-func-gallant-dewdney","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncgallantdewdneycwkipree","registry_namespace_id":"4949f4b6-e60a-4c60-b7bd-521b69d1681f","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:08.583281Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "561"
+                - "594"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:29 GMT
+                - Wed, 27 Aug 2025 15:06:14 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2063,10 +2063,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 70e8106b-a30d-41b9-957b-4293611218d1
+                - c2e44bff-772f-4856-b26f-70eb363f15f1
         status: 200 OK
         code: 200
-        duration: 75.579833ms
+        duration: 43.326783ms
     - id: 42
       request:
         proto: HTTP/1.1
@@ -2082,8 +2082,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/eb76e881-c5b1-43b3-b1fe-f97f315d8b39
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e20e7cde-edd8-4038-8c85-6031974a3346
         method: GET
       response:
         proto: HTTP/2.0
@@ -2091,20 +2091,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 561
+        content_length: 594
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:39.703168Z","description":"","environment_variables":{},"error_message":null,"id":"eb76e881-c5b1-43b3-b1fe-f97f315d8b39","name":"tf-func-gallant-greider","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncgallantgreidereooqd604","registry_namespace_id":"afbcaee1-7a8c-46ff-8640-6032e4bb4491","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:45:13.690732Z"}'
+        body: '{"created_at":"2025-08-27T15:05:29.106915Z","description":"","environment_variables":{},"error_message":null,"id":"e20e7cde-edd8-4038-8c85-6031974a3346","name":"tf-func-gallant-dewdney","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncgallantdewdneycwkipree","registry_namespace_id":"4949f4b6-e60a-4c60-b7bd-521b69d1681f","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:08.583281Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "561"
+                - "594"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:34 GMT
+                - Wed, 27 Aug 2025 15:06:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2112,10 +2112,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 45c741ff-3232-4708-ba08-ab9d1c38b0e2
+                - 9bd5a270-14cc-47fa-9f3c-e749a83926d9
         status: 200 OK
         code: 200
-        duration: 80.9635ms
+        duration: 62.363838ms
     - id: 43
       request:
         proto: HTTP/1.1
@@ -2131,8 +2131,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/eb76e881-c5b1-43b3-b1fe-f97f315d8b39
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e20e7cde-edd8-4038-8c85-6031974a3346
         method: GET
       response:
         proto: HTTP/2.0
@@ -2140,20 +2140,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 561
+        content_length: 594
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:39.703168Z","description":"","environment_variables":{},"error_message":null,"id":"eb76e881-c5b1-43b3-b1fe-f97f315d8b39","name":"tf-func-gallant-greider","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncgallantgreidereooqd604","registry_namespace_id":"afbcaee1-7a8c-46ff-8640-6032e4bb4491","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:45:13.690732Z"}'
+        body: '{"created_at":"2025-08-27T15:05:29.106915Z","description":"","environment_variables":{},"error_message":null,"id":"e20e7cde-edd8-4038-8c85-6031974a3346","name":"tf-func-gallant-dewdney","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncgallantdewdneycwkipree","registry_namespace_id":"4949f4b6-e60a-4c60-b7bd-521b69d1681f","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:08.583281Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "561"
+                - "594"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:39 GMT
+                - Wed, 27 Aug 2025 15:06:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2161,10 +2161,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c4c2ef5c-e920-4fa7-a791-19e07d0739b4
+                - 4f1f0cc0-aa53-4d13-9730-99be7b5cdaba
         status: 200 OK
         code: 200
-        duration: 69.363791ms
+        duration: 47.834724ms
     - id: 44
       request:
         proto: HTTP/1.1
@@ -2180,8 +2180,253 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/eb76e881-c5b1-43b3-b1fe-f97f315d8b39
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e20e7cde-edd8-4038-8c85-6031974a3346
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 594
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:29.106915Z","description":"","environment_variables":{},"error_message":null,"id":"e20e7cde-edd8-4038-8c85-6031974a3346","name":"tf-func-gallant-dewdney","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncgallantdewdneycwkipree","registry_namespace_id":"4949f4b6-e60a-4c60-b7bd-521b69d1681f","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:08.583281Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "594"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:29 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 62bd2a7d-6e59-4cc2-85d9-bd931ca9b8d7
+        status: 200 OK
+        code: 200
+        duration: 51.10404ms
+    - id: 45
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e20e7cde-edd8-4038-8c85-6031974a3346
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 594
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:29.106915Z","description":"","environment_variables":{},"error_message":null,"id":"e20e7cde-edd8-4038-8c85-6031974a3346","name":"tf-func-gallant-dewdney","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncgallantdewdneycwkipree","registry_namespace_id":"4949f4b6-e60a-4c60-b7bd-521b69d1681f","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:08.583281Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "594"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - d48e3c0e-046a-455f-be55-70f290e3b3d6
+        status: 200 OK
+        code: 200
+        duration: 49.394522ms
+    - id: 46
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e20e7cde-edd8-4038-8c85-6031974a3346
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 594
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:29.106915Z","description":"","environment_variables":{},"error_message":null,"id":"e20e7cde-edd8-4038-8c85-6031974a3346","name":"tf-func-gallant-dewdney","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncgallantdewdneycwkipree","registry_namespace_id":"4949f4b6-e60a-4c60-b7bd-521b69d1681f","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:08.583281Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "594"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:39 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 01ceea3e-068a-4412-bbf5-f5f6987dd2b1
+        status: 200 OK
+        code: 200
+        duration: 44.53293ms
+    - id: 47
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e20e7cde-edd8-4038-8c85-6031974a3346
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 594
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:29.106915Z","description":"","environment_variables":{},"error_message":null,"id":"e20e7cde-edd8-4038-8c85-6031974a3346","name":"tf-func-gallant-dewdney","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncgallantdewdneycwkipree","registry_namespace_id":"4949f4b6-e60a-4c60-b7bd-521b69d1681f","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:08.583281Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "594"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:44 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b41e1949-e333-46d6-bfb0-43794a84d6f5
+        status: 200 OK
+        code: 200
+        duration: 51.945451ms
+    - id: 48
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e20e7cde-edd8-4038-8c85-6031974a3346
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 594
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:29.106915Z","description":"","environment_variables":{},"error_message":null,"id":"e20e7cde-edd8-4038-8c85-6031974a3346","name":"tf-func-gallant-dewdney","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncgallantdewdneycwkipree","registry_namespace_id":"4949f4b6-e60a-4c60-b7bd-521b69d1681f","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:08.583281Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "594"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 71e20dda-be6b-4c18-97d3-af535d901823
+        status: 200 OK
+        code: 200
+        duration: 51.973233ms
+    - id: 49
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e20e7cde-edd8-4038-8c85-6031974a3346
         method: GET
       response:
         proto: HTTP/2.0
@@ -2200,9 +2445,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:44 GMT
+                - Wed, 27 Aug 2025 15:06:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2210,11 +2455,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1b5c9b72-bdf9-4068-922b-4efd8666d9d3
+                - d5be3eec-7193-499b-8fc3-07d27536ec4c
         status: 404 Not Found
         code: 404
-        duration: 82.762542ms
-    - id: 45
+        duration: 29.248299ms
+    - id: 50
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2229,8 +2474,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/9013c4b2-a4bb-4b70-a7f0-d2850206369c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/cf90e081-5268-4ba9-88fb-48173a71b144
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -2249,9 +2494,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:44 GMT
+                - Wed, 27 Aug 2025 15:06:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2259,7 +2504,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a8dffb13-aeae-4967-803e-09a5f5bd4b42
+                - 449eefb2-6018-45c7-a1d3-f17a6a585c77
         status: 404 Not Found
         code: 404
-        duration: 35.078875ms
+        duration: 23.503027ms

--- a/internal/services/function/testdata/function-timeout.cassette.yaml
+++ b/internal/services/function/testdata/function-timeout.cassette.yaml
@@ -6,19 +6,19 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 161
+        content_length: 196
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-func-recursing-swanson","environment_variables":{},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","secret_environment_variables":[],"tags":null}'
+        body: '{"name":"tf-func-clever-chandrasekhar","environment_variables":{},"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","secret_environment_variables":[],"tags":null,"activate_vpc_integration":true}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces
         method: POST
       response:
@@ -27,20 +27,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 477
+        content_length: 513
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:23.346930765Z","description":"","environment_variables":{},"error_message":null,"id":"31066ad6-87e2-4075-ae04-c22348ebf5c2","name":"tf-func-recursing-swanson","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:44:23.346930765Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.174908583Z","description":"","environment_variables":{},"error_message":null,"id":"a96206e6-ddd0-46a0-a21d-ef721b140465","name":"tf-func-clever-chandrasekhar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:41.174908583Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "477"
+                - "513"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:23 GMT
+                - Wed, 27 Aug 2025 15:05:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 90fdb582-547d-41e2-9765-67c320cd30ee
+                - 30f3301b-c326-428a-9864-5dd0ab6960c8
         status: 200 OK
         code: 200
-        duration: 345.928833ms
+        duration: 4.903360443s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -67,8 +67,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/31066ad6-87e2-4075-ae04-c22348ebf5c2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a96206e6-ddd0-46a0-a21d-ef721b140465
         method: GET
       response:
         proto: HTTP/2.0
@@ -76,20 +76,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 471
+        content_length: 507
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:23.346931Z","description":"","environment_variables":{},"error_message":null,"id":"31066ad6-87e2-4075-ae04-c22348ebf5c2","name":"tf-func-recursing-swanson","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:44:23.346931Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.174909Z","description":"","environment_variables":{},"error_message":null,"id":"a96206e6-ddd0-46a0-a21d-ef721b140465","name":"tf-func-clever-chandrasekhar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:41.174909Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "471"
+                - "507"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:23 GMT
+                - Wed, 27 Aug 2025 15:05:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - dff95aa2-3101-4db1-81d8-2db2f574ebdb
+                - 11a8db80-0b27-4279-a3b3-d64995ebe34e
         status: 200 OK
         code: 200
-        duration: 73.206833ms
+        duration: 42.203521ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -116,8 +116,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/31066ad6-87e2-4075-ae04-c22348ebf5c2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a96206e6-ddd0-46a0-a21d-ef721b140465
         method: GET
       response:
         proto: HTTP/2.0
@@ -125,20 +125,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 560
+        content_length: 507
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:23.346931Z","description":"","environment_variables":{},"error_message":null,"id":"31066ad6-87e2-4075-ae04-c22348ebf5c2","name":"tf-func-recursing-swanson","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncrecursingswans0wcypqhr","registry_namespace_id":"bdc70379-d1d8-4c74-bd7a-066e2a4cb816","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:44:24.976762Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.174909Z","description":"","environment_variables":{},"error_message":null,"id":"a96206e6-ddd0-46a0-a21d-ef721b140465","name":"tf-func-clever-chandrasekhar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:42.038204Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "560"
+                - "507"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:28 GMT
+                - Wed, 27 Aug 2025 15:05:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -146,10 +146,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ce62151a-9949-4e63-92b2-8ae5a5c9d6fd
+                - 62c02100-7de1-4b35-92f9-3a8019292e59
         status: 200 OK
         code: 200
-        duration: 75.455791ms
+        duration: 40.731449ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -165,8 +165,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/31066ad6-87e2-4075-ae04-c22348ebf5c2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a96206e6-ddd0-46a0-a21d-ef721b140465
         method: GET
       response:
         proto: HTTP/2.0
@@ -174,20 +174,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 560
+        content_length: 598
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:23.346931Z","description":"","environment_variables":{},"error_message":null,"id":"31066ad6-87e2-4075-ae04-c22348ebf5c2","name":"tf-func-recursing-swanson","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncrecursingswans0wcypqhr","registry_namespace_id":"bdc70379-d1d8-4c74-bd7a-066e2a4cb816","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:44:24.976762Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.174909Z","description":"","environment_variables":{},"error_message":null,"id":"a96206e6-ddd0-46a0-a21d-ef721b140465","name":"tf-func-clever-chandrasekhar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunccleverchandrasptrbvmiv","registry_namespace_id":"14451d08-4bcf-4b18-b7ed-e101fdaae126","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:47.161208Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "560"
+                - "598"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:28 GMT
+                - Wed, 27 Aug 2025 15:05:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -195,50 +195,48 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9b9a68d2-df52-48e1-a3ed-ecaef3a2d0c5
+                - 4bdff7de-d267-4918-9003-39d656a2b8aa
         status: 200 OK
         code: 200
-        duration: 68.720375ms
+        duration: 56.912903ms
     - id: 4
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 324
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"foobar","namespace_id":"31066ad6-87e2-4075-ae04-c22348ebf5c2","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"node22","memory_limit":256,"timeout":"10.000000000s","handler":"handler.handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox"}'
+        body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions
-        method: POST
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a96206e6-ddd0-46a0-a21d-ef721b140465
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 669
+        content_length: 596
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:28.923131094Z","description":"","domain_name":"tffuncrecursingswans0wcypqhr-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"fb27f0f9-6ebf-4a16-945b-e47060391dcc","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"31066ad6-87e2-4075-ae04-c22348ebf5c2","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"10s","updated_at":"2025-01-24T15:44:28.923131094Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.174909Z","description":"","environment_variables":{},"error_message":null,"id":"a96206e6-ddd0-46a0-a21d-ef721b140465","name":"tf-func-clever-chandrasekhar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunccleverchandrasptrbvmiv","registry_namespace_id":"14451d08-4bcf-4b18-b7ed-e101fdaae126","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:53.133909Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "669"
+                - "596"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:28 GMT
+                - Wed, 27 Aug 2025 15:05:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -246,10 +244,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 215ddf98-bfda-44f0-886b-06eeea0e5016
+                - ba56762d-cee6-4e69-bc34-c07c6ffbb4a3
         status: 200 OK
         code: 200
-        duration: 253.016416ms
+        duration: 40.163175ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -265,8 +263,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/fb27f0f9-6ebf-4a16-945b-e47060391dcc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a96206e6-ddd0-46a0-a21d-ef721b140465
         method: GET
       response:
         proto: HTTP/2.0
@@ -274,20 +272,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 663
+        content_length: 596
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:28.923131Z","description":"","domain_name":"tffuncrecursingswans0wcypqhr-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"fb27f0f9-6ebf-4a16-945b-e47060391dcc","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"31066ad6-87e2-4075-ae04-c22348ebf5c2","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"10s","updated_at":"2025-01-24T15:44:28.923131Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.174909Z","description":"","environment_variables":{},"error_message":null,"id":"a96206e6-ddd0-46a0-a21d-ef721b140465","name":"tf-func-clever-chandrasekhar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunccleverchandrasptrbvmiv","registry_namespace_id":"14451d08-4bcf-4b18-b7ed-e101fdaae126","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:53.133909Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "663"
+                - "596"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:29 GMT
+                - Wed, 27 Aug 2025 15:05:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -295,48 +293,50 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c4c37a3a-efdd-412c-8a45-4ef917c55f7e
+                - 93f434ac-ba4d-488e-8970-79bc03970eb7
         status: 200 OK
         code: 200
-        duration: 71.780875ms
+        duration: 54.007783ms
     - id: 6
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 336
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"name":"foobar","namespace_id":"a96206e6-ddd0-46a0-a21d-ef721b140465","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"node22","memory_limit":256,"timeout":"10.000000000s","handler":"handler.handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox","tags":null}'
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/fb27f0f9-6ebf-4a16-945b-e47060391dcc
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 663
+        content_length: 705
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:28.923131Z","description":"","domain_name":"tffuncrecursingswans0wcypqhr-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"fb27f0f9-6ebf-4a16-945b-e47060391dcc","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"31066ad6-87e2-4075-ae04-c22348ebf5c2","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"10s","updated_at":"2025-01-24T15:44:28.923131Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:57.462268707Z","description":"","domain_name":"tffunccleverchandrasptrbvmiv-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"bf1ab288-b39f-43f4-a738-b3b31496e56f","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"a96206e6-ddd0-46a0-a21d-ef721b140465","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"10s","updated_at":"2025-08-27T15:05:57.462268707Z"}'
         headers:
             Content-Length:
-                - "663"
+                - "705"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:29 GMT
+                - Wed, 27 Aug 2025 15:05:57 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -344,10 +344,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1ac24930-ff39-4443-99d4-723829083594
+                - db4ea0fa-ccc6-4010-9d82-d0655604f10d
         status: 200 OK
         code: 200
-        duration: 74.237542ms
+        duration: 1.043800544s
     - id: 7
       request:
         proto: HTTP/1.1
@@ -363,8 +363,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/fb27f0f9-6ebf-4a16-945b-e47060391dcc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/bf1ab288-b39f-43f4-a738-b3b31496e56f
         method: GET
       response:
         proto: HTTP/2.0
@@ -372,20 +372,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 663
+        content_length: 699
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:28.923131Z","description":"","domain_name":"tffuncrecursingswans0wcypqhr-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"fb27f0f9-6ebf-4a16-945b-e47060391dcc","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"31066ad6-87e2-4075-ae04-c22348ebf5c2","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"10s","updated_at":"2025-01-24T15:44:28.923131Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:57.462269Z","description":"","domain_name":"tffunccleverchandrasptrbvmiv-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"bf1ab288-b39f-43f4-a738-b3b31496e56f","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"a96206e6-ddd0-46a0-a21d-ef721b140465","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"10s","updated_at":"2025-08-27T15:05:57.462269Z"}'
         headers:
             Content-Length:
-                - "663"
+                - "699"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:29 GMT
+                - Wed, 27 Aug 2025 15:05:57 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -393,10 +393,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9cdc4e59-604f-487e-ac9b-2815dfc60e7a
+                - b0469dc0-48b3-463e-9790-d8e3eec73890
         status: 200 OK
         code: 200
-        duration: 81.194417ms
+        duration: 53.035359ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -412,8 +412,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/31066ad6-87e2-4075-ae04-c22348ebf5c2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/bf1ab288-b39f-43f4-a738-b3b31496e56f
         method: GET
       response:
         proto: HTTP/2.0
@@ -421,20 +421,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 560
+        content_length: 699
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:23.346931Z","description":"","environment_variables":{},"error_message":null,"id":"31066ad6-87e2-4075-ae04-c22348ebf5c2","name":"tf-func-recursing-swanson","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncrecursingswans0wcypqhr","registry_namespace_id":"bdc70379-d1d8-4c74-bd7a-066e2a4cb816","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:44:24.976762Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:57.462269Z","description":"","domain_name":"tffunccleverchandrasptrbvmiv-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"bf1ab288-b39f-43f4-a738-b3b31496e56f","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"a96206e6-ddd0-46a0-a21d-ef721b140465","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"10s","updated_at":"2025-08-27T15:05:57.462269Z"}'
         headers:
             Content-Length:
-                - "560"
+                - "699"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:30 GMT
+                - Wed, 27 Aug 2025 15:05:57 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -442,10 +442,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 05b6ef4f-23d4-42fa-ad25-408a7a51f834
+                - 062a3665-307f-4c04-b285-db5fce73d926
         status: 200 OK
         code: 200
-        duration: 72.058292ms
+        duration: 52.431225ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -461,8 +461,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/fb27f0f9-6ebf-4a16-945b-e47060391dcc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/bf1ab288-b39f-43f4-a738-b3b31496e56f
         method: GET
       response:
         proto: HTTP/2.0
@@ -470,20 +470,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 663
+        content_length: 699
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:28.923131Z","description":"","domain_name":"tffuncrecursingswans0wcypqhr-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"fb27f0f9-6ebf-4a16-945b-e47060391dcc","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"31066ad6-87e2-4075-ae04-c22348ebf5c2","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"10s","updated_at":"2025-01-24T15:44:28.923131Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:57.462269Z","description":"","domain_name":"tffunccleverchandrasptrbvmiv-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"bf1ab288-b39f-43f4-a738-b3b31496e56f","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"a96206e6-ddd0-46a0-a21d-ef721b140465","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"10s","updated_at":"2025-08-27T15:05:57.462269Z"}'
         headers:
             Content-Length:
-                - "663"
+                - "699"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:30 GMT
+                - Wed, 27 Aug 2025 15:05:57 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -491,10 +491,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bdb9308a-5613-4d9e-a165-7ba928ff4601
+                - a948e220-509d-4094-84ac-00cd5a2bf3d1
         status: 200 OK
         code: 200
-        duration: 72.55175ms
+        duration: 63.992709ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -510,8 +510,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/fb27f0f9-6ebf-4a16-945b-e47060391dcc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a96206e6-ddd0-46a0-a21d-ef721b140465
         method: GET
       response:
         proto: HTTP/2.0
@@ -519,20 +519,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 663
+        content_length: 596
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:28.923131Z","description":"","domain_name":"tffuncrecursingswans0wcypqhr-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"fb27f0f9-6ebf-4a16-945b-e47060391dcc","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"31066ad6-87e2-4075-ae04-c22348ebf5c2","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"10s","updated_at":"2025-01-24T15:44:28.923131Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.174909Z","description":"","environment_variables":{},"error_message":null,"id":"a96206e6-ddd0-46a0-a21d-ef721b140465","name":"tf-func-clever-chandrasekhar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunccleverchandrasptrbvmiv","registry_namespace_id":"14451d08-4bcf-4b18-b7ed-e101fdaae126","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:53.133909Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "663"
+                - "596"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:31 GMT
+                - Wed, 27 Aug 2025 15:05:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -540,10 +540,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 69056e41-c338-497e-9947-0de2479af244
+                - 70c8d7b6-5d6e-470a-8da7-7a9f30feb768
         status: 200 OK
         code: 200
-        duration: 112.349625ms
+        duration: 95.856501ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -559,29 +559,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/fb27f0f9-6ebf-4a16-945b-e47060391dcc
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/bf1ab288-b39f-43f4-a738-b3b31496e56f
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 667
+        content_length: 699
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:28.923131Z","description":"","domain_name":"tffuncrecursingswans0wcypqhr-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"fb27f0f9-6ebf-4a16-945b-e47060391dcc","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"31066ad6-87e2-4075-ae04-c22348ebf5c2","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"deleting","timeout":"10s","updated_at":"2025-01-24T15:44:31.425859757Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:57.462269Z","description":"","domain_name":"tffunccleverchandrasptrbvmiv-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"bf1ab288-b39f-43f4-a738-b3b31496e56f","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"a96206e6-ddd0-46a0-a21d-ef721b140465","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"10s","updated_at":"2025-08-27T15:05:57.462269Z"}'
         headers:
             Content-Length:
-                - "667"
+                - "699"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:31 GMT
+                - Wed, 27 Aug 2025 15:05:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -589,10 +589,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 22ac2784-50f0-4358-a828-a8e20171b281
+                - 761717b4-d3b3-4f5b-8bde-52f675ed4cc2
         status: 200 OK
         code: 200
-        duration: 146.422875ms
+        duration: 55.509692ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -608,8 +608,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/31066ad6-87e2-4075-ae04-c22348ebf5c2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/bf1ab288-b39f-43f4-a738-b3b31496e56f
         method: GET
       response:
         proto: HTTP/2.0
@@ -617,20 +617,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 560
+        content_length: 699
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:23.346931Z","description":"","environment_variables":{},"error_message":null,"id":"31066ad6-87e2-4075-ae04-c22348ebf5c2","name":"tf-func-recursing-swanson","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncrecursingswans0wcypqhr","registry_namespace_id":"bdc70379-d1d8-4c74-bd7a-066e2a4cb816","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:44:24.976762Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:57.462269Z","description":"","domain_name":"tffunccleverchandrasptrbvmiv-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"bf1ab288-b39f-43f4-a738-b3b31496e56f","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"a96206e6-ddd0-46a0-a21d-ef721b140465","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"10s","updated_at":"2025-08-27T15:05:57.462269Z"}'
         headers:
             Content-Length:
-                - "560"
+                - "699"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:31 GMT
+                - Wed, 27 Aug 2025 15:05:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -638,10 +638,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1c537fe0-84a7-4bd8-80f7-7029f2f33e1c
+                - 7d9163d3-d7e9-4a12-ae78-7da849763d6f
         status: 200 OK
         code: 200
-        duration: 74.544459ms
+        duration: 58.537784ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -657,8 +657,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/31066ad6-87e2-4075-ae04-c22348ebf5c2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/bf1ab288-b39f-43f4-a738-b3b31496e56f
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -666,20 +666,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 566
+        content_length: 703
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:23.346931Z","description":"","environment_variables":{},"error_message":null,"id":"31066ad6-87e2-4075-ae04-c22348ebf5c2","name":"tf-func-recursing-swanson","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncrecursingswans0wcypqhr","registry_namespace_id":"bdc70379-d1d8-4c74-bd7a-066e2a4cb816","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:44:31.638910823Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:57.462269Z","description":"","domain_name":"tffunccleverchandrasptrbvmiv-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"bf1ab288-b39f-43f4-a738-b3b31496e56f","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"a96206e6-ddd0-46a0-a21d-ef721b140465","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"10s","updated_at":"2025-08-27T15:05:58.639355211Z"}'
         headers:
             Content-Length:
-                - "566"
+                - "703"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:31 GMT
+                - Wed, 27 Aug 2025 15:05:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -687,10 +687,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3f226eea-f26a-4bb2-a5e8-078af1f78f2e
+                - aca4836f-eb02-4686-b1b1-d6239dbc5f1e
         status: 200 OK
         code: 200
-        duration: 209.550583ms
+        duration: 245.66994ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -706,8 +706,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/31066ad6-87e2-4075-ae04-c22348ebf5c2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a96206e6-ddd0-46a0-a21d-ef721b140465
         method: GET
       response:
         proto: HTTP/2.0
@@ -715,20 +715,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 563
+        content_length: 596
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:23.346931Z","description":"","environment_variables":{},"error_message":null,"id":"31066ad6-87e2-4075-ae04-c22348ebf5c2","name":"tf-func-recursing-swanson","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncrecursingswans0wcypqhr","registry_namespace_id":"bdc70379-d1d8-4c74-bd7a-066e2a4cb816","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:44:31.638911Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.174909Z","description":"","environment_variables":{},"error_message":null,"id":"a96206e6-ddd0-46a0-a21d-ef721b140465","name":"tf-func-clever-chandrasekhar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunccleverchandrasptrbvmiv","registry_namespace_id":"14451d08-4bcf-4b18-b7ed-e101fdaae126","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:53.133909Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "563"
+                - "596"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:31 GMT
+                - Wed, 27 Aug 2025 15:05:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -736,10 +736,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 207792b8-d7bd-4294-9212-f8d7d9a71c88
+                - e2e66c0b-0083-4445-928e-6681d05f37ac
         status: 200 OK
         code: 200
-        duration: 63.671625ms
+        duration: 45.412534ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -755,29 +755,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/31066ad6-87e2-4075-ae04-c22348ebf5c2
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a96206e6-ddd0-46a0-a21d-ef721b140465
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 563
+        content_length: 602
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:23.346931Z","description":"","environment_variables":{},"error_message":null,"id":"31066ad6-87e2-4075-ae04-c22348ebf5c2","name":"tf-func-recursing-swanson","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncrecursingswans0wcypqhr","registry_namespace_id":"bdc70379-d1d8-4c74-bd7a-066e2a4cb816","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:44:31.638911Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.174909Z","description":"","environment_variables":{},"error_message":null,"id":"a96206e6-ddd0-46a0-a21d-ef721b140465","name":"tf-func-clever-chandrasekhar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunccleverchandrasptrbvmiv","registry_namespace_id":"14451d08-4bcf-4b18-b7ed-e101fdaae126","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:58.919992357Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "563"
+                - "602"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:36 GMT
+                - Wed, 27 Aug 2025 15:05:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -785,10 +785,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 48faffbe-9bfa-4e66-8732-9c6400bf53d9
+                - be73d129-da65-49e0-ab5a-8489218f0020
         status: 200 OK
         code: 200
-        duration: 74.689708ms
+        duration: 383.868094ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -804,8 +804,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/31066ad6-87e2-4075-ae04-c22348ebf5c2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a96206e6-ddd0-46a0-a21d-ef721b140465
         method: GET
       response:
         proto: HTTP/2.0
@@ -813,20 +813,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 563
+        content_length: 599
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:23.346931Z","description":"","environment_variables":{},"error_message":null,"id":"31066ad6-87e2-4075-ae04-c22348ebf5c2","name":"tf-func-recursing-swanson","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncrecursingswans0wcypqhr","registry_namespace_id":"bdc70379-d1d8-4c74-bd7a-066e2a4cb816","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:44:31.638911Z"}'
+        body: '{"created_at":"2025-08-27T15:05:41.174909Z","description":"","environment_variables":{},"error_message":null,"id":"a96206e6-ddd0-46a0-a21d-ef721b140465","name":"tf-func-clever-chandrasekhar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunccleverchandrasptrbvmiv","registry_namespace_id":"14451d08-4bcf-4b18-b7ed-e101fdaae126","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:58.919992Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "563"
+                - "599"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:41 GMT
+                - Wed, 27 Aug 2025 15:05:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -834,10 +834,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b4adc2ed-54fe-41ff-a2d6-f4e882360456
+                - 46072195-8472-448b-8833-920a56450d07
         status: 200 OK
         code: 200
-        duration: 63.63425ms
+        duration: 55.092529ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -853,155 +853,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/31066ad6-87e2-4075-ae04-c22348ebf5c2
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 563
-        uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:23.346931Z","description":"","environment_variables":{},"error_message":null,"id":"31066ad6-87e2-4075-ae04-c22348ebf5c2","name":"tf-func-recursing-swanson","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncrecursingswans0wcypqhr","registry_namespace_id":"bdc70379-d1d8-4c74-bd7a-066e2a4cb816","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:44:31.638911Z"}'
-        headers:
-            Content-Length:
-                - "563"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:44:47 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 1a137709-99a4-4c01-abf6-6813a1f66d46
-        status: 200 OK
-        code: 200
-        duration: 58.929625ms
-    - id: 18
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/31066ad6-87e2-4075-ae04-c22348ebf5c2
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 563
-        uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:23.346931Z","description":"","environment_variables":{},"error_message":null,"id":"31066ad6-87e2-4075-ae04-c22348ebf5c2","name":"tf-func-recursing-swanson","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncrecursingswans0wcypqhr","registry_namespace_id":"bdc70379-d1d8-4c74-bd7a-066e2a4cb816","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:44:31.638911Z"}'
-        headers:
-            Content-Length:
-                - "563"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:44:52 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 4256a00e-4299-4fbc-aafe-b3dd5d7d65fd
-        status: 200 OK
-        code: 200
-        duration: 57.7745ms
-    - id: 19
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/31066ad6-87e2-4075-ae04-c22348ebf5c2
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 563
-        uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:23.346931Z","description":"","environment_variables":{},"error_message":null,"id":"31066ad6-87e2-4075-ae04-c22348ebf5c2","name":"tf-func-recursing-swanson","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncrecursingswans0wcypqhr","registry_namespace_id":"bdc70379-d1d8-4c74-bd7a-066e2a4cb816","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:44:31.638911Z"}'
-        headers:
-            Content-Length:
-                - "563"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:44:57 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 928f716b-48bd-4d26-b5c9-8f937131ae32
-        status: 200 OK
-        code: 200
-        duration: 68.178667ms
-    - id: 20
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/31066ad6-87e2-4075-ae04-c22348ebf5c2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a96206e6-ddd0-46a0-a21d-ef721b140465
         method: GET
       response:
         proto: HTTP/2.0
@@ -1020,9 +873,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:02 GMT
+                - Wed, 27 Aug 2025 15:06:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1030,11 +883,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 54ced8a7-d856-4c57-ad75-bab33e28f715
+                - 59fb9642-d2d1-49e5-9423-4efd69efc24a
         status: 404 Not Found
         code: 404
-        duration: 87.1085ms
-    - id: 21
+        duration: 21.013721ms
+    - id: 18
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1049,8 +902,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/fb27f0f9-6ebf-4a16-945b-e47060391dcc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/bf1ab288-b39f-43f4-a738-b3b31496e56f
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1069,9 +922,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:02 GMT
+                - Wed, 27 Aug 2025 15:06:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1079,7 +932,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d42c7139-cc0a-4e32-a0c2-34e2048250a2
+                - ce710826-8205-4243-9ab9-eb6714cd1537
         status: 404 Not Found
         code: 404
-        duration: 21.323542ms
+        duration: 24.4127ms

--- a/internal/services/function/testdata/function-token-basic.cassette.yaml
+++ b/internal/services/function/testdata/function-token-basic.cassette.yaml
@@ -6,19 +6,19 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 158
+        content_length: 190
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"test-function-token-ns","environment_variables":{},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","secret_environment_variables":[],"tags":null}'
+        body: '{"name":"test-function-token-ns","environment_variables":{},"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","secret_environment_variables":[],"tags":null,"activate_vpc_integration":true}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces
         method: POST
       response:
@@ -27,20 +27,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 488
+        content_length: 507
         uncompressed: false
-        body: '{"created_at":"2025-01-27T14:55:39.687270119Z","description":"","environment_variables":{},"error_message":null,"id":"d96f82e9-092e-45db-be16-8d26d0ecc01e","name":"test-function-token-ns","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-27T14:55:39.687270119Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.806237878Z","description":"","environment_variables":{},"error_message":null,"id":"2d37fd88-5987-4d1a-90f3-d39903d9e975","name":"test-function-token-ns","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:13.806237878Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "488"
+                - "507"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:55:39 GMT
+                - Wed, 27 Aug 2025 15:05:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9af6d14b-15e4-4bd7-8d30-c0bb47cfe52f
+                - ff801d71-f9e1-47a2-b11b-a6324bda2691
         status: 200 OK
         code: 200
-        duration: 700.312584ms
+        duration: 5.610616081s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -67,8 +67,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d96f82e9-092e-45db-be16-8d26d0ecc01e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/2d37fd88-5987-4d1a-90f3-d39903d9e975
         method: GET
       response:
         proto: HTTP/2.0
@@ -76,20 +76,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 482
+        content_length: 501
         uncompressed: false
-        body: '{"created_at":"2025-01-27T14:55:39.687270Z","description":"","environment_variables":{},"error_message":null,"id":"d96f82e9-092e-45db-be16-8d26d0ecc01e","name":"test-function-token-ns","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-27T14:55:39.687270Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.806238Z","description":"","environment_variables":{},"error_message":null,"id":"2d37fd88-5987-4d1a-90f3-d39903d9e975","name":"test-function-token-ns","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:13.806238Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "482"
+                - "501"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:55:39 GMT
+                - Wed, 27 Aug 2025 15:05:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fda062fc-a7e3-487c-9450-d48b9484c67f
+                - fb26ea0d-63e5-4293-9613-d74bbacabf63
         status: 200 OK
         code: 200
-        duration: 92.598625ms
+        duration: 40.323109ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -116,8 +116,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d96f82e9-092e-45db-be16-8d26d0ecc01e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/2d37fd88-5987-4d1a-90f3-d39903d9e975
         method: GET
       response:
         proto: HTTP/2.0
@@ -125,20 +125,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 570
+        content_length: 501
         uncompressed: false
-        body: '{"created_at":"2025-01-27T14:55:39.687270Z","description":"","environment_variables":{},"error_message":null,"id":"d96f82e9-092e-45db-be16-8d26d0ecc01e","name":"test-function-token-ns","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontokennsiofaru86","registry_namespace_id":"18eacdf4-0e77-49d2-98b1-7986746d828d","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-27T14:55:40.771390Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.806238Z","description":"","environment_variables":{},"error_message":null,"id":"2d37fd88-5987-4d1a-90f3-d39903d9e975","name":"test-function-token-ns","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:16.853937Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "570"
+                - "501"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:55:44 GMT
+                - Wed, 27 Aug 2025 15:05:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -146,10 +146,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d39aef3a-fdb3-40a7-8bd8-96915d0c1fe4
+                - df589dce-e68d-45ec-947f-9ece88f4b8a9
         status: 200 OK
         code: 200
-        duration: 74.575042ms
+        duration: 497.657252ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -165,8 +165,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d96f82e9-092e-45db-be16-8d26d0ecc01e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/2d37fd88-5987-4d1a-90f3-d39903d9e975
         method: GET
       response:
         proto: HTTP/2.0
@@ -174,20 +174,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 570
+        content_length: 589
         uncompressed: false
-        body: '{"created_at":"2025-01-27T14:55:39.687270Z","description":"","environment_variables":{},"error_message":null,"id":"d96f82e9-092e-45db-be16-8d26d0ecc01e","name":"test-function-token-ns","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontokennsiofaru86","registry_namespace_id":"18eacdf4-0e77-49d2-98b1-7986746d828d","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-27T14:55:40.771390Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.806238Z","description":"","environment_variables":{},"error_message":null,"id":"2d37fd88-5987-4d1a-90f3-d39903d9e975","name":"test-function-token-ns","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontokennsxaepsa5r","registry_namespace_id":"a982d119-765d-4d00-83d4-71532bcf9acd","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:21.647444Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "570"
+                - "589"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:55:44 GMT
+                - Wed, 27 Aug 2025 15:05:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -195,11 +195,60 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 76a26448-153d-4bd9-8b13-f47bd0ca1cc0
+                - 0cc3f468-178d-4336-b6c3-506fd2d40326
         status: 200 OK
         code: 200
-        duration: 87.74675ms
+        duration: 38.516881ms
     - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/2d37fd88-5987-4d1a-90f3-d39903d9e975
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 589
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:13.806238Z","description":"","environment_variables":{},"error_message":null,"id":"2d37fd88-5987-4d1a-90f3-d39903d9e975","name":"test-function-token-ns","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontokennsxaepsa5r","registry_namespace_id":"a982d119-765d-4d00-83d4-71532bcf9acd","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:21.647444Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "589"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:05:24 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 4af25b7d-0bfb-40c1-b8b9-0600e79c715b
+        status: 200 OK
+        code: 200
+        duration: 51.030441ms
+    - id: 5
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -210,13 +259,13 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"namespace_id":"d96f82e9-092e-45db-be16-8d26d0ecc01e","expires_at":"2025-01-28T15:55:38+01:00"}'
+        body: '{"namespace_id":"2d37fd88-5987-4d1a-90f3-d39903d9e975","expires_at":"2025-08-28T17:05:06+02:00"}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens
         method: POST
       response:
@@ -225,20 +274,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2056
+        content_length: 2050
         uncompressed: false
-        body: '{"description":"","expires_at":"2025-01-28T14:55:38Z","id":"c1467714-de0f-4ee5-aca1-fc1898469246","namespace_id":"d96f82e9-092e-45db-be16-8d26d0ecc01e","public_key":"-----BEGIN RSA PUBLIC KEY-----\nMIICCgKCAgEAxmHz0kjC5oo8qdE2+JEsUtFZJV1Ij+7GvtcKa9hrPOuxfh7n2ebp\nzLrynKVlS9zsRtuDF5ZhgTuw5fsH8pgA9kXDvE189mQhmiU68gQbheOF1MVtXVBV\nj1DoGCQrCZTxrb1mxGdH4BBEho4Hx3X8Am7TCWkAOZkU/r/NwxW+ZE2fME22yira\nzmy10lDpj8iHlxlYZp3yMyoKNObE+eoIrJIoZjMzVx0vyLdMS/wYrxGaCqkxDMzZ\nMv/IMIzcgnRWbWhEJST67i+X5g6Irp3wkmsAmHjZy9wDlqhqoGq4wxI//2T4pXFK\n10nY4Q6BK3Cbs3siygO8XN4jW+Pez/uN/28F6b38rPoSW3zdVYcR1u3F6PttoMUs\nL2mrOpe/etYcfE2p/oZJ1+hVXXAnusESvSj6EKVDOa0uGGIewb3PnGQdnk46wSGg\nlQ7gt9IULd3F5hAr2JL0AN6VF+kLaf50f5iEWk7/VdncfWVw/Tu0aUoyPvh3S9YV\nYs5+KLXQP1NG/1O9MOUdqKm5bkOTz4fXGUo0zUnRHCgr1jtZitbHkKFnLfzpr9QI\nUpQC6WPV7nkD6wJinoLwcRLg81Sdky6aPkRZ9dWTb37ex+UjpLT0se4yfajl/pY6\nD5FjNh2eiHDoyAVWjstV4U/qbA8jnPCMJ1lt/xgdjM1iA+cxQpg5rusCAwEAAQ==\n-----END RSA PUBLIC KEY-----\n","status":"creating","token":"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJhcHBsaWNhdGlvbl9jbGFpbSI6W3sibmFtZXNwYWNlX2lkIjoiZDk2ZjgyZTktMDkyZS00NWRiLWJlMTYtOGQyNmQwZWNjMDFlIiwiYXBwbGljYXRpb25faWQiOiIifV0sInZlcnNpb24iOjIsImF1ZCI6ImZ1bmN0aW9ucyIsImV4cCI6MTczODA3NjEzOCwianRpIjoiYzE0Njc3MTQtZGUwZi00ZWU1LWFjYTEtZmMxODk4NDY5MjQ2IiwiaWF0IjoxNzM3OTg5NzQ1LCJpc3MiOiJTQ0FMRVdBWSIsIm5iZiI6MTczNzk4OTc0NSwic3ViIjoidG9rZW4ifQ.vhu_vvAChIFEMxuu1FPsb_nihQl94GrfkgpwftUxj2m0cmrAQPldBnM873IXj8Ft-dfkk5lcmahSZYGo9tVYEWUXwJEFpSz7Z66ILbhdofAzH3Y7TVgP4-GLPQwehOKFMaSwsMpzg1Ift054x5EedAl8ejyacgKMxRs7NHv3UFVCdT7zubdvgkwzaAhNkl7sZDIqpYe-s1VrB6u_Q8pjUdwuUPtMRV9IMaSvtD9LKn6JjEr3SSFU-pWkb3tb7-jKaUz5sQYH45MHp33w-jDO1ROe1asfNtH9sSCMtIkT4PKxcdvCaeVCvdx6vbOIo69yDFCZ2EyuyqL_4bdCRxFyANNYUySlYgaHPfLGag7Le3V-Pg0ndSwy9EiooR2oeNyvFyfYA07sfyusFd1S2blZ4Ack0ZAv3RecNMglVxSy-7uue-_fYzKZ275wA2FD90UjdnVNGvwJvocvyJ03hzGerD7skW0_uOxiQXtudlP3p1ju_1AanLn1LVBFsxSw44BgCAd6rZur7BuaRlTpwSvcYdhJtJtPeJFBuCIodREuEnEYeFX1XI5tRCHRvTI4yKY_-IFPLz2XT7Tup8Aq8Z7EO5jaWGFjCvDw8XB003a0Vpm99T9xmDtHEmnGEekBLBQo5hx8wSBnt7CthehgMFP4TCVunUW9bf2k8cleGrczcgQ"}'
+        body: '{"description":"","expires_at":"2025-08-28T15:05:06Z","id":"6acf5d1c-fab0-45ed-ac85-022315e4bbb3","namespace_id":"2d37fd88-5987-4d1a-90f3-d39903d9e975","public_key":"-----BEGIN RSA PUBLIC KEY-----\nMIICCgKCAgEAu5F9qe0ffeZtwew/KDQ+m+NfOMZ22mDSK17hbJbvQlpRlyXmT5/C\nLn3T4cj/o4Rdl2j8+DEUqH+Yro2sfSHYakV2GOcYkU87qfg1chnV64I25dzXih9h\nrWe/oTJKOXAeHdSYezGQcYvG6TZIhTJ9yg1FqBVSBkjWCupb2QumnJ3W/P71dxLj\n5f86EWQ7Zm73Q8cUBGKx1ZBBfEDlRq7d7eSXlU89v2OWmUrghvmK27ND2LFawr8X\nuEZ0r8a2MLLNPtbnZPmFTBrbgfIwKY7NIvo3fdZyOdymQ9qmgpmbNqcYHjcGDdul\nad3dkEkUjT0JuF4PUVn2w8kHZQx2u8G16zxREXd5qZNBrNVaZJ+JH2dhi7JFLo8J\n0KNKP/N/KQqye+pCo7sZZe+SeyBsMsTXCJuOV5FSWVZGYJZ8WYgH+TLmDqbNGAXr\nOYiWuBgZZq1PknTjVz98B7PhvYuwJUXBD/M/HQVsNE6K267+HtD+tJzhGwdzWs34\nsJKHJ2RJ+obZJUTr8e4Qa6E4HhPtmWcMcIhjWwEP3kzAxbcrudCdRYpL3gmYCqQX\nKCsxV/7s91KsU5ba3oA7mRSl4O4fF5FLaxQIsepkI/TeylKNapeEfEZpuxdncJn8\nFqsMHj2PtZ2LqzNj71XM2UKiKlnw3FvvXGgUmD8lzCtr0rMO1j79V3kCAwEAAQ==\n-----END RSA PUBLIC KEY-----\n","status":"creating","token":"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJhcHBsaWNhdGlvbl9jbGFpbSI6W3sibmFtZXNwYWNlX2lkIjoiMmQzN2ZkODgtNTk4Ny00ZDFhLTkwZjMtZDM5OTAzZDllOTc1IiwiYXBwbGljYXRpb25faWQiOiIifV0sInZlcnNpb24iOjIsImF1ZCI6ImZ1bmN0aW9ucyIsImV4cCI6MTc1NjM5MzUwNiwianRpIjoiNmFjZjVkMWMtZmFiMC00NWVkLWFjODUtMDIyMzE1ZTRiYmIzIiwiaWF0IjoxNzU2MzA3MTI1LCJpc3MiOiJTQ0FMRVdBWSIsIm5iZiI6MTc1NjMwNzEyNSwic3ViIjoidG9rZW4ifQ.poakDv_C4y_wKJKtfJJfxcCg4QHd7yso09t-BRuVBG9MGyl2Px9VJCGs31xX9oVLQd2erRUgOhstDbZLd8KzcYF1UIVGOOtsxkt4qD1MGFQljFxzGZZHiawS1cacaXUvtURX21jonltQZreItxnqWAElDkY6vXNFNQbhK9jjV3XRzXoS51XpFUxh-Zv1UAcacCWU69U7CGenT_DwyrMgixTutSH_wBeP5A3o15A3Q39yB8dM9WUxzeIO8haNWqz1s1wCA-QoXx9BKfYpk0Q9VoZqG3Y5FyyAu5knPq34dT_n-5sdhjTrBfOErJ49rR4m4uInpOnzOG_5Qjto0ZcxrTZNUEjQaLnRrfYbxscmyUEBCEUeZiPrLpTym05xt2zzNr50QrnIlkkHvVW6A7cMZ4EjGgXz2ZVoDfnf4R988IgoiAOxBtb6_wbuZ3ZQg3lwEZJ13dGqFpvPIsfp4g9HvM40cSx5A9y_hUx-OklCAHLesZQTNHhRnhr42ortk7r5CBuFkC_tLMV_uUKWphQksH_0MyoZY6uQeHwF-0_K6t8L_1RgFprjqHoBxay_-gi_1NGPTAFngY863z_ZHQ4kZOskJhL6RCo7mfBwcKNftCVU9LP1xw-pfTrGygT3_OidetQHjBx36VVE4iLoI2hvus07jDukkiV-GxhfwotuqZk"}'
         headers:
             Content-Length:
-                - "2056"
+                - "2050"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:55:45 GMT
+                - Wed, 27 Aug 2025 15:05:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -246,11 +295,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 29a6fc67-df14-4d7f-9d0a-27b7aca678ed
+                - ffd4fe71-e5b6-48b0-9569-e80dbd4130b1
         status: 200 OK
         code: 200
-        duration: 152.331ms
-    - id: 5
+        duration: 959.920385ms
+    - id: 6
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -265,8 +314,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens/c1467714-de0f-4ee5-aca1-fc1898469246
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens/6acf5d1c-fab0-45ed-ac85-022315e4bbb3
         method: GET
       response:
         proto: HTTP/2.0
@@ -274,20 +323,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 213
+        content_length: 207
         uncompressed: false
-        body: '{"description":"","expires_at":"2025-01-28T14:55:38Z","id":"c1467714-de0f-4ee5-aca1-fc1898469246","namespace_id":"d96f82e9-092e-45db-be16-8d26d0ecc01e","public_key":"","status":"creating","token":"\u003chidden\u003e"}'
+        body: '{"description":"","expires_at":"2025-08-28T15:05:06Z","id":"6acf5d1c-fab0-45ed-ac85-022315e4bbb3","namespace_id":"2d37fd88-5987-4d1a-90f3-d39903d9e975","public_key":"","status":"creating","token":"\u003chidden\u003e"}'
         headers:
             Content-Length:
-                - "213"
+                - "207"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:55:45 GMT
+                - Wed, 27 Aug 2025 15:05:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -295,28 +344,28 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e625cf4d-9d4a-4c3d-9052-e3946190ada9
+                - bbe71ac2-8ff2-4105-81a5-b6a1255f8abd
         status: 200 OK
         code: 200
-        duration: 107.238542ms
-    - id: 6
+        duration: 45.043999ms
+    - id: 7
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 315
+        content_length: 326
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-func-hopeful-jackson","namespace_id":"d96f82e9-092e-45db-be16-8d26d0ecc01e","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"node22","memory_limit":256,"handler":"handler.handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox"}'
+        body: '{"name":"tf-func-sad-sutherland","namespace_id":"2d37fd88-5987-4d1a-90f3-d39903d9e975","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"node22","memory_limit":256,"handler":"handler.handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox","tags":null}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions
         method: POST
       response:
@@ -325,20 +374,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 727
+        content_length: 737
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-27T14:55:45.226658767Z","description":"","domain_name":"testfunctiontokennsiofaru86-tf-func-hopeful-jackson.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"4b07c639-d32c-48ec-8b1c-0962be19273e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-hopeful-jackson","namespace_id":"d96f82e9-092e-45db-be16-8d26d0ecc01e","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-27T14:55:45.226658767Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:25.879818948Z","description":"","domain_name":"testfunctiontokennsxaepsa5r-tf-func-sad-sutherland.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"46aebf26-7295-45ca-a248-13bd09921d41","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-sad-sutherland","namespace_id":"2d37fd88-5987-4d1a-90f3-d39903d9e975","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:25.879818948Z"}'
         headers:
             Content-Length:
-                - "727"
+                - "737"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:55:45 GMT
+                - Wed, 27 Aug 2025 15:05:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -346,59 +395,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6e0e9a38-e2d0-486c-8eda-aff800bd4c1f
+                - 44195622-7395-4ffb-a119-1014f5dc73f0
         status: 200 OK
         code: 200
-        duration: 271.689375ms
-    - id: 7
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4b07c639-d32c-48ec-8b1c-0962be19273e
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 721
-        uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-27T14:55:45.226659Z","description":"","domain_name":"testfunctiontokennsiofaru86-tf-func-hopeful-jackson.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"4b07c639-d32c-48ec-8b1c-0962be19273e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-hopeful-jackson","namespace_id":"d96f82e9-092e-45db-be16-8d26d0ecc01e","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-27T14:55:45.226659Z"}'
-        headers:
-            Content-Length:
-                - "721"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 14:55:45 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 64f62f0e-cd5f-4878-bb97-6c90efc124ad
-        status: 200 OK
-        code: 200
-        duration: 82.107291ms
+        duration: 1.508464527s
     - id: 8
       request:
         proto: HTTP/1.1
@@ -414,8 +414,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4b07c639-d32c-48ec-8b1c-0962be19273e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/46aebf26-7295-45ca-a248-13bd09921d41
         method: GET
       response:
         proto: HTTP/2.0
@@ -423,20 +423,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 721
+        content_length: 731
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-27T14:55:45.226659Z","description":"","domain_name":"testfunctiontokennsiofaru86-tf-func-hopeful-jackson.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"4b07c639-d32c-48ec-8b1c-0962be19273e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-hopeful-jackson","namespace_id":"d96f82e9-092e-45db-be16-8d26d0ecc01e","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-27T14:55:45.226659Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:25.879819Z","description":"","domain_name":"testfunctiontokennsxaepsa5r-tf-func-sad-sutherland.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"46aebf26-7295-45ca-a248-13bd09921d41","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-sad-sutherland","namespace_id":"2d37fd88-5987-4d1a-90f3-d39903d9e975","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:25.879819Z"}'
         headers:
             Content-Length:
-                - "721"
+                - "731"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:55:45 GMT
+                - Wed, 27 Aug 2025 15:05:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -444,62 +444,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8a6a0b42-ec0c-4181-915a-357489a40884
+                - 607c2f1d-b67b-4d8a-ba49-f6991ead6a4b
         status: 200 OK
         code: 200
-        duration: 89.321958ms
+        duration: 46.460607ms
     - id: 9
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 54
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"function_id":"4b07c639-d32c-48ec-8b1c-0962be19273e"}'
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2014
-        uncompressed: false
-        body: '{"description":"","expires_at":null,"function_id":"4b07c639-d32c-48ec-8b1c-0962be19273e","id":"62733f02-f61b-44b0-82ed-72d0d22cc1ff","public_key":"-----BEGIN RSA PUBLIC KEY-----\nMIICCgKCAgEAxmHz0kjC5oo8qdE2+JEsUtFZJV1Ij+7GvtcKa9hrPOuxfh7n2ebp\nzLrynKVlS9zsRtuDF5ZhgTuw5fsH8pgA9kXDvE189mQhmiU68gQbheOF1MVtXVBV\nj1DoGCQrCZTxrb1mxGdH4BBEho4Hx3X8Am7TCWkAOZkU/r/NwxW+ZE2fME22yira\nzmy10lDpj8iHlxlYZp3yMyoKNObE+eoIrJIoZjMzVx0vyLdMS/wYrxGaCqkxDMzZ\nMv/IMIzcgnRWbWhEJST67i+X5g6Irp3wkmsAmHjZy9wDlqhqoGq4wxI//2T4pXFK\n10nY4Q6BK3Cbs3siygO8XN4jW+Pez/uN/28F6b38rPoSW3zdVYcR1u3F6PttoMUs\nL2mrOpe/etYcfE2p/oZJ1+hVXXAnusESvSj6EKVDOa0uGGIewb3PnGQdnk46wSGg\nlQ7gt9IULd3F5hAr2JL0AN6VF+kLaf50f5iEWk7/VdncfWVw/Tu0aUoyPvh3S9YV\nYs5+KLXQP1NG/1O9MOUdqKm5bkOTz4fXGUo0zUnRHCgr1jtZitbHkKFnLfzpr9QI\nUpQC6WPV7nkD6wJinoLwcRLg81Sdky6aPkRZ9dWTb37ex+UjpLT0se4yfajl/pY6\nD5FjNh2eiHDoyAVWjstV4U/qbA8jnPCMJ1lt/xgdjM1iA+cxQpg5rusCAwEAAQ==\n-----END RSA PUBLIC KEY-----\n","status":"creating","token":"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJhcHBsaWNhdGlvbl9jbGFpbSI6W3sibmFtZXNwYWNlX2lkIjoiIiwiYXBwbGljYXRpb25faWQiOiI0YjA3YzYzOS1kMzJjLTQ4ZWMtOGIxYy0wOTYyYmUxOTI3M2UifV0sInZlcnNpb24iOjIsImF1ZCI6ImZ1bmN0aW9ucyIsImp0aSI6IjYyNzMzZjAyLWY2MWItNDRiMC04MmVkLTcyZDBkMjJjYzFmZiIsImlhdCI6MTczNzk4OTc0NSwiaXNzIjoiU0NBTEVXQVkiLCJuYmYiOjE3Mzc5ODk3NDUsInN1YiI6InRva2VuIn0.VjDGexHA-AwrrjFQfp2SUwdXVi4SwXz-tyD5S-kHx-YdARG7DhaBzEMUh-nPpQiWzOTBonL2W-OFss5YhOqj5WpZW3grOO3jAMLEP_ovjfYoB7s2AnUIVkyfM3kkaQYevaSw8IMQPWy_Sp1M3JFSSiQlm92nzdeOavb9lN5GZ7yF3QKgZ89mLMQB0ZMtf3iZ_TXMZSuBQexeaERptHROon0Dntk-cj1II7TLaD_oJU18De59wg-i9d91_HcQwBI1gSUZbk2fAcJC_6-cA-G7caPMcPiUSjyGcWrQKqZuJMG4TGtPU2GUAagd5xQ5NZ-8bJYf47NBb6Me61ttCgb9D4o4PMqFydCUhoJLWg6sPE5ZWuKJi54A3EDwBM1J-qKuZgNvkMCw1ZJHzNyQUlNipnImeHBOAAex3rKZ8csSPrT6uuJj54AV5A68KCl-NE9V4HeUBxH-tWhxyYMUu2q45y3cRdrsAFycJK2V9axdjqIH8ck1GgnL_JTJGr_I0eH8Z1iLEj9xIyZwnixHRGkZEXthdipI1RwlpcwyHiQV4YXAibPu4DzLNS3nf2mH04paqwIzkM_Vwv57PN_s40bJz7E6VopDRngTZc9op7dNYFO1GjpVPqqk0lzdXHOP3XTB2t9IwcY-UMutW5a5ZOtha-qKUqRjW1vMsSQN4xUGMGI"}'
-        headers:
-            Content-Length:
-                - "2014"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 14:55:45 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 2ff1c8dd-1c35-43c7-a7d0-fb032271a3c8
-        status: 200 OK
-        code: 200
-        duration: 152.868292ms
-    - id: 10
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -514,8 +463,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens/62733f02-f61b-44b0-82ed-72d0d22cc1ff
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/46aebf26-7295-45ca-a248-13bd09921d41
         method: GET
       response:
         proto: HTTP/2.0
@@ -523,20 +472,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 194
+        content_length: 731
         uncompressed: false
-        body: '{"description":"","expires_at":null,"function_id":"4b07c639-d32c-48ec-8b1c-0962be19273e","id":"62733f02-f61b-44b0-82ed-72d0d22cc1ff","public_key":"","status":"creating","token":"\u003chidden\u003e"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:25.879819Z","description":"","domain_name":"testfunctiontokennsxaepsa5r-tf-func-sad-sutherland.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"46aebf26-7295-45ca-a248-13bd09921d41","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-sad-sutherland","namespace_id":"2d37fd88-5987-4d1a-90f3-d39903d9e975","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:25.879819Z"}'
         headers:
             Content-Length:
-                - "194"
+                - "731"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:55:45 GMT
+                - Wed, 27 Aug 2025 15:05:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -544,10 +493,61 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7a0fee24-7deb-481e-8722-3fc5af815cf6
+                - b12a2627-48b1-4bbd-82d0-139f976b124b
         status: 200 OK
         code: 200
-        duration: 95.229ms
+        duration: 57.103367ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 54
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"function_id":"46aebf26-7295-45ca-a248-13bd09921d41"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2008
+        uncompressed: false
+        body: '{"description":"","expires_at":null,"function_id":"46aebf26-7295-45ca-a248-13bd09921d41","id":"a51cb277-edd3-42d6-a15b-a042d8597b7c","public_key":"-----BEGIN RSA PUBLIC KEY-----\nMIICCgKCAgEAu5F9qe0ffeZtwew/KDQ+m+NfOMZ22mDSK17hbJbvQlpRlyXmT5/C\nLn3T4cj/o4Rdl2j8+DEUqH+Yro2sfSHYakV2GOcYkU87qfg1chnV64I25dzXih9h\nrWe/oTJKOXAeHdSYezGQcYvG6TZIhTJ9yg1FqBVSBkjWCupb2QumnJ3W/P71dxLj\n5f86EWQ7Zm73Q8cUBGKx1ZBBfEDlRq7d7eSXlU89v2OWmUrghvmK27ND2LFawr8X\nuEZ0r8a2MLLNPtbnZPmFTBrbgfIwKY7NIvo3fdZyOdymQ9qmgpmbNqcYHjcGDdul\nad3dkEkUjT0JuF4PUVn2w8kHZQx2u8G16zxREXd5qZNBrNVaZJ+JH2dhi7JFLo8J\n0KNKP/N/KQqye+pCo7sZZe+SeyBsMsTXCJuOV5FSWVZGYJZ8WYgH+TLmDqbNGAXr\nOYiWuBgZZq1PknTjVz98B7PhvYuwJUXBD/M/HQVsNE6K267+HtD+tJzhGwdzWs34\nsJKHJ2RJ+obZJUTr8e4Qa6E4HhPtmWcMcIhjWwEP3kzAxbcrudCdRYpL3gmYCqQX\nKCsxV/7s91KsU5ba3oA7mRSl4O4fF5FLaxQIsepkI/TeylKNapeEfEZpuxdncJn8\nFqsMHj2PtZ2LqzNj71XM2UKiKlnw3FvvXGgUmD8lzCtr0rMO1j79V3kCAwEAAQ==\n-----END RSA PUBLIC KEY-----\n","status":"creating","token":"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJhcHBsaWNhdGlvbl9jbGFpbSI6W3sibmFtZXNwYWNlX2lkIjoiIiwiYXBwbGljYXRpb25faWQiOiI0NmFlYmYyNi03Mjk1LTQ1Y2EtYTI0OC0xM2JkMDk5MjFkNDEifV0sInZlcnNpb24iOjIsImF1ZCI6ImZ1bmN0aW9ucyIsImp0aSI6ImE1MWNiMjc3LWVkZDMtNDJkNi1hMTViLWEwNDJkODU5N2I3YyIsImlhdCI6MTc1NjMwNzEyNiwiaXNzIjoiU0NBTEVXQVkiLCJuYmYiOjE3NTYzMDcxMjYsInN1YiI6InRva2VuIn0.bTZsDt5KZDIGyY8qLMPJg6BaLsSmJ6T9yh-RrW8zKOt8mHp11VZ0Cq4oBmmdqXsINyRAo1T09o3Xc-PFyg-qe-UIH3LUUTnvVITieXzikcov2WSNK0WhikWhqUXjgU1zr8iwVlOjqhz7aLp2vOcJKmQWx_WuR-UKcks1vgaaYI0_r-akpIRHhKe20ckcY1p4L6eSBy2cIUKaeaCZU5PdoUc-K0OybQx3K8upEp8O4Abo4i33V3X9Qibwp5M40_W8zrP_AzQkI5HU3tuLj-7IE0BnMhckHXWWJ2zXdPP90vGoWtnctfPUZu78YvHTe5Gr7DwRuahqQGfORgf7zWkDan6FjYSkwyNwc0LfRLIFU4X2_CrbCfU2obApQlLC0xr3jmtzViKsglBSrADROYOmYW9QshWJw3pM_IYeVGHwSjtIBjyvgvmoN6c4NZZN-y1j728pGj352iZKRHN-nkjx1JOwQsAvCwOBNeOrV5FNu4xIaje61EIo2M40BkDRPqFtAK9S3-OYknTjBFQ2nglvk-zLSw70U44zuJMqls3YbrA0pgYHNVO-K6HdAFy4EIYxN7itrjIMea-QuPvKRfDCMVjX9b8Fba_nmziA7ANLWlC-Y2t2-JntyB_tEJlVH_484MZOyfzQIVdDZNSuHlBD60e0nUGfcvFjtCDr9z9pdw4"}'
+        headers:
+            Content-Length:
+                - "2008"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:05:26 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 8f17c6c0-42d8-4e60-bbc2-38a0fab163fa
+        status: 200 OK
+        code: 200
+        duration: 346.158957ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -563,8 +563,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens/c1467714-de0f-4ee5-aca1-fc1898469246
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens/a51cb277-edd3-42d6-a15b-a042d8597b7c
         method: GET
       response:
         proto: HTTP/2.0
@@ -572,20 +572,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 210
+        content_length: 188
         uncompressed: false
-        body: '{"description":"","expires_at":"2025-01-28T14:55:38Z","id":"c1467714-de0f-4ee5-aca1-fc1898469246","namespace_id":"d96f82e9-092e-45db-be16-8d26d0ecc01e","public_key":"","status":"ready","token":"\u003chidden\u003e"}'
+        body: '{"description":"","expires_at":null,"function_id":"46aebf26-7295-45ca-a248-13bd09921d41","id":"a51cb277-edd3-42d6-a15b-a042d8597b7c","public_key":"","status":"creating","token":"\u003chidden\u003e"}'
         headers:
             Content-Length:
-                - "210"
+                - "188"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:55:45 GMT
+                - Wed, 27 Aug 2025 15:05:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -593,10 +593,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 001e9db2-118a-49d9-b7c5-76321ca1afbc
+                - da270938-9ca8-429e-8ad3-6867bb7e0bb2
         status: 200 OK
         code: 200
-        duration: 69.959333ms
+        duration: 48.155476ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -612,8 +612,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens/62733f02-f61b-44b0-82ed-72d0d22cc1ff
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens/6acf5d1c-fab0-45ed-ac85-022315e4bbb3
         method: GET
       response:
         proto: HTTP/2.0
@@ -621,20 +621,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 191
+        content_length: 204
         uncompressed: false
-        body: '{"description":"","expires_at":null,"function_id":"4b07c639-d32c-48ec-8b1c-0962be19273e","id":"62733f02-f61b-44b0-82ed-72d0d22cc1ff","public_key":"","status":"ready","token":"\u003chidden\u003e"}'
+        body: '{"description":"","expires_at":"2025-08-28T15:05:06Z","id":"6acf5d1c-fab0-45ed-ac85-022315e4bbb3","namespace_id":"2d37fd88-5987-4d1a-90f3-d39903d9e975","public_key":"","status":"ready","token":"\u003chidden\u003e"}'
         headers:
             Content-Length:
-                - "191"
+                - "204"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:55:45 GMT
+                - Wed, 27 Aug 2025 15:05:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -642,10 +642,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a66d58d9-ad9e-4ba6-995b-ba5c280ee020
+                - b754ce3a-8e55-4697-9658-b44a6d520060
         status: 200 OK
         code: 200
-        duration: 96.612125ms
+        duration: 51.942813ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -661,8 +661,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d96f82e9-092e-45db-be16-8d26d0ecc01e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens/a51cb277-edd3-42d6-a15b-a042d8597b7c
         method: GET
       response:
         proto: HTTP/2.0
@@ -670,20 +670,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 570
+        content_length: 185
         uncompressed: false
-        body: '{"created_at":"2025-01-27T14:55:39.687270Z","description":"","environment_variables":{},"error_message":null,"id":"d96f82e9-092e-45db-be16-8d26d0ecc01e","name":"test-function-token-ns","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontokennsiofaru86","registry_namespace_id":"18eacdf4-0e77-49d2-98b1-7986746d828d","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-27T14:55:40.771390Z"}'
+        body: '{"description":"","expires_at":null,"function_id":"46aebf26-7295-45ca-a248-13bd09921d41","id":"a51cb277-edd3-42d6-a15b-a042d8597b7c","public_key":"","status":"ready","token":"\u003chidden\u003e"}'
         headers:
             Content-Length:
-                - "570"
+                - "185"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:55:46 GMT
+                - Wed, 27 Aug 2025 15:05:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -691,10 +691,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f07e9c8b-b549-4675-a8b9-3327d47cc4d0
+                - 1acc57f8-3335-4f47-8e0f-7efb29e585af
         status: 200 OK
         code: 200
-        duration: 66.915041ms
+        duration: 59.234575ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -710,8 +710,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens/c1467714-de0f-4ee5-aca1-fc1898469246
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/2d37fd88-5987-4d1a-90f3-d39903d9e975
         method: GET
       response:
         proto: HTTP/2.0
@@ -719,20 +719,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 210
+        content_length: 589
         uncompressed: false
-        body: '{"description":"","expires_at":"2025-01-28T14:55:38Z","id":"c1467714-de0f-4ee5-aca1-fc1898469246","namespace_id":"d96f82e9-092e-45db-be16-8d26d0ecc01e","public_key":"","status":"ready","token":"\u003chidden\u003e"}'
+        body: '{"created_at":"2025-08-27T15:05:13.806238Z","description":"","environment_variables":{},"error_message":null,"id":"2d37fd88-5987-4d1a-90f3-d39903d9e975","name":"test-function-token-ns","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontokennsxaepsa5r","registry_namespace_id":"a982d119-765d-4d00-83d4-71532bcf9acd","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:21.647444Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "210"
+                - "589"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:55:46 GMT
+                - Wed, 27 Aug 2025 15:05:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -740,10 +740,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a1af3454-0364-41a7-89a7-495a75178d80
+                - c57bf395-f568-4419-9bda-e00d0a12970e
         status: 200 OK
         code: 200
-        duration: 73.0925ms
+        duration: 47.888376ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -759,8 +759,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4b07c639-d32c-48ec-8b1c-0962be19273e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens/6acf5d1c-fab0-45ed-ac85-022315e4bbb3
         method: GET
       response:
         proto: HTTP/2.0
@@ -768,20 +768,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 721
+        content_length: 204
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-27T14:55:45.226659Z","description":"","domain_name":"testfunctiontokennsiofaru86-tf-func-hopeful-jackson.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"4b07c639-d32c-48ec-8b1c-0962be19273e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-hopeful-jackson","namespace_id":"d96f82e9-092e-45db-be16-8d26d0ecc01e","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-27T14:55:45.226659Z"}'
+        body: '{"description":"","expires_at":"2025-08-28T15:05:06Z","id":"6acf5d1c-fab0-45ed-ac85-022315e4bbb3","namespace_id":"2d37fd88-5987-4d1a-90f3-d39903d9e975","public_key":"","status":"ready","token":"\u003chidden\u003e"}'
         headers:
             Content-Length:
-                - "721"
+                - "204"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:55:46 GMT
+                - Wed, 27 Aug 2025 15:05:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -789,10 +789,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e78aa5e9-d8d4-4400-9c47-99a6178734e7
+                - 1162f3c8-fd76-4884-97cf-d074df0d20bf
         status: 200 OK
         code: 200
-        duration: 72.443417ms
+        duration: 43.281101ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -808,8 +808,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens/62733f02-f61b-44b0-82ed-72d0d22cc1ff
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/46aebf26-7295-45ca-a248-13bd09921d41
         method: GET
       response:
         proto: HTTP/2.0
@@ -817,20 +817,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 191
+        content_length: 731
         uncompressed: false
-        body: '{"description":"","expires_at":null,"function_id":"4b07c639-d32c-48ec-8b1c-0962be19273e","id":"62733f02-f61b-44b0-82ed-72d0d22cc1ff","public_key":"","status":"ready","token":"\u003chidden\u003e"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:25.879819Z","description":"","domain_name":"testfunctiontokennsxaepsa5r-tf-func-sad-sutherland.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"46aebf26-7295-45ca-a248-13bd09921d41","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-sad-sutherland","namespace_id":"2d37fd88-5987-4d1a-90f3-d39903d9e975","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:25.879819Z"}'
         headers:
             Content-Length:
-                - "191"
+                - "731"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:55:46 GMT
+                - Wed, 27 Aug 2025 15:05:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -838,10 +838,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b4589cdd-27ae-4b38-adac-384903e289fb
+                - 5897fb9a-6bcc-4100-8061-820312ba7323
         status: 200 OK
         code: 200
-        duration: 89.165333ms
+        duration: 59.473483ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -857,29 +857,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/tokens/c1467714-de0f-4ee5-aca1-fc1898469246
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens/a51cb277-edd3-42d6-a15b-a042d8597b7c
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 37
+        content_length: 185
         uncompressed: false
-        body: '{"message":"Container was not found"}'
+        body: '{"description":"","expires_at":null,"function_id":"46aebf26-7295-45ca-a248-13bd09921d41","id":"a51cb277-edd3-42d6-a15b-a042d8597b7c","public_key":"","status":"ready","token":"\u003chidden\u003e"}'
         headers:
             Content-Length:
-                - "37"
+                - "185"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:55:46 GMT
+                - Wed, 27 Aug 2025 15:05:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -887,10 +887,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4fc9b921-41de-4527-9f6c-f23d7b1f5f8f
-        status: 404 Not Found
-        code: 404
-        duration: 37.6105ms
+                - c6d75ae1-69e5-4b5b-b15c-9ddb4e3e8259
+        status: 200 OK
+        code: 200
+        duration: 71.189507ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -906,8 +906,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/tokens/62733f02-f61b-44b0-82ed-72d0d22cc1ff
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/tokens/6acf5d1c-fab0-45ed-ac85-022315e4bbb3
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -926,9 +926,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:55:46 GMT
+                - Wed, 27 Aug 2025 15:05:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -936,10 +936,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 681cc26b-1cca-4bd2-9c84-ec8bef40b4f7
+                - 3f724343-9606-4717-9fad-5c8d3c6852e1
         status: 404 Not Found
         code: 404
-        duration: 43.573834ms
+        duration: 30.608362ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -955,29 +955,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4b07c639-d32c-48ec-8b1c-0962be19273e
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/tokens/a51cb277-edd3-42d6-a15b-a042d8597b7c
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 721
+        content_length: 37
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-27T14:55:45.226659Z","description":"","domain_name":"testfunctiontokennsiofaru86-tf-func-hopeful-jackson.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"4b07c639-d32c-48ec-8b1c-0962be19273e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-hopeful-jackson","namespace_id":"d96f82e9-092e-45db-be16-8d26d0ecc01e","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-27T14:55:45.226659Z"}'
+        body: '{"message":"Container was not found"}'
         headers:
             Content-Length:
-                - "721"
+                - "37"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:55:46 GMT
+                - Wed, 27 Aug 2025 15:05:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -985,10 +985,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bc64ccba-9160-4e2d-849e-74bd33b0eefe
-        status: 200 OK
-        code: 200
-        duration: 80.336084ms
+                - 966180d2-dd3f-4be8-9ff0-7323b88babfb
+        status: 404 Not Found
+        code: 404
+        duration: 41.074491ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1004,29 +1004,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4b07c639-d32c-48ec-8b1c-0962be19273e
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/46aebf26-7295-45ca-a248-13bd09921d41
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 725
+        content_length: 731
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-27T14:55:45.226659Z","description":"","domain_name":"testfunctiontokennsiofaru86-tf-func-hopeful-jackson.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"4b07c639-d32c-48ec-8b1c-0962be19273e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-hopeful-jackson","namespace_id":"d96f82e9-092e-45db-be16-8d26d0ecc01e","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"deleting","timeout":"300s","updated_at":"2025-01-27T14:55:46.861693133Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:25.879819Z","description":"","domain_name":"testfunctiontokennsxaepsa5r-tf-func-sad-sutherland.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"46aebf26-7295-45ca-a248-13bd09921d41","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-sad-sutherland","namespace_id":"2d37fd88-5987-4d1a-90f3-d39903d9e975","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:25.879819Z"}'
         headers:
             Content-Length:
-                - "725"
+                - "731"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:55:46 GMT
+                - Wed, 27 Aug 2025 15:05:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1034,10 +1034,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8d123194-a223-42ff-860d-004669e59433
+                - 8f9bd539-9d1b-47b9-98e2-c3465a4ed552
         status: 200 OK
         code: 200
-        duration: 160.730917ms
+        duration: 70.111394ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1053,29 +1053,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d96f82e9-092e-45db-be16-8d26d0ecc01e
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/46aebf26-7295-45ca-a248-13bd09921d41
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 570
+        content_length: 735
         uncompressed: false
-        body: '{"created_at":"2025-01-27T14:55:39.687270Z","description":"","environment_variables":{},"error_message":null,"id":"d96f82e9-092e-45db-be16-8d26d0ecc01e","name":"test-function-token-ns","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontokennsiofaru86","registry_namespace_id":"18eacdf4-0e77-49d2-98b1-7986746d828d","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-27T14:55:40.771390Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:25.879819Z","description":"","domain_name":"testfunctiontokennsxaepsa5r-tf-func-sad-sutherland.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"46aebf26-7295-45ca-a248-13bd09921d41","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-sad-sutherland","namespace_id":"2d37fd88-5987-4d1a-90f3-d39903d9e975","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:27.793407493Z"}'
         headers:
             Content-Length:
-                - "570"
+                - "735"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:55:47 GMT
+                - Wed, 27 Aug 2025 15:05:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1083,10 +1083,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 79e91c45-f13b-4251-a9ef-e51b84270410
+                - 998a6c45-3a20-4490-9586-292ce60f13b0
         status: 200 OK
         code: 200
-        duration: 89.418083ms
+        duration: 256.11845ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1102,29 +1102,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d96f82e9-092e-45db-be16-8d26d0ecc01e
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/2d37fd88-5987-4d1a-90f3-d39903d9e975
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 576
+        content_length: 589
         uncompressed: false
-        body: '{"created_at":"2025-01-27T14:55:39.687270Z","description":"","environment_variables":{},"error_message":null,"id":"d96f82e9-092e-45db-be16-8d26d0ecc01e","name":"test-function-token-ns","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontokennsiofaru86","registry_namespace_id":"18eacdf4-0e77-49d2-98b1-7986746d828d","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-27T14:55:47.117770934Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.806238Z","description":"","environment_variables":{},"error_message":null,"id":"2d37fd88-5987-4d1a-90f3-d39903d9e975","name":"test-function-token-ns","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontokennsxaepsa5r","registry_namespace_id":"a982d119-765d-4d00-83d4-71532bcf9acd","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:21.647444Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "576"
+                - "589"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:55:47 GMT
+                - Wed, 27 Aug 2025 15:05:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1132,10 +1132,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a854699f-2e76-4294-acca-099550653a84
+                - 875ec98d-1beb-4319-8c37-d824a53755cb
         status: 200 OK
         code: 200
-        duration: 251.084ms
+        duration: 50.476251ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1151,29 +1151,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d96f82e9-092e-45db-be16-8d26d0ecc01e
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/2d37fd88-5987-4d1a-90f3-d39903d9e975
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 573
+        content_length: 595
         uncompressed: false
-        body: '{"created_at":"2025-01-27T14:55:39.687270Z","description":"","environment_variables":{},"error_message":null,"id":"d96f82e9-092e-45db-be16-8d26d0ecc01e","name":"test-function-token-ns","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontokennsiofaru86","registry_namespace_id":"18eacdf4-0e77-49d2-98b1-7986746d828d","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-27T14:55:47.117771Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.806238Z","description":"","environment_variables":{},"error_message":null,"id":"2d37fd88-5987-4d1a-90f3-d39903d9e975","name":"test-function-token-ns","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontokennsxaepsa5r","registry_namespace_id":"a982d119-765d-4d00-83d4-71532bcf9acd","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:28.123673456Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "573"
+                - "595"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:55:47 GMT
+                - Wed, 27 Aug 2025 15:05:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1181,10 +1181,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a0a1e4ba-74ef-49da-957d-5caaf0f65a8e
+                - 1af11b9d-9299-4aeb-8201-c65a878f5e91
         status: 200 OK
         code: 200
-        duration: 119.158417ms
+        duration: 379.921049ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1200,8 +1200,57 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d96f82e9-092e-45db-be16-8d26d0ecc01e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/2d37fd88-5987-4d1a-90f3-d39903d9e975
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 592
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:13.806238Z","description":"","environment_variables":{},"error_message":null,"id":"2d37fd88-5987-4d1a-90f3-d39903d9e975","name":"test-function-token-ns","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontokennsxaepsa5r","registry_namespace_id":"a982d119-765d-4d00-83d4-71532bcf9acd","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:28.123673Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "592"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:05:28 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - d79de9f3-9933-4c67-b374-576cb54c6abf
+        status: 200 OK
+        code: 200
+        duration: 121.789491ms
+    - id: 25
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/2d37fd88-5987-4d1a-90f3-d39903d9e975
         method: GET
       response:
         proto: HTTP/2.0
@@ -1220,9 +1269,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:55:52 GMT
+                - Wed, 27 Aug 2025 15:05:33 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1230,59 +1279,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 803afc87-2550-4b55-afcf-0d86751a4205
+                - 9df34f1a-f1c1-4ad7-adee-030b332278a0
         status: 404 Not Found
         code: 404
-        duration: 28.021625ms
-    - id: 25
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens/62733f02-f61b-44b0-82ed-72d0d22cc1ff
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 33
-        uncompressed: false
-        body: '{"message":"Token was not found"}'
-        headers:
-            Content-Length:
-                - "33"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 14:55:52 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 3c7b277d-8450-444d-abf5-3eff1f98d453
-        status: 404 Not Found
-        code: 404
-        duration: 26.53125ms
+        duration: 25.50634ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1298,8 +1298,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens/c1467714-de0f-4ee5-aca1-fc1898469246
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens/a51cb277-edd3-42d6-a15b-a042d8597b7c
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1318,9 +1318,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:55:52 GMT
+                - Wed, 27 Aug 2025 15:05:33 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1328,7 +1328,56 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e6687c6c-76e8-433e-813e-8ce209093463
+                - 18ffa56f-df31-4262-aa59-91ccec2bb95f
         status: 404 Not Found
         code: 404
-        duration: 22.621917ms
+        duration: 23.983873ms
+    - id: 27
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens/6acf5d1c-fab0-45ed-ac85-022315e4bbb3
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 33
+        uncompressed: false
+        body: '{"message":"Token was not found"}'
+        headers:
+            Content-Length:
+                - "33"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:05:33 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ae42b6bd-c465-4a47-b3f2-a6853f2d418a
+        status: 404 Not Found
+        code: 404
+        duration: 21.137061ms

--- a/internal/services/function/testdata/function-trigger-nats.cassette.yaml
+++ b/internal/services/function/testdata/function-trigger-nats.cassette.yaml
@@ -6,19 +6,19 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 99
+        content_length: 95
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-nats-account-modest-chandrasekhar","project_id":"105bdce1-64c0-48ab-899d-868455867ecf"}'
+        body: '{"name":"tf-nats-account-blissful-johnson","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552"}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/nats-accounts
         method: POST
       response:
@@ -27,20 +27,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 327
+        content_length: 323
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.022651560Z","endpoint":"nats://nats.mnq.fr-par.scaleway.com:4222","id":"ABJB6EGKXFTAXU6LCTWMS6SU7LTX4HSWIUHFI2DUFRD2RY5RWNX2EBXY","name":"tf-nats-account-modest-chandrasekhar","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","updated_at":"2025-01-24T15:44:07.022651560Z"}'
+        body: '{"created_at":"2025-08-27T15:05:08.345573982Z","endpoint":"nats://nats.mnq.fr-par.scaleway.com:4222","id":"ADMU4AEVWFQIDQDCOXRKO3DA6FJIZQTNCEXYXT4OZSP6NHNFXB4LTFLZ","name":"tf-nats-account-blissful-johnson","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","updated_at":"2025-08-27T15:05:08.345573982Z"}'
         headers:
             Content-Length:
-                - "327"
+                - "323"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:07 GMT
+                - Wed, 27 Aug 2025 15:05:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1552c3e6-413d-4e35-9d1a-3b0da3468fa9
+                - 13515198-c2fe-4952-8285-72fb45f21b9e
         status: 200 OK
         code: 200
-        duration: 207.525042ms
+        duration: 324.445415ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -67,8 +67,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/nats-accounts/ABJB6EGKXFTAXU6LCTWMS6SU7LTX4HSWIUHFI2DUFRD2RY5RWNX2EBXY
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/nats-accounts/ADMU4AEVWFQIDQDCOXRKO3DA6FJIZQTNCEXYXT4OZSP6NHNFXB4LTFLZ
         method: GET
       response:
         proto: HTTP/2.0
@@ -76,20 +76,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 321
+        content_length: 317
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.022651Z","endpoint":"nats://nats.mnq.fr-par.scaleway.com:4222","id":"ABJB6EGKXFTAXU6LCTWMS6SU7LTX4HSWIUHFI2DUFRD2RY5RWNX2EBXY","name":"tf-nats-account-modest-chandrasekhar","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","updated_at":"2025-01-24T15:44:07.022651Z"}'
+        body: '{"created_at":"2025-08-27T15:05:08.345573Z","endpoint":"nats://nats.mnq.fr-par.scaleway.com:4222","id":"ADMU4AEVWFQIDQDCOXRKO3DA6FJIZQTNCEXYXT4OZSP6NHNFXB4LTFLZ","name":"tf-nats-account-blissful-johnson","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","updated_at":"2025-08-27T15:05:08.345573Z"}'
         headers:
             Content-Length:
-                - "321"
+                - "317"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:07 GMT
+                - Wed, 27 Aug 2025 15:05:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,28 +97,28 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b69f76c7-d0bd-4c6d-8808-3b0bf73501d3
+                - 49a879c2-8339-463f-9576-b5ca2fe7070c
         status: 200 OK
         code: 200
-        duration: 86.760416ms
+        duration: 51.620395ms
     - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 161
+        content_length: 193
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"test-function-trigger-sqs","environment_variables":{},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","secret_environment_variables":[],"tags":null}'
+        body: '{"name":"test-function-trigger-sqs","environment_variables":{},"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","secret_environment_variables":[],"tags":null,"activate_vpc_integration":true}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces
         method: POST
       response:
@@ -127,20 +127,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 477
+        content_length: 510
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.683077718Z","description":"","environment_variables":{},"error_message":null,"id":"39794f7e-3fb2-40d8-9ccb-54b2789ddfa8","name":"test-function-trigger-sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:44:07.683077718Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.653786295Z","description":"","environment_variables":{},"error_message":null,"id":"55616aec-771d-4b6a-82e7-ab135f67f899","name":"test-function-trigger-sqs","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:13.653786295Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "477"
+                - "510"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:07 GMT
+                - Wed, 27 Aug 2025 15:05:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -148,10 +148,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e279dfe7-5682-459f-badb-7bdb22edbcac
+                - 32721e6e-a428-4945-a27b-e7309d6f9706
         status: 200 OK
         code: 200
-        duration: 777.914666ms
+        duration: 5.534875559s
     - id: 3
       request:
         proto: HTTP/1.1
@@ -167,8 +167,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/39794f7e-3fb2-40d8-9ccb-54b2789ddfa8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/55616aec-771d-4b6a-82e7-ab135f67f899
         method: GET
       response:
         proto: HTTP/2.0
@@ -176,20 +176,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 471
+        content_length: 504
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.683078Z","description":"","environment_variables":{},"error_message":null,"id":"39794f7e-3fb2-40d8-9ccb-54b2789ddfa8","name":"test-function-trigger-sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:44:07.683078Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.653786Z","description":"","environment_variables":{},"error_message":null,"id":"55616aec-771d-4b6a-82e7-ab135f67f899","name":"test-function-trigger-sqs","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:13.653786Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "471"
+                - "504"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:07 GMT
+                - Wed, 27 Aug 2025 15:05:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -197,10 +197,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1d1ed042-a917-4004-9ce1-edf08ffa513b
+                - bbe97e52-1a56-42e6-9f1c-7880d708c55f
         status: 200 OK
         code: 200
-        duration: 62.711541ms
+        duration: 39.905715ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -216,8 +216,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/39794f7e-3fb2-40d8-9ccb-54b2789ddfa8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/55616aec-771d-4b6a-82e7-ab135f67f899
         method: GET
       response:
         proto: HTTP/2.0
@@ -225,20 +225,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 560
+        content_length: 595
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.683078Z","description":"","environment_variables":{},"error_message":null,"id":"39794f7e-3fb2-40d8-9ccb-54b2789ddfa8","name":"test-function-trigger-sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggerscpqkjeyb","registry_namespace_id":"fbc408ce-460d-4238-8e24-645bc5b2c041","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:44:10.581199Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.653786Z","description":"","environment_variables":{},"error_message":null,"id":"55616aec-771d-4b6a-82e7-ab135f67f899","name":"test-function-trigger-sqs","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggersxwgl5txd","registry_namespace_id":"97e5c2bd-0c1f-4eb5-966a-43ee4c2a1018","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:16.853961Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "560"
+                - "595"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:12 GMT
+                - Wed, 27 Aug 2025 15:05:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -246,10 +246,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 66a28894-037b-4a7c-bee3-9c974eabef1c
+                - 0b915191-9299-476d-8b12-b1f180104aeb
         status: 200 OK
         code: 200
-        duration: 66.790875ms
+        duration: 458.401511ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -265,8 +265,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/39794f7e-3fb2-40d8-9ccb-54b2789ddfa8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/55616aec-771d-4b6a-82e7-ab135f67f899
         method: GET
       response:
         proto: HTTP/2.0
@@ -274,20 +274,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 560
+        content_length: 593
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.683078Z","description":"","environment_variables":{},"error_message":null,"id":"39794f7e-3fb2-40d8-9ccb-54b2789ddfa8","name":"test-function-trigger-sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggerscpqkjeyb","registry_namespace_id":"fbc408ce-460d-4238-8e24-645bc5b2c041","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:44:10.581199Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.653786Z","description":"","environment_variables":{},"error_message":null,"id":"55616aec-771d-4b6a-82e7-ab135f67f899","name":"test-function-trigger-sqs","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggersxwgl5txd","registry_namespace_id":"97e5c2bd-0c1f-4eb5-966a-43ee4c2a1018","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:19.271213Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "560"
+                - "593"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:12 GMT
+                - Wed, 27 Aug 2025 15:05:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -295,62 +295,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0c820943-dfd0-4a8a-8299-233ceec626ce
+                - 0fe3dc0a-8b46-4507-8fd1-c5a6813de9d2
         status: 200 OK
         code: 200
-        duration: 96.093416ms
+        duration: 46.868411ms
     - id: 6
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 317
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"name":"test-function-trigger-sqs","namespace_id":"39794f7e-3fb2-40d8-9ccb-54b2789ddfa8","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"node22","memory_limit":256,"handler":"handler.handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox"}'
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 708
-        uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:13.293900112Z","description":"","domain_name":"testfunctiontriggerscpqkjeyb-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"566fa6bf-f3b8-4b70-ac6f-5a20ab9ed8ea","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"39794f7e-3fb2-40d8-9ccb-54b2789ddfa8","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:13.293900112Z"}'
-        headers:
-            Content-Length:
-                - "708"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:44:13 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - a0215c26-1b3b-40b9-b1ce-33b036dddbbf
-        status: 200 OK
-        code: 200
-        duration: 382.181667ms
-    - id: 7
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -365,8 +314,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/566fa6bf-f3b8-4b70-ac6f-5a20ab9ed8ea
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/55616aec-771d-4b6a-82e7-ab135f67f899
         method: GET
       response:
         proto: HTTP/2.0
@@ -374,20 +323,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 702
+        content_length: 593
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:13.293900Z","description":"","domain_name":"testfunctiontriggerscpqkjeyb-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"566fa6bf-f3b8-4b70-ac6f-5a20ab9ed8ea","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"39794f7e-3fb2-40d8-9ccb-54b2789ddfa8","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:13.293900Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.653786Z","description":"","environment_variables":{},"error_message":null,"id":"55616aec-771d-4b6a-82e7-ab135f67f899","name":"test-function-trigger-sqs","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggersxwgl5txd","registry_namespace_id":"97e5c2bd-0c1f-4eb5-966a-43ee4c2a1018","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:19.271213Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "702"
+                - "593"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:13 GMT
+                - Wed, 27 Aug 2025 15:05:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -395,10 +344,61 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - eae7ab6b-13af-4736-a088-f73bf035acc3
+                - c7363a67-b3d1-495b-8198-d1fa1be46f03
         status: 200 OK
         code: 200
-        duration: 75.088333ms
+        duration: 42.981588ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 329
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"name":"test-function-trigger-sqs","namespace_id":"55616aec-771d-4b6a-82e7-ab135f67f899","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"node22","memory_limit":256,"handler":"handler.handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox","tags":null}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 744
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:25.397303219Z","description":"","domain_name":"testfunctiontriggersxwgl5txd-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"d2ab0a30-8169-451f-bf91-ff7a4b234863","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"55616aec-771d-4b6a-82e7-ab135f67f899","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:25.397303219Z"}'
+        headers:
+            Content-Length:
+                - "744"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:05:25 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 87caa862-9de2-4522-9b1b-267f3ee6601d
+        status: 200 OK
+        code: 200
+        duration: 1.092582365s
     - id: 8
       request:
         proto: HTTP/1.1
@@ -414,8 +414,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/566fa6bf-f3b8-4b70-ac6f-5a20ab9ed8ea
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d2ab0a30-8169-451f-bf91-ff7a4b234863
         method: GET
       response:
         proto: HTTP/2.0
@@ -423,20 +423,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 702
+        content_length: 738
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:13.293900Z","description":"","domain_name":"testfunctiontriggerscpqkjeyb-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"566fa6bf-f3b8-4b70-ac6f-5a20ab9ed8ea","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"39794f7e-3fb2-40d8-9ccb-54b2789ddfa8","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:13.293900Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:25.397303Z","description":"","domain_name":"testfunctiontriggersxwgl5txd-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"d2ab0a30-8169-451f-bf91-ff7a4b234863","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"55616aec-771d-4b6a-82e7-ab135f67f899","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:25.397303Z"}'
         headers:
             Content-Length:
-                - "702"
+                - "738"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:13 GMT
+                - Wed, 27 Aug 2025 15:05:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -444,62 +444,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0f59cbe7-161e-4e10-ae62-5afa62d9f229
+                - 4458c2d8-e859-446d-8310-9dc8a61733bb
         status: 200 OK
         code: 200
-        duration: 70.512167ms
+        duration: 56.084454ms
     - id: 9
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 293
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"name":"test-function-trigger-nats","function_id":"566fa6bf-f3b8-4b70-ac6f-5a20ab9ed8ea","scw_nats_config":{"subject":"TestSubject","mnq_nats_account_id":"ABJB6EGKXFTAXU6LCTWMS6SU7LTX4HSWIUHFI2DUFRD2RY5RWNX2EBXY","mnq_project_id":"105bdce1-64c0-48ab-899d-868455867ecf","mnq_region":"fr-par"}}'
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 444
-        uncompressed: false
-        body: '{"description":"","error_message":null,"function_id":"566fa6bf-f3b8-4b70-ac6f-5a20ab9ed8ea","id":"d61296e0-24e3-49fb-a502-7f055d01db2f","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":null,"mnq_nats_account_id":"ABJB6EGKXFTAXU6LCTWMS6SU7LTX4HSWIUHFI2DUFRD2RY5RWNX2EBXY","mnq_project_id":"105bdce1-64c0-48ab-899d-868455867ecf","mnq_region":"fr-par","subject":"TestSubject"},"status":"creating"}'
-        headers:
-            Content-Length:
-                - "444"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:44:13 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - bd358d0a-f062-4f3e-8e1a-08667f7c4b8b
-        status: 200 OK
-        code: 200
-        duration: 207.945084ms
-    - id: 10
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -514,9 +463,60 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/d61296e0-24e3-49fb-a502-7f055d01db2f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d2ab0a30-8169-451f-bf91-ff7a4b234863
         method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 738
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:25.397303Z","description":"","domain_name":"testfunctiontriggersxwgl5txd-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"d2ab0a30-8169-451f-bf91-ff7a4b234863","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"55616aec-771d-4b6a-82e7-ab135f67f899","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:25.397303Z"}'
+        headers:
+            Content-Length:
+                - "738"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:05:25 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ba989d59-f711-4203-b754-64e6d0302333
+        status: 200 OK
+        code: 200
+        duration: 45.532134ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 293
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"name":"test-function-trigger-nats","function_id":"d2ab0a30-8169-451f-bf91-ff7a4b234863","scw_nats_config":{"subject":"TestSubject","mnq_nats_account_id":"ADMU4AEVWFQIDQDCOXRKO3DA6FJIZQTNCEXYXT4OZSP6NHNFXB4LTFLZ","mnq_project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","mnq_region":"fr-par"}}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
@@ -525,7 +525,7 @@ interactions:
         trailer: {}
         content_length: 444
         uncompressed: false
-        body: '{"description":"","error_message":null,"function_id":"566fa6bf-f3b8-4b70-ac6f-5a20ab9ed8ea","id":"d61296e0-24e3-49fb-a502-7f055d01db2f","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":null,"mnq_nats_account_id":"ABJB6EGKXFTAXU6LCTWMS6SU7LTX4HSWIUHFI2DUFRD2RY5RWNX2EBXY","mnq_project_id":"105bdce1-64c0-48ab-899d-868455867ecf","mnq_region":"fr-par","subject":"TestSubject"},"status":"creating"}'
+        body: '{"description":"","error_message":null,"function_id":"d2ab0a30-8169-451f-bf91-ff7a4b234863","id":"3aa572d4-1cd1-40f8-ba85-59416149c5df","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":null,"mnq_nats_account_id":"ADMU4AEVWFQIDQDCOXRKO3DA6FJIZQTNCEXYXT4OZSP6NHNFXB4LTFLZ","mnq_project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","mnq_region":"fr-par","subject":"TestSubject"},"status":"creating"}'
         headers:
             Content-Length:
                 - "444"
@@ -534,9 +534,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:13 GMT
+                - Wed, 27 Aug 2025 15:05:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -544,10 +544,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 34644fc1-f55a-4cde-ac7e-e2d0ce1f974b
+                - 7a441a22-440b-45b4-b657-e17c8a8a54f2
         status: 200 OK
         code: 200
-        duration: 85.9015ms
+        duration: 1.367571657s
     - id: 11
       request:
         proto: HTTP/1.1
@@ -563,8 +563,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/d61296e0-24e3-49fb-a502-7f055d01db2f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/3aa572d4-1cd1-40f8-ba85-59416149c5df
         method: GET
       response:
         proto: HTTP/2.0
@@ -572,20 +572,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 478
+        content_length: 444
         uncompressed: false
-        body: '{"description":"","error_message":null,"function_id":"566fa6bf-f3b8-4b70-ac6f-5a20ab9ed8ea","id":"d61296e0-24e3-49fb-a502-7f055d01db2f","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":"ca2ff124-e739-4707-a235-a66c501a1b20","mnq_nats_account_id":"ABJB6EGKXFTAXU6LCTWMS6SU7LTX4HSWIUHFI2DUFRD2RY5RWNX2EBXY","mnq_project_id":"105bdce1-64c0-48ab-899d-868455867ecf","mnq_region":"fr-par","subject":"TestSubject"},"status":"creating"}'
+        body: '{"description":"","error_message":null,"function_id":"d2ab0a30-8169-451f-bf91-ff7a4b234863","id":"3aa572d4-1cd1-40f8-ba85-59416149c5df","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":null,"mnq_nats_account_id":"ADMU4AEVWFQIDQDCOXRKO3DA6FJIZQTNCEXYXT4OZSP6NHNFXB4LTFLZ","mnq_project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","mnq_region":"fr-par","subject":"TestSubject"},"status":"creating"}'
         headers:
             Content-Length:
-                - "478"
+                - "444"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:18 GMT
+                - Wed, 27 Aug 2025 15:05:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -593,10 +593,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1efccd20-b703-4cb9-a302-adcfd03b1e77
+                - 246a31b2-0dde-44ca-b19e-29b6e8100ea4
         status: 200 OK
         code: 200
-        duration: 89.566958ms
+        duration: 61.915436ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -612,8 +612,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/d61296e0-24e3-49fb-a502-7f055d01db2f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/3aa572d4-1cd1-40f8-ba85-59416149c5df
         method: GET
       response:
         proto: HTTP/2.0
@@ -623,7 +623,7 @@ interactions:
         trailer: {}
         content_length: 478
         uncompressed: false
-        body: '{"description":"","error_message":null,"function_id":"566fa6bf-f3b8-4b70-ac6f-5a20ab9ed8ea","id":"d61296e0-24e3-49fb-a502-7f055d01db2f","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":"ca2ff124-e739-4707-a235-a66c501a1b20","mnq_nats_account_id":"ABJB6EGKXFTAXU6LCTWMS6SU7LTX4HSWIUHFI2DUFRD2RY5RWNX2EBXY","mnq_project_id":"105bdce1-64c0-48ab-899d-868455867ecf","mnq_region":"fr-par","subject":"TestSubject"},"status":"creating"}'
+        body: '{"description":"","error_message":null,"function_id":"d2ab0a30-8169-451f-bf91-ff7a4b234863","id":"3aa572d4-1cd1-40f8-ba85-59416149c5df","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":"0aa99b2d-f472-436d-9463-008e1a08ac7d","mnq_nats_account_id":"ADMU4AEVWFQIDQDCOXRKO3DA6FJIZQTNCEXYXT4OZSP6NHNFXB4LTFLZ","mnq_project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","mnq_region":"fr-par","subject":"TestSubject"},"status":"creating"}'
         headers:
             Content-Length:
                 - "478"
@@ -632,9 +632,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:23 GMT
+                - Wed, 27 Aug 2025 15:05:32 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -642,10 +642,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 40cc5276-2435-477a-b1c4-9e819a6081f7
+                - ff11eaf4-be25-45eb-a091-56a085e3e9a2
         status: 200 OK
         code: 200
-        duration: 80.647584ms
+        duration: 55.475512ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -661,8 +661,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/d61296e0-24e3-49fb-a502-7f055d01db2f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/3aa572d4-1cd1-40f8-ba85-59416149c5df
         method: GET
       response:
         proto: HTTP/2.0
@@ -670,20 +670,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 475
+        content_length: 478
         uncompressed: false
-        body: '{"description":"","error_message":null,"function_id":"566fa6bf-f3b8-4b70-ac6f-5a20ab9ed8ea","id":"d61296e0-24e3-49fb-a502-7f055d01db2f","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":"ca2ff124-e739-4707-a235-a66c501a1b20","mnq_nats_account_id":"ABJB6EGKXFTAXU6LCTWMS6SU7LTX4HSWIUHFI2DUFRD2RY5RWNX2EBXY","mnq_project_id":"105bdce1-64c0-48ab-899d-868455867ecf","mnq_region":"fr-par","subject":"TestSubject"},"status":"ready"}'
+        body: '{"description":"","error_message":null,"function_id":"d2ab0a30-8169-451f-bf91-ff7a4b234863","id":"3aa572d4-1cd1-40f8-ba85-59416149c5df","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":"0aa99b2d-f472-436d-9463-008e1a08ac7d","mnq_nats_account_id":"ADMU4AEVWFQIDQDCOXRKO3DA6FJIZQTNCEXYXT4OZSP6NHNFXB4LTFLZ","mnq_project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","mnq_region":"fr-par","subject":"TestSubject"},"status":"creating"}'
         headers:
             Content-Length:
-                - "475"
+                - "478"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:29 GMT
+                - Wed, 27 Aug 2025 15:05:37 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -691,10 +691,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 63a04c23-5bf5-475e-ae03-a4fa40fe603e
+                - 871b51ae-032a-40de-b831-749e209b9683
         status: 200 OK
         code: 200
-        duration: 83.006833ms
+        duration: 70.2841ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -710,8 +710,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/d61296e0-24e3-49fb-a502-7f055d01db2f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/3aa572d4-1cd1-40f8-ba85-59416149c5df
         method: GET
       response:
         proto: HTTP/2.0
@@ -719,20 +719,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 475
+        content_length: 478
         uncompressed: false
-        body: '{"description":"","error_message":null,"function_id":"566fa6bf-f3b8-4b70-ac6f-5a20ab9ed8ea","id":"d61296e0-24e3-49fb-a502-7f055d01db2f","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":"ca2ff124-e739-4707-a235-a66c501a1b20","mnq_nats_account_id":"ABJB6EGKXFTAXU6LCTWMS6SU7LTX4HSWIUHFI2DUFRD2RY5RWNX2EBXY","mnq_project_id":"105bdce1-64c0-48ab-899d-868455867ecf","mnq_region":"fr-par","subject":"TestSubject"},"status":"ready"}'
+        body: '{"description":"","error_message":null,"function_id":"d2ab0a30-8169-451f-bf91-ff7a4b234863","id":"3aa572d4-1cd1-40f8-ba85-59416149c5df","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":"0aa99b2d-f472-436d-9463-008e1a08ac7d","mnq_nats_account_id":"ADMU4AEVWFQIDQDCOXRKO3DA6FJIZQTNCEXYXT4OZSP6NHNFXB4LTFLZ","mnq_project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","mnq_region":"fr-par","subject":"TestSubject"},"status":"creating"}'
         headers:
             Content-Length:
-                - "475"
+                - "478"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:29 GMT
+                - Wed, 27 Aug 2025 15:05:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -740,10 +740,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c67422b1-5320-4a47-bdbd-d95bb9e91b82
+                - 75089949-6bd4-4a64-815f-e61e0d567703
         status: 200 OK
         code: 200
-        duration: 73.041333ms
+        duration: 68.952784ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -759,8 +759,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/d61296e0-24e3-49fb-a502-7f055d01db2f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/3aa572d4-1cd1-40f8-ba85-59416149c5df
         method: GET
       response:
         proto: HTTP/2.0
@@ -770,7 +770,7 @@ interactions:
         trailer: {}
         content_length: 475
         uncompressed: false
-        body: '{"description":"","error_message":null,"function_id":"566fa6bf-f3b8-4b70-ac6f-5a20ab9ed8ea","id":"d61296e0-24e3-49fb-a502-7f055d01db2f","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":"ca2ff124-e739-4707-a235-a66c501a1b20","mnq_nats_account_id":"ABJB6EGKXFTAXU6LCTWMS6SU7LTX4HSWIUHFI2DUFRD2RY5RWNX2EBXY","mnq_project_id":"105bdce1-64c0-48ab-899d-868455867ecf","mnq_region":"fr-par","subject":"TestSubject"},"status":"ready"}'
+        body: '{"description":"","error_message":null,"function_id":"d2ab0a30-8169-451f-bf91-ff7a4b234863","id":"3aa572d4-1cd1-40f8-ba85-59416149c5df","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":"0aa99b2d-f472-436d-9463-008e1a08ac7d","mnq_nats_account_id":"ADMU4AEVWFQIDQDCOXRKO3DA6FJIZQTNCEXYXT4OZSP6NHNFXB4LTFLZ","mnq_project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","mnq_region":"fr-par","subject":"TestSubject"},"status":"ready"}'
         headers:
             Content-Length:
                 - "475"
@@ -779,9 +779,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:29 GMT
+                - Wed, 27 Aug 2025 15:05:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -789,10 +789,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 21b9e578-d192-4b31-8263-3015047f7484
+                - 99daad72-969e-4859-9178-e61c63b9d4a7
         status: 200 OK
         code: 200
-        duration: 84.068417ms
+        duration: 59.02171ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -808,8 +808,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/d61296e0-24e3-49fb-a502-7f055d01db2f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/3aa572d4-1cd1-40f8-ba85-59416149c5df
         method: GET
       response:
         proto: HTTP/2.0
@@ -819,7 +819,7 @@ interactions:
         trailer: {}
         content_length: 475
         uncompressed: false
-        body: '{"description":"","error_message":null,"function_id":"566fa6bf-f3b8-4b70-ac6f-5a20ab9ed8ea","id":"d61296e0-24e3-49fb-a502-7f055d01db2f","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":"ca2ff124-e739-4707-a235-a66c501a1b20","mnq_nats_account_id":"ABJB6EGKXFTAXU6LCTWMS6SU7LTX4HSWIUHFI2DUFRD2RY5RWNX2EBXY","mnq_project_id":"105bdce1-64c0-48ab-899d-868455867ecf","mnq_region":"fr-par","subject":"TestSubject"},"status":"ready"}'
+        body: '{"description":"","error_message":null,"function_id":"d2ab0a30-8169-451f-bf91-ff7a4b234863","id":"3aa572d4-1cd1-40f8-ba85-59416149c5df","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":"0aa99b2d-f472-436d-9463-008e1a08ac7d","mnq_nats_account_id":"ADMU4AEVWFQIDQDCOXRKO3DA6FJIZQTNCEXYXT4OZSP6NHNFXB4LTFLZ","mnq_project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","mnq_region":"fr-par","subject":"TestSubject"},"status":"ready"}'
         headers:
             Content-Length:
                 - "475"
@@ -828,9 +828,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:29 GMT
+                - Wed, 27 Aug 2025 15:05:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -838,10 +838,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c4bbef62-01fe-4e84-ae31-c0701251e5c0
+                - a3d089ab-3d4f-407d-a3f1-2aba6e596955
         status: 200 OK
         code: 200
-        duration: 79.795709ms
+        duration: 58.054466ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -857,8 +857,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/39794f7e-3fb2-40d8-9ccb-54b2789ddfa8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/3aa572d4-1cd1-40f8-ba85-59416149c5df
         method: GET
       response:
         proto: HTTP/2.0
@@ -866,20 +866,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 560
+        content_length: 475
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.683078Z","description":"","environment_variables":{},"error_message":null,"id":"39794f7e-3fb2-40d8-9ccb-54b2789ddfa8","name":"test-function-trigger-sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggerscpqkjeyb","registry_namespace_id":"fbc408ce-460d-4238-8e24-645bc5b2c041","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:44:10.581199Z"}'
+        body: '{"description":"","error_message":null,"function_id":"d2ab0a30-8169-451f-bf91-ff7a4b234863","id":"3aa572d4-1cd1-40f8-ba85-59416149c5df","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":"0aa99b2d-f472-436d-9463-008e1a08ac7d","mnq_nats_account_id":"ADMU4AEVWFQIDQDCOXRKO3DA6FJIZQTNCEXYXT4OZSP6NHNFXB4LTFLZ","mnq_project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","mnq_region":"fr-par","subject":"TestSubject"},"status":"ready"}'
         headers:
             Content-Length:
-                - "560"
+                - "475"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:30 GMT
+                - Wed, 27 Aug 2025 15:05:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -887,10 +887,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d9933502-d677-41ba-85cc-bdfb1f016860
+                - 7e7decf0-0306-49c8-9a79-195cdb8a9b75
         status: 200 OK
         code: 200
-        duration: 59.531625ms
+        duration: 46.09824ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -906,8 +906,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/nats-accounts/ABJB6EGKXFTAXU6LCTWMS6SU7LTX4HSWIUHFI2DUFRD2RY5RWNX2EBXY
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/3aa572d4-1cd1-40f8-ba85-59416149c5df
         method: GET
       response:
         proto: HTTP/2.0
@@ -915,20 +915,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 321
+        content_length: 475
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.022651Z","endpoint":"nats://nats.mnq.fr-par.scaleway.com:4222","id":"ABJB6EGKXFTAXU6LCTWMS6SU7LTX4HSWIUHFI2DUFRD2RY5RWNX2EBXY","name":"tf-nats-account-modest-chandrasekhar","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","updated_at":"2025-01-24T15:44:07.022651Z"}'
+        body: '{"description":"","error_message":null,"function_id":"d2ab0a30-8169-451f-bf91-ff7a4b234863","id":"3aa572d4-1cd1-40f8-ba85-59416149c5df","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":"0aa99b2d-f472-436d-9463-008e1a08ac7d","mnq_nats_account_id":"ADMU4AEVWFQIDQDCOXRKO3DA6FJIZQTNCEXYXT4OZSP6NHNFXB4LTFLZ","mnq_project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","mnq_region":"fr-par","subject":"TestSubject"},"status":"ready"}'
         headers:
             Content-Length:
-                - "321"
+                - "475"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:30 GMT
+                - Wed, 27 Aug 2025 15:05:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -936,10 +936,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a00f9621-ced3-40e1-be22-016529acbbc5
+                - ab6037e3-6fb9-4972-a4dd-a0ac47a1286c
         status: 200 OK
         code: 200
-        duration: 69.523708ms
+        duration: 65.137114ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -955,8 +955,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/566fa6bf-f3b8-4b70-ac6f-5a20ab9ed8ea
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/55616aec-771d-4b6a-82e7-ab135f67f899
         method: GET
       response:
         proto: HTTP/2.0
@@ -964,20 +964,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 702
+        content_length: 593
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:13.293900Z","description":"","domain_name":"testfunctiontriggerscpqkjeyb-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"566fa6bf-f3b8-4b70-ac6f-5a20ab9ed8ea","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"39794f7e-3fb2-40d8-9ccb-54b2789ddfa8","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:13.293900Z"}'
+        body: '{"created_at":"2025-08-27T15:05:13.653786Z","description":"","environment_variables":{},"error_message":null,"id":"55616aec-771d-4b6a-82e7-ab135f67f899","name":"test-function-trigger-sqs","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggersxwgl5txd","registry_namespace_id":"97e5c2bd-0c1f-4eb5-966a-43ee4c2a1018","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:19.271213Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "702"
+                - "593"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:30 GMT
+                - Wed, 27 Aug 2025 15:05:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -985,10 +985,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 60253cf1-51e3-4c87-b0c7-f518b54356ab
+                - 40e8f959-a5d7-4b17-87fc-86b2bb298e95
         status: 200 OK
         code: 200
-        duration: 83.492708ms
+        duration: 40.66271ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1004,8 +1004,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/d61296e0-24e3-49fb-a502-7f055d01db2f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/nats-accounts/ADMU4AEVWFQIDQDCOXRKO3DA6FJIZQTNCEXYXT4OZSP6NHNFXB4LTFLZ
         method: GET
       response:
         proto: HTTP/2.0
@@ -1013,20 +1013,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 475
+        content_length: 317
         uncompressed: false
-        body: '{"description":"","error_message":null,"function_id":"566fa6bf-f3b8-4b70-ac6f-5a20ab9ed8ea","id":"d61296e0-24e3-49fb-a502-7f055d01db2f","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":"ca2ff124-e739-4707-a235-a66c501a1b20","mnq_nats_account_id":"ABJB6EGKXFTAXU6LCTWMS6SU7LTX4HSWIUHFI2DUFRD2RY5RWNX2EBXY","mnq_project_id":"105bdce1-64c0-48ab-899d-868455867ecf","mnq_region":"fr-par","subject":"TestSubject"},"status":"ready"}'
+        body: '{"created_at":"2025-08-27T15:05:08.345573Z","endpoint":"nats://nats.mnq.fr-par.scaleway.com:4222","id":"ADMU4AEVWFQIDQDCOXRKO3DA6FJIZQTNCEXYXT4OZSP6NHNFXB4LTFLZ","name":"tf-nats-account-blissful-johnson","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","updated_at":"2025-08-27T15:05:08.345573Z"}'
         headers:
             Content-Length:
-                - "475"
+                - "317"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:30 GMT
+                - Wed, 27 Aug 2025 15:05:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1034,10 +1034,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8b6930ee-b942-4674-8677-7a9990d254b0
+                - 5d941c41-8dc3-4309-a5c0-509eadf25167
         status: 200 OK
         code: 200
-        duration: 96.302208ms
+        duration: 42.302067ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1053,8 +1053,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/nats-accounts/ABJB6EGKXFTAXU6LCTWMS6SU7LTX4HSWIUHFI2DUFRD2RY5RWNX2EBXY
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d2ab0a30-8169-451f-bf91-ff7a4b234863
         method: GET
       response:
         proto: HTTP/2.0
@@ -1062,20 +1062,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 321
+        content_length: 738
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.022651Z","endpoint":"nats://nats.mnq.fr-par.scaleway.com:4222","id":"ABJB6EGKXFTAXU6LCTWMS6SU7LTX4HSWIUHFI2DUFRD2RY5RWNX2EBXY","name":"tf-nats-account-modest-chandrasekhar","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","updated_at":"2025-01-24T15:44:07.022651Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:25.397303Z","description":"","domain_name":"testfunctiontriggersxwgl5txd-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"d2ab0a30-8169-451f-bf91-ff7a4b234863","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"55616aec-771d-4b6a-82e7-ab135f67f899","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:25.397303Z"}'
         headers:
             Content-Length:
-                - "321"
+                - "738"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:31 GMT
+                - Wed, 27 Aug 2025 15:05:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1083,10 +1083,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - dbaf0de6-134c-4084-93f1-dfef0b1a18ff
+                - d8c7caa9-db3b-4a24-952a-cc5fe01ba829
         status: 200 OK
         code: 200
-        duration: 136.47ms
+        duration: 61.877047ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1102,8 +1102,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/39794f7e-3fb2-40d8-9ccb-54b2789ddfa8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/3aa572d4-1cd1-40f8-ba85-59416149c5df
         method: GET
       response:
         proto: HTTP/2.0
@@ -1111,20 +1111,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 560
+        content_length: 475
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.683078Z","description":"","environment_variables":{},"error_message":null,"id":"39794f7e-3fb2-40d8-9ccb-54b2789ddfa8","name":"test-function-trigger-sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggerscpqkjeyb","registry_namespace_id":"fbc408ce-460d-4238-8e24-645bc5b2c041","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:44:10.581199Z"}'
+        body: '{"description":"","error_message":null,"function_id":"d2ab0a30-8169-451f-bf91-ff7a4b234863","id":"3aa572d4-1cd1-40f8-ba85-59416149c5df","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":"0aa99b2d-f472-436d-9463-008e1a08ac7d","mnq_nats_account_id":"ADMU4AEVWFQIDQDCOXRKO3DA6FJIZQTNCEXYXT4OZSP6NHNFXB4LTFLZ","mnq_project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","mnq_region":"fr-par","subject":"TestSubject"},"status":"ready"}'
         headers:
             Content-Length:
-                - "560"
+                - "475"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:31 GMT
+                - Wed, 27 Aug 2025 15:05:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1132,10 +1132,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0753432d-c9a3-4a30-b202-382cc6b6d930
+                - 59d7c05f-b6ed-4712-be41-9bc09f850aaf
         status: 200 OK
         code: 200
-        duration: 137.838ms
+        duration: 61.531309ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1151,8 +1151,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/566fa6bf-f3b8-4b70-ac6f-5a20ab9ed8ea
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/nats-accounts/ADMU4AEVWFQIDQDCOXRKO3DA6FJIZQTNCEXYXT4OZSP6NHNFXB4LTFLZ
         method: GET
       response:
         proto: HTTP/2.0
@@ -1160,20 +1160,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 702
+        content_length: 317
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:13.293900Z","description":"","domain_name":"testfunctiontriggerscpqkjeyb-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"566fa6bf-f3b8-4b70-ac6f-5a20ab9ed8ea","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"39794f7e-3fb2-40d8-9ccb-54b2789ddfa8","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:13.293900Z"}'
+        body: '{"created_at":"2025-08-27T15:05:08.345573Z","endpoint":"nats://nats.mnq.fr-par.scaleway.com:4222","id":"ADMU4AEVWFQIDQDCOXRKO3DA6FJIZQTNCEXYXT4OZSP6NHNFXB4LTFLZ","name":"tf-nats-account-blissful-johnson","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","updated_at":"2025-08-27T15:05:08.345573Z"}'
         headers:
             Content-Length:
-                - "702"
+                - "317"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:31 GMT
+                - Wed, 27 Aug 2025 15:05:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1181,10 +1181,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fda436ca-ec54-4a3f-895f-3bdd370e8bc2
+                - efd29a3a-ec1f-4998-ae7b-114fd97dcf37
         status: 200 OK
         code: 200
-        duration: 76.766458ms
+        duration: 40.940441ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1200,8 +1200,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/d61296e0-24e3-49fb-a502-7f055d01db2f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/55616aec-771d-4b6a-82e7-ab135f67f899
         method: GET
       response:
         proto: HTTP/2.0
@@ -1209,20 +1209,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 475
+        content_length: 593
         uncompressed: false
-        body: '{"description":"","error_message":null,"function_id":"566fa6bf-f3b8-4b70-ac6f-5a20ab9ed8ea","id":"d61296e0-24e3-49fb-a502-7f055d01db2f","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":"ca2ff124-e739-4707-a235-a66c501a1b20","mnq_nats_account_id":"ABJB6EGKXFTAXU6LCTWMS6SU7LTX4HSWIUHFI2DUFRD2RY5RWNX2EBXY","mnq_project_id":"105bdce1-64c0-48ab-899d-868455867ecf","mnq_region":"fr-par","subject":"TestSubject"},"status":"ready"}'
+        body: '{"created_at":"2025-08-27T15:05:13.653786Z","description":"","environment_variables":{},"error_message":null,"id":"55616aec-771d-4b6a-82e7-ab135f67f899","name":"test-function-trigger-sqs","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggersxwgl5txd","registry_namespace_id":"97e5c2bd-0c1f-4eb5-966a-43ee4c2a1018","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:19.271213Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "475"
+                - "593"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:31 GMT
+                - Wed, 27 Aug 2025 15:05:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1230,10 +1230,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 17578f8c-717c-43f1-ad22-6816551a5972
+                - 65caef34-3002-4f73-b9cd-ab686ca97512
         status: 200 OK
         code: 200
-        duration: 78.263042ms
+        duration: 42.72984ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1249,8 +1249,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/39794f7e-3fb2-40d8-9ccb-54b2789ddfa8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d2ab0a30-8169-451f-bf91-ff7a4b234863
         method: GET
       response:
         proto: HTTP/2.0
@@ -1258,20 +1258,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 560
+        content_length: 738
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.683078Z","description":"","environment_variables":{},"error_message":null,"id":"39794f7e-3fb2-40d8-9ccb-54b2789ddfa8","name":"test-function-trigger-sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggerscpqkjeyb","registry_namespace_id":"fbc408ce-460d-4238-8e24-645bc5b2c041","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:44:10.581199Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:25.397303Z","description":"","domain_name":"testfunctiontriggersxwgl5txd-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"d2ab0a30-8169-451f-bf91-ff7a4b234863","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"55616aec-771d-4b6a-82e7-ab135f67f899","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:25.397303Z"}'
         headers:
             Content-Length:
-                - "560"
+                - "738"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:32 GMT
+                - Wed, 27 Aug 2025 15:05:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1279,10 +1279,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 222f98d3-5745-4752-8a6b-59243d170950
+                - d4867701-e026-447a-9945-a44ba30b472b
         status: 200 OK
         code: 200
-        duration: 68.779583ms
+        duration: 64.406013ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1298,8 +1298,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/nats-accounts/ABJB6EGKXFTAXU6LCTWMS6SU7LTX4HSWIUHFI2DUFRD2RY5RWNX2EBXY
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/3aa572d4-1cd1-40f8-ba85-59416149c5df
         method: GET
       response:
         proto: HTTP/2.0
@@ -1307,20 +1307,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 321
+        content_length: 475
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.022651Z","endpoint":"nats://nats.mnq.fr-par.scaleway.com:4222","id":"ABJB6EGKXFTAXU6LCTWMS6SU7LTX4HSWIUHFI2DUFRD2RY5RWNX2EBXY","name":"tf-nats-account-modest-chandrasekhar","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","updated_at":"2025-01-24T15:44:07.022651Z"}'
+        body: '{"description":"","error_message":null,"function_id":"d2ab0a30-8169-451f-bf91-ff7a4b234863","id":"3aa572d4-1cd1-40f8-ba85-59416149c5df","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":"0aa99b2d-f472-436d-9463-008e1a08ac7d","mnq_nats_account_id":"ADMU4AEVWFQIDQDCOXRKO3DA6FJIZQTNCEXYXT4OZSP6NHNFXB4LTFLZ","mnq_project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","mnq_region":"fr-par","subject":"TestSubject"},"status":"ready"}'
         headers:
             Content-Length:
-                - "321"
+                - "475"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:32 GMT
+                - Wed, 27 Aug 2025 15:05:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1328,10 +1328,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 07428e63-a49b-40fe-8bed-bc275cf0150e
+                - d906dc78-2d73-404d-ae38-d43012a173ca
         status: 200 OK
         code: 200
-        duration: 75.660458ms
+        duration: 52.294337ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1347,8 +1347,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/566fa6bf-f3b8-4b70-ac6f-5a20ab9ed8ea
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/nats-accounts/ADMU4AEVWFQIDQDCOXRKO3DA6FJIZQTNCEXYXT4OZSP6NHNFXB4LTFLZ
         method: GET
       response:
         proto: HTTP/2.0
@@ -1356,20 +1356,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 702
+        content_length: 317
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:13.293900Z","description":"","domain_name":"testfunctiontriggerscpqkjeyb-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"566fa6bf-f3b8-4b70-ac6f-5a20ab9ed8ea","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"39794f7e-3fb2-40d8-9ccb-54b2789ddfa8","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:13.293900Z"}'
+        body: '{"created_at":"2025-08-27T15:05:08.345573Z","endpoint":"nats://nats.mnq.fr-par.scaleway.com:4222","id":"ADMU4AEVWFQIDQDCOXRKO3DA6FJIZQTNCEXYXT4OZSP6NHNFXB4LTFLZ","name":"tf-nats-account-blissful-johnson","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","updated_at":"2025-08-27T15:05:08.345573Z"}'
         headers:
             Content-Length:
-                - "702"
+                - "317"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:32 GMT
+                - Wed, 27 Aug 2025 15:05:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1377,10 +1377,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cf41a854-0ddb-46cb-98ad-7cc80d1fdfc3
+                - ab85562c-90fd-471d-819f-ff6b8c58d253
         status: 200 OK
         code: 200
-        duration: 66.553ms
+        duration: 44.779746ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1396,8 +1396,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/d61296e0-24e3-49fb-a502-7f055d01db2f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/55616aec-771d-4b6a-82e7-ab135f67f899
         method: GET
       response:
         proto: HTTP/2.0
@@ -1405,20 +1405,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 475
+        content_length: 593
         uncompressed: false
-        body: '{"description":"","error_message":null,"function_id":"566fa6bf-f3b8-4b70-ac6f-5a20ab9ed8ea","id":"d61296e0-24e3-49fb-a502-7f055d01db2f","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":"ca2ff124-e739-4707-a235-a66c501a1b20","mnq_nats_account_id":"ABJB6EGKXFTAXU6LCTWMS6SU7LTX4HSWIUHFI2DUFRD2RY5RWNX2EBXY","mnq_project_id":"105bdce1-64c0-48ab-899d-868455867ecf","mnq_region":"fr-par","subject":"TestSubject"},"status":"ready"}'
+        body: '{"created_at":"2025-08-27T15:05:13.653786Z","description":"","environment_variables":{},"error_message":null,"id":"55616aec-771d-4b6a-82e7-ab135f67f899","name":"test-function-trigger-sqs","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggersxwgl5txd","registry_namespace_id":"97e5c2bd-0c1f-4eb5-966a-43ee4c2a1018","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:19.271213Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "475"
+                - "593"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:32 GMT
+                - Wed, 27 Aug 2025 15:05:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1426,10 +1426,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 43569592-ab1e-4479-940e-9a0caee62380
+                - d88ea574-de89-42a5-a3c4-a0fd120dcba2
         status: 200 OK
         code: 200
-        duration: 83.241334ms
+        duration: 48.438602ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1445,8 +1445,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/d61296e0-24e3-49fb-a502-7f055d01db2f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d2ab0a30-8169-451f-bf91-ff7a4b234863
         method: GET
       response:
         proto: HTTP/2.0
@@ -1454,20 +1454,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 475
+        content_length: 738
         uncompressed: false
-        body: '{"description":"","error_message":null,"function_id":"566fa6bf-f3b8-4b70-ac6f-5a20ab9ed8ea","id":"d61296e0-24e3-49fb-a502-7f055d01db2f","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":"ca2ff124-e739-4707-a235-a66c501a1b20","mnq_nats_account_id":"ABJB6EGKXFTAXU6LCTWMS6SU7LTX4HSWIUHFI2DUFRD2RY5RWNX2EBXY","mnq_project_id":"105bdce1-64c0-48ab-899d-868455867ecf","mnq_region":"fr-par","subject":"TestSubject"},"status":"ready"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:25.397303Z","description":"","domain_name":"testfunctiontriggersxwgl5txd-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"d2ab0a30-8169-451f-bf91-ff7a4b234863","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"55616aec-771d-4b6a-82e7-ab135f67f899","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:25.397303Z"}'
         headers:
             Content-Length:
-                - "475"
+                - "738"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:33 GMT
+                - Wed, 27 Aug 2025 15:05:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1475,10 +1475,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 714445a6-376a-41ce-a46e-145079eff575
+                - ade94892-b288-45d6-acb8-bde1a9cfbe21
         status: 200 OK
         code: 200
-        duration: 81.612792ms
+        duration: 57.54004ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1494,29 +1494,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/d61296e0-24e3-49fb-a502-7f055d01db2f
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/3aa572d4-1cd1-40f8-ba85-59416149c5df
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 478
+        content_length: 475
         uncompressed: false
-        body: '{"description":"","error_message":null,"function_id":"566fa6bf-f3b8-4b70-ac6f-5a20ab9ed8ea","id":"d61296e0-24e3-49fb-a502-7f055d01db2f","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":"ca2ff124-e739-4707-a235-a66c501a1b20","mnq_nats_account_id":"ABJB6EGKXFTAXU6LCTWMS6SU7LTX4HSWIUHFI2DUFRD2RY5RWNX2EBXY","mnq_project_id":"105bdce1-64c0-48ab-899d-868455867ecf","mnq_region":"fr-par","subject":"TestSubject"},"status":"deleting"}'
+        body: '{"description":"","error_message":null,"function_id":"d2ab0a30-8169-451f-bf91-ff7a4b234863","id":"3aa572d4-1cd1-40f8-ba85-59416149c5df","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":"0aa99b2d-f472-436d-9463-008e1a08ac7d","mnq_nats_account_id":"ADMU4AEVWFQIDQDCOXRKO3DA6FJIZQTNCEXYXT4OZSP6NHNFXB4LTFLZ","mnq_project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","mnq_region":"fr-par","subject":"TestSubject"},"status":"ready"}'
         headers:
             Content-Length:
-                - "478"
+                - "475"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:33 GMT
+                - Wed, 27 Aug 2025 15:05:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1524,10 +1524,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9d465703-b254-43e2-92d4-27a223a975c5
+                - 71ffe2e7-0293-494d-9082-a733ebd4b611
         status: 200 OK
         code: 200
-        duration: 109.956917ms
+        duration: 38.564323ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1543,8 +1543,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/d61296e0-24e3-49fb-a502-7f055d01db2f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/3aa572d4-1cd1-40f8-ba85-59416149c5df
         method: GET
       response:
         proto: HTTP/2.0
@@ -1552,20 +1552,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 478
+        content_length: 475
         uncompressed: false
-        body: '{"description":"","error_message":null,"function_id":"566fa6bf-f3b8-4b70-ac6f-5a20ab9ed8ea","id":"d61296e0-24e3-49fb-a502-7f055d01db2f","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":"ca2ff124-e739-4707-a235-a66c501a1b20","mnq_nats_account_id":"ABJB6EGKXFTAXU6LCTWMS6SU7LTX4HSWIUHFI2DUFRD2RY5RWNX2EBXY","mnq_project_id":"105bdce1-64c0-48ab-899d-868455867ecf","mnq_region":"fr-par","subject":"TestSubject"},"status":"deleting"}'
+        body: '{"description":"","error_message":null,"function_id":"d2ab0a30-8169-451f-bf91-ff7a4b234863","id":"3aa572d4-1cd1-40f8-ba85-59416149c5df","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":"0aa99b2d-f472-436d-9463-008e1a08ac7d","mnq_nats_account_id":"ADMU4AEVWFQIDQDCOXRKO3DA6FJIZQTNCEXYXT4OZSP6NHNFXB4LTFLZ","mnq_project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","mnq_region":"fr-par","subject":"TestSubject"},"status":"ready"}'
         headers:
             Content-Length:
-                - "478"
+                - "475"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:33 GMT
+                - Wed, 27 Aug 2025 15:05:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1573,10 +1573,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e20e2d84-8021-4b08-acea-e9cd1c3dae3e
+                - 629ab00b-ff4d-4dd3-9023-dc45ec04cee1
         status: 200 OK
         code: 200
-        duration: 81.913083ms
+        duration: 63.864908ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1592,9 +1592,9 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/d61296e0-24e3-49fb-a502-7f055d01db2f
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/3aa572d4-1cd1-40f8-ba85-59416149c5df
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
@@ -1603,7 +1603,7 @@ interactions:
         trailer: {}
         content_length: 478
         uncompressed: false
-        body: '{"description":"","error_message":null,"function_id":"566fa6bf-f3b8-4b70-ac6f-5a20ab9ed8ea","id":"d61296e0-24e3-49fb-a502-7f055d01db2f","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":"ca2ff124-e739-4707-a235-a66c501a1b20","mnq_nats_account_id":"ABJB6EGKXFTAXU6LCTWMS6SU7LTX4HSWIUHFI2DUFRD2RY5RWNX2EBXY","mnq_project_id":"105bdce1-64c0-48ab-899d-868455867ecf","mnq_region":"fr-par","subject":"TestSubject"},"status":"deleting"}'
+        body: '{"description":"","error_message":null,"function_id":"d2ab0a30-8169-451f-bf91-ff7a4b234863","id":"3aa572d4-1cd1-40f8-ba85-59416149c5df","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":"0aa99b2d-f472-436d-9463-008e1a08ac7d","mnq_nats_account_id":"ADMU4AEVWFQIDQDCOXRKO3DA6FJIZQTNCEXYXT4OZSP6NHNFXB4LTFLZ","mnq_project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","mnq_region":"fr-par","subject":"TestSubject"},"status":"deleting"}'
         headers:
             Content-Length:
                 - "478"
@@ -1612,9 +1612,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:38 GMT
+                - Wed, 27 Aug 2025 15:05:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1622,10 +1622,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e31f2998-d271-4848-b991-b7e89f7f934e
+                - af573bfb-814a-44ba-9c44-eda77488b3b9
         status: 200 OK
         code: 200
-        duration: 79.1325ms
+        duration: 95.34568ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1641,8 +1641,155 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/d61296e0-24e3-49fb-a502-7f055d01db2f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/3aa572d4-1cd1-40f8-ba85-59416149c5df
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 478
+        uncompressed: false
+        body: '{"description":"","error_message":null,"function_id":"d2ab0a30-8169-451f-bf91-ff7a4b234863","id":"3aa572d4-1cd1-40f8-ba85-59416149c5df","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":"0aa99b2d-f472-436d-9463-008e1a08ac7d","mnq_nats_account_id":"ADMU4AEVWFQIDQDCOXRKO3DA6FJIZQTNCEXYXT4OZSP6NHNFXB4LTFLZ","mnq_project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","mnq_region":"fr-par","subject":"TestSubject"},"status":"deleting"}'
+        headers:
+            Content-Length:
+                - "478"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:05:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 0b918e0e-65fc-4a2d-b4e1-4d50e6f41db9
+        status: 200 OK
+        code: 200
+        duration: 70.236414ms
+    - id: 34
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/3aa572d4-1cd1-40f8-ba85-59416149c5df
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 478
+        uncompressed: false
+        body: '{"description":"","error_message":null,"function_id":"d2ab0a30-8169-451f-bf91-ff7a4b234863","id":"3aa572d4-1cd1-40f8-ba85-59416149c5df","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":"0aa99b2d-f472-436d-9463-008e1a08ac7d","mnq_nats_account_id":"ADMU4AEVWFQIDQDCOXRKO3DA6FJIZQTNCEXYXT4OZSP6NHNFXB4LTFLZ","mnq_project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","mnq_region":"fr-par","subject":"TestSubject"},"status":"deleting"}'
+        headers:
+            Content-Length:
+                - "478"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:05:54 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - fca5147e-5718-438c-be25-6ca97bbe815d
+        status: 200 OK
+        code: 200
+        duration: 145.042615ms
+    - id: 35
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/3aa572d4-1cd1-40f8-ba85-59416149c5df
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 478
+        uncompressed: false
+        body: '{"description":"","error_message":null,"function_id":"d2ab0a30-8169-451f-bf91-ff7a4b234863","id":"3aa572d4-1cd1-40f8-ba85-59416149c5df","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":"0aa99b2d-f472-436d-9463-008e1a08ac7d","mnq_nats_account_id":"ADMU4AEVWFQIDQDCOXRKO3DA6FJIZQTNCEXYXT4OZSP6NHNFXB4LTFLZ","mnq_project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","mnq_region":"fr-par","subject":"TestSubject"},"status":"deleting"}'
+        headers:
+            Content-Length:
+                - "478"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:05:59 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - d043106e-e8b1-4d25-b3ce-75baa900f40d
+        status: 200 OK
+        code: 200
+        duration: 133.961553ms
+    - id: 36
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/3aa572d4-1cd1-40f8-ba85-59416149c5df
         method: GET
       response:
         proto: HTTP/2.0
@@ -1661,9 +1808,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:43 GMT
+                - Wed, 27 Aug 2025 15:06:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1671,155 +1818,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8abe92f2-5fdc-42ff-8753-aa2ad72fb753
+                - 2a831c48-095d-43eb-a30a-e899310716b4
         status: 404 Not Found
         code: 404
-        duration: 34.88375ms
-    - id: 34
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/566fa6bf-f3b8-4b70-ac6f-5a20ab9ed8ea
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 702
-        uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:13.293900Z","description":"","domain_name":"testfunctiontriggerscpqkjeyb-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"566fa6bf-f3b8-4b70-ac6f-5a20ab9ed8ea","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"39794f7e-3fb2-40d8-9ccb-54b2789ddfa8","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:13.293900Z"}'
-        headers:
-            Content-Length:
-                - "702"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:44:43 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - c64de37f-3570-4eba-b679-36e6d10f9778
-        status: 200 OK
-        code: 200
-        duration: 84.162875ms
-    - id: 35
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/566fa6bf-f3b8-4b70-ac6f-5a20ab9ed8ea
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 706
-        uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:13.293900Z","description":"","domain_name":"testfunctiontriggerscpqkjeyb-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"566fa6bf-f3b8-4b70-ac6f-5a20ab9ed8ea","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"39794f7e-3fb2-40d8-9ccb-54b2789ddfa8","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"deleting","timeout":"300s","updated_at":"2025-01-24T15:44:43.822602963Z"}'
-        headers:
-            Content-Length:
-                - "706"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:44:43 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 3fc67716-d11c-4444-a66a-44004a057b66
-        status: 200 OK
-        code: 200
-        duration: 127.976625ms
-    - id: 36
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/nats-accounts/ABJB6EGKXFTAXU6LCTWMS6SU7LTX4HSWIUHFI2DUFRD2RY5RWNX2EBXY
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 0
-        uncompressed: false
-        body: ""
-        headers:
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:44:43 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 2c316a3c-f3cd-4c0a-ab85-ac9ca818c38c
-        status: 204 No Content
-        code: 204
-        duration: 232.239125ms
+        duration: 24.240877ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1835,8 +1837,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/39794f7e-3fb2-40d8-9ccb-54b2789ddfa8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d2ab0a30-8169-451f-bf91-ff7a4b234863
         method: GET
       response:
         proto: HTTP/2.0
@@ -1844,20 +1846,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 560
+        content_length: 738
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.683078Z","description":"","environment_variables":{},"error_message":null,"id":"39794f7e-3fb2-40d8-9ccb-54b2789ddfa8","name":"test-function-trigger-sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggerscpqkjeyb","registry_namespace_id":"fbc408ce-460d-4238-8e24-645bc5b2c041","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:44:10.581199Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:25.397303Z","description":"","domain_name":"testfunctiontriggersxwgl5txd-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"d2ab0a30-8169-451f-bf91-ff7a4b234863","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"55616aec-771d-4b6a-82e7-ab135f67f899","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:25.397303Z"}'
         headers:
             Content-Length:
-                - "560"
+                - "738"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:43 GMT
+                - Wed, 27 Aug 2025 15:06:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1865,10 +1867,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 842d57cb-0cca-4f55-ae79-a6dc9bfb7bd4
+                - 1443ab14-d18d-4f8f-b6db-3f1f33ec6c9f
         status: 200 OK
         code: 200
-        duration: 68.778792ms
+        duration: 56.619465ms
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1884,8 +1886,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/39794f7e-3fb2-40d8-9ccb-54b2789ddfa8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/nats-accounts/ADMU4AEVWFQIDQDCOXRKO3DA6FJIZQTNCEXYXT4OZSP6NHNFXB4LTFLZ
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1893,20 +1895,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 566
+        content_length: 0
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.683078Z","description":"","environment_variables":{},"error_message":null,"id":"39794f7e-3fb2-40d8-9ccb-54b2789ddfa8","name":"test-function-trigger-sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggerscpqkjeyb","registry_namespace_id":"fbc408ce-460d-4238-8e24-645bc5b2c041","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:44:44.023487193Z"}'
+        body: ""
         headers:
-            Content-Length:
-                - "566"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:44 GMT
+                - Wed, 27 Aug 2025 15:06:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1914,10 +1914,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8948d8c4-49a6-4e66-97fa-5d9e3f5a12af
-        status: 200 OK
-        code: 200
-        duration: 253.679458ms
+                - de76e2c2-f01d-4fa6-96c6-857379e923ce
+        status: 204 No Content
+        code: 204
+        duration: 150.742666ms
     - id: 39
       request:
         proto: HTTP/1.1
@@ -1933,29 +1933,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/39794f7e-3fb2-40d8-9ccb-54b2789ddfa8
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d2ab0a30-8169-451f-bf91-ff7a4b234863
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 563
+        content_length: 742
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.683078Z","description":"","environment_variables":{},"error_message":null,"id":"39794f7e-3fb2-40d8-9ccb-54b2789ddfa8","name":"test-function-trigger-sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggerscpqkjeyb","registry_namespace_id":"fbc408ce-460d-4238-8e24-645bc5b2c041","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:44:44.023487Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:25.397303Z","description":"","domain_name":"testfunctiontriggersxwgl5txd-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"d2ab0a30-8169-451f-bf91-ff7a4b234863","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"55616aec-771d-4b6a-82e7-ab135f67f899","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:04.795142479Z"}'
         headers:
             Content-Length:
-                - "563"
+                - "742"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:44 GMT
+                - Wed, 27 Aug 2025 15:06:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1963,10 +1963,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f56a07bd-f4d2-4324-9b23-a045070bace7
+                - e443d06b-4822-49e0-9b2a-673178f4fca6
         status: 200 OK
         code: 200
-        duration: 64.248958ms
+        duration: 165.09107ms
     - id: 40
       request:
         proto: HTTP/1.1
@@ -1982,8 +1982,155 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/39794f7e-3fb2-40d8-9ccb-54b2789ddfa8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/55616aec-771d-4b6a-82e7-ab135f67f899
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 593
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:13.653786Z","description":"","environment_variables":{},"error_message":null,"id":"55616aec-771d-4b6a-82e7-ab135f67f899","name":"test-function-trigger-sqs","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggersxwgl5txd","registry_namespace_id":"97e5c2bd-0c1f-4eb5-966a-43ee4c2a1018","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:19.271213Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "593"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:05 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b572864c-3fd8-44f5-8776-2b364a86831f
+        status: 200 OK
+        code: 200
+        duration: 53.751323ms
+    - id: 41
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/55616aec-771d-4b6a-82e7-ab135f67f899
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 599
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:13.653786Z","description":"","environment_variables":{},"error_message":null,"id":"55616aec-771d-4b6a-82e7-ab135f67f899","name":"test-function-trigger-sqs","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggersxwgl5txd","registry_namespace_id":"97e5c2bd-0c1f-4eb5-966a-43ee4c2a1018","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:05.041708357Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "599"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:05 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 307899d3-a5e4-4d30-b8d7-ed008158bc6b
+        status: 200 OK
+        code: 200
+        duration: 254.064557ms
+    - id: 42
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/55616aec-771d-4b6a-82e7-ab135f67f899
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 596
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:13.653786Z","description":"","environment_variables":{},"error_message":null,"id":"55616aec-771d-4b6a-82e7-ab135f67f899","name":"test-function-trigger-sqs","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggersxwgl5txd","registry_namespace_id":"97e5c2bd-0c1f-4eb5-966a-43ee4c2a1018","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:06:05.041708Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "596"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:05 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 805a45d8-de13-4b16-8a4e-6ab9287bc2d2
+        status: 200 OK
+        code: 200
+        duration: 43.595636ms
+    - id: 43
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/55616aec-771d-4b6a-82e7-ab135f67f899
         method: GET
       response:
         proto: HTTP/2.0
@@ -2002,9 +2149,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:49 GMT
+                - Wed, 27 Aug 2025 15:06:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2012,11 +2159,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 17237940-3f9f-41f8-840f-ad5ac2e466b7
+                - 9bd50ad8-de97-4047-9989-ff299080400c
         status: 404 Not Found
         code: 404
-        duration: 27.630208ms
-    - id: 41
+        duration: 27.989201ms
+    - id: 44
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2031,8 +2178,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/d61296e0-24e3-49fb-a502-7f055d01db2f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/3aa572d4-1cd1-40f8-ba85-59416149c5df
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -2042,7 +2189,7 @@ interactions:
         trailer: {}
         content_length: 105
         uncompressed: false
-        body: '{"message":"trigger does not exist: could not find trigger with id d61296e0-24e3-49fb-a502-7f055d01db2f"}'
+        body: '{"message":"trigger does not exist: could not find trigger with id 3aa572d4-1cd1-40f8-ba85-59416149c5df"}'
         headers:
             Content-Length:
                 - "105"
@@ -2051,9 +2198,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:49 GMT
+                - Wed, 27 Aug 2025 15:06:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2061,7 +2208,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fe8329e3-bb88-4844-8962-703617846ca4
+                - 13f70c44-59c3-4612-93f5-c2d5e3bf2cd7
         status: 404 Not Found
         code: 404
-        duration: 25.979958ms
+        duration: 24.837528ms

--- a/internal/services/function/testdata/function-trigger-sqs.cassette.yaml
+++ b/internal/services/function/testdata/function-trigger-sqs.cassette.yaml
@@ -18,7 +18,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/account/v3/projects
         method: POST
       response:
@@ -27,20 +27,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 244
+        content_length: 265
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:06.784363Z","description":"","id":"e3193f4c-2b75-4f42-8467-9331a6db6b75","name":"tf_tests_function_trigger_sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","updated_at":"2025-01-24T15:44:06.784363Z"}'
+        body: '{"created_at":"2025-08-27T15:06:19.403028Z","description":"","id":"52b94a0b-0f98-4f84-9b02-f19b6970eed0","name":"tf_tests_function_trigger_sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","qualification":null,"updated_at":"2025-08-27T15:06:19.403028Z"}'
         headers:
             Content-Length:
-                - "244"
+                - "265"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:07 GMT
+                - Wed, 27 Aug 2025 15:06:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f7e0d0a4-7a6f-485a-a530-51e4c17d8a6c
+                - 034e0b25-a66f-48bb-abb2-c8edd4facfab
         status: 200 OK
         code: 200
-        duration: 412.640291ms
+        duration: 446.348704ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -67,8 +67,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/account/v3/projects/e3193f4c-2b75-4f42-8467-9331a6db6b75
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/account/v3/projects/52b94a0b-0f98-4f84-9b02-f19b6970eed0
         method: GET
       response:
         proto: HTTP/2.0
@@ -76,20 +76,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 244
+        content_length: 310
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:06.784363Z","description":"","id":"e3193f4c-2b75-4f42-8467-9331a6db6b75","name":"tf_tests_function_trigger_sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","updated_at":"2025-01-24T15:44:06.784363Z"}'
+        body: '{"created_at":"2025-08-27T15:06:19.403028Z","description":"","id":"52b94a0b-0f98-4f84-9b02-f19b6970eed0","name":"tf_tests_function_trigger_sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","qualification":{"architecture_type":"unknown_architecture_type"},"updated_at":"2025-08-27T15:06:19.403028Z"}'
         headers:
             Content-Length:
-                - "244"
+                - "310"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:07 GMT
+                - Wed, 27 Aug 2025 15:06:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6cb3b6fd-8071-404c-8834-34f3e4aafe49
+                - c0cf1470-e9b9-4c5d-b30f-149a68eabe95
         status: 200 OK
         code: 200
-        duration: 126.108ms
+        duration: 232.065837ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -112,13 +112,13 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"project_id":"e3193f4c-2b75-4f42-8467-9331a6db6b75"}'
+        body: '{"project_id":"52b94a0b-0f98-4f84-9b02-f19b6970eed0"}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/activate-sqs
         method: POST
       response:
@@ -129,7 +129,7 @@ interactions:
         trailer: {}
         content_length: 239
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.295889290Z","project_id":"e3193f4c-2b75-4f42-8467-9331a6db6b75","region":"fr-par","sqs_endpoint_url":"https://sqs.mnq.fr-par.scaleway.com","status":"enabled","updated_at":"2025-01-24T15:44:07.295889290Z"}'
+        body: '{"created_at":"2025-08-27T15:06:19.969953963Z","project_id":"52b94a0b-0f98-4f84-9b02-f19b6970eed0","region":"fr-par","sqs_endpoint_url":"https://sqs.mnq.fr-par.scaleway.com","status":"enabled","updated_at":"2025-08-27T15:06:19.969953963Z"}'
         headers:
             Content-Length:
                 - "239"
@@ -138,9 +138,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:07 GMT
+                - Wed, 27 Aug 2025 15:06:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -148,10 +148,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7f7c9e79-fc38-42f2-ad52-5a41e4d37ec9
+                - 5b478139-2088-415c-ac3e-31aa04ba1dad
         status: 200 OK
         code: 200
-        duration: 179.60525ms
+        duration: 191.680945ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -167,8 +167,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-info?project_id=e3193f4c-2b75-4f42-8467-9331a6db6b75
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-info?project_id=52b94a0b-0f98-4f84-9b02-f19b6970eed0
         method: GET
       response:
         proto: HTTP/2.0
@@ -178,7 +178,7 @@ interactions:
         trailer: {}
         content_length: 233
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.295889Z","project_id":"e3193f4c-2b75-4f42-8467-9331a6db6b75","region":"fr-par","sqs_endpoint_url":"https://sqs.mnq.fr-par.scaleway.com","status":"enabled","updated_at":"2025-01-24T15:44:07.295889Z"}'
+        body: '{"created_at":"2025-08-27T15:06:19.969953Z","project_id":"52b94a0b-0f98-4f84-9b02-f19b6970eed0","region":"fr-par","sqs_endpoint_url":"https://sqs.mnq.fr-par.scaleway.com","status":"enabled","updated_at":"2025-08-27T15:06:19.969953Z"}'
         headers:
             Content-Length:
                 - "233"
@@ -187,9 +187,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:07 GMT
+                - Wed, 27 Aug 2025 15:06:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -197,28 +197,28 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 17223ee1-f87e-4d70-bde4-15735a1ae705
+                - 2d365fd1-c0a5-4158-ad07-ca7806e7d251
         status: 200 OK
         code: 200
-        duration: 62.043709ms
+        duration: 74.700478ms
     - id: 4
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 169
+        content_length: 168
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"project_id":"e3193f4c-2b75-4f42-8467-9331a6db6b75","name":"tf-sqs-credentials-charming-pascal","permissions":{"can_publish":true,"can_receive":true,"can_manage":true}}'
+        body: '{"project_id":"52b94a0b-0f98-4f84-9b02-f19b6970eed0","name":"tf-sqs-credentials-gallant-mclean","permissions":{"can_publish":true,"can_receive":true,"can_manage":true}}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-credentials
         method: POST
       response:
@@ -227,20 +227,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 500
+        content_length: 499
         uncompressed: false
-        body: '{"access_key":"HG5XrGM6wISpjrwoqbLo","created_at":"2025-01-24T15:44:07.547668440Z","id":"6be9a259-8001-4e52-85a1-f942a3758d6c","name":"tf-sqs-credentials-charming-pascal","permissions":{"can_manage":true,"can_publish":true,"can_receive":true},"project_id":"e3193f4c-2b75-4f42-8467-9331a6db6b75","region":"fr-par","secret_checksum":"79f084fa78e9408da4c9095afc90aaa71d963b46","secret_key":"00000000-0000-0000-0000-000000000000","updated_at":"2025-01-24T15:44:07.547668440Z"}'
+        body: '{"access_key":"CzoighBpAX8xTKHVnLaq","created_at":"2025-08-27T15:06:20.258532811Z","id":"cdcc9ac4-fbdb-400c-bf7e-683edb95fc41","name":"tf-sqs-credentials-gallant-mclean","permissions":{"can_manage":true,"can_publish":true,"can_receive":true},"project_id":"52b94a0b-0f98-4f84-9b02-f19b6970eed0","region":"fr-par","secret_checksum":"24ad85e21e25174cfd68c9fc789cd65518fc07ed","secret_key":"00000000-0000-0000-0000-000000000000","updated_at":"2025-08-27T15:06:20.258532811Z"}'
         headers:
             Content-Length:
-                - "500"
+                - "499"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:07 GMT
+                - Wed, 27 Aug 2025 15:06:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -248,10 +248,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d6dcbfa6-5b2a-47a3-8994-a543729d8590
+                - 551c6189-2d52-4cc3-8719-66cdd989ca99
         status: 200 OK
         code: 200
-        duration: 88.964333ms
+        duration: 131.554786ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -267,8 +267,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-credentials/6be9a259-8001-4e52-85a1-f942a3758d6c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-credentials/cdcc9ac4-fbdb-400c-bf7e-683edb95fc41
         method: GET
       response:
         proto: HTTP/2.0
@@ -276,20 +276,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 430
+        content_length: 429
         uncompressed: false
-        body: '{"access_key":"HG5XrGM6wISpjrwoqbLo","created_at":"2025-01-24T15:44:07.547668Z","id":"6be9a259-8001-4e52-85a1-f942a3758d6c","name":"tf-sqs-credentials-charming-pascal","permissions":{"can_manage":true,"can_publish":true,"can_receive":true},"project_id":"e3193f4c-2b75-4f42-8467-9331a6db6b75","region":"fr-par","secret_checksum":"79f084fa78e9408da4c9095afc90aaa71d963b46","secret_key":"00000000-0000-0000-0000-000000000000","updated_at":"2025-01-24T15:44:07.547668Z"}'
+        body: '{"access_key":"CzoighBpAX8xTKHVnLaq","created_at":"2025-08-27T15:06:20.258532Z","id":"cdcc9ac4-fbdb-400c-bf7e-683edb95fc41","name":"tf-sqs-credentials-gallant-mclean","permissions":{"can_manage":true,"can_publish":true,"can_receive":true},"project_id":"52b94a0b-0f98-4f84-9b02-f19b6970eed0","region":"fr-par","secret_checksum":"24ad85e21e25174cfd68c9fc789cd65518fc07ed","secret_key":"00000000-0000-0000-0000-000000000000","updated_at":"2025-08-27T15:06:20.258532Z"}'
         headers:
             Content-Length:
-                - "430"
+                - "429"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:07 GMT
+                - Wed, 27 Aug 2025 15:06:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -297,10 +297,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 97277f1b-93f7-4605-8109-69d70676d0b6
+                - 17241841-7ef7-4d49-8d38-2e4ab97aa9a2
         status: 200 OK
         code: 200
-        duration: 97.68425ms
+        duration: 92.759365ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -316,8 +316,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-info?project_id=e3193f4c-2b75-4f42-8467-9331a6db6b75
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-info?project_id=52b94a0b-0f98-4f84-9b02-f19b6970eed0
         method: GET
       response:
         proto: HTTP/2.0
@@ -327,7 +327,7 @@ interactions:
         trailer: {}
         content_length: 233
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.295889Z","project_id":"e3193f4c-2b75-4f42-8467-9331a6db6b75","region":"fr-par","sqs_endpoint_url":"https://sqs.mnq.fr-par.scaleway.com","status":"enabled","updated_at":"2025-01-24T15:44:07.295889Z"}'
+        body: '{"created_at":"2025-08-27T15:06:19.969953Z","project_id":"52b94a0b-0f98-4f84-9b02-f19b6970eed0","region":"fr-par","sqs_endpoint_url":"https://sqs.mnq.fr-par.scaleway.com","status":"enabled","updated_at":"2025-08-27T15:06:19.969953Z"}'
         headers:
             Content-Length:
                 - "233"
@@ -336,9 +336,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:07 GMT
+                - Wed, 27 Aug 2025 15:06:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -346,111 +346,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6e4d2dac-29ce-4f0f-a45e-0e61328a7873
+                - 2206585a-d6d0-4551-8c95-0ec2496ec1ba
         status: 200 OK
         code: 200
-        duration: 53.880334ms
+        duration: 82.141951ms
     - id: 7
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 161
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"name":"test-function-trigger-sqs","environment_variables":{},"project_id":"e3193f4c-2b75-4f42-8467-9331a6db6b75","secret_environment_variables":[],"tags":null}'
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 477
-        uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.719841462Z","description":"","environment_variables":{},"error_message":null,"id":"520a545e-7353-4080-8f8f-d64ac490b8a1","name":"test-function-trigger-sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"e3193f4c-2b75-4f42-8467-9331a6db6b75","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:44:07.719841462Z"}'
-        headers:
-            Content-Length:
-                - "477"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:44:07 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 7d61d7b3-f3a5-44d5-bf33-173f4bffec02
-        status: 200 OK
-        code: 200
-        duration: 508.0895ms
-    - id: 8
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/520a545e-7353-4080-8f8f-d64ac490b8a1
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 471
-        uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.719841Z","description":"","environment_variables":{},"error_message":null,"id":"520a545e-7353-4080-8f8f-d64ac490b8a1","name":"test-function-trigger-sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"e3193f4c-2b75-4f42-8467-9331a6db6b75","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:44:07.719841Z"}'
-        headers:
-            Content-Length:
-                - "471"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:44:07 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 85b81716-2edf-4749-abf3-dddd926e0c2e
-        status: 200 OK
-        code: 200
-        duration: 67.070041ms
-    - id: 9
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -465,15 +365,15 @@ interactions:
         form: {}
         headers:
             Amz-Sdk-Invocation-Id:
-                - 4b63c5e9-e806-4528-a130-03badb49d4df
+                - 4c1b7f85-3195-4408-8e50-ad8c9bbeb135
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
                 - application/x-amz-json-1.0
             User-Agent:
-                - aws-sdk-go-v2/1.32.7 ua/2.1 os/macos lang/go#1.23.3 md/GOOS#darwin md/GOARCH#arm64 api/sqs#1.37.3 m/E
+                - aws-sdk-go-v2/1.37.1 ua/2.1 os/linux lang/go#1.24.1 md/GOOS#linux md/GOARCH#amd64 api/sqs#1.38.6 m/E,e
             X-Amz-Date:
-                - 20250124T154407Z
+                - 20250827T150620Z
             X-Amz-Target:
                 - AmazonSQS.CreateQueue
             X-Amzn-Query-Mode:
@@ -488,20 +388,20 @@ interactions:
         trailer: {}
         content_length: 106
         uncompressed: false
-        body: '{"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-e3193f4c-2b75-4f42-8467-9331a6db6b75/TestQueue"}'
+        body: '{"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-52b94a0b-0f98-4f84-9b02-f19b6970eed0/TestQueue"}'
         headers:
             Content-Length:
                 - "106"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 24 Jan 2025 15:44:08 GMT
+                - Wed, 27 Aug 2025 15:06:20 GMT
             X-Amzn-Requestid:
-                - tx88166c44-2f1a-4c83-9562-2052e02d6fdf
+                - txe91cdd1c-4fee-4541-b1ef-6df57eee0b1c
         status: 200 OK
         code: 200
-        duration: 564.4425ms
-    - id: 10
+        duration: 215.213925ms
+    - id: 8
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -516,15 +416,15 @@ interactions:
         form: {}
         headers:
             Amz-Sdk-Invocation-Id:
-                - 5ced6727-f534-4695-98a1-8ef642842049
+                - 4cea2fe2-91dd-4fa3-b1cc-284ae96be189
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
                 - application/x-amz-json-1.0
             User-Agent:
-                - aws-sdk-go-v2/1.32.7 ua/2.1 os/macos lang/go#1.23.3 md/GOOS#darwin md/GOARCH#arm64 api/sqs#1.37.3 m/E
+                - aws-sdk-go-v2/1.37.1 ua/2.1 os/linux lang/go#1.24.1 md/GOOS#linux md/GOARCH#amd64 api/sqs#1.38.6 m/E,e
             X-Amz-Date:
-                - 20250124T154408Z
+                - 20250827T150620Z
             X-Amz-Target:
                 - AmazonSQS.GetQueueUrl
             X-Amzn-Query-Mode:
@@ -539,20 +439,20 @@ interactions:
         trailer: {}
         content_length: 106
         uncompressed: false
-        body: '{"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-e3193f4c-2b75-4f42-8467-9331a6db6b75/TestQueue"}'
+        body: '{"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-52b94a0b-0f98-4f84-9b02-f19b6970eed0/TestQueue"}'
         headers:
             Content-Length:
                 - "106"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 24 Jan 2025 15:44:08 GMT
+                - Wed, 27 Aug 2025 15:06:20 GMT
             X-Amzn-Requestid:
-                - txb043fea5-9e36-4c9b-8a30-efd169fbd64f
+                - tx2867f8d1-0013-42ff-8ee1-bd067301846a
         status: 200 OK
         code: 200
-        duration: 30.069125ms
-    - id: 11
+        duration: 49.118813ms
+    - id: 9
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -563,19 +463,19 @@ interactions:
         host: sqs.mnq.fr-par.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"AttributeNames":["MessageRetentionPeriod","FifoQueue","ContentBasedDeduplication","ReceiveMessageWaitTimeSeconds","VisibilityTimeout","MaximumMessageSize"],"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-e3193f4c-2b75-4f42-8467-9331a6db6b75/TestQueue"}'
+        body: '{"AttributeNames":["ReceiveMessageWaitTimeSeconds","VisibilityTimeout","MaximumMessageSize","MessageRetentionPeriod","FifoQueue","ContentBasedDeduplication"],"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-52b94a0b-0f98-4f84-9b02-f19b6970eed0/TestQueue"}'
         form: {}
         headers:
             Amz-Sdk-Invocation-Id:
-                - feb5b89c-097d-40cf-b2d2-21283c5e0834
+                - 64dce68a-9401-47a9-a979-e640e42b75ac
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
                 - application/x-amz-json-1.0
             User-Agent:
-                - aws-sdk-go-v2/1.32.7 ua/2.1 os/macos lang/go#1.23.3 md/GOOS#darwin md/GOARCH#arm64 api/sqs#1.37.3 m/E
+                - aws-sdk-go-v2/1.37.1 ua/2.1 os/linux lang/go#1.24.1 md/GOOS#linux md/GOARCH#amd64 api/sqs#1.38.6 m/E,e
             X-Amz-Date:
-                - 20250124T154408Z
+                - 20250827T150620Z
             X-Amz-Target:
                 - AmazonSQS.GetQueueAttributes
             X-Amzn-Query-Mode:
@@ -597,12 +497,112 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 24 Jan 2025 15:44:08 GMT
+                - Wed, 27 Aug 2025 15:06:20 GMT
             X-Amzn-Requestid:
-                - tx7057e098-7761-4d08-8763-8f925e399546
+                - txbe13d15c-48ec-4e96-a55a-8c255c37a050
         status: 200 OK
         code: 200
-        duration: 38.763708ms
+        duration: 26.119283ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 193
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"name":"test-function-trigger-sqs","environment_variables":{},"project_id":"52b94a0b-0f98-4f84-9b02-f19b6970eed0","secret_environment_variables":[],"tags":null,"activate_vpc_integration":true}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 510
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:06:21.464382375Z","description":"","environment_variables":{},"error_message":null,"id":"8c3e5206-c129-4532-92a4-272b9d16e6f0","name":"test-function-trigger-sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"52b94a0b-0f98-4f84-9b02-f19b6970eed0","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:06:21.464382375Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "510"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:21 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b20df48d-9443-4744-b125-0e345bbcbce4
+        status: 200 OK
+        code: 200
+        duration: 1.683854191s
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8c3e5206-c129-4532-92a4-272b9d16e6f0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 504
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:06:21.464382Z","description":"","environment_variables":{},"error_message":null,"id":"8c3e5206-c129-4532-92a4-272b9d16e6f0","name":"test-function-trigger-sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"52b94a0b-0f98-4f84-9b02-f19b6970eed0","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:06:21.464382Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "504"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:21 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 5c8e38ab-12d0-4e30-b34d-8c8de55523fd
+        status: 200 OK
+        code: 200
+        duration: 91.407289ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -618,8 +618,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/520a545e-7353-4080-8f8f-d64ac490b8a1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8c3e5206-c129-4532-92a4-272b9d16e6f0
         method: GET
       response:
         proto: HTTP/2.0
@@ -627,20 +627,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 562
+        content_length: 593
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.719841Z","description":"","environment_variables":{},"error_message":null,"id":"520a545e-7353-4080-8f8f-d64ac490b8a1","name":"test-function-trigger-sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"e3193f4c-2b75-4f42-8467-9331a6db6b75","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggersnzpipacm","registry_namespace_id":"0c845ed2-e3ed-43f6-b062-eb4b0d5c4df1","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:44:11.246881Z"}'
+        body: '{"created_at":"2025-08-27T15:06:21.464382Z","description":"","environment_variables":{},"error_message":null,"id":"8c3e5206-c129-4532-92a4-272b9d16e6f0","name":"test-function-trigger-sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"52b94a0b-0f98-4f84-9b02-f19b6970eed0","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggersjhzlswz4","registry_namespace_id":"ad6dd704-2b22-4ac0-ba04-6c1fbd78a1da","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:25.489989Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "562"
+                - "593"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:12 GMT
+                - Wed, 27 Aug 2025 15:06:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -648,10 +648,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7eccaf58-9763-4ae0-a799-f09d59c80b69
+                - 4e6218b2-1e86-47aa-95eb-bbba5945d8d7
         status: 200 OK
         code: 200
-        duration: 80.07475ms
+        duration: 80.7545ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -667,8 +667,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/520a545e-7353-4080-8f8f-d64ac490b8a1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8c3e5206-c129-4532-92a4-272b9d16e6f0
         method: GET
       response:
         proto: HTTP/2.0
@@ -676,20 +676,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 562
+        content_length: 593
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.719841Z","description":"","environment_variables":{},"error_message":null,"id":"520a545e-7353-4080-8f8f-d64ac490b8a1","name":"test-function-trigger-sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"e3193f4c-2b75-4f42-8467-9331a6db6b75","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggersnzpipacm","registry_namespace_id":"0c845ed2-e3ed-43f6-b062-eb4b0d5c4df1","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:44:11.246881Z"}'
+        body: '{"created_at":"2025-08-27T15:06:21.464382Z","description":"","environment_variables":{},"error_message":null,"id":"8c3e5206-c129-4532-92a4-272b9d16e6f0","name":"test-function-trigger-sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"52b94a0b-0f98-4f84-9b02-f19b6970eed0","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggersjhzlswz4","registry_namespace_id":"ad6dd704-2b22-4ac0-ba04-6c1fbd78a1da","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:25.489989Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "562"
+                - "593"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:17 GMT
+                - Wed, 27 Aug 2025 15:06:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -697,48 +697,50 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d419c971-0f9e-486d-bc6b-b529ee829087
+                - e961b1e2-cc80-443e-a6c0-38edd6121b7a
         status: 200 OK
         code: 200
-        duration: 71.865667ms
+        duration: 86.570283ms
     - id: 14
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 329
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"name":"test-function-trigger-sqs","namespace_id":"8c3e5206-c129-4532-92a4-272b9d16e6f0","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"node22","memory_limit":256,"handler":"handler.handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox","tags":null}'
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/520a545e-7353-4080-8f8f-d64ac490b8a1
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 562
+        content_length: 744
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.719841Z","description":"","environment_variables":{},"error_message":null,"id":"520a545e-7353-4080-8f8f-d64ac490b8a1","name":"test-function-trigger-sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"e3193f4c-2b75-4f42-8467-9331a6db6b75","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggersnzpipacm","registry_namespace_id":"0c845ed2-e3ed-43f6-b062-eb4b0d5c4df1","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:44:11.246881Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:06:27.585910657Z","description":"","domain_name":"testfunctiontriggersjhzlswz4-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"478b4ede-72e2-4734-9b11-0ad89b7494b2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"8c3e5206-c129-4532-92a4-272b9d16e6f0","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:27.585910657Z"}'
         headers:
             Content-Length:
-                - "562"
+                - "744"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:23 GMT
+                - Wed, 27 Aug 2025 15:06:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -746,10 +748,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6c2f931d-003e-4a60-b41e-a608958589d2
+                - e85391a3-ba11-4395-a790-65569049e1eb
         status: 200 OK
         code: 200
-        duration: 60.806083ms
+        duration: 787.15786ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -765,8 +767,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/520a545e-7353-4080-8f8f-d64ac490b8a1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/478b4ede-72e2-4734-9b11-0ad89b7494b2
         method: GET
       response:
         proto: HTTP/2.0
@@ -774,20 +776,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 562
+        content_length: 738
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.719841Z","description":"","environment_variables":{},"error_message":null,"id":"520a545e-7353-4080-8f8f-d64ac490b8a1","name":"test-function-trigger-sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"e3193f4c-2b75-4f42-8467-9331a6db6b75","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggersnzpipacm","registry_namespace_id":"0c845ed2-e3ed-43f6-b062-eb4b0d5c4df1","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:44:11.246881Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:06:27.585911Z","description":"","domain_name":"testfunctiontriggersjhzlswz4-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"478b4ede-72e2-4734-9b11-0ad89b7494b2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"8c3e5206-c129-4532-92a4-272b9d16e6f0","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:27.585911Z"}'
         headers:
             Content-Length:
-                - "562"
+                - "738"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:28 GMT
+                - Wed, 27 Aug 2025 15:06:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -795,10 +797,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8c4c19a9-54ed-4655-adb8-1609e19b5730
+                - 99c5d4e4-d2b9-434b-9600-7605046d9273
         status: 200 OK
         code: 200
-        duration: 141.328834ms
+        duration: 136.51137ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -814,8 +816,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/520a545e-7353-4080-8f8f-d64ac490b8a1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/478b4ede-72e2-4734-9b11-0ad89b7494b2
         method: GET
       response:
         proto: HTTP/2.0
@@ -823,20 +825,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 562
+        content_length: 738
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.719841Z","description":"","environment_variables":{},"error_message":null,"id":"520a545e-7353-4080-8f8f-d64ac490b8a1","name":"test-function-trigger-sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"e3193f4c-2b75-4f42-8467-9331a6db6b75","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggersnzpipacm","registry_namespace_id":"0c845ed2-e3ed-43f6-b062-eb4b0d5c4df1","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:44:11.246881Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:06:27.585911Z","description":"","domain_name":"testfunctiontriggersjhzlswz4-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"478b4ede-72e2-4734-9b11-0ad89b7494b2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"8c3e5206-c129-4532-92a4-272b9d16e6f0","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:27.585911Z"}'
         headers:
             Content-Length:
-                - "562"
+                - "738"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:33 GMT
+                - Wed, 27 Aug 2025 15:06:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -844,48 +846,50 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1b27fab8-cc59-47dc-baeb-567b39c3abf5
+                - 33d8a714-f73f-4486-b74c-1f5f9314044a
         status: 200 OK
         code: 200
-        duration: 69.417959ms
+        duration: 93.548308ms
     - id: 17
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 206
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"name":"test-function-trigger-sqs","function_id":"478b4ede-72e2-4734-9b11-0ad89b7494b2","scw_sqs_config":{"queue":"TestQueue","mnq_project_id":"52b94a0b-0f98-4f84-9b02-f19b6970eed0","mnq_region":"fr-par"}}'
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/520a545e-7353-4080-8f8f-d64ac490b8a1
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 562
+        content_length: 356
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.719841Z","description":"","environment_variables":{},"error_message":null,"id":"520a545e-7353-4080-8f8f-d64ac490b8a1","name":"test-function-trigger-sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"e3193f4c-2b75-4f42-8467-9331a6db6b75","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggersnzpipacm","registry_namespace_id":"0c845ed2-e3ed-43f6-b062-eb4b0d5c4df1","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:44:11.246881Z"}'
+        body: '{"description":"","error_message":null,"function_id":"478b4ede-72e2-4734-9b11-0ad89b7494b2","id":"5b9489f7-e9cd-4f0f-aaa9-e2ed48bf457b","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":null,"mnq_project_id":"52b94a0b-0f98-4f84-9b02-f19b6970eed0","mnq_region":"fr-par","queue":"TestQueue"},"status":"creating"}'
         headers:
             Content-Length:
-                - "562"
+                - "356"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:38 GMT
+                - Wed, 27 Aug 2025 15:06:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -893,10 +897,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ad58a6e6-5793-425e-8b02-f650de9011b8
+                - 261d851a-b732-4350-a7cc-f5a04057758c
         status: 200 OK
         code: 200
-        duration: 63.704375ms
+        duration: 702.448141ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -912,8 +916,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/520a545e-7353-4080-8f8f-d64ac490b8a1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/5b9489f7-e9cd-4f0f-aaa9-e2ed48bf457b
         method: GET
       response:
         proto: HTTP/2.0
@@ -921,20 +925,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 560
+        content_length: 356
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.719841Z","description":"","environment_variables":{},"error_message":null,"id":"520a545e-7353-4080-8f8f-d64ac490b8a1","name":"test-function-trigger-sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"e3193f4c-2b75-4f42-8467-9331a6db6b75","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggersnzpipacm","registry_namespace_id":"0c845ed2-e3ed-43f6-b062-eb4b0d5c4df1","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:44:41.578505Z"}'
+        body: '{"description":"","error_message":null,"function_id":"478b4ede-72e2-4734-9b11-0ad89b7494b2","id":"5b9489f7-e9cd-4f0f-aaa9-e2ed48bf457b","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":null,"mnq_project_id":"52b94a0b-0f98-4f84-9b02-f19b6970eed0","mnq_region":"fr-par","queue":"TestQueue"},"status":"creating"}'
         headers:
             Content-Length:
-                - "560"
+                - "356"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:43 GMT
+                - Wed, 27 Aug 2025 15:06:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -942,10 +946,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ab9851ec-db62-4b23-b73a-29f95bbc665b
+                - d1ca5633-8c4c-47b5-b85e-7503fe6bb808
         status: 200 OK
         code: 200
-        duration: 66.948167ms
+        duration: 101.506462ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -961,8 +965,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/520a545e-7353-4080-8f8f-d64ac490b8a1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/5b9489f7-e9cd-4f0f-aaa9-e2ed48bf457b
         method: GET
       response:
         proto: HTTP/2.0
@@ -970,20 +974,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 560
+        content_length: 390
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.719841Z","description":"","environment_variables":{},"error_message":null,"id":"520a545e-7353-4080-8f8f-d64ac490b8a1","name":"test-function-trigger-sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"e3193f4c-2b75-4f42-8467-9331a6db6b75","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggersnzpipacm","registry_namespace_id":"0c845ed2-e3ed-43f6-b062-eb4b0d5c4df1","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:44:41.578505Z"}'
+        body: '{"description":"","error_message":null,"function_id":"478b4ede-72e2-4734-9b11-0ad89b7494b2","id":"5b9489f7-e9cd-4f0f-aaa9-e2ed48bf457b","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"09b19b46-8f95-4ac9-b677-cdf22b19926d","mnq_project_id":"52b94a0b-0f98-4f84-9b02-f19b6970eed0","mnq_region":"fr-par","queue":"TestQueue"},"status":"creating"}'
         headers:
             Content-Length:
-                - "560"
+                - "390"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:43 GMT
+                - Wed, 27 Aug 2025 15:06:33 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -991,50 +995,48 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7a94840b-a954-4f1a-ba85-30ac103fe116
+                - 9d72089d-efd8-410a-9a53-01341675154e
         status: 200 OK
         code: 200
-        duration: 69.419292ms
+        duration: 92.576667ms
     - id: 20
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 317
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"test-function-trigger-sqs","namespace_id":"520a545e-7353-4080-8f8f-d64ac490b8a1","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"node22","memory_limit":256,"handler":"handler.handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox"}'
+        body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions
-        method: POST
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/5b9489f7-e9cd-4f0f-aaa9-e2ed48bf457b
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 708
+        content_length: 390
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:43.761912964Z","description":"","domain_name":"testfunctiontriggersnzpipacm-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"f92e27c0-2f3a-423e-894a-97df57dee517","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"520a545e-7353-4080-8f8f-d64ac490b8a1","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:43.761912964Z"}'
+        body: '{"description":"","error_message":null,"function_id":"478b4ede-72e2-4734-9b11-0ad89b7494b2","id":"5b9489f7-e9cd-4f0f-aaa9-e2ed48bf457b","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"09b19b46-8f95-4ac9-b677-cdf22b19926d","mnq_project_id":"52b94a0b-0f98-4f84-9b02-f19b6970eed0","mnq_region":"fr-par","queue":"TestQueue"},"status":"creating"}'
         headers:
             Content-Length:
-                - "708"
+                - "390"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:43 GMT
+                - Wed, 27 Aug 2025 15:06:38 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1042,10 +1044,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 64b75bdf-ca9f-4a81-9789-0ce34613ca72
+                - 22d4a1a9-1f0b-4f2e-9a4e-ede6452536c4
         status: 200 OK
         code: 200
-        duration: 348.204791ms
+        duration: 117.030929ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1061,8 +1063,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/f92e27c0-2f3a-423e-894a-97df57dee517
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/5b9489f7-e9cd-4f0f-aaa9-e2ed48bf457b
         method: GET
       response:
         proto: HTTP/2.0
@@ -1070,20 +1072,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 702
+        content_length: 390
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:43.761913Z","description":"","domain_name":"testfunctiontriggersnzpipacm-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"f92e27c0-2f3a-423e-894a-97df57dee517","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"520a545e-7353-4080-8f8f-d64ac490b8a1","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:43.761913Z"}'
+        body: '{"description":"","error_message":null,"function_id":"478b4ede-72e2-4734-9b11-0ad89b7494b2","id":"5b9489f7-e9cd-4f0f-aaa9-e2ed48bf457b","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"09b19b46-8f95-4ac9-b677-cdf22b19926d","mnq_project_id":"52b94a0b-0f98-4f84-9b02-f19b6970eed0","mnq_region":"fr-par","queue":"TestQueue"},"status":"creating"}'
         headers:
             Content-Length:
-                - "702"
+                - "390"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:43 GMT
+                - Wed, 27 Aug 2025 15:06:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1091,10 +1093,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0df4408f-fe23-4c38-81c4-8f261ca52349
+                - 9e516b54-b0fb-4ea5-8f35-e27ea6f549ad
         status: 200 OK
         code: 200
-        duration: 65.113333ms
+        duration: 80.914374ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1110,8 +1112,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/f92e27c0-2f3a-423e-894a-97df57dee517
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/5b9489f7-e9cd-4f0f-aaa9-e2ed48bf457b
         method: GET
       response:
         proto: HTTP/2.0
@@ -1119,20 +1121,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 702
+        content_length: 387
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:43.761913Z","description":"","domain_name":"testfunctiontriggersnzpipacm-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"f92e27c0-2f3a-423e-894a-97df57dee517","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"520a545e-7353-4080-8f8f-d64ac490b8a1","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:43.761913Z"}'
+        body: '{"description":"","error_message":null,"function_id":"478b4ede-72e2-4734-9b11-0ad89b7494b2","id":"5b9489f7-e9cd-4f0f-aaa9-e2ed48bf457b","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"09b19b46-8f95-4ac9-b677-cdf22b19926d","mnq_project_id":"52b94a0b-0f98-4f84-9b02-f19b6970eed0","mnq_region":"fr-par","queue":"TestQueue"},"status":"ready"}'
         headers:
             Content-Length:
-                - "702"
+                - "387"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:43 GMT
+                - Wed, 27 Aug 2025 15:06:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1140,50 +1142,48 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 527b0349-59f5-474d-a167-246d7fbdd419
+                - 1791d248-a53a-4824-85a2-7d631c2a949d
         status: 200 OK
         code: 200
-        duration: 92.614041ms
+        duration: 96.198507ms
     - id: 23
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 206
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"test-function-trigger-sqs","function_id":"f92e27c0-2f3a-423e-894a-97df57dee517","scw_sqs_config":{"queue":"TestQueue","mnq_project_id":"e3193f4c-2b75-4f42-8467-9331a6db6b75","mnq_region":"fr-par"}}'
+        body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers
-        method: POST
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/5b9489f7-e9cd-4f0f-aaa9-e2ed48bf457b
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 356
+        content_length: 387
         uncompressed: false
-        body: '{"description":"","error_message":null,"function_id":"f92e27c0-2f3a-423e-894a-97df57dee517","id":"84d843a6-e829-463a-97b0-2f4bc5f7c2f9","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":null,"mnq_project_id":"e3193f4c-2b75-4f42-8467-9331a6db6b75","mnq_region":"fr-par","queue":"TestQueue"},"status":"creating"}'
+        body: '{"description":"","error_message":null,"function_id":"478b4ede-72e2-4734-9b11-0ad89b7494b2","id":"5b9489f7-e9cd-4f0f-aaa9-e2ed48bf457b","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"09b19b46-8f95-4ac9-b677-cdf22b19926d","mnq_project_id":"52b94a0b-0f98-4f84-9b02-f19b6970eed0","mnq_region":"fr-par","queue":"TestQueue"},"status":"ready"}'
         headers:
             Content-Length:
-                - "356"
+                - "387"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:44 GMT
+                - Wed, 27 Aug 2025 15:06:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1191,10 +1191,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 174b33f4-ff5e-4dd0-840a-9dcde1e1b76a
+                - f29ddf03-39a1-4905-90d8-ba6326a79698
         status: 200 OK
         code: 200
-        duration: 188.086958ms
+        duration: 94.427133ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1210,8 +1210,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/84d843a6-e829-463a-97b0-2f4bc5f7c2f9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/5b9489f7-e9cd-4f0f-aaa9-e2ed48bf457b
         method: GET
       response:
         proto: HTTP/2.0
@@ -1219,20 +1219,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 356
+        content_length: 387
         uncompressed: false
-        body: '{"description":"","error_message":null,"function_id":"f92e27c0-2f3a-423e-894a-97df57dee517","id":"84d843a6-e829-463a-97b0-2f4bc5f7c2f9","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":null,"mnq_project_id":"e3193f4c-2b75-4f42-8467-9331a6db6b75","mnq_region":"fr-par","queue":"TestQueue"},"status":"creating"}'
+        body: '{"description":"","error_message":null,"function_id":"478b4ede-72e2-4734-9b11-0ad89b7494b2","id":"5b9489f7-e9cd-4f0f-aaa9-e2ed48bf457b","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"09b19b46-8f95-4ac9-b677-cdf22b19926d","mnq_project_id":"52b94a0b-0f98-4f84-9b02-f19b6970eed0","mnq_region":"fr-par","queue":"TestQueue"},"status":"ready"}'
         headers:
             Content-Length:
-                - "356"
+                - "387"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:44 GMT
+                - Wed, 27 Aug 2025 15:06:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1240,10 +1240,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e5fdf042-302c-4a11-a023-4ef2b3980790
+                - 67747dd9-440a-4967-ad81-8a20fb81b730
         status: 200 OK
         code: 200
-        duration: 88.204125ms
+        duration: 101.398886ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1259,8 +1259,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/84d843a6-e829-463a-97b0-2f4bc5f7c2f9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/5b9489f7-e9cd-4f0f-aaa9-e2ed48bf457b
         method: GET
       response:
         proto: HTTP/2.0
@@ -1268,20 +1268,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 390
+        content_length: 387
         uncompressed: false
-        body: '{"description":"","error_message":null,"function_id":"f92e27c0-2f3a-423e-894a-97df57dee517","id":"84d843a6-e829-463a-97b0-2f4bc5f7c2f9","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"404e92e7-41cb-4530-ae28-9bed2dc8ee2e","mnq_project_id":"e3193f4c-2b75-4f42-8467-9331a6db6b75","mnq_region":"fr-par","queue":"TestQueue"},"status":"creating"}'
+        body: '{"description":"","error_message":null,"function_id":"478b4ede-72e2-4734-9b11-0ad89b7494b2","id":"5b9489f7-e9cd-4f0f-aaa9-e2ed48bf457b","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"09b19b46-8f95-4ac9-b677-cdf22b19926d","mnq_project_id":"52b94a0b-0f98-4f84-9b02-f19b6970eed0","mnq_region":"fr-par","queue":"TestQueue"},"status":"ready"}'
         headers:
             Content-Length:
-                - "390"
+                - "387"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:49 GMT
+                - Wed, 27 Aug 2025 15:06:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1289,10 +1289,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 54e5527f-f729-4755-8c74-59617d301d70
+                - 8b6f9fae-8bb8-4418-bd35-b91b3aaea23d
         status: 200 OK
         code: 200
-        duration: 81.2875ms
+        duration: 104.275284ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1308,8 +1308,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/84d843a6-e829-463a-97b0-2f4bc5f7c2f9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/account/v3/projects/52b94a0b-0f98-4f84-9b02-f19b6970eed0
         method: GET
       response:
         proto: HTTP/2.0
@@ -1317,20 +1317,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 390
+        content_length: 310
         uncompressed: false
-        body: '{"description":"","error_message":null,"function_id":"f92e27c0-2f3a-423e-894a-97df57dee517","id":"84d843a6-e829-463a-97b0-2f4bc5f7c2f9","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"404e92e7-41cb-4530-ae28-9bed2dc8ee2e","mnq_project_id":"e3193f4c-2b75-4f42-8467-9331a6db6b75","mnq_region":"fr-par","queue":"TestQueue"},"status":"creating"}'
+        body: '{"created_at":"2025-08-27T15:06:19.403028Z","description":"","id":"52b94a0b-0f98-4f84-9b02-f19b6970eed0","name":"tf_tests_function_trigger_sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","qualification":{"architecture_type":"unknown_architecture_type"},"updated_at":"2025-08-27T15:06:19.403028Z"}'
         headers:
             Content-Length:
-                - "390"
+                - "310"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:54 GMT
+                - Wed, 27 Aug 2025 15:06:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1338,10 +1338,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 334781e6-e9ce-48b4-889b-25660d4e2599
+                - e4d2f172-0fee-4476-87af-afdb7ff8bb3b
         status: 200 OK
         code: 200
-        duration: 92.290875ms
+        duration: 175.768289ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1357,8 +1357,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/84d843a6-e829-463a-97b0-2f4bc5f7c2f9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8c3e5206-c129-4532-92a4-272b9d16e6f0
         method: GET
       response:
         proto: HTTP/2.0
@@ -1366,20 +1366,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 387
+        content_length: 593
         uncompressed: false
-        body: '{"description":"","error_message":null,"function_id":"f92e27c0-2f3a-423e-894a-97df57dee517","id":"84d843a6-e829-463a-97b0-2f4bc5f7c2f9","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"404e92e7-41cb-4530-ae28-9bed2dc8ee2e","mnq_project_id":"e3193f4c-2b75-4f42-8467-9331a6db6b75","mnq_region":"fr-par","queue":"TestQueue"},"status":"ready"}'
+        body: '{"created_at":"2025-08-27T15:06:21.464382Z","description":"","environment_variables":{},"error_message":null,"id":"8c3e5206-c129-4532-92a4-272b9d16e6f0","name":"test-function-trigger-sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"52b94a0b-0f98-4f84-9b02-f19b6970eed0","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggersjhzlswz4","registry_namespace_id":"ad6dd704-2b22-4ac0-ba04-6c1fbd78a1da","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:25.489989Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "387"
+                - "593"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:59 GMT
+                - Wed, 27 Aug 2025 15:06:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1387,10 +1387,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 78b7713e-4cb0-4e1e-acc3-87734aca6432
+                - dee9a109-5964-448a-9c4d-17b1f803a2a5
         status: 200 OK
         code: 200
-        duration: 173.151875ms
+        duration: 81.695421ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1406,8 +1406,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/84d843a6-e829-463a-97b0-2f4bc5f7c2f9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-info?project_id=52b94a0b-0f98-4f84-9b02-f19b6970eed0
         method: GET
       response:
         proto: HTTP/2.0
@@ -1415,20 +1415,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 387
+        content_length: 233
         uncompressed: false
-        body: '{"description":"","error_message":null,"function_id":"f92e27c0-2f3a-423e-894a-97df57dee517","id":"84d843a6-e829-463a-97b0-2f4bc5f7c2f9","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"404e92e7-41cb-4530-ae28-9bed2dc8ee2e","mnq_project_id":"e3193f4c-2b75-4f42-8467-9331a6db6b75","mnq_region":"fr-par","queue":"TestQueue"},"status":"ready"}'
+        body: '{"created_at":"2025-08-27T15:06:19.969953Z","project_id":"52b94a0b-0f98-4f84-9b02-f19b6970eed0","region":"fr-par","sqs_endpoint_url":"https://sqs.mnq.fr-par.scaleway.com","status":"enabled","updated_at":"2025-08-27T15:06:19.969953Z"}'
         headers:
             Content-Length:
-                - "387"
+                - "233"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:59 GMT
+                - Wed, 27 Aug 2025 15:06:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1436,10 +1436,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 755a7058-4b47-41d3-9508-c1de60773d2d
+                - 5a21601d-406a-4c45-b9ba-aa0a3669e792
         status: 200 OK
         code: 200
-        duration: 79.566584ms
+        duration: 82.14771ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1455,8 +1455,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/84d843a6-e829-463a-97b0-2f4bc5f7c2f9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-credentials/cdcc9ac4-fbdb-400c-bf7e-683edb95fc41
         method: GET
       response:
         proto: HTTP/2.0
@@ -1464,20 +1464,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 387
+        content_length: 429
         uncompressed: false
-        body: '{"description":"","error_message":null,"function_id":"f92e27c0-2f3a-423e-894a-97df57dee517","id":"84d843a6-e829-463a-97b0-2f4bc5f7c2f9","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"404e92e7-41cb-4530-ae28-9bed2dc8ee2e","mnq_project_id":"e3193f4c-2b75-4f42-8467-9331a6db6b75","mnq_region":"fr-par","queue":"TestQueue"},"status":"ready"}'
+        body: '{"access_key":"CzoighBpAX8xTKHVnLaq","created_at":"2025-08-27T15:06:20.258532Z","id":"cdcc9ac4-fbdb-400c-bf7e-683edb95fc41","name":"tf-sqs-credentials-gallant-mclean","permissions":{"can_manage":true,"can_publish":true,"can_receive":true},"project_id":"52b94a0b-0f98-4f84-9b02-f19b6970eed0","region":"fr-par","secret_checksum":"24ad85e21e25174cfd68c9fc789cd65518fc07ed","secret_key":"00000000-0000-0000-0000-000000000000","updated_at":"2025-08-27T15:06:20.258532Z"}'
         headers:
             Content-Length:
-                - "387"
+                - "429"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:59 GMT
+                - Wed, 27 Aug 2025 15:06:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1485,10 +1485,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4d4e2d4e-511b-47c3-b767-5e7d082dee24
+                - 20618b7f-af11-421e-89a6-386622bc6213
         status: 200 OK
         code: 200
-        duration: 107.617083ms
+        duration: 87.608968ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1504,8 +1504,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/84d843a6-e829-463a-97b0-2f4bc5f7c2f9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/478b4ede-72e2-4734-9b11-0ad89b7494b2
         method: GET
       response:
         proto: HTTP/2.0
@@ -1513,20 +1513,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 387
+        content_length: 738
         uncompressed: false
-        body: '{"description":"","error_message":null,"function_id":"f92e27c0-2f3a-423e-894a-97df57dee517","id":"84d843a6-e829-463a-97b0-2f4bc5f7c2f9","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"404e92e7-41cb-4530-ae28-9bed2dc8ee2e","mnq_project_id":"e3193f4c-2b75-4f42-8467-9331a6db6b75","mnq_region":"fr-par","queue":"TestQueue"},"status":"ready"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:06:27.585911Z","description":"","domain_name":"testfunctiontriggersjhzlswz4-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"478b4ede-72e2-4734-9b11-0ad89b7494b2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"8c3e5206-c129-4532-92a4-272b9d16e6f0","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:27.585911Z"}'
         headers:
             Content-Length:
-                - "387"
+                - "738"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:00 GMT
+                - Wed, 27 Aug 2025 15:06:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1534,108 +1534,112 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3ee9c37d-a63d-4f24-8bac-bad1179ab70e
+                - a2017372-71c6-417c-ac8f-d204648d90e4
         status: 200 OK
         code: 200
-        duration: 86.575333ms
+        duration: 87.058867ms
     - id: 31
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 25
         transfer_encoding: []
         trailer: {}
-        host: api.scaleway.com
+        host: sqs.mnq.fr-par.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"QueueName":"TestQueue"}'
         form: {}
         headers:
+            Amz-Sdk-Invocation-Id:
+                - f4f7187b-81ba-44e8-98b2-be0e9c6bd235
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            Content-Type:
+                - application/x-amz-json-1.0
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/account/v3/projects/e3193f4c-2b75-4f42-8467-9331a6db6b75
-        method: GET
+                - aws-sdk-go-v2/1.37.1 ua/2.1 os/linux lang/go#1.24.1 md/GOOS#linux md/GOARCH#amd64 api/sqs#1.38.6 m/E,e
+            X-Amz-Date:
+                - 20250827T150650Z
+            X-Amz-Target:
+                - AmazonSQS.GetQueueUrl
+            X-Amzn-Query-Mode:
+                - "true"
+        url: https://sqs.mnq.fr-par.scaleway.com/
+        method: POST
       response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
         transfer_encoding: []
         trailer: {}
-        content_length: 244
+        content_length: 106
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:06.784363Z","description":"","id":"e3193f4c-2b75-4f42-8467-9331a6db6b75","name":"tf_tests_function_trigger_sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","updated_at":"2025-01-24T15:44:06.784363Z"}'
+        body: '{"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-52b94a0b-0f98-4f84-9b02-f19b6970eed0/TestQueue"}'
         headers:
             Content-Length:
-                - "244"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
+                - "106"
             Content-Type:
-                - application/json
+                - application/json; charset=utf-8
             Date:
-                - Fri, 24 Jan 2025 15:45:00 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 97c55249-0590-41b8-9e2c-4ad165635bbb
+                - Wed, 27 Aug 2025 15:06:50 GMT
+            X-Amzn-Requestid:
+                - tx20439ee2-66c7-4ffb-88f6-80ceac7ca3fa
         status: 200 OK
         code: 200
-        duration: 135.166834ms
+        duration: 27.079879ms
     - id: 32
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 262
         transfer_encoding: []
         trailer: {}
-        host: api.scaleway.com
+        host: sqs.mnq.fr-par.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"AttributeNames":["MaximumMessageSize","MessageRetentionPeriod","FifoQueue","ContentBasedDeduplication","ReceiveMessageWaitTimeSeconds","VisibilityTimeout"],"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-52b94a0b-0f98-4f84-9b02-f19b6970eed0/TestQueue"}'
         form: {}
         headers:
+            Amz-Sdk-Invocation-Id:
+                - 80dbecac-8060-4612-b197-13f4667c3a1b
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            Content-Type:
+                - application/x-amz-json-1.0
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-info?project_id=e3193f4c-2b75-4f42-8467-9331a6db6b75
-        method: GET
+                - aws-sdk-go-v2/1.37.1 ua/2.1 os/linux lang/go#1.24.1 md/GOOS#linux md/GOARCH#amd64 api/sqs#1.38.6 m/E,e
+            X-Amz-Date:
+                - 20250827T150650Z
+            X-Amz-Target:
+                - AmazonSQS.GetQueueAttributes
+            X-Amzn-Query-Mode:
+                - "true"
+        url: https://sqs.mnq.fr-par.scaleway.com/
+        method: POST
       response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
         transfer_encoding: []
         trailer: {}
-        content_length: 233
+        content_length: 142
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.295889Z","project_id":"e3193f4c-2b75-4f42-8467-9331a6db6b75","region":"fr-par","sqs_endpoint_url":"https://sqs.mnq.fr-par.scaleway.com","status":"enabled","updated_at":"2025-01-24T15:44:07.295889Z"}'
+        body: '{"Attributes":{"MaximumMessageSize":"262144","MessageRetentionPeriod":"345600","ReceiveMessageWaitTimeSeconds":"0","VisibilityTimeout":"30"}}'
         headers:
             Content-Length:
-                - "233"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
+                - "142"
             Content-Type:
-                - application/json
+                - application/json; charset=utf-8
             Date:
-                - Fri, 24 Jan 2025 15:45:00 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - f91d4f1e-be6e-47fb-9b7a-709fae17abe0
+                - Wed, 27 Aug 2025 15:06:50 GMT
+            X-Amzn-Requestid:
+                - tx3e3ddb5d-b4f3-4ea9-8793-1b59decc0318
         status: 200 OK
         code: 200
-        duration: 53.0915ms
+        duration: 42.628578ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1651,8 +1655,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/520a545e-7353-4080-8f8f-d64ac490b8a1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/5b9489f7-e9cd-4f0f-aaa9-e2ed48bf457b
         method: GET
       response:
         proto: HTTP/2.0
@@ -1660,20 +1664,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 560
+        content_length: 387
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.719841Z","description":"","environment_variables":{},"error_message":null,"id":"520a545e-7353-4080-8f8f-d64ac490b8a1","name":"test-function-trigger-sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"e3193f4c-2b75-4f42-8467-9331a6db6b75","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggersnzpipacm","registry_namespace_id":"0c845ed2-e3ed-43f6-b062-eb4b0d5c4df1","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:44:41.578505Z"}'
+        body: '{"description":"","error_message":null,"function_id":"478b4ede-72e2-4734-9b11-0ad89b7494b2","id":"5b9489f7-e9cd-4f0f-aaa9-e2ed48bf457b","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"09b19b46-8f95-4ac9-b677-cdf22b19926d","mnq_project_id":"52b94a0b-0f98-4f84-9b02-f19b6970eed0","mnq_region":"fr-par","queue":"TestQueue"},"status":"ready"}'
         headers:
             Content-Length:
-                - "560"
+                - "387"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:00 GMT
+                - Wed, 27 Aug 2025 15:06:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1681,10 +1685,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 662981c1-7d33-4aea-84fc-d65bfb8458ee
+                - dfbd85d8-e0f2-4671-af33-891a11402faf
         status: 200 OK
         code: 200
-        duration: 67.87725ms
+        duration: 94.801677ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1700,8 +1704,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-credentials/6be9a259-8001-4e52-85a1-f942a3758d6c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/account/v3/projects/52b94a0b-0f98-4f84-9b02-f19b6970eed0
         method: GET
       response:
         proto: HTTP/2.0
@@ -1709,20 +1713,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 430
+        content_length: 310
         uncompressed: false
-        body: '{"access_key":"HG5XrGM6wISpjrwoqbLo","created_at":"2025-01-24T15:44:07.547668Z","id":"6be9a259-8001-4e52-85a1-f942a3758d6c","name":"tf-sqs-credentials-charming-pascal","permissions":{"can_manage":true,"can_publish":true,"can_receive":true},"project_id":"e3193f4c-2b75-4f42-8467-9331a6db6b75","region":"fr-par","secret_checksum":"79f084fa78e9408da4c9095afc90aaa71d963b46","secret_key":"00000000-0000-0000-0000-000000000000","updated_at":"2025-01-24T15:44:07.547668Z"}'
+        body: '{"created_at":"2025-08-27T15:06:19.403028Z","description":"","id":"52b94a0b-0f98-4f84-9b02-f19b6970eed0","name":"tf_tests_function_trigger_sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","qualification":{"architecture_type":"unknown_architecture_type"},"updated_at":"2025-08-27T15:06:19.403028Z"}'
         headers:
             Content-Length:
-                - "430"
+                - "310"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:00 GMT
+                - Wed, 27 Aug 2025 15:06:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1730,10 +1734,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a88c1d84-1693-4ede-8129-06e77c922f93
+                - b3f8b333-a3b9-427b-87c5-8ec4babda28f
         status: 200 OK
         code: 200
-        duration: 66.5855ms
+        duration: 180.611369ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1749,8 +1753,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/f92e27c0-2f3a-423e-894a-97df57dee517
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-info?project_id=52b94a0b-0f98-4f84-9b02-f19b6970eed0
         method: GET
       response:
         proto: HTTP/2.0
@@ -1758,20 +1762,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 702
+        content_length: 233
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:43.761913Z","description":"","domain_name":"testfunctiontriggersnzpipacm-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"f92e27c0-2f3a-423e-894a-97df57dee517","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"520a545e-7353-4080-8f8f-d64ac490b8a1","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:43.761913Z"}'
+        body: '{"created_at":"2025-08-27T15:06:19.969953Z","project_id":"52b94a0b-0f98-4f84-9b02-f19b6970eed0","region":"fr-par","sqs_endpoint_url":"https://sqs.mnq.fr-par.scaleway.com","status":"enabled","updated_at":"2025-08-27T15:06:19.969953Z"}'
         headers:
             Content-Length:
-                - "702"
+                - "233"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:00 GMT
+                - Wed, 27 Aug 2025 15:06:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1779,112 +1783,108 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 69794cdc-a0c6-461d-bb83-1f71e786983f
+                - 6263e6ba-3e2e-468e-899e-7ab58f294fa4
         status: 200 OK
         code: 200
-        duration: 70.063584ms
+        duration: 81.49225ms
     - id: 36
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 25
+        content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: sqs.mnq.fr-par.scaleway.com
+        host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"QueueName":"TestQueue"}'
+        body: ""
         form: {}
         headers:
-            Amz-Sdk-Invocation-Id:
-                - 35667827-fe5f-47fc-b160-f69786e08c49
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            Content-Type:
-                - application/x-amz-json-1.0
             User-Agent:
-                - aws-sdk-go-v2/1.32.7 ua/2.1 os/macos lang/go#1.23.3 md/GOOS#darwin md/GOARCH#arm64 api/sqs#1.37.3 m/E
-            X-Amz-Date:
-                - 20250124T154500Z
-            X-Amz-Target:
-                - AmazonSQS.GetQueueUrl
-            X-Amzn-Query-Mode:
-                - "true"
-        url: https://sqs.mnq.fr-par.scaleway.com/
-        method: POST
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8c3e5206-c129-4532-92a4-272b9d16e6f0
+        method: GET
       response:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 106
+        content_length: 593
         uncompressed: false
-        body: '{"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-e3193f4c-2b75-4f42-8467-9331a6db6b75/TestQueue"}'
+        body: '{"created_at":"2025-08-27T15:06:21.464382Z","description":"","environment_variables":{},"error_message":null,"id":"8c3e5206-c129-4532-92a4-272b9d16e6f0","name":"test-function-trigger-sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"52b94a0b-0f98-4f84-9b02-f19b6970eed0","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggersjhzlswz4","registry_namespace_id":"ad6dd704-2b22-4ac0-ba04-6c1fbd78a1da","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:25.489989Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "106"
+                - "593"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
-                - application/json; charset=utf-8
+                - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:00 GMT
-            X-Amzn-Requestid:
-                - tx6ce4e8ea-98c2-4c55-9e78-647b690d3a49
+                - Wed, 27 Aug 2025 15:06:50 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - fea4a2c3-59d9-4be5-89d3-9043751cd47f
         status: 200 OK
         code: 200
-        duration: 28.855333ms
+        duration: 95.374682ms
     - id: 37
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 262
+        content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: sqs.mnq.fr-par.scaleway.com
+        host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"AttributeNames":["FifoQueue","ContentBasedDeduplication","ReceiveMessageWaitTimeSeconds","VisibilityTimeout","MaximumMessageSize","MessageRetentionPeriod"],"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-e3193f4c-2b75-4f42-8467-9331a6db6b75/TestQueue"}'
+        body: ""
         form: {}
         headers:
-            Amz-Sdk-Invocation-Id:
-                - 0dcde575-ccde-450f-ab14-c97083bd904e
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            Content-Type:
-                - application/x-amz-json-1.0
             User-Agent:
-                - aws-sdk-go-v2/1.32.7 ua/2.1 os/macos lang/go#1.23.3 md/GOOS#darwin md/GOARCH#arm64 api/sqs#1.37.3 m/E
-            X-Amz-Date:
-                - 20250124T154500Z
-            X-Amz-Target:
-                - AmazonSQS.GetQueueAttributes
-            X-Amzn-Query-Mode:
-                - "true"
-        url: https://sqs.mnq.fr-par.scaleway.com/
-        method: POST
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-credentials/cdcc9ac4-fbdb-400c-bf7e-683edb95fc41
+        method: GET
       response:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 142
+        content_length: 429
         uncompressed: false
-        body: '{"Attributes":{"MaximumMessageSize":"262144","MessageRetentionPeriod":"345600","ReceiveMessageWaitTimeSeconds":"0","VisibilityTimeout":"30"}}'
+        body: '{"access_key":"CzoighBpAX8xTKHVnLaq","created_at":"2025-08-27T15:06:20.258532Z","id":"cdcc9ac4-fbdb-400c-bf7e-683edb95fc41","name":"tf-sqs-credentials-gallant-mclean","permissions":{"can_manage":true,"can_publish":true,"can_receive":true},"project_id":"52b94a0b-0f98-4f84-9b02-f19b6970eed0","region":"fr-par","secret_checksum":"24ad85e21e25174cfd68c9fc789cd65518fc07ed","secret_key":"00000000-0000-0000-0000-000000000000","updated_at":"2025-08-27T15:06:20.258532Z"}'
         headers:
             Content-Length:
-                - "142"
+                - "429"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
-                - application/json; charset=utf-8
+                - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:01 GMT
-            X-Amzn-Requestid:
-                - txb762e002-5775-42cf-904b-524a3741d391
+                - Wed, 27 Aug 2025 15:06:50 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 60f227cd-1cad-49d5-82ca-bc2088cacc54
         status: 200 OK
         code: 200
-        duration: 32.150167ms
+        duration: 88.494731ms
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1900,8 +1900,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/84d843a6-e829-463a-97b0-2f4bc5f7c2f9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/478b4ede-72e2-4734-9b11-0ad89b7494b2
         method: GET
       response:
         proto: HTTP/2.0
@@ -1909,20 +1909,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 387
+        content_length: 738
         uncompressed: false
-        body: '{"description":"","error_message":null,"function_id":"f92e27c0-2f3a-423e-894a-97df57dee517","id":"84d843a6-e829-463a-97b0-2f4bc5f7c2f9","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"404e92e7-41cb-4530-ae28-9bed2dc8ee2e","mnq_project_id":"e3193f4c-2b75-4f42-8467-9331a6db6b75","mnq_region":"fr-par","queue":"TestQueue"},"status":"ready"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:06:27.585911Z","description":"","domain_name":"testfunctiontriggersjhzlswz4-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"478b4ede-72e2-4734-9b11-0ad89b7494b2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"8c3e5206-c129-4532-92a4-272b9d16e6f0","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:27.585911Z"}'
         headers:
             Content-Length:
-                - "387"
+                - "738"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:01 GMT
+                - Wed, 27 Aug 2025 15:06:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1930,108 +1930,112 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7ccce882-85e9-4e09-8d68-5ee5cc687b6d
+                - 2e67400a-f312-4c18-99eb-6a634a162bd7
         status: 200 OK
         code: 200
-        duration: 78.361375ms
+        duration: 89.734727ms
     - id: 39
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 25
         transfer_encoding: []
         trailer: {}
-        host: api.scaleway.com
+        host: sqs.mnq.fr-par.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"QueueName":"TestQueue"}'
         form: {}
         headers:
+            Amz-Sdk-Invocation-Id:
+                - 2e9a58c9-3b6c-4739-aea3-8d2823bae463
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            Content-Type:
+                - application/x-amz-json-1.0
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/account/v3/projects/e3193f4c-2b75-4f42-8467-9331a6db6b75
-        method: GET
+                - aws-sdk-go-v2/1.37.1 ua/2.1 os/linux lang/go#1.24.1 md/GOOS#linux md/GOARCH#amd64 api/sqs#1.38.6 m/E,e
+            X-Amz-Date:
+                - 20250827T150650Z
+            X-Amz-Target:
+                - AmazonSQS.GetQueueUrl
+            X-Amzn-Query-Mode:
+                - "true"
+        url: https://sqs.mnq.fr-par.scaleway.com/
+        method: POST
       response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
         transfer_encoding: []
         trailer: {}
-        content_length: 244
+        content_length: 106
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:06.784363Z","description":"","id":"e3193f4c-2b75-4f42-8467-9331a6db6b75","name":"tf_tests_function_trigger_sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","updated_at":"2025-01-24T15:44:06.784363Z"}'
+        body: '{"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-52b94a0b-0f98-4f84-9b02-f19b6970eed0/TestQueue"}'
         headers:
             Content-Length:
-                - "244"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
+                - "106"
             Content-Type:
-                - application/json
+                - application/json; charset=utf-8
             Date:
-                - Fri, 24 Jan 2025 15:45:02 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 3dba5341-c137-42f9-8f1c-674b1b92f14e
+                - Wed, 27 Aug 2025 15:06:50 GMT
+            X-Amzn-Requestid:
+                - txe4c58b89-1bd1-4b2c-99ea-5eb27c8f9faa
         status: 200 OK
         code: 200
-        duration: 315.555917ms
+        duration: 23.431402ms
     - id: 40
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 262
         transfer_encoding: []
         trailer: {}
-        host: api.scaleway.com
+        host: sqs.mnq.fr-par.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"AttributeNames":["MessageRetentionPeriod","FifoQueue","ContentBasedDeduplication","ReceiveMessageWaitTimeSeconds","VisibilityTimeout","MaximumMessageSize"],"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-52b94a0b-0f98-4f84-9b02-f19b6970eed0/TestQueue"}'
         form: {}
         headers:
+            Amz-Sdk-Invocation-Id:
+                - f1734564-f6d1-4c0d-9abb-14b1ff7d84de
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            Content-Type:
+                - application/x-amz-json-1.0
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-info?project_id=e3193f4c-2b75-4f42-8467-9331a6db6b75
-        method: GET
+                - aws-sdk-go-v2/1.37.1 ua/2.1 os/linux lang/go#1.24.1 md/GOOS#linux md/GOARCH#amd64 api/sqs#1.38.6 m/E,e
+            X-Amz-Date:
+                - 20250827T150650Z
+            X-Amz-Target:
+                - AmazonSQS.GetQueueAttributes
+            X-Amzn-Query-Mode:
+                - "true"
+        url: https://sqs.mnq.fr-par.scaleway.com/
+        method: POST
       response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
         transfer_encoding: []
         trailer: {}
-        content_length: 233
+        content_length: 142
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.295889Z","project_id":"e3193f4c-2b75-4f42-8467-9331a6db6b75","region":"fr-par","sqs_endpoint_url":"https://sqs.mnq.fr-par.scaleway.com","status":"enabled","updated_at":"2025-01-24T15:44:07.295889Z"}'
+        body: '{"Attributes":{"MaximumMessageSize":"262144","MessageRetentionPeriod":"345600","ReceiveMessageWaitTimeSeconds":"0","VisibilityTimeout":"30"}}'
         headers:
             Content-Length:
-                - "233"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
+                - "142"
             Content-Type:
-                - application/json
+                - application/json; charset=utf-8
             Date:
-                - Fri, 24 Jan 2025 15:45:02 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - ade4269b-84c8-459d-a0c1-3f8a1449d873
+                - Wed, 27 Aug 2025 15:06:50 GMT
+            X-Amzn-Requestid:
+                - txc852627e-2e70-45d5-8a37-8db35cebe21e
         status: 200 OK
         code: 200
-        duration: 61.892792ms
+        duration: 35.836852ms
     - id: 41
       request:
         proto: HTTP/1.1
@@ -2047,8 +2051,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/520a545e-7353-4080-8f8f-d64ac490b8a1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/5b9489f7-e9cd-4f0f-aaa9-e2ed48bf457b
         method: GET
       response:
         proto: HTTP/2.0
@@ -2056,20 +2060,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 560
+        content_length: 387
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.719841Z","description":"","environment_variables":{},"error_message":null,"id":"520a545e-7353-4080-8f8f-d64ac490b8a1","name":"test-function-trigger-sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"e3193f4c-2b75-4f42-8467-9331a6db6b75","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggersnzpipacm","registry_namespace_id":"0c845ed2-e3ed-43f6-b062-eb4b0d5c4df1","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:44:41.578505Z"}'
+        body: '{"description":"","error_message":null,"function_id":"478b4ede-72e2-4734-9b11-0ad89b7494b2","id":"5b9489f7-e9cd-4f0f-aaa9-e2ed48bf457b","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"09b19b46-8f95-4ac9-b677-cdf22b19926d","mnq_project_id":"52b94a0b-0f98-4f84-9b02-f19b6970eed0","mnq_region":"fr-par","queue":"TestQueue"},"status":"ready"}'
         headers:
             Content-Length:
-                - "560"
+                - "387"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:02 GMT
+                - Wed, 27 Aug 2025 15:06:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2077,10 +2081,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 86367b8b-1b24-4673-8d61-853110388ee3
+                - 562edc21-d549-4cff-bca3-ac51217bd131
         status: 200 OK
         code: 200
-        duration: 62.386042ms
+        duration: 84.951532ms
     - id: 42
       request:
         proto: HTTP/1.1
@@ -2096,8 +2100,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-credentials/6be9a259-8001-4e52-85a1-f942a3758d6c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/account/v3/projects/52b94a0b-0f98-4f84-9b02-f19b6970eed0
         method: GET
       response:
         proto: HTTP/2.0
@@ -2105,20 +2109,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 430
+        content_length: 310
         uncompressed: false
-        body: '{"access_key":"HG5XrGM6wISpjrwoqbLo","created_at":"2025-01-24T15:44:07.547668Z","id":"6be9a259-8001-4e52-85a1-f942a3758d6c","name":"tf-sqs-credentials-charming-pascal","permissions":{"can_manage":true,"can_publish":true,"can_receive":true},"project_id":"e3193f4c-2b75-4f42-8467-9331a6db6b75","region":"fr-par","secret_checksum":"79f084fa78e9408da4c9095afc90aaa71d963b46","secret_key":"00000000-0000-0000-0000-000000000000","updated_at":"2025-01-24T15:44:07.547668Z"}'
+        body: '{"created_at":"2025-08-27T15:06:19.403028Z","description":"","id":"52b94a0b-0f98-4f84-9b02-f19b6970eed0","name":"tf_tests_function_trigger_sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","qualification":{"architecture_type":"unknown_architecture_type"},"updated_at":"2025-08-27T15:06:19.403028Z"}'
         headers:
             Content-Length:
-                - "430"
+                - "310"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:02 GMT
+                - Wed, 27 Aug 2025 15:06:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2126,10 +2130,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4175bde9-01c5-4e32-9730-d13f425876cb
+                - 7d4357dd-ed4d-479d-acb8-cee9d6ddc1c6
         status: 200 OK
         code: 200
-        duration: 148.462708ms
+        duration: 204.679135ms
     - id: 43
       request:
         proto: HTTP/1.1
@@ -2145,8 +2149,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/f92e27c0-2f3a-423e-894a-97df57dee517
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-info?project_id=52b94a0b-0f98-4f84-9b02-f19b6970eed0
         method: GET
       response:
         proto: HTTP/2.0
@@ -2154,20 +2158,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 702
+        content_length: 233
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:43.761913Z","description":"","domain_name":"testfunctiontriggersnzpipacm-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"f92e27c0-2f3a-423e-894a-97df57dee517","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"520a545e-7353-4080-8f8f-d64ac490b8a1","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:43.761913Z"}'
+        body: '{"created_at":"2025-08-27T15:06:19.969953Z","project_id":"52b94a0b-0f98-4f84-9b02-f19b6970eed0","region":"fr-par","sqs_endpoint_url":"https://sqs.mnq.fr-par.scaleway.com","status":"enabled","updated_at":"2025-08-27T15:06:19.969953Z"}'
         headers:
             Content-Length:
-                - "702"
+                - "233"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:02 GMT
+                - Wed, 27 Aug 2025 15:06:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2175,112 +2179,108 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b02d38e3-3f4e-4945-b04c-0f3fbd3a4f62
+                - 4d55eba7-f483-4c3e-9076-3c849c8e9da0
         status: 200 OK
         code: 200
-        duration: 142.380084ms
+        duration: 69.327803ms
     - id: 44
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 25
+        content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: sqs.mnq.fr-par.scaleway.com
+        host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"QueueName":"TestQueue"}'
+        body: ""
         form: {}
         headers:
-            Amz-Sdk-Invocation-Id:
-                - b30490a1-af62-48cc-b6bf-e52b65af45e3
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            Content-Type:
-                - application/x-amz-json-1.0
             User-Agent:
-                - aws-sdk-go-v2/1.32.7 ua/2.1 os/macos lang/go#1.23.3 md/GOOS#darwin md/GOARCH#arm64 api/sqs#1.37.3 m/E
-            X-Amz-Date:
-                - 20250124T154502Z
-            X-Amz-Target:
-                - AmazonSQS.GetQueueUrl
-            X-Amzn-Query-Mode:
-                - "true"
-        url: https://sqs.mnq.fr-par.scaleway.com/
-        method: POST
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8c3e5206-c129-4532-92a4-272b9d16e6f0
+        method: GET
       response:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 106
+        content_length: 593
         uncompressed: false
-        body: '{"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-e3193f4c-2b75-4f42-8467-9331a6db6b75/TestQueue"}'
+        body: '{"created_at":"2025-08-27T15:06:21.464382Z","description":"","environment_variables":{},"error_message":null,"id":"8c3e5206-c129-4532-92a4-272b9d16e6f0","name":"test-function-trigger-sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"52b94a0b-0f98-4f84-9b02-f19b6970eed0","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggersjhzlswz4","registry_namespace_id":"ad6dd704-2b22-4ac0-ba04-6c1fbd78a1da","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:25.489989Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "106"
+                - "593"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
-                - application/json; charset=utf-8
+                - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:02 GMT
-            X-Amzn-Requestid:
-                - tx38e8d3ac-6ff6-4995-933c-59a5e6533d14
+                - Wed, 27 Aug 2025 15:06:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 03404764-0650-458a-9c47-0c8c2bd901f9
         status: 200 OK
         code: 200
-        duration: 27.740667ms
+        duration: 84.080868ms
     - id: 45
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 262
+        content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: sqs.mnq.fr-par.scaleway.com
+        host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"AttributeNames":["VisibilityTimeout","MaximumMessageSize","MessageRetentionPeriod","FifoQueue","ContentBasedDeduplication","ReceiveMessageWaitTimeSeconds"],"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-e3193f4c-2b75-4f42-8467-9331a6db6b75/TestQueue"}'
+        body: ""
         form: {}
         headers:
-            Amz-Sdk-Invocation-Id:
-                - df5225d9-052c-4594-a408-c3b1e155a68a
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            Content-Type:
-                - application/x-amz-json-1.0
             User-Agent:
-                - aws-sdk-go-v2/1.32.7 ua/2.1 os/macos lang/go#1.23.3 md/GOOS#darwin md/GOARCH#arm64 api/sqs#1.37.3 m/E
-            X-Amz-Date:
-                - 20250124T154502Z
-            X-Amz-Target:
-                - AmazonSQS.GetQueueAttributes
-            X-Amzn-Query-Mode:
-                - "true"
-        url: https://sqs.mnq.fr-par.scaleway.com/
-        method: POST
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-credentials/cdcc9ac4-fbdb-400c-bf7e-683edb95fc41
+        method: GET
       response:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 142
+        content_length: 429
         uncompressed: false
-        body: '{"Attributes":{"MaximumMessageSize":"262144","MessageRetentionPeriod":"345600","ReceiveMessageWaitTimeSeconds":"0","VisibilityTimeout":"30"}}'
+        body: '{"access_key":"CzoighBpAX8xTKHVnLaq","created_at":"2025-08-27T15:06:20.258532Z","id":"cdcc9ac4-fbdb-400c-bf7e-683edb95fc41","name":"tf-sqs-credentials-gallant-mclean","permissions":{"can_manage":true,"can_publish":true,"can_receive":true},"project_id":"52b94a0b-0f98-4f84-9b02-f19b6970eed0","region":"fr-par","secret_checksum":"24ad85e21e25174cfd68c9fc789cd65518fc07ed","secret_key":"00000000-0000-0000-0000-000000000000","updated_at":"2025-08-27T15:06:20.258532Z"}'
         headers:
             Content-Length:
-                - "142"
+                - "429"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
-                - application/json; charset=utf-8
+                - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:02 GMT
-            X-Amzn-Requestid:
-                - tx2fbb8514-0b7e-4934-91b9-a71afd125b62
+                - Wed, 27 Aug 2025 15:06:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 6d4f9931-37fc-4c27-b327-6413fee6e2b1
         status: 200 OK
         code: 200
-        duration: 29.3225ms
+        duration: 78.994493ms
     - id: 46
       request:
         proto: HTTP/1.1
@@ -2296,8 +2296,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/84d843a6-e829-463a-97b0-2f4bc5f7c2f9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/478b4ede-72e2-4734-9b11-0ad89b7494b2
         method: GET
       response:
         proto: HTTP/2.0
@@ -2305,20 +2305,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 387
+        content_length: 738
         uncompressed: false
-        body: '{"description":"","error_message":null,"function_id":"f92e27c0-2f3a-423e-894a-97df57dee517","id":"84d843a6-e829-463a-97b0-2f4bc5f7c2f9","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"404e92e7-41cb-4530-ae28-9bed2dc8ee2e","mnq_project_id":"e3193f4c-2b75-4f42-8467-9331a6db6b75","mnq_region":"fr-par","queue":"TestQueue"},"status":"ready"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:06:27.585911Z","description":"","domain_name":"testfunctiontriggersjhzlswz4-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"478b4ede-72e2-4734-9b11-0ad89b7494b2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"8c3e5206-c129-4532-92a4-272b9d16e6f0","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:27.585911Z"}'
         headers:
             Content-Length:
-                - "387"
+                - "738"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:02 GMT
+                - Wed, 27 Aug 2025 15:06:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2326,256 +2326,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ba4ecf25-c8c3-4003-a4c3-1eb42e0ccb4b
+                - ebd8f9d1-42e4-4752-918a-c3411013f1eb
         status: 200 OK
         code: 200
-        duration: 72.805166ms
+        duration: 70.015723ms
     - id: 47
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/account/v3/projects/e3193f4c-2b75-4f42-8467-9331a6db6b75
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 244
-        uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:06.784363Z","description":"","id":"e3193f4c-2b75-4f42-8467-9331a6db6b75","name":"tf_tests_function_trigger_sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","updated_at":"2025-01-24T15:44:06.784363Z"}'
-        headers:
-            Content-Length:
-                - "244"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:45:03 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - bcab9578-01a8-4356-ac5d-84404f157cdb
-        status: 200 OK
-        code: 200
-        duration: 143.879042ms
-    - id: 48
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/520a545e-7353-4080-8f8f-d64ac490b8a1
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 560
-        uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.719841Z","description":"","environment_variables":{},"error_message":null,"id":"520a545e-7353-4080-8f8f-d64ac490b8a1","name":"test-function-trigger-sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"e3193f4c-2b75-4f42-8467-9331a6db6b75","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggersnzpipacm","registry_namespace_id":"0c845ed2-e3ed-43f6-b062-eb4b0d5c4df1","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:44:41.578505Z"}'
-        headers:
-            Content-Length:
-                - "560"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:45:03 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - ec997a73-2830-43fb-a6a1-ac52a770a09f
-        status: 200 OK
-        code: 200
-        duration: 125.84225ms
-    - id: 49
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-info?project_id=e3193f4c-2b75-4f42-8467-9331a6db6b75
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 233
-        uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.295889Z","project_id":"e3193f4c-2b75-4f42-8467-9331a6db6b75","region":"fr-par","sqs_endpoint_url":"https://sqs.mnq.fr-par.scaleway.com","status":"enabled","updated_at":"2025-01-24T15:44:07.295889Z"}'
-        headers:
-            Content-Length:
-                - "233"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:45:03 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - b0acf220-8882-44ad-bdab-6afde160a1ca
-        status: 200 OK
-        code: 200
-        duration: 129.46675ms
-    - id: 50
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-credentials/6be9a259-8001-4e52-85a1-f942a3758d6c
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 430
-        uncompressed: false
-        body: '{"access_key":"HG5XrGM6wISpjrwoqbLo","created_at":"2025-01-24T15:44:07.547668Z","id":"6be9a259-8001-4e52-85a1-f942a3758d6c","name":"tf-sqs-credentials-charming-pascal","permissions":{"can_manage":true,"can_publish":true,"can_receive":true},"project_id":"e3193f4c-2b75-4f42-8467-9331a6db6b75","region":"fr-par","secret_checksum":"79f084fa78e9408da4c9095afc90aaa71d963b46","secret_key":"00000000-0000-0000-0000-000000000000","updated_at":"2025-01-24T15:44:07.547668Z"}'
-        headers:
-            Content-Length:
-                - "430"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:45:03 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 0aefc657-2219-4a5c-a739-fe6aaa7f7148
-        status: 200 OK
-        code: 200
-        duration: 58.765166ms
-    - id: 51
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/f92e27c0-2f3a-423e-894a-97df57dee517
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 702
-        uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:43.761913Z","description":"","domain_name":"testfunctiontriggersnzpipacm-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"f92e27c0-2f3a-423e-894a-97df57dee517","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"520a545e-7353-4080-8f8f-d64ac490b8a1","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:43.761913Z"}'
-        headers:
-            Content-Length:
-                - "702"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:45:03 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 9e80205e-5de8-405a-80c6-5b5098c725ac
-        status: 200 OK
-        code: 200
-        duration: 79.522625ms
-    - id: 52
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2590,15 +2345,15 @@ interactions:
         form: {}
         headers:
             Amz-Sdk-Invocation-Id:
-                - dcc34bf3-00c4-425c-a3dd-d34080f17e38
+                - 1a0f0599-3f2b-48f3-99f5-18ca20f43b0c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
                 - application/x-amz-json-1.0
             User-Agent:
-                - aws-sdk-go-v2/1.32.7 ua/2.1 os/macos lang/go#1.23.3 md/GOOS#darwin md/GOARCH#arm64 api/sqs#1.37.3 m/E
+                - aws-sdk-go-v2/1.37.1 ua/2.1 os/linux lang/go#1.24.1 md/GOOS#linux md/GOARCH#amd64 api/sqs#1.38.6 m/E,e
             X-Amz-Date:
-                - 20250124T154503Z
+                - 20250827T150651Z
             X-Amz-Target:
                 - AmazonSQS.GetQueueUrl
             X-Amzn-Query-Mode:
@@ -2613,20 +2368,20 @@ interactions:
         trailer: {}
         content_length: 106
         uncompressed: false
-        body: '{"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-e3193f4c-2b75-4f42-8467-9331a6db6b75/TestQueue"}'
+        body: '{"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-52b94a0b-0f98-4f84-9b02-f19b6970eed0/TestQueue"}'
         headers:
             Content-Length:
                 - "106"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 24 Jan 2025 15:45:03 GMT
+                - Wed, 27 Aug 2025 15:06:51 GMT
             X-Amzn-Requestid:
-                - tx91db69a7-dc19-4102-aa6a-568c90381801
+                - txeb9abb12-6c36-4242-b342-eff89ee0e556
         status: 200 OK
         code: 200
-        duration: 26.726291ms
-    - id: 53
+        duration: 28.807771ms
+    - id: 48
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2637,19 +2392,19 @@ interactions:
         host: sqs.mnq.fr-par.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"AttributeNames":["MaximumMessageSize","MessageRetentionPeriod","FifoQueue","ContentBasedDeduplication","ReceiveMessageWaitTimeSeconds","VisibilityTimeout"],"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-e3193f4c-2b75-4f42-8467-9331a6db6b75/TestQueue"}'
+        body: '{"AttributeNames":["FifoQueue","ContentBasedDeduplication","ReceiveMessageWaitTimeSeconds","VisibilityTimeout","MaximumMessageSize","MessageRetentionPeriod"],"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-52b94a0b-0f98-4f84-9b02-f19b6970eed0/TestQueue"}'
         form: {}
         headers:
             Amz-Sdk-Invocation-Id:
-                - 567f686d-4afe-4d14-9528-ac67514a2b4f
+                - f75e59fc-bd4e-48ab-b8e7-e79983b1dc97
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
                 - application/x-amz-json-1.0
             User-Agent:
-                - aws-sdk-go-v2/1.32.7 ua/2.1 os/macos lang/go#1.23.3 md/GOOS#darwin md/GOARCH#arm64 api/sqs#1.37.3 m/E
+                - aws-sdk-go-v2/1.37.1 ua/2.1 os/linux lang/go#1.24.1 md/GOOS#linux md/GOARCH#amd64 api/sqs#1.38.6 m/E,e
             X-Amz-Date:
-                - 20250124T154503Z
+                - 20250827T150651Z
             X-Amz-Target:
                 - AmazonSQS.GetQueueAttributes
             X-Amzn-Query-Mode:
@@ -2671,13 +2426,13 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 24 Jan 2025 15:45:03 GMT
+                - Wed, 27 Aug 2025 15:06:51 GMT
             X-Amzn-Requestid:
-                - tx6cfbae99-9dc9-4e6f-8aca-7b0346bee5af
+                - tx895cdbd0-f2d0-4c17-8d5a-1358136b664a
         status: 200 OK
         code: 200
-        duration: 38.169584ms
-    - id: 54
+        duration: 27.87518ms
+    - id: 49
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2692,8 +2447,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/84d843a6-e829-463a-97b0-2f4bc5f7c2f9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/5b9489f7-e9cd-4f0f-aaa9-e2ed48bf457b
         method: GET
       response:
         proto: HTTP/2.0
@@ -2703,7 +2458,7 @@ interactions:
         trailer: {}
         content_length: 387
         uncompressed: false
-        body: '{"description":"","error_message":null,"function_id":"f92e27c0-2f3a-423e-894a-97df57dee517","id":"84d843a6-e829-463a-97b0-2f4bc5f7c2f9","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"404e92e7-41cb-4530-ae28-9bed2dc8ee2e","mnq_project_id":"e3193f4c-2b75-4f42-8467-9331a6db6b75","mnq_region":"fr-par","queue":"TestQueue"},"status":"ready"}'
+        body: '{"description":"","error_message":null,"function_id":"478b4ede-72e2-4734-9b11-0ad89b7494b2","id":"5b9489f7-e9cd-4f0f-aaa9-e2ed48bf457b","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"09b19b46-8f95-4ac9-b677-cdf22b19926d","mnq_project_id":"52b94a0b-0f98-4f84-9b02-f19b6970eed0","mnq_region":"fr-par","queue":"TestQueue"},"status":"ready"}'
         headers:
             Content-Length:
                 - "387"
@@ -2712,9 +2467,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:03 GMT
+                - Wed, 27 Aug 2025 15:06:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2722,11 +2477,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cb19424f-cb54-4f3a-b88b-582f1d50f065
+                - e2b1f209-33e6-476a-9f7e-875f5e155f31
         status: 200 OK
         code: 200
-        duration: 81.332ms
-    - id: 55
+        duration: 85.373974ms
+    - id: 50
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2741,15 +2496,15 @@ interactions:
         form: {}
         headers:
             Amz-Sdk-Invocation-Id:
-                - 28df81d1-dd0c-4fac-967f-341f6abb0dde
+                - 2ffca6ec-843d-4411-8d68-6ce66fc02a03
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
                 - application/x-amz-json-1.0
             User-Agent:
-                - aws-sdk-go-v2/1.32.7 ua/2.1 os/macos lang/go#1.23.3 md/GOOS#darwin md/GOARCH#arm64 api/sqs#1.37.3 m/E
+                - aws-sdk-go-v2/1.37.1 ua/2.1 os/linux lang/go#1.24.1 md/GOOS#linux md/GOARCH#amd64 api/sqs#1.38.6 m/E,e
             X-Amz-Date:
-                - 20250124T154504Z
+                - 20250827T150652Z
             X-Amz-Target:
                 - AmazonSQS.GetQueueUrl
             X-Amzn-Query-Mode:
@@ -2764,20 +2519,20 @@ interactions:
         trailer: {}
         content_length: 106
         uncompressed: false
-        body: '{"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-e3193f4c-2b75-4f42-8467-9331a6db6b75/TestQueue"}'
+        body: '{"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-52b94a0b-0f98-4f84-9b02-f19b6970eed0/TestQueue"}'
         headers:
             Content-Length:
                 - "106"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 24 Jan 2025 15:45:04 GMT
+                - Wed, 27 Aug 2025 15:06:52 GMT
             X-Amzn-Requestid:
-                - tx8a30f99c-2d6e-4860-9b15-827e2c6f1def
+                - tx1a789236-1cd8-4314-89da-2c2da61c0fb5
         status: 200 OK
         code: 200
-        duration: 29.195916ms
-    - id: 56
+        duration: 26.338939ms
+    - id: 51
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2788,19 +2543,19 @@ interactions:
         host: sqs.mnq.fr-par.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-e3193f4c-2b75-4f42-8467-9331a6db6b75/TestQueue"}'
+        body: '{"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-52b94a0b-0f98-4f84-9b02-f19b6970eed0/TestQueue"}'
         form: {}
         headers:
             Amz-Sdk-Invocation-Id:
-                - 30159a32-ed2e-4268-9916-b95e6a63c7e2
+                - 746fdae9-393a-415a-8e88-8e92a8afd7a4
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
                 - application/x-amz-json-1.0
             User-Agent:
-                - aws-sdk-go-v2/1.32.7 ua/2.1 os/macos lang/go#1.23.3 md/GOOS#darwin md/GOARCH#arm64 api/sqs#1.37.3 m/E
+                - aws-sdk-go-v2/1.37.1 ua/2.1 os/linux lang/go#1.24.1 md/GOOS#linux md/GOARCH#amd64 api/sqs#1.38.6 m/E,e
             X-Amz-Date:
-                - 20250124T154504Z
+                - 20250827T150652Z
             X-Amz-Target:
                 - AmazonSQS.DeleteQueue
             X-Amzn-Query-Mode:
@@ -2822,62 +2577,13 @@ interactions:
             Content-Type:
                 - application/x-amz-json-1.0; charset=utf-8
             Date:
-                - Fri, 24 Jan 2025 15:45:04 GMT
+                - Wed, 27 Aug 2025 15:06:52 GMT
             X-Amzn-Requestid:
-                - txf69299a6-3358-433b-ba87-7302e8689816
+                - txe44f171f-7e4e-4450-934a-ea2f155d30a1
         status: 200 OK
         code: 200
-        duration: 31.207959ms
-    - id: 57
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/84d843a6-e829-463a-97b0-2f4bc5f7c2f9
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 387
-        uncompressed: false
-        body: '{"description":"","error_message":null,"function_id":"f92e27c0-2f3a-423e-894a-97df57dee517","id":"84d843a6-e829-463a-97b0-2f4bc5f7c2f9","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"404e92e7-41cb-4530-ae28-9bed2dc8ee2e","mnq_project_id":"e3193f4c-2b75-4f42-8467-9331a6db6b75","mnq_region":"fr-par","queue":"TestQueue"},"status":"ready"}'
-        headers:
-            Content-Length:
-                - "387"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:45:04 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 18130d89-d02e-49c7-a183-9c1017bcc37d
-        status: 200 OK
-        code: 200
-        duration: 77.871709ms
-    - id: 58
+        duration: 34.854629ms
+    - id: 52
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2892,15 +2598,15 @@ interactions:
         form: {}
         headers:
             Amz-Sdk-Invocation-Id:
-                - 104cf069-eb4d-479c-bea4-0d7b13f643a8
+                - 78528c19-b410-4a6b-9ddc-8cfa532c8e4e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
                 - application/x-amz-json-1.0
             User-Agent:
-                - aws-sdk-go-v2/1.32.7 ua/2.1 os/macos lang/go#1.23.3 md/GOOS#darwin md/GOARCH#arm64 api/sqs#1.37.3 m/E
+                - aws-sdk-go-v2/1.37.1 ua/2.1 os/linux lang/go#1.24.1 md/GOOS#linux md/GOARCH#amd64 api/sqs#1.38.6 m/E,e
             X-Amz-Date:
-                - 20250124T154504Z
+                - 20250827T150652Z
             X-Amz-Target:
                 - AmazonSQS.GetQueueUrl
             X-Amzn-Query-Mode:
@@ -2922,14 +2628,306 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 24 Jan 2025 15:45:04 GMT
+                - Wed, 27 Aug 2025 15:06:52 GMT
             X-Amzn-Query-Error:
                 - AWS.SimpleQueueService.NonExistentQueue;Sender
             X-Amzn-Requestid:
-                - txb05f8db8-bd19-4205-9bd3-280297a2bdd0
+                - tx99446cb8-2b66-48b7-8e02-665f43cd4886
         status: 404 Not Found
         code: 404
-        duration: 21.05175ms
+        duration: 31.849439ms
+    - id: 53
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/5b9489f7-e9cd-4f0f-aaa9-e2ed48bf457b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 387
+        uncompressed: false
+        body: '{"description":"","error_message":null,"function_id":"478b4ede-72e2-4734-9b11-0ad89b7494b2","id":"5b9489f7-e9cd-4f0f-aaa9-e2ed48bf457b","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"09b19b46-8f95-4ac9-b677-cdf22b19926d","mnq_project_id":"52b94a0b-0f98-4f84-9b02-f19b6970eed0","mnq_region":"fr-par","queue":"TestQueue"},"status":"ready"}'
+        headers:
+            Content-Length:
+                - "387"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - a474aee9-9b9e-4d15-9f20-747c15659ba5
+        status: 200 OK
+        code: 200
+        duration: 109.833546ms
+    - id: 54
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/5b9489f7-e9cd-4f0f-aaa9-e2ed48bf457b
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 390
+        uncompressed: false
+        body: '{"description":"","error_message":null,"function_id":"478b4ede-72e2-4734-9b11-0ad89b7494b2","id":"5b9489f7-e9cd-4f0f-aaa9-e2ed48bf457b","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"09b19b46-8f95-4ac9-b677-cdf22b19926d","mnq_project_id":"52b94a0b-0f98-4f84-9b02-f19b6970eed0","mnq_region":"fr-par","queue":"TestQueue"},"status":"deleting"}'
+        headers:
+            Content-Length:
+                - "390"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f3f48391-cbd2-4614-a653-1187d24d6e0f
+        status: 200 OK
+        code: 200
+        duration: 125.112127ms
+    - id: 55
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-credentials/cdcc9ac4-fbdb-400c-bf7e-683edb95fc41
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 742d3297-3fed-4415-9bb7-06aaf6159add
+        status: 204 No Content
+        code: 204
+        duration: 137.146401ms
+    - id: 56
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/5b9489f7-e9cd-4f0f-aaa9-e2ed48bf457b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 390
+        uncompressed: false
+        body: '{"description":"","error_message":null,"function_id":"478b4ede-72e2-4734-9b11-0ad89b7494b2","id":"5b9489f7-e9cd-4f0f-aaa9-e2ed48bf457b","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"09b19b46-8f95-4ac9-b677-cdf22b19926d","mnq_project_id":"52b94a0b-0f98-4f84-9b02-f19b6970eed0","mnq_region":"fr-par","queue":"TestQueue"},"status":"deleting"}'
+        headers:
+            Content-Length:
+                - "390"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 1ea8ffa1-c102-4fd1-88f8-17bdaa36663e
+        status: 200 OK
+        code: 200
+        duration: 105.047225ms
+    - id: 57
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/5b9489f7-e9cd-4f0f-aaa9-e2ed48bf457b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 390
+        uncompressed: false
+        body: '{"description":"","error_message":null,"function_id":"478b4ede-72e2-4734-9b11-0ad89b7494b2","id":"5b9489f7-e9cd-4f0f-aaa9-e2ed48bf457b","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"09b19b46-8f95-4ac9-b677-cdf22b19926d","mnq_project_id":"52b94a0b-0f98-4f84-9b02-f19b6970eed0","mnq_region":"fr-par","queue":"TestQueue"},"status":"deleting"}'
+        headers:
+            Content-Length:
+                - "390"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:57 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 9443959b-649d-473a-ada8-7b0253516e1f
+        status: 200 OK
+        code: 200
+        duration: 102.90903ms
+    - id: 58
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/5b9489f7-e9cd-4f0f-aaa9-e2ed48bf457b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 390
+        uncompressed: false
+        body: '{"description":"","error_message":null,"function_id":"478b4ede-72e2-4734-9b11-0ad89b7494b2","id":"5b9489f7-e9cd-4f0f-aaa9-e2ed48bf457b","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"09b19b46-8f95-4ac9-b677-cdf22b19926d","mnq_project_id":"52b94a0b-0f98-4f84-9b02-f19b6970eed0","mnq_region":"fr-par","queue":"TestQueue"},"status":"deleting"}'
+        headers:
+            Content-Length:
+                - "390"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:07:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - aac5149d-62a2-48e1-824a-b7dc063e1a51
+        status: 200 OK
+        code: 200
+        duration: 93.509274ms
     - id: 59
       request:
         proto: HTTP/1.1
@@ -2945,27 +2943,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-credentials/6be9a259-8001-4e52-85a1-f942a3758d6c
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/5b9489f7-e9cd-4f0f-aaa9-e2ed48bf457b
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 390
         uncompressed: false
-        body: ""
+        body: '{"description":"","error_message":null,"function_id":"478b4ede-72e2-4734-9b11-0ad89b7494b2","id":"5b9489f7-e9cd-4f0f-aaa9-e2ed48bf457b","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"09b19b46-8f95-4ac9-b677-cdf22b19926d","mnq_project_id":"52b94a0b-0f98-4f84-9b02-f19b6970eed0","mnq_region":"fr-par","queue":"TestQueue"},"status":"deleting"}'
         headers:
+            Content-Length:
+                - "390"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:04 GMT
+                - Wed, 27 Aug 2025 15:07:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2973,10 +2973,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cfbbeb09-4f20-4c5d-8a6e-0a81de1ad9a1
-        status: 204 No Content
-        code: 204
-        duration: 94.150917ms
+                - 91f8f2c6-411c-459d-9c26-ba5247cfd971
+        status: 200 OK
+        code: 200
+        duration: 97.325929ms
     - id: 60
       request:
         proto: HTTP/1.1
@@ -2992,9 +2992,9 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/84d843a6-e829-463a-97b0-2f4bc5f7c2f9
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/5b9489f7-e9cd-4f0f-aaa9-e2ed48bf457b
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
@@ -3003,7 +3003,7 @@ interactions:
         trailer: {}
         content_length: 390
         uncompressed: false
-        body: '{"description":"","error_message":null,"function_id":"f92e27c0-2f3a-423e-894a-97df57dee517","id":"84d843a6-e829-463a-97b0-2f4bc5f7c2f9","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"404e92e7-41cb-4530-ae28-9bed2dc8ee2e","mnq_project_id":"e3193f4c-2b75-4f42-8467-9331a6db6b75","mnq_region":"fr-par","queue":"TestQueue"},"status":"deleting"}'
+        body: '{"description":"","error_message":null,"function_id":"478b4ede-72e2-4734-9b11-0ad89b7494b2","id":"5b9489f7-e9cd-4f0f-aaa9-e2ed48bf457b","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"09b19b46-8f95-4ac9-b677-cdf22b19926d","mnq_project_id":"52b94a0b-0f98-4f84-9b02-f19b6970eed0","mnq_region":"fr-par","queue":"TestQueue"},"status":"deleting"}'
         headers:
             Content-Length:
                 - "390"
@@ -3012,9 +3012,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:04 GMT
+                - Wed, 27 Aug 2025 15:07:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3022,10 +3022,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2ca25b99-02fa-47a8-beb7-7798ae6bb854
+                - ee9a6efc-34fb-4c5f-a8b8-348f3bf041b2
         status: 200 OK
         code: 200
-        duration: 136.187583ms
+        duration: 90.034897ms
     - id: 61
       request:
         proto: HTTP/1.1
@@ -3041,155 +3041,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/84d843a6-e829-463a-97b0-2f4bc5f7c2f9
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 390
-        uncompressed: false
-        body: '{"description":"","error_message":null,"function_id":"f92e27c0-2f3a-423e-894a-97df57dee517","id":"84d843a6-e829-463a-97b0-2f4bc5f7c2f9","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"404e92e7-41cb-4530-ae28-9bed2dc8ee2e","mnq_project_id":"e3193f4c-2b75-4f42-8467-9331a6db6b75","mnq_region":"fr-par","queue":"TestQueue"},"status":"deleting"}'
-        headers:
-            Content-Length:
-                - "390"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:45:04 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - ac6bf344-84d8-40cf-ac85-6954e6cd84a0
-        status: 200 OK
-        code: 200
-        duration: 79.8975ms
-    - id: 62
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/84d843a6-e829-463a-97b0-2f4bc5f7c2f9
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 390
-        uncompressed: false
-        body: '{"description":"","error_message":null,"function_id":"f92e27c0-2f3a-423e-894a-97df57dee517","id":"84d843a6-e829-463a-97b0-2f4bc5f7c2f9","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"404e92e7-41cb-4530-ae28-9bed2dc8ee2e","mnq_project_id":"e3193f4c-2b75-4f42-8467-9331a6db6b75","mnq_region":"fr-par","queue":"TestQueue"},"status":"deleting"}'
-        headers:
-            Content-Length:
-                - "390"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:45:09 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - e9cb1533-c300-4a49-a444-43ddbbd37c89
-        status: 200 OK
-        code: 200
-        duration: 91.052541ms
-    - id: 63
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/84d843a6-e829-463a-97b0-2f4bc5f7c2f9
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 390
-        uncompressed: false
-        body: '{"description":"","error_message":null,"function_id":"f92e27c0-2f3a-423e-894a-97df57dee517","id":"84d843a6-e829-463a-97b0-2f4bc5f7c2f9","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"404e92e7-41cb-4530-ae28-9bed2dc8ee2e","mnq_project_id":"e3193f4c-2b75-4f42-8467-9331a6db6b75","mnq_region":"fr-par","queue":"TestQueue"},"status":"deleting"}'
-        headers:
-            Content-Length:
-                - "390"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:45:14 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - f55ab2a7-7950-4015-8a95-f03ef27e63d5
-        status: 200 OK
-        code: 200
-        duration: 76.052208ms
-    - id: 64
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/84d843a6-e829-463a-97b0-2f4bc5f7c2f9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/5b9489f7-e9cd-4f0f-aaa9-e2ed48bf457b
         method: GET
       response:
         proto: HTTP/2.0
@@ -3208,9 +3061,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:19 GMT
+                - Wed, 27 Aug 2025 15:07:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3218,11 +3071,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 50f9716d-d3a7-4e7f-b25e-a569acad9ed4
+                - 39029671-4e64-4f5b-a58c-55f0b724f989
         status: 404 Not Found
         code: 404
-        duration: 24.78525ms
-    - id: 65
+        duration: 31.596899ms
+    - id: 62
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3237,8 +3090,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-info?project_id=e3193f4c-2b75-4f42-8467-9331a6db6b75
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-info?project_id=52b94a0b-0f98-4f84-9b02-f19b6970eed0
         method: GET
       response:
         proto: HTTP/2.0
@@ -3248,7 +3101,7 @@ interactions:
         trailer: {}
         content_length: 233
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.295889Z","project_id":"e3193f4c-2b75-4f42-8467-9331a6db6b75","region":"fr-par","sqs_endpoint_url":"https://sqs.mnq.fr-par.scaleway.com","status":"enabled","updated_at":"2025-01-24T15:44:07.295889Z"}'
+        body: '{"created_at":"2025-08-27T15:06:19.969953Z","project_id":"52b94a0b-0f98-4f84-9b02-f19b6970eed0","region":"fr-par","sqs_endpoint_url":"https://sqs.mnq.fr-par.scaleway.com","status":"enabled","updated_at":"2025-08-27T15:06:19.969953Z"}'
         headers:
             Content-Length:
                 - "233"
@@ -3257,9 +3110,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:19 GMT
+                - Wed, 27 Aug 2025 15:07:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3267,10 +3120,159 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 242220e4-5ecb-4a92-a673-f273d1fad0bb
+                - 7588508f-82b2-474b-9cff-a6c687e677a0
         status: 200 OK
         code: 200
-        duration: 55.373959ms
+        duration: 80.239585ms
+    - id: 63
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/478b4ede-72e2-4734-9b11-0ad89b7494b2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 738
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:06:27.585911Z","description":"","domain_name":"testfunctiontriggersjhzlswz4-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"478b4ede-72e2-4734-9b11-0ad89b7494b2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"8c3e5206-c129-4532-92a4-272b9d16e6f0","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:06:27.585911Z"}'
+        headers:
+            Content-Length:
+                - "738"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:07:17 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 1cbdebe0-79f2-4b38-a3a8-ed799805e40c
+        status: 200 OK
+        code: 200
+        duration: 83.602095ms
+    - id: 64
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/478b4ede-72e2-4734-9b11-0ad89b7494b2
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 742
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:06:27.585911Z","description":"","domain_name":"testfunctiontriggersjhzlswz4-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"478b4ede-72e2-4734-9b11-0ad89b7494b2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"8c3e5206-c129-4532-92a4-272b9d16e6f0","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:07:18.075903260Z"}'
+        headers:
+            Content-Length:
+                - "742"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:07:18 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b1a64744-791d-4861-a373-a70b5c476639
+        status: 200 OK
+        code: 200
+        duration: 158.074437ms
+    - id: 65
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 53
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"project_id":"52b94a0b-0f98-4f84-9b02-f19b6970eed0"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/deactivate-sqs
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 184
+        uncompressed: false
+        body: '{"created_at":null,"project_id":"52b94a0b-0f98-4f84-9b02-f19b6970eed0","region":"fr-par","sqs_endpoint_url":"https://sqs.mnq.fr-par.scaleway.com","status":"disabled","updated_at":null}'
+        headers:
+            Content-Length:
+                - "184"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:07:18 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b5f218a2-81a4-4d1b-ab6a-10ad96720510
+        status: 200 OK
+        code: 200
+        duration: 252.38001ms
     - id: 66
       request:
         proto: HTTP/1.1
@@ -3286,8 +3288,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/f92e27c0-2f3a-423e-894a-97df57dee517
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8c3e5206-c129-4532-92a4-272b9d16e6f0
         method: GET
       response:
         proto: HTTP/2.0
@@ -3295,20 +3297,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 702
+        content_length: 593
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:43.761913Z","description":"","domain_name":"testfunctiontriggersnzpipacm-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"f92e27c0-2f3a-423e-894a-97df57dee517","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"520a545e-7353-4080-8f8f-d64ac490b8a1","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:44:43.761913Z"}'
+        body: '{"created_at":"2025-08-27T15:06:21.464382Z","description":"","environment_variables":{},"error_message":null,"id":"8c3e5206-c129-4532-92a4-272b9d16e6f0","name":"test-function-trigger-sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"52b94a0b-0f98-4f84-9b02-f19b6970eed0","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggersjhzlswz4","registry_namespace_id":"ad6dd704-2b22-4ac0-ba04-6c1fbd78a1da","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:06:25.489989Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "702"
+                - "593"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:19 GMT
+                - Wed, 27 Aug 2025 15:07:18 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3316,50 +3318,48 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7d3f7876-3905-492f-a708-a685240d9861
+                - da64fcb8-87c1-4bbc-9edb-04150a5ab29c
         status: 200 OK
         code: 200
-        duration: 76.520792ms
+        duration: 90.456039ms
     - id: 67
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 53
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"project_id":"e3193f4c-2b75-4f42-8467-9331a6db6b75"}'
+        body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/deactivate-sqs
-        method: POST
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8c3e5206-c129-4532-92a4-272b9d16e6f0
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 184
+        content_length: 599
         uncompressed: false
-        body: '{"created_at":null,"project_id":"e3193f4c-2b75-4f42-8467-9331a6db6b75","region":"fr-par","sqs_endpoint_url":"https://sqs.mnq.fr-par.scaleway.com","status":"disabled","updated_at":null}'
+        body: '{"created_at":"2025-08-27T15:06:21.464382Z","description":"","environment_variables":{},"error_message":null,"id":"8c3e5206-c129-4532-92a4-272b9d16e6f0","name":"test-function-trigger-sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"52b94a0b-0f98-4f84-9b02-f19b6970eed0","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggersjhzlswz4","registry_namespace_id":"ad6dd704-2b22-4ac0-ba04-6c1fbd78a1da","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:07:18.265541768Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "184"
+                - "599"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:20 GMT
+                - Wed, 27 Aug 2025 15:07:18 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3367,10 +3367,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 28f0db4b-303e-46e5-aa86-3d138f1538d1
+                - 490d7766-e4ab-4a10-8e5e-ba1b28773af4
         status: 200 OK
         code: 200
-        duration: 232.330666ms
+        duration: 751.314519ms
     - id: 68
       request:
         proto: HTTP/1.1
@@ -3386,29 +3386,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/f92e27c0-2f3a-423e-894a-97df57dee517
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8c3e5206-c129-4532-92a4-272b9d16e6f0
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 706
+        content_length: 596
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:44:43.761913Z","description":"","domain_name":"testfunctiontriggersnzpipacm-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"f92e27c0-2f3a-423e-894a-97df57dee517","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"520a545e-7353-4080-8f8f-d64ac490b8a1","privacy":"private","ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"deleting","timeout":"300s","updated_at":"2025-01-24T15:45:20.003868239Z"}'
+        body: '{"created_at":"2025-08-27T15:06:21.464382Z","description":"","environment_variables":{},"error_message":null,"id":"8c3e5206-c129-4532-92a4-272b9d16e6f0","name":"test-function-trigger-sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"52b94a0b-0f98-4f84-9b02-f19b6970eed0","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggersjhzlswz4","registry_namespace_id":"ad6dd704-2b22-4ac0-ba04-6c1fbd78a1da","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:07:18.265542Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "706"
+                - "596"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:20 GMT
+                - Wed, 27 Aug 2025 15:07:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3416,10 +3416,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2e45aff2-4019-40d3-b41b-956aaf47e1e0
+                - 1ffbdbdb-86bd-43f6-a2b4-4d14acce0334
         status: 200 OK
         code: 200
-        duration: 209.727417ms
+        duration: 85.616226ms
     - id: 69
       request:
         proto: HTTP/1.1
@@ -3435,400 +3435,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/520a545e-7353-4080-8f8f-d64ac490b8a1
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 560
-        uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.719841Z","description":"","environment_variables":{},"error_message":null,"id":"520a545e-7353-4080-8f8f-d64ac490b8a1","name":"test-function-trigger-sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"e3193f4c-2b75-4f42-8467-9331a6db6b75","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggersnzpipacm","registry_namespace_id":"0c845ed2-e3ed-43f6-b062-eb4b0d5c4df1","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:44:41.578505Z"}'
-        headers:
-            Content-Length:
-                - "560"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:45:20 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 7bb4e927-4962-4d80-a73b-f3ee0fbde303
-        status: 200 OK
-        code: 200
-        duration: 78.749083ms
-    - id: 70
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/520a545e-7353-4080-8f8f-d64ac490b8a1
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 566
-        uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.719841Z","description":"","environment_variables":{},"error_message":null,"id":"520a545e-7353-4080-8f8f-d64ac490b8a1","name":"test-function-trigger-sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"e3193f4c-2b75-4f42-8467-9331a6db6b75","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggersnzpipacm","registry_namespace_id":"0c845ed2-e3ed-43f6-b062-eb4b0d5c4df1","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:45:20.291836692Z"}'
-        headers:
-            Content-Length:
-                - "566"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:45:20 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - e03b3ed5-d319-4049-9823-dc4984d7091c
-        status: 200 OK
-        code: 200
-        duration: 171.477125ms
-    - id: 71
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/520a545e-7353-4080-8f8f-d64ac490b8a1
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 563
-        uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.719841Z","description":"","environment_variables":{},"error_message":null,"id":"520a545e-7353-4080-8f8f-d64ac490b8a1","name":"test-function-trigger-sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"e3193f4c-2b75-4f42-8467-9331a6db6b75","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggersnzpipacm","registry_namespace_id":"0c845ed2-e3ed-43f6-b062-eb4b0d5c4df1","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:45:20.291837Z"}'
-        headers:
-            Content-Length:
-                - "563"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:45:20 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - a4fd323e-aa9d-4267-8551-4ab0da4d3516
-        status: 200 OK
-        code: 200
-        duration: 65.563458ms
-    - id: 72
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/520a545e-7353-4080-8f8f-d64ac490b8a1
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 563
-        uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.719841Z","description":"","environment_variables":{},"error_message":null,"id":"520a545e-7353-4080-8f8f-d64ac490b8a1","name":"test-function-trigger-sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"e3193f4c-2b75-4f42-8467-9331a6db6b75","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggersnzpipacm","registry_namespace_id":"0c845ed2-e3ed-43f6-b062-eb4b0d5c4df1","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:45:20.291837Z"}'
-        headers:
-            Content-Length:
-                - "563"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:45:25 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - f3bab4cb-ced8-4916-8968-5c7349a6fbef
-        status: 200 OK
-        code: 200
-        duration: 144.356416ms
-    - id: 73
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/520a545e-7353-4080-8f8f-d64ac490b8a1
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 563
-        uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.719841Z","description":"","environment_variables":{},"error_message":null,"id":"520a545e-7353-4080-8f8f-d64ac490b8a1","name":"test-function-trigger-sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"e3193f4c-2b75-4f42-8467-9331a6db6b75","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggersnzpipacm","registry_namespace_id":"0c845ed2-e3ed-43f6-b062-eb4b0d5c4df1","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:45:20.291837Z"}'
-        headers:
-            Content-Length:
-                - "563"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:45:30 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - da08b169-61c5-491d-a0a0-8c56c78ad9b6
-        status: 200 OK
-        code: 200
-        duration: 60.594917ms
-    - id: 74
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/520a545e-7353-4080-8f8f-d64ac490b8a1
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 563
-        uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.719841Z","description":"","environment_variables":{},"error_message":null,"id":"520a545e-7353-4080-8f8f-d64ac490b8a1","name":"test-function-trigger-sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"e3193f4c-2b75-4f42-8467-9331a6db6b75","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggersnzpipacm","registry_namespace_id":"0c845ed2-e3ed-43f6-b062-eb4b0d5c4df1","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:45:20.291837Z"}'
-        headers:
-            Content-Length:
-                - "563"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:45:35 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - d4610742-f96d-4054-b9df-67c877ba3e39
-        status: 200 OK
-        code: 200
-        duration: 75.78925ms
-    - id: 75
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/520a545e-7353-4080-8f8f-d64ac490b8a1
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 563
-        uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.719841Z","description":"","environment_variables":{},"error_message":null,"id":"520a545e-7353-4080-8f8f-d64ac490b8a1","name":"test-function-trigger-sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"e3193f4c-2b75-4f42-8467-9331a6db6b75","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggersnzpipacm","registry_namespace_id":"0c845ed2-e3ed-43f6-b062-eb4b0d5c4df1","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:45:20.291837Z"}'
-        headers:
-            Content-Length:
-                - "563"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:45:40 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 40e13ede-c47d-42df-bca3-11270ad3a7cd
-        status: 200 OK
-        code: 200
-        duration: 67.458916ms
-    - id: 76
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/520a545e-7353-4080-8f8f-d64ac490b8a1
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 563
-        uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:07.719841Z","description":"","environment_variables":{},"error_message":null,"id":"520a545e-7353-4080-8f8f-d64ac490b8a1","name":"test-function-trigger-sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"e3193f4c-2b75-4f42-8467-9331a6db6b75","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggersnzpipacm","registry_namespace_id":"0c845ed2-e3ed-43f6-b062-eb4b0d5c4df1","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:45:20.291837Z"}'
-        headers:
-            Content-Length:
-                - "563"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:45:45 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - f4c53b93-96ae-43d6-b275-94b7ec6a24af
-        status: 200 OK
-        code: 200
-        duration: 81.206958ms
-    - id: 77
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/520a545e-7353-4080-8f8f-d64ac490b8a1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8c3e5206-c129-4532-92a4-272b9d16e6f0
         method: GET
       response:
         proto: HTTP/2.0
@@ -3847,9 +3455,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:50 GMT
+                - Wed, 27 Aug 2025 15:07:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3857,11 +3465,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 763a1755-63c4-4ef9-af21-b56b6bca08f0
+                - e3c0bbfa-b82c-4b82-8ef8-ca62f2e03c70
         status: 404 Not Found
         code: 404
-        duration: 29.669209ms
-    - id: 78
+        duration: 28.789109ms
+    - id: 70
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3876,8 +3484,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/account/v3/projects/e3193f4c-2b75-4f42-8467-9331a6db6b75
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/account/v3/projects/52b94a0b-0f98-4f84-9b02-f19b6970eed0
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -3894,9 +3502,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:52 GMT
+                - Wed, 27 Aug 2025 15:07:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3904,11 +3512,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f136dadd-d699-4340-8b08-efecd6908b68
+                - 875a7350-3223-4411-b6a8-a9f23e50ccc2
         status: 204 No Content
         code: 204
-        duration: 1.450793459s
-    - id: 79
+        duration: 1.468755254s
+    - id: 71
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3923,8 +3531,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/84d843a6-e829-463a-97b0-2f4bc5f7c2f9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/5b9489f7-e9cd-4f0f-aaa9-e2ed48bf457b
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -3934,7 +3542,7 @@ interactions:
         trailer: {}
         content_length: 105
         uncompressed: false
-        body: '{"message":"trigger does not exist: could not find trigger with id 84d843a6-e829-463a-97b0-2f4bc5f7c2f9"}'
+        body: '{"message":"trigger does not exist: could not find trigger with id 5b9489f7-e9cd-4f0f-aaa9-e2ed48bf457b"}'
         headers:
             Content-Length:
                 - "105"
@@ -3943,9 +3551,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:52 GMT
+                - Wed, 27 Aug 2025 15:07:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3953,7 +3561,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f99091f4-0215-49f6-8249-d4ca8328c864
+                - 915ed374-2880-443c-a58a-92409beb940a
         status: 404 Not Found
         code: 404
-        duration: 34.464834ms
+        duration: 22.858179ms

--- a/internal/services/function/testdata/function-upload.cassette.yaml
+++ b/internal/services/function/testdata/function-upload.cassette.yaml
@@ -6,19 +6,19 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 163
+        content_length: 189
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-func-fervent-nightingale","environment_variables":{},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","secret_environment_variables":[],"tags":null}'
+        body: '{"name":"tf-func-relaxed-dirac","environment_variables":{},"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","secret_environment_variables":[],"tags":null,"activate_vpc_integration":true}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces
         method: POST
       response:
@@ -27,20 +27,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 479
+        content_length: 506
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:45.502948714Z","description":"","environment_variables":{},"error_message":null,"id":"40fc92e8-aca6-4a2e-91de-27b700d7c960","name":"tf-func-fervent-nightingale","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:44:45.502948714Z"}'
+        body: '{"created_at":"2025-08-27T15:05:35.106724604Z","description":"","environment_variables":{},"error_message":null,"id":"f92ef171-6edd-4736-9dbe-ba4a6c7c8dd5","name":"tf-func-relaxed-dirac","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:35.106724604Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "479"
+                - "506"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:45 GMT
+                - Wed, 27 Aug 2025 15:05:35 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - dfaca19c-a7a4-4dd9-9f21-b92ffd7de227
+                - bed0a89f-6efa-41a3-a033-6c8f9c86c408
         status: 200 OK
         code: 200
-        duration: 344.762833ms
+        duration: 981.421792ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -67,8 +67,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/40fc92e8-aca6-4a2e-91de-27b700d7c960
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/f92ef171-6edd-4736-9dbe-ba4a6c7c8dd5
         method: GET
       response:
         proto: HTTP/2.0
@@ -76,20 +76,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 473
+        content_length: 500
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:45.502949Z","description":"","environment_variables":{},"error_message":null,"id":"40fc92e8-aca6-4a2e-91de-27b700d7c960","name":"tf-func-fervent-nightingale","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:44:45.502949Z"}'
+        body: '{"created_at":"2025-08-27T15:05:35.106725Z","description":"","environment_variables":{},"error_message":null,"id":"f92ef171-6edd-4736-9dbe-ba4a6c7c8dd5","name":"tf-func-relaxed-dirac","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-08-27T15:05:35.106725Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "473"
+                - "500"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:45 GMT
+                - Wed, 27 Aug 2025 15:05:35 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 383a04cf-86d5-459f-af89-f2a831ca6c5b
+                - 156d736f-f29b-49ca-9e90-3c506e40df33
         status: 200 OK
         code: 200
-        duration: 76.648292ms
+        duration: 40.233153ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -116,8 +116,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/40fc92e8-aca6-4a2e-91de-27b700d7c960
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/f92ef171-6edd-4736-9dbe-ba4a6c7c8dd5
         method: GET
       response:
         proto: HTTP/2.0
@@ -125,20 +125,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 473
+        content_length: 587
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:45.502949Z","description":"","environment_variables":{},"error_message":null,"id":"40fc92e8-aca6-4a2e-91de-27b700d7c960","name":"tf-func-fervent-nightingale","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:44:47.433386Z"}'
+        body: '{"created_at":"2025-08-27T15:05:35.106725Z","description":"","environment_variables":{},"error_message":null,"id":"f92ef171-6edd-4736-9dbe-ba4a6c7c8dd5","name":"tf-func-relaxed-dirac","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncrelaxeddirac406dzjao","registry_namespace_id":"5d5f5ffc-7625-43a3-95a7-7d7b542bf80e","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:37.083048Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "473"
+                - "587"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:50 GMT
+                - Wed, 27 Aug 2025 15:05:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -146,10 +146,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bd570042-9847-4dad-b8f8-d9636c8c8671
+                - eb6ac1ef-382d-4941-a128-901146f8a824
         status: 200 OK
         code: 200
-        duration: 63.466792ms
+        duration: 44.087476ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -165,8 +165,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/40fc92e8-aca6-4a2e-91de-27b700d7c960
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/f92ef171-6edd-4736-9dbe-ba4a6c7c8dd5
         method: GET
       response:
         proto: HTTP/2.0
@@ -174,20 +174,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 473
+        content_length: 587
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:45.502949Z","description":"","environment_variables":{},"error_message":null,"id":"40fc92e8-aca6-4a2e-91de-27b700d7c960","name":"tf-func-fervent-nightingale","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2025-01-24T15:44:47.433386Z"}'
+        body: '{"created_at":"2025-08-27T15:05:35.106725Z","description":"","environment_variables":{},"error_message":null,"id":"f92ef171-6edd-4736-9dbe-ba4a6c7c8dd5","name":"tf-func-relaxed-dirac","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncrelaxeddirac406dzjao","registry_namespace_id":"5d5f5ffc-7625-43a3-95a7-7d7b542bf80e","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:37.083048Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "473"
+                - "587"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:44:55 GMT
+                - Wed, 27 Aug 2025 15:05:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -195,48 +195,50 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 095919a2-1c97-4950-9581-0aca1fab05a2
+                - 31ca78f1-acb2-404f-9269-165c40f9c809
         status: 200 OK
         code: 200
-        duration: 133.173375ms
+        duration: 47.57509ms
     - id: 4
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 301
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"name":"foobar","namespace_id":"f92ef171-6edd-4736-9dbe-ba4a6c7c8dd5","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"go122","memory_limit":256,"handler":"Handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox","tags":null}'
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/40fc92e8-aca6-4a2e-91de-27b700d7c960
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 562
+        content_length: 695
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:45.502949Z","description":"","environment_variables":{},"error_message":null,"id":"40fc92e8-aca6-4a2e-91de-27b700d7c960","name":"tf-func-fervent-nightingale","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncferventnightin32cvo0cr","registry_namespace_id":"b7ffcf71-4b36-4c69-bc71-e15aba54a568","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:44:57.766010Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:41.229669646Z","description":"","domain_name":"tffuncrelaxeddirac406dzjao-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"151e1fa5-8c80-4ee8-ad5a-c14c14a2bcbb","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"f92ef171-6edd-4736-9dbe-ba4a6c7c8dd5","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:41.229669646Z"}'
         headers:
             Content-Length:
-                - "562"
+                - "695"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:00 GMT
+                - Wed, 27 Aug 2025 15:05:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -244,10 +246,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9e43ca9a-5130-4fa2-8090-44cc8f8f9c1a
+                - 25e99a63-c885-4422-a07e-15dc250566c8
         status: 200 OK
         code: 200
-        duration: 74.833708ms
+        duration: 982.188972ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -263,108 +265,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/40fc92e8-aca6-4a2e-91de-27b700d7c960
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 562
-        uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:45.502949Z","description":"","environment_variables":{},"error_message":null,"id":"40fc92e8-aca6-4a2e-91de-27b700d7c960","name":"tf-func-fervent-nightingale","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncferventnightin32cvo0cr","registry_namespace_id":"b7ffcf71-4b36-4c69-bc71-e15aba54a568","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:44:57.766010Z"}'
-        headers:
-            Content-Length:
-                - "562"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:45:00 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 63dda253-3ecc-4f53-ad9f-46689237844c
-        status: 200 OK
-        code: 200
-        duration: 63.386417ms
-    - id: 6
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 289
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"name":"foobar","namespace_id":"40fc92e8-aca6-4a2e-91de-27b700d7c960","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"go122","memory_limit":256,"handler":"Handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox"}'
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 661
-        uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:45:01.159154667Z","description":"","domain_name":"tffuncferventnightin32cvo0cr-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"248594dd-f24a-4f23-be00-d9ba28b377d9","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"40fc92e8-aca6-4a2e-91de-27b700d7c960","privacy":"private","ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:45:01.159154667Z"}'
-        headers:
-            Content-Length:
-                - "661"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 15:45:01 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 5b11ed13-9dd1-4aa7-9b5b-ef5714746c9b
-        status: 200 OK
-        code: 200
-        duration: 226.943917ms
-    - id: 7
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/248594dd-f24a-4f23-be00-d9ba28b377d9/upload-url?content_length=780
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/151e1fa5-8c80-4ee8-ad5a-c14c14a2bcbb/upload-url?content_length=780
         method: GET
       response:
         proto: HTTP/2.0
@@ -374,7 +276,7 @@ interactions:
         trailer: {}
         content_length: 510
         uncompressed: false
-        body: '{"headers":{"content-length":["780"],"content-type":["application/octet-stream"]},"url":"https://s3.fr-par.scw.cloud/serverless-functions-code-prod-fr-par/uploads/function-248594dd-f24a-4f23-be00-d9ba28b377d9.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256\u0026X-Amz-Credential=SCW3S98HDC0MAE9CBTQ5%2F20250124%2Ffr-par%2Fs3%2Faws4_request\u0026X-Amz-Date=20250124T154501Z\u0026X-Amz-Expires=3600\u0026X-Amz-SignedHeaders=content-length%3Bcontent-type%3Bhost\u0026X-Amz-Signature=cbf317643e62610aa63b4513e538cec28c0694a03cff215db18715cf93ca606b"}'
+        body: '{"headers":{"content-length":["780"],"content-type":["application/octet-stream"]},"url":"https://s3.fr-par.scw.cloud/serverless-functions-code-prod-fr-par/uploads/function-151e1fa5-8c80-4ee8-ad5a-c14c14a2bcbb.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256\u0026X-Amz-Credential=SCW3S98HDC0MAE9CBTQ5%2F20250827%2Ffr-par%2Fs3%2Faws4_request\u0026X-Amz-Date=20250827T150541Z\u0026X-Amz-Expires=3600\u0026X-Amz-SignedHeaders=content-length%3Bcontent-type%3Bhost\u0026X-Amz-Signature=a9fa25f353df74f13b566f7ae3eb2d02a234162ed9ab81087b24018c28916948"}'
         headers:
             Content-Length:
                 - "510"
@@ -383,9 +285,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:01 GMT
+                - Wed, 27 Aug 2025 15:05:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -393,11 +295,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4b1f6e34-ab42-479a-a059-f51d25f81881
+                - c74fabcf-6f6f-491c-9037-41c64215def8
         status: 200 OK
         code: 200
-        duration: 81.78175ms
-    - id: 8
+        duration: 56.37362ms
+    - id: 6
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -430,7 +332,7 @@ interactions:
                 - "780"
             Content-Type:
                 - application/octet-stream
-        url: https://s3.fr-par.scw.cloud/serverless-functions-code-prod-fr-par/uploads/function-248594dd-f24a-4f23-be00-d9ba28b377d9.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=SCW3S98HDC0MAE9CBTQ5%2F20250124%2Ffr-par%2Fs3%2Faws4_request&X-Amz-Date=20250124T154501Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=content-length%3Bcontent-type%3Bhost&X-Amz-Signature=cbf317643e62610aa63b4513e538cec28c0694a03cff215db18715cf93ca606b
+        url: https://s3.fr-par.scw.cloud/serverless-functions-code-prod-fr-par/uploads/function-151e1fa5-8c80-4ee8-ad5a-c14c14a2bcbb.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=SCW3S98HDC0MAE9CBTQ5%2F20250827%2Ffr-par%2Fs3%2Faws4_request&X-Amz-Date=20250827T150541Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=content-length%3Bcontent-type%3Bhost&X-Amz-Signature=a9fa25f353df74f13b566f7ae3eb2d02a234162ed9ab81087b24018c28916948
         method: PUT
       response:
         proto: HTTP/2.0
@@ -445,16 +347,114 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Fri, 24 Jan 2025 15:45:01 GMT
+                - Wed, 27 Aug 2025 15:05:41 GMT
             Etag:
                 - '"10633bf7a5ff211d8f3eee3856a28101"'
             X-Amz-Id-2:
-                - txg049f193ee217466fb751-006793b57d
+                - txg62df4cf712bc4b9290a9-0068af1ec5
             X-Amz-Request-Id:
-                - txg049f193ee217466fb751-006793b57d
+                - txg62df4cf712bc4b9290a9-0068af1ec5
         status: 200 OK
         code: 200
-        duration: 86.828709ms
+        duration: 432.647663ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/151e1fa5-8c80-4ee8-ad5a-c14c14a2bcbb
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 689
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:41.229670Z","description":"","domain_name":"tffuncrelaxeddirac406dzjao-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"151e1fa5-8c80-4ee8-ad5a-c14c14a2bcbb","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"f92ef171-6edd-4736-9dbe-ba4a6c7c8dd5","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:41.229670Z"}'
+        headers:
+            Content-Length:
+                - "689"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:05:41 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 58142033-6ee4-4112-8d00-73f10ed35e6b
+        status: 200 OK
+        code: 200
+        duration: 59.042257ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/151e1fa5-8c80-4ee8-ad5a-c14c14a2bcbb
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 689
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:41.229670Z","description":"","domain_name":"tffuncrelaxeddirac406dzjao-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"151e1fa5-8c80-4ee8-ad5a-c14c14a2bcbb","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"f92ef171-6edd-4736-9dbe-ba4a6c7c8dd5","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:41.229670Z"}'
+        headers:
+            Content-Length:
+                - "689"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:05:41 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 4b605bed-e6df-441e-a4c2-321de1e29f14
+        status: 200 OK
+        code: 200
+        duration: 75.360727ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -470,8 +470,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/248594dd-f24a-4f23-be00-d9ba28b377d9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/151e1fa5-8c80-4ee8-ad5a-c14c14a2bcbb
         method: GET
       response:
         proto: HTTP/2.0
@@ -479,20 +479,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 655
+        content_length: 689
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:45:01.159155Z","description":"","domain_name":"tffuncferventnightin32cvo0cr-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"248594dd-f24a-4f23-be00-d9ba28b377d9","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"40fc92e8-aca6-4a2e-91de-27b700d7c960","privacy":"private","ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:45:01.159155Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:41.229670Z","description":"","domain_name":"tffuncrelaxeddirac406dzjao-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"151e1fa5-8c80-4ee8-ad5a-c14c14a2bcbb","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"f92ef171-6edd-4736-9dbe-ba4a6c7c8dd5","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:41.229670Z"}'
         headers:
             Content-Length:
-                - "655"
+                - "689"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:01 GMT
+                - Wed, 27 Aug 2025 15:05:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -500,10 +500,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f8e5ceda-605e-41af-bf1c-6fff7fa24b60
+                - 5163766c-1c86-4e83-b0a1-78fa7b5730e0
         status: 200 OK
         code: 200
-        duration: 87.742958ms
+        duration: 60.720597ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -519,8 +519,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/248594dd-f24a-4f23-be00-d9ba28b377d9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/f92ef171-6edd-4736-9dbe-ba4a6c7c8dd5
         method: GET
       response:
         proto: HTTP/2.0
@@ -528,20 +528,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 655
+        content_length: 587
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:45:01.159155Z","description":"","domain_name":"tffuncferventnightin32cvo0cr-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"248594dd-f24a-4f23-be00-d9ba28b377d9","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"40fc92e8-aca6-4a2e-91de-27b700d7c960","privacy":"private","ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:45:01.159155Z"}'
+        body: '{"created_at":"2025-08-27T15:05:35.106725Z","description":"","environment_variables":{},"error_message":null,"id":"f92ef171-6edd-4736-9dbe-ba4a6c7c8dd5","name":"tf-func-relaxed-dirac","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncrelaxeddirac406dzjao","registry_namespace_id":"5d5f5ffc-7625-43a3-95a7-7d7b542bf80e","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:37.083048Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "655"
+                - "587"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:01 GMT
+                - Wed, 27 Aug 2025 15:05:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -549,10 +549,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cbde66ee-3338-46f8-91cf-9d159c36f131
+                - 49eb29e4-4586-4a95-ac42-212e2bffabc9
         status: 200 OK
         code: 200
-        duration: 450.60025ms
+        duration: 37.409806ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -568,8 +568,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/248594dd-f24a-4f23-be00-d9ba28b377d9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/151e1fa5-8c80-4ee8-ad5a-c14c14a2bcbb
         method: GET
       response:
         proto: HTTP/2.0
@@ -577,20 +577,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 655
+        content_length: 689
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:45:01.159155Z","description":"","domain_name":"tffuncferventnightin32cvo0cr-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"248594dd-f24a-4f23-be00-d9ba28b377d9","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"40fc92e8-aca6-4a2e-91de-27b700d7c960","privacy":"private","ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:45:01.159155Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:41.229670Z","description":"","domain_name":"tffuncrelaxeddirac406dzjao-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"151e1fa5-8c80-4ee8-ad5a-c14c14a2bcbb","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"f92ef171-6edd-4736-9dbe-ba4a6c7c8dd5","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:41.229670Z"}'
         headers:
             Content-Length:
-                - "655"
+                - "689"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:02 GMT
+                - Wed, 27 Aug 2025 15:05:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -598,10 +598,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - deb80fe5-9513-404d-98ff-7d91bfb2fda8
+                - 8e8160f6-ccd4-4042-b525-8130c1490744
         status: 200 OK
         code: 200
-        duration: 163.591916ms
+        duration: 60.168391ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -617,8 +617,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/40fc92e8-aca6-4a2e-91de-27b700d7c960
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/151e1fa5-8c80-4ee8-ad5a-c14c14a2bcbb
         method: GET
       response:
         proto: HTTP/2.0
@@ -626,20 +626,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 562
+        content_length: 689
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:45.502949Z","description":"","environment_variables":{},"error_message":null,"id":"40fc92e8-aca6-4a2e-91de-27b700d7c960","name":"tf-func-fervent-nightingale","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncferventnightin32cvo0cr","registry_namespace_id":"b7ffcf71-4b36-4c69-bc71-e15aba54a568","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:44:57.766010Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:41.229670Z","description":"","domain_name":"tffuncrelaxeddirac406dzjao-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"151e1fa5-8c80-4ee8-ad5a-c14c14a2bcbb","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"f92ef171-6edd-4736-9dbe-ba4a6c7c8dd5","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:41.229670Z"}'
         headers:
             Content-Length:
-                - "562"
+                - "689"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:02 GMT
+                - Wed, 27 Aug 2025 15:05:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -647,10 +647,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 732ce558-09af-4ec8-a35e-128f0a1dc2e8
+                - 0bc9ce3c-fef8-4902-b917-cff62504b63d
         status: 200 OK
         code: 200
-        duration: 76.6675ms
+        duration: 53.624922ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -666,29 +666,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/248594dd-f24a-4f23-be00-d9ba28b377d9
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/151e1fa5-8c80-4ee8-ad5a-c14c14a2bcbb
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 655
+        content_length: 693
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:45:01.159155Z","description":"","domain_name":"tffuncferventnightin32cvo0cr-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"248594dd-f24a-4f23-be00-d9ba28b377d9","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"40fc92e8-aca6-4a2e-91de-27b700d7c960","privacy":"private","ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:45:01.159155Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-08-27T15:05:41.229670Z","description":"","domain_name":"tffuncrelaxeddirac406dzjao-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"151e1fa5-8c80-4ee8-ad5a-c14c14a2bcbb","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"f92ef171-6edd-4736-9dbe-ba4a6c7c8dd5","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2025-08-27T15:05:42.891194338Z"}'
         headers:
             Content-Length:
-                - "655"
+                - "693"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:03 GMT
+                - Wed, 27 Aug 2025 15:05:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -696,10 +696,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3574f3bc-0bc9-46fa-92b9-9f08d5fbfbc0
+                - e0bbe795-c73c-4b41-b2a5-b75acdccf73a
         status: 200 OK
         code: 200
-        duration: 76.348416ms
+        duration: 158.309344ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -715,8 +715,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/248594dd-f24a-4f23-be00-d9ba28b377d9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/f92ef171-6edd-4736-9dbe-ba4a6c7c8dd5
         method: GET
       response:
         proto: HTTP/2.0
@@ -724,20 +724,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 655
+        content_length: 587
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:45:01.159155Z","description":"","domain_name":"tffuncferventnightin32cvo0cr-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"248594dd-f24a-4f23-be00-d9ba28b377d9","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"40fc92e8-aca6-4a2e-91de-27b700d7c960","privacy":"private","ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","timeout":"300s","updated_at":"2025-01-24T15:45:01.159155Z"}'
+        body: '{"created_at":"2025-08-27T15:05:35.106725Z","description":"","environment_variables":{},"error_message":null,"id":"f92ef171-6edd-4736-9dbe-ba4a6c7c8dd5","name":"tf-func-relaxed-dirac","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncrelaxeddirac406dzjao","registry_namespace_id":"5d5f5ffc-7625-43a3-95a7-7d7b542bf80e","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-08-27T15:05:37.083048Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "655"
+                - "587"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:03 GMT
+                - Wed, 27 Aug 2025 15:05:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -745,10 +745,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 357c5bde-ab75-4fc1-8f27-e9695616af39
+                - 7cc99398-c836-4d9b-ad41-9bdeb8a02499
         status: 200 OK
         code: 200
-        duration: 66.4885ms
+        duration: 58.124275ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -764,8 +764,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/248594dd-f24a-4f23-be00-d9ba28b377d9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/f92ef171-6edd-4736-9dbe-ba4a6c7c8dd5
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -773,20 +773,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 659
+        content_length: 593
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2025-01-24T15:45:01.159155Z","description":"","domain_name":"tffuncferventnightin32cvo0cr-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"248594dd-f24a-4f23-be00-d9ba28b377d9","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"40fc92e8-aca6-4a2e-91de-27b700d7c960","privacy":"private","ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"deleting","timeout":"300s","updated_at":"2025-01-24T15:45:04.009233318Z"}'
+        body: '{"created_at":"2025-08-27T15:05:35.106725Z","description":"","environment_variables":{},"error_message":null,"id":"f92ef171-6edd-4736-9dbe-ba4a6c7c8dd5","name":"tf-func-relaxed-dirac","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncrelaxeddirac406dzjao","registry_namespace_id":"5d5f5ffc-7625-43a3-95a7-7d7b542bf80e","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:43.095768288Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "659"
+                - "593"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:04 GMT
+                - Wed, 27 Aug 2025 15:05:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -794,10 +794,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f44c40f9-a94b-46cd-b991-cd233e01bb97
+                - 63d97156-415d-4fad-aca9-80b52b07d702
         status: 200 OK
         code: 200
-        duration: 137.656542ms
+        duration: 210.219928ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -813,8 +813,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/40fc92e8-aca6-4a2e-91de-27b700d7c960
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/f92ef171-6edd-4736-9dbe-ba4a6c7c8dd5
         method: GET
       response:
         proto: HTTP/2.0
@@ -822,20 +822,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 562
+        content_length: 590
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:45.502949Z","description":"","environment_variables":{},"error_message":null,"id":"40fc92e8-aca6-4a2e-91de-27b700d7c960","name":"tf-func-fervent-nightingale","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncferventnightin32cvo0cr","registry_namespace_id":"b7ffcf71-4b36-4c69-bc71-e15aba54a568","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2025-01-24T15:44:57.766010Z"}'
+        body: '{"created_at":"2025-08-27T15:05:35.106725Z","description":"","environment_variables":{},"error_message":null,"id":"f92ef171-6edd-4736-9dbe-ba4a6c7c8dd5","name":"tf-func-relaxed-dirac","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncrelaxeddirac406dzjao","registry_namespace_id":"5d5f5ffc-7625-43a3-95a7-7d7b542bf80e","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:43.095768Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "562"
+                - "590"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:04 GMT
+                - Wed, 27 Aug 2025 15:05:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -843,10 +843,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 900c8f04-adfa-4a1e-aa36-43006d9f5fce
+                - 8f21fb7f-c40b-4d38-9ceb-fadf0d0ce27d
         status: 200 OK
         code: 200
-        duration: 68.61675ms
+        duration: 49.370279ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -862,29 +862,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/40fc92e8-aca6-4a2e-91de-27b700d7c960
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/f92ef171-6edd-4736-9dbe-ba4a6c7c8dd5
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 568
+        content_length: 590
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:45.502949Z","description":"","environment_variables":{},"error_message":null,"id":"40fc92e8-aca6-4a2e-91de-27b700d7c960","name":"tf-func-fervent-nightingale","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncferventnightin32cvo0cr","registry_namespace_id":"b7ffcf71-4b36-4c69-bc71-e15aba54a568","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:45:04.251222541Z"}'
+        body: '{"created_at":"2025-08-27T15:05:35.106725Z","description":"","environment_variables":{},"error_message":null,"id":"f92ef171-6edd-4736-9dbe-ba4a6c7c8dd5","name":"tf-func-relaxed-dirac","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncrelaxeddirac406dzjao","registry_namespace_id":"5d5f5ffc-7625-43a3-95a7-7d7b542bf80e","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:43.095768Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "568"
+                - "590"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:04 GMT
+                - Wed, 27 Aug 2025 15:05:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -892,10 +892,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 660b55f4-763a-4d81-ba53-f5879d18eba7
+                - 0c680fcb-484a-471e-9ffb-140d6fc333da
         status: 200 OK
         code: 200
-        duration: 252.215875ms
+        duration: 46.948746ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -911,8 +911,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/40fc92e8-aca6-4a2e-91de-27b700d7c960
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/f92ef171-6edd-4736-9dbe-ba4a6c7c8dd5
         method: GET
       response:
         proto: HTTP/2.0
@@ -920,20 +920,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 565
+        content_length: 590
         uncompressed: false
-        body: '{"created_at":"2025-01-24T15:44:45.502949Z","description":"","environment_variables":{},"error_message":null,"id":"40fc92e8-aca6-4a2e-91de-27b700d7c960","name":"tf-func-fervent-nightingale","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncferventnightin32cvo0cr","registry_namespace_id":"b7ffcf71-4b36-4c69-bc71-e15aba54a568","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-01-24T15:45:04.251223Z"}'
+        body: '{"created_at":"2025-08-27T15:05:35.106725Z","description":"","environment_variables":{},"error_message":null,"id":"f92ef171-6edd-4736-9dbe-ba4a6c7c8dd5","name":"tf-func-relaxed-dirac","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncrelaxeddirac406dzjao","registry_namespace_id":"5d5f5ffc-7625-43a3-95a7-7d7b542bf80e","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:43.095768Z","vpc_integration_activated":true}'
         headers:
             Content-Length:
-                - "565"
+                - "590"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:04 GMT
+                - Wed, 27 Aug 2025 15:05:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -941,10 +941,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6acf83b9-bfef-4454-800e-4b690982e598
+                - f85a31c6-ff9b-452d-a7f0-febe9d4caf8a
         status: 200 OK
         code: 200
-        duration: 74.316792ms
+        duration: 41.446492ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -960,8 +960,204 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/40fc92e8-aca6-4a2e-91de-27b700d7c960
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/f92ef171-6edd-4736-9dbe-ba4a6c7c8dd5
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 590
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:35.106725Z","description":"","environment_variables":{},"error_message":null,"id":"f92ef171-6edd-4736-9dbe-ba4a6c7c8dd5","name":"tf-func-relaxed-dirac","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncrelaxeddirac406dzjao","registry_namespace_id":"5d5f5ffc-7625-43a3-95a7-7d7b542bf80e","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:43.095768Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "590"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:05:58 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f11c7815-de8b-42b8-b007-d91cc45af78e
+        status: 200 OK
+        code: 200
+        duration: 37.445214ms
+    - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/f92ef171-6edd-4736-9dbe-ba4a6c7c8dd5
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 590
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:35.106725Z","description":"","environment_variables":{},"error_message":null,"id":"f92ef171-6edd-4736-9dbe-ba4a6c7c8dd5","name":"tf-func-relaxed-dirac","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncrelaxeddirac406dzjao","registry_namespace_id":"5d5f5ffc-7625-43a3-95a7-7d7b542bf80e","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:43.095768Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "590"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:03 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - cc7abe86-5d2a-45f0-8a44-5215be005728
+        status: 200 OK
+        code: 200
+        duration: 49.437137ms
+    - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/f92ef171-6edd-4736-9dbe-ba4a6c7c8dd5
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 590
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:35.106725Z","description":"","environment_variables":{},"error_message":null,"id":"f92ef171-6edd-4736-9dbe-ba4a6c7c8dd5","name":"tf-func-relaxed-dirac","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncrelaxeddirac406dzjao","registry_namespace_id":"5d5f5ffc-7625-43a3-95a7-7d7b542bf80e","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:43.095768Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "590"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:08 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - bdcaf816-f1fc-4ead-be7e-4fcfaff0d436
+        status: 200 OK
+        code: 200
+        duration: 41.640888ms
+    - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/f92ef171-6edd-4736-9dbe-ba4a6c7c8dd5
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 590
+        uncompressed: false
+        body: '{"created_at":"2025-08-27T15:05:35.106725Z","description":"","environment_variables":{},"error_message":null,"id":"f92ef171-6edd-4736-9dbe-ba4a6c7c8dd5","name":"tf-func-relaxed-dirac","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncrelaxeddirac406dzjao","registry_namespace_id":"5d5f5ffc-7625-43a3-95a7-7d7b542bf80e","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2025-08-27T15:05:43.095768Z","vpc_integration_activated":true}'
+        headers:
+            Content-Length:
+                - "590"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 Aug 2025 15:06:13 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ad41b390-62b3-4b91-b0de-b60358db7106
+        status: 200 OK
+        code: 200
+        duration: 61.013172ms
+    - id: 23
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/f92ef171-6edd-4736-9dbe-ba4a6c7c8dd5
         method: GET
       response:
         proto: HTTP/2.0
@@ -980,9 +1176,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:09 GMT
+                - Wed, 27 Aug 2025 15:06:18 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -990,11 +1186,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5a08c5bb-d928-40da-8412-34e556e5b7a3
+                - 6b3c285f-601a-492d-b806-7f9eccf6c9e4
         status: 404 Not Found
         code: 404
-        duration: 29.020958ms
-    - id: 20
+        duration: 26.185648ms
+    - id: 24
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1009,8 +1205,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/248594dd-f24a-4f23-be00-d9ba28b377d9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/151e1fa5-8c80-4ee8-ad5a-c14c14a2bcbb
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1029,9 +1225,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 15:45:09 GMT
+                - Wed, 27 Aug 2025 15:06:18 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1039,7 +1235,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3db3627e-d089-49c9-9dd0-e86a457cc667
+                - 4ec3cc49-5a68-47c1-98df-d9d1a43c1785
         status: 404 Not Found
         code: 404
-        duration: 24.322292ms
+        duration: 24.331388ms

--- a/internal/services/function/token_test.go
+++ b/internal/services/function/token_test.go
@@ -21,7 +21,7 @@ func TestAccFunctionToken_Basic(t *testing.T) {
 	if !*acctest.UpdateCassettes {
 		// This hardcoded value has to be replaced with the expiration in cassettes.
 		// Should be in the first "POST /tokens" request.
-		expiresAt = "2025-01-28T15:55:38+01:00"
+		expiresAt = "2025-08-28T17:05:06+02:00"
 	}
 
 	resource.ParallelTest(t, resource.TestCase{


### PR DESCRIPTION
Since VPC integration is now available on all namespaces, the `activate_vpc_integration` attribute is deprecated and will always be set to `true`. Changing its value will not have any effect. 