### PR TITLE
fix(mongo-db): pass region when creating or restoring instances

### DIFF
--- a/internal/services/mongodb/instance.go
+++ b/internal/services/mongodb/instance.go
@@ -294,6 +294,7 @@ func ResourceInstanceCreate(ctx context.Context, d *schema.ResourceData, m any) 
 
 	if exist {
 		restoreSnapshotRequest := &mongodb.RestoreSnapshotRequest{
+			Region:       region,
 			SnapshotID:   regional.ExpandID(snapshotID.(string)).ID,
 			InstanceName: types.ExpandOrGenerateString(d.Get("name"), "mongodb"),
 			NodeAmount:   *nodeNumber,
@@ -310,6 +311,7 @@ func ResourceInstanceCreate(ctx context.Context, d *schema.ResourceData, m any) 
 		normalizeVersion := NormalizeMongoDBVersion(version)
 
 		createReq := &mongodb.CreateInstanceRequest{
+			Region:     region,
 			ProjectID:  d.Get("project_id").(string),
 			Name:       types.ExpandOrGenerateString(d.Get("name"), "mongodb"),
 			Version:    normalizeVersion,


### PR DESCRIPTION
close [#3461](https://github.com/scaleway/terraform-provider-scaleway/issues/3461)