### PR TITLE
chore(tests): sweep account last, match iam resources name with sweep

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,5 +1,6 @@
 SWEEP?=all_regions
-SWEEP_DIR?=./internal/services/*
+SWEEP_ACCOUNT_DIR?=./internal/services/account
+SWEEP_DIR?=$(filter-out $(SWEEP_ACCOUNT_DIR), $(wildcard ./internal/services/*))
 TEST?=$$(go list ./... |grep -v 'vendor')
 GOFMT_FILES?=$$(find . -name '*.go' |grep -v vendor)
 WEBSITE_REPO=github.com/hashicorp/terraform-website
@@ -14,6 +15,7 @@ build: fmtcheck
 sweep:
 	@echo "WARNING: This will destroy infrastructure. Use only in development accounts."
 	go test $(SWEEP_DIR) -v -sweep=$(SWEEP) $(SWEEPARGS) -timeout 60m
+	go test $(SWEEP_ACCOUNT_DIR) -v -sweep=$(SWEEP) $(SWEEPARGS) -timeout 60m
 
 test: fmtcheck
 	go test $(TEST) || exit 1

--- a/internal/acctest/fixtures.go
+++ b/internal/acctest/fixtures.go
@@ -70,9 +70,9 @@ func CreateFakeIAMManager(tt *TestTools) (*account.Project, *iam.APIKey, *iam.Po
 		return nil
 	}
 
-	projectName := sdkacctest.RandomWithPrefix("test-acc-scaleway-project")
-	iamApplicationName := sdkacctest.RandomWithPrefix("test-acc-scaleway-iam-app")
-	iamPolicyName := sdkacctest.RandomWithPrefix("test-acc-scaleway-iam-policy")
+	projectName := sdkacctest.RandomWithPrefix("tf-test-scaleway-project")
+	iamApplicationName := sdkacctest.RandomWithPrefix("tf-test-scaleway-iam-app")
+	iamPolicyName := sdkacctest.RandomWithPrefix("tf-test-scaleway-iam-policy")
 
 	projectAPI := account.NewProjectAPI(tt.Meta.ScwClient())
 
@@ -175,9 +175,9 @@ func CreateFakeSideProject(tt *TestTools) (*account.Project, *iam.APIKey, FakeSi
 		return nil
 	}
 
-	projectName := sdkacctest.RandomWithPrefix("test-acc-scaleway-project")
-	iamApplicationName := sdkacctest.RandomWithPrefix("test-acc-scaleway-iam-app")
-	iamPolicyName := sdkacctest.RandomWithPrefix("test-acc-scaleway-iam-policy")
+	projectName := sdkacctest.RandomWithPrefix("tf-test-scaleway-project")
+	iamApplicationName := sdkacctest.RandomWithPrefix("tf-test-scaleway-iam-app")
+	iamPolicyName := sdkacctest.RandomWithPrefix("tf-test-scaleway-iam-policy")
 
 	projectAPI := account.NewProjectAPI(tt.Meta.ScwClient())
 


### PR DESCRIPTION
- IAM sweep currently expects resources name to start with 'tf-test': I updated the fixture to match this expectation and prevent dangling iam resources
- Account sweep currently runs first, and fails when it attempts to delete unswept projects. I updated the Makefile to ensure it runs last. (Note : if some other sweeps have issues and leave behind resources, the project deletion in the account sweep will still fail).