### PR TITLE
feat(jobs): add local_storage_capacity to job_definition resource

### DIFF
--- a/docs/resources/job_definition.md
+++ b/docs/resources/job_definition.md
@@ -66,6 +66,7 @@ The following arguments are supported:
 
 - `cpu_limit` - (Required) The amount of vCPU computing resources to allocate to each container running the job.
 - `memory_limit` - (Required) The memory computing resources in MB to allocate to each container running the job.
+- `local_storage_capacity` - (Optional) The local storage capacity of the job in MiB.
 - `image_uri` - (Required) The uri of the container image that will be used for the job run.
 - `name` - (Optional) The name of the job.
 - `description` - (Optional) The description of the job

--- a/internal/services/jobs/action_start_job_definition_action_test.go
+++ b/internal/services/jobs/action_start_job_definition_action_test.go
@@ -183,11 +183,12 @@ func TestAccActionJobDefinitionStart_Basic(t *testing.T) {
 			{
 				Config: `
 					resource "scaleway_job_definition" "main" {
-						name         = "test-jobs-action-start"
-						cpu_limit    = 120
-						memory_limit = 256
-						image_uri    = "docker.io/alpine:latest"
-						command      = "echo 'Hello World'"
+						name                   = "test-jobs-action-start"
+						cpu_limit              = 120
+						memory_limit           = 256
+						local_storage_capacity = 5120
+						image_uri              = "docker.io/alpine:latest"
+						command                = "echo 'Hello World'"
 
 						lifecycle {
 							action_trigger {

--- a/internal/services/jobs/jobs.go
+++ b/internal/services/jobs/jobs.go
@@ -84,6 +84,11 @@ func definitionSchema() map[string]*schema.Schema {
 			},
 			ValidateDiagFunc: validation.MapKeyLenBetween(0, 100),
 		},
+		"local_storage_capacity": {
+			Type:        schema.TypeInt,
+			Description: "Local storage capacity of the job in MiB",
+			Optional:    true,
+		},
 		"cron": {
 			Type:        schema.TypeList,
 			Description: "Cron expression",
@@ -190,6 +195,10 @@ func ResourceJobDefinitionCreate(ctx context.Context, d *schema.ResourceData, m 
 		req.JobTimeout = scw.NewDurationFromTimeDuration(duration)
 	}
 
+	if localStorageCapacity, ok := d.GetOk("local_storage_capacity"); ok {
+		req.LocalStorageCapacity = types.ExpandUint32Ptr(localStorageCapacity)
+	}
+
 	definition, err := api.CreateJobDefinition(req, scw.WithContext(ctx))
 	if err != nil {
 		return diag.FromErr(err)
@@ -237,6 +246,7 @@ func ResourceJobDefinitionRead(ctx context.Context, d *schema.ResourceData, m an
 	_ = d.Set("name", definition.Name)
 	_ = d.Set("cpu_limit", int(definition.CPULimit))
 	_ = d.Set("memory_limit", int(definition.MemoryLimit))
+	_ = d.Set("local_storage_capacity", int(definition.LocalStorageCapacity))
 	_ = d.Set("image_uri", definition.ImageURI)
 	_ = d.Set("command", definition.Command)
 	_ = d.Set("env", types.FlattenMap(definition.EnvironmentVariables))
@@ -271,6 +281,10 @@ func ResourceJobDefinitionUpdate(ctx context.Context, d *schema.ResourceData, m 
 
 	if d.HasChange("memory_limit") {
 		req.MemoryLimit = types.ExpandUint32Ptr(d.Get("memory_limit"))
+	}
+
+	if d.HasChange("local_storage_capacity") {
+		req.LocalStorageCapacity = types.ExpandUint32Ptr(d.Get("local_storage_capacity"))
 	}
 
 	if d.HasChange("image_uri") {

--- a/internal/services/jobs/jobs_test.go
+++ b/internal/services/jobs/jobs_test.go
@@ -31,6 +31,7 @@ func TestAccJobDefinition_Basic(t *testing.T) {
 						name = "test-jobs-job-definition-basic"
 						cpu_limit = 120
 						memory_limit = 256
+						local_storage_capacity = 5120
 						image_uri = "docker.io/alpine:latest"
 					}
 				`,
@@ -58,6 +59,7 @@ func TestAccJobDefinition_Timeout(t *testing.T) {
 						name = "test-jobs-job-definition-timeout"
 						cpu_limit = 120
 						memory_limit = 256
+						local_storage_capacity = 5120
 						image_uri = "docker.io/alpine:latest"
 						timeout = "20m"
 					}
@@ -75,6 +77,7 @@ func TestAccJobDefinition_Timeout(t *testing.T) {
 						name = "test-jobs-job-definition-timeout"
 						cpu_limit = 120
 						memory_limit = 256
+						local_storage_capacity = 5120
 						image_uri = "docker.io/alpine:latest"
 						timeout = "1h30m"
 					}
@@ -84,6 +87,52 @@ func TestAccJobDefinition_Timeout(t *testing.T) {
 					acctest.CheckResourceAttrUUID("scaleway_job_definition.main", "id"),
 					resource.TestCheckResourceAttr("scaleway_job_definition.main", "name", "test-jobs-job-definition-timeout"),
 					resource.TestCheckResourceAttr("scaleway_job_definition.main", "timeout", "1h30m0s"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccJobDefinition_LocalStorageCapacity(t *testing.T) {
+	tt := acctest.NewTestTools(t)
+	defer tt.Cleanup()
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: tt.ProviderFactories,
+		CheckDestroy:             testAccCheckJobDefinitionDestroy(tt),
+		Steps: []resource.TestStep{
+			{
+				Config: `
+					resource scaleway_job_definition main {
+						name = "test-jobs-job-definition-local-storage"
+						cpu_limit = 120
+						memory_limit = 256
+						image_uri = "docker.io/alpine:latest"
+						local_storage_capacity = 1000
+					}
+				`,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckJobDefinitionExists(tt, "scaleway_job_definition.main"),
+					acctest.CheckResourceAttrUUID("scaleway_job_definition.main", "id"),
+					resource.TestCheckResourceAttr("scaleway_job_definition.main", "name", "test-jobs-job-definition-local-storage"),
+					resource.TestCheckResourceAttr("scaleway_job_definition.main", "local_storage_capacity", "1000"),
+				),
+			},
+			{
+				Config: `
+					resource scaleway_job_definition main {
+						name = "test-jobs-job-definition-local-storage"
+						cpu_limit = 120
+						memory_limit = 256
+						image_uri = "docker.io/alpine:latest"
+						local_storage_capacity = 2000
+					}
+				`,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckJobDefinitionExists(tt, "scaleway_job_definition.main"),
+					acctest.CheckResourceAttrUUID("scaleway_job_definition.main", "id"),
+					resource.TestCheckResourceAttr("scaleway_job_definition.main", "name", "test-jobs-job-definition-local-storage"),
+					resource.TestCheckResourceAttr("scaleway_job_definition.main", "local_storage_capacity", "2000"),
 				),
 			},
 		},
@@ -104,6 +153,7 @@ func TestAccJobDefinition_Cron(t *testing.T) {
 						name = "test-jobs-job-definition-cron"
 						cpu_limit = 120
 						memory_limit = 256
+						local_storage_capacity = 5120
 						image_uri = "docker.io/alpine:latest"
 						cron {
 							schedule = "5 4 1 * *"
@@ -126,6 +176,7 @@ func TestAccJobDefinition_Cron(t *testing.T) {
 						name = "test-jobs-job-definition-cron"
 						cpu_limit = 120
 						memory_limit = 256
+						local_storage_capacity = 5120
 						image_uri = "docker.io/alpine:latest"
 						cron {
 							schedule = "5 5 * * *"
@@ -148,6 +199,7 @@ func TestAccJobDefinition_Cron(t *testing.T) {
 						name = "test-jobs-job-definition-cron"
 						cpu_limit = 120
 						memory_limit = 256
+						local_storage_capacity = 5120
 						image_uri = "docker.io/alpine:latest"
 					}
 				`,
@@ -185,6 +237,7 @@ func TestAccJobDefinition_SecretReference(t *testing.T) {
 						name = "test-jobs-job-definition-secret"
 						cpu_limit = 120
 						memory_limit = 256
+						local_storage_capacity = 5120
 						image_uri = "docker.io/alpine:latest"
 						secret_reference {
 							secret_id = scaleway_secret.main.id
@@ -222,6 +275,7 @@ func TestAccJobDefinition_SecretReference(t *testing.T) {
 						name = "test-jobs-job-definition-secret"
 						cpu_limit = 120
 						memory_limit = 256
+						local_storage_capacity = 5120
 						image_uri = "docker.io/alpine:latest"
 						secret_reference {
 							secret_id = split("/", scaleway_secret.main.id)[1]
@@ -260,6 +314,7 @@ func TestAccJobDefinition_SecretReference(t *testing.T) {
 						name = "test-jobs-job-definition-secret"
 						cpu_limit = 120
 						memory_limit = 256
+						local_storage_capacity = 5120
 						image_uri = "docker.io/alpine:latest"
 						secret_reference {
 							secret_id = scaleway_secret.main.id
@@ -302,6 +357,7 @@ func TestAccJobDefinition_WrongSecretReference(t *testing.T) {
 						name = "test-jobs-job-definition-secret"
 						cpu_limit = 120
 						memory_limit = 256
+						local_storage_capacity = 5120
 						image_uri = "docker.io/alpine:latest"
 						secret_reference {
 							secret_id = scaleway_secret.main.id
@@ -319,11 +375,12 @@ func TestAccJobDefinition_WrongSecretReference(t *testing.T) {
 		  			  secret_id   = scaleway_secret.main.id
 					  data        = "your_secret"
 					}
-		
+
 					resource scaleway_job_definition main {
 						name = "test-jobs-job-definition-secret"
 						cpu_limit = 120
 						memory_limit = 256
+						local_storage_capacity = 5120
 						image_uri = "docker.io/alpine:latest"
 						secret_reference {
 							secret_id = scaleway_secret.main.id

--- a/internal/services/jobs/testdata/job-definition-local-storage-capacity.cassette.yaml
+++ b/internal/services/jobs/testdata/job-definition-local-storage-capacity.cassette.yaml
@@ -1,0 +1,789 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 261
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"name":"test-jobs-job-definition-local-storage","cpu_limit":120,"memory_limit":256,"local_storage_capacity":1000,"image_uri":"docker.io/alpine:latest","command":"","project_id":"c1f69d33-c8a3-45fb-90be-05dbfa5ee465","environment_variables":{},"description":""}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/serverless-jobs/v1alpha1/regions/fr-par/job-definitions
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 453
+        uncompressed: false
+        body: '{"command":"","cpu_limit":120,"created_at":"2025-12-10T15:21:05.207909Z","cron_schedule":null,"description":"","environment_variables":{},"id":"a28e7846-3b32-4556-ab08-c8adf7e6285d","image_uri":"docker.io/alpine:latest","job_timeout":"86400s","local_storage_capacity":1000,"memory_limit":256,"name":"test-jobs-job-definition-local-storage","project_id":"c1f69d33-c8a3-45fb-90be-05dbfa5ee465","region":"fr-par","updated_at":"2025-12-10T15:21:05.207909Z"}'
+        headers:
+            Content-Length:
+                - "453"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 10 Dec 2025 15:21:05 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 48e316ba-8379-4834-8008-5404267ad881
+        status: 200 OK
+        code: 200
+        duration: 261.986292ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/serverless-jobs/v1alpha1/regions/fr-par/job-definitions/a28e7846-3b32-4556-ab08-c8adf7e6285d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 453
+        uncompressed: false
+        body: '{"command":"","cpu_limit":120,"created_at":"2025-12-10T15:21:05.207909Z","cron_schedule":null,"description":"","environment_variables":{},"id":"a28e7846-3b32-4556-ab08-c8adf7e6285d","image_uri":"docker.io/alpine:latest","job_timeout":"86400s","local_storage_capacity":1000,"memory_limit":256,"name":"test-jobs-job-definition-local-storage","project_id":"c1f69d33-c8a3-45fb-90be-05dbfa5ee465","region":"fr-par","updated_at":"2025-12-10T15:21:05.207909Z"}'
+        headers:
+            Content-Length:
+                - "453"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 10 Dec 2025 15:21:05 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 37bc4820-bee5-4303-951c-84d96ec1ce3a
+        status: 200 OK
+        code: 200
+        duration: 66.668625ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/serverless-jobs/v1alpha1/regions/fr-par/job-definitions/a28e7846-3b32-4556-ab08-c8adf7e6285d/secrets
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 30
+        uncompressed: false
+        body: '{"secrets":[],"total_count":0}'
+        headers:
+            Content-Length:
+                - "30"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 10 Dec 2025 15:21:05 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 5d5b69ea-3eca-4131-98a9-81470866e860
+        status: 200 OK
+        code: 200
+        duration: 123.062625ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/serverless-jobs/v1alpha1/regions/fr-par/job-definitions/a28e7846-3b32-4556-ab08-c8adf7e6285d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 453
+        uncompressed: false
+        body: '{"command":"","cpu_limit":120,"created_at":"2025-12-10T15:21:05.207909Z","cron_schedule":null,"description":"","environment_variables":{},"id":"a28e7846-3b32-4556-ab08-c8adf7e6285d","image_uri":"docker.io/alpine:latest","job_timeout":"86400s","local_storage_capacity":1000,"memory_limit":256,"name":"test-jobs-job-definition-local-storage","project_id":"c1f69d33-c8a3-45fb-90be-05dbfa5ee465","region":"fr-par","updated_at":"2025-12-10T15:21:05.207909Z"}'
+        headers:
+            Content-Length:
+                - "453"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 10 Dec 2025 15:21:05 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 737e07e7-ed4a-436a-a602-90dda33d211d
+        status: 200 OK
+        code: 200
+        duration: 67.493792ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/serverless-jobs/v1alpha1/regions/fr-par/job-definitions/a28e7846-3b32-4556-ab08-c8adf7e6285d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 453
+        uncompressed: false
+        body: '{"command":"","cpu_limit":120,"created_at":"2025-12-10T15:21:05.207909Z","cron_schedule":null,"description":"","environment_variables":{},"id":"a28e7846-3b32-4556-ab08-c8adf7e6285d","image_uri":"docker.io/alpine:latest","job_timeout":"86400s","local_storage_capacity":1000,"memory_limit":256,"name":"test-jobs-job-definition-local-storage","project_id":"c1f69d33-c8a3-45fb-90be-05dbfa5ee465","region":"fr-par","updated_at":"2025-12-10T15:21:05.207909Z"}'
+        headers:
+            Content-Length:
+                - "453"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 10 Dec 2025 15:21:05 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 98e15c22-3ecb-432e-92ab-67bf33431b91
+        status: 200 OK
+        code: 200
+        duration: 141.554583ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/serverless-jobs/v1alpha1/regions/fr-par/job-definitions/a28e7846-3b32-4556-ab08-c8adf7e6285d/secrets
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 30
+        uncompressed: false
+        body: '{"secrets":[],"total_count":0}'
+        headers:
+            Content-Length:
+                - "30"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 10 Dec 2025 15:21:05 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 7eda4a2c-14d9-4966-8feb-3dd1a82aa6e4
+        status: 200 OK
+        code: 200
+        duration: 131.755541ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/serverless-jobs/v1alpha1/regions/fr-par/job-definitions/a28e7846-3b32-4556-ab08-c8adf7e6285d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 453
+        uncompressed: false
+        body: '{"command":"","cpu_limit":120,"created_at":"2025-12-10T15:21:05.207909Z","cron_schedule":null,"description":"","environment_variables":{},"id":"a28e7846-3b32-4556-ab08-c8adf7e6285d","image_uri":"docker.io/alpine:latest","job_timeout":"86400s","local_storage_capacity":1000,"memory_limit":256,"name":"test-jobs-job-definition-local-storage","project_id":"c1f69d33-c8a3-45fb-90be-05dbfa5ee465","region":"fr-par","updated_at":"2025-12-10T15:21:05.207909Z"}'
+        headers:
+            Content-Length:
+                - "453"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 10 Dec 2025 15:21:06 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3fd493ab-cd73-44b7-8fc3-2e26c78dc4ad
+        status: 200 OK
+        code: 200
+        duration: 55.421791ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/serverless-jobs/v1alpha1/regions/fr-par/job-definitions/a28e7846-3b32-4556-ab08-c8adf7e6285d/secrets
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 30
+        uncompressed: false
+        body: '{"secrets":[],"total_count":0}'
+        headers:
+            Content-Length:
+                - "30"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 10 Dec 2025 15:21:06 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - a4cc6224-b1ce-4a69-8693-16036c02f2da
+        status: 200 OK
+        code: 200
+        duration: 55.986417ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 31
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"local_storage_capacity":2000}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/serverless-jobs/v1alpha1/regions/fr-par/job-definitions/a28e7846-3b32-4556-ab08-c8adf7e6285d
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 453
+        uncompressed: false
+        body: '{"command":"","cpu_limit":120,"created_at":"2025-12-10T15:21:05.207909Z","cron_schedule":null,"description":"","environment_variables":{},"id":"a28e7846-3b32-4556-ab08-c8adf7e6285d","image_uri":"docker.io/alpine:latest","job_timeout":"86400s","local_storage_capacity":2000,"memory_limit":256,"name":"test-jobs-job-definition-local-storage","project_id":"c1f69d33-c8a3-45fb-90be-05dbfa5ee465","region":"fr-par","updated_at":"2025-12-10T15:21:06.370049Z"}'
+        headers:
+            Content-Length:
+                - "453"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 10 Dec 2025 15:21:06 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 902f9fdb-7685-4270-9a16-4c10ff62bee0
+        status: 200 OK
+        code: 200
+        duration: 141.444417ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/serverless-jobs/v1alpha1/regions/fr-par/job-definitions/a28e7846-3b32-4556-ab08-c8adf7e6285d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 453
+        uncompressed: false
+        body: '{"command":"","cpu_limit":120,"created_at":"2025-12-10T15:21:05.207909Z","cron_schedule":null,"description":"","environment_variables":{},"id":"a28e7846-3b32-4556-ab08-c8adf7e6285d","image_uri":"docker.io/alpine:latest","job_timeout":"86400s","local_storage_capacity":2000,"memory_limit":256,"name":"test-jobs-job-definition-local-storage","project_id":"c1f69d33-c8a3-45fb-90be-05dbfa5ee465","region":"fr-par","updated_at":"2025-12-10T15:21:06.370049Z"}'
+        headers:
+            Content-Length:
+                - "453"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 10 Dec 2025 15:21:06 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - d6bf9d7d-f571-482e-a334-9a3a66c236fc
+        status: 200 OK
+        code: 200
+        duration: 102.117542ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/serverless-jobs/v1alpha1/regions/fr-par/job-definitions/a28e7846-3b32-4556-ab08-c8adf7e6285d/secrets
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 30
+        uncompressed: false
+        body: '{"secrets":[],"total_count":0}'
+        headers:
+            Content-Length:
+                - "30"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 10 Dec 2025 15:21:06 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - c8d89a01-5c95-47fd-a05b-64faa4f9e627
+        status: 200 OK
+        code: 200
+        duration: 48.329958ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/serverless-jobs/v1alpha1/regions/fr-par/job-definitions/a28e7846-3b32-4556-ab08-c8adf7e6285d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 453
+        uncompressed: false
+        body: '{"command":"","cpu_limit":120,"created_at":"2025-12-10T15:21:05.207909Z","cron_schedule":null,"description":"","environment_variables":{},"id":"a28e7846-3b32-4556-ab08-c8adf7e6285d","image_uri":"docker.io/alpine:latest","job_timeout":"86400s","local_storage_capacity":2000,"memory_limit":256,"name":"test-jobs-job-definition-local-storage","project_id":"c1f69d33-c8a3-45fb-90be-05dbfa5ee465","region":"fr-par","updated_at":"2025-12-10T15:21:06.370049Z"}'
+        headers:
+            Content-Length:
+                - "453"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 10 Dec 2025 15:21:06 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 4e46f2f7-d6aa-4836-8525-9547fe4119ae
+        status: 200 OK
+        code: 200
+        duration: 44.496709ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/serverless-jobs/v1alpha1/regions/fr-par/job-definitions/a28e7846-3b32-4556-ab08-c8adf7e6285d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 453
+        uncompressed: false
+        body: '{"command":"","cpu_limit":120,"created_at":"2025-12-10T15:21:05.207909Z","cron_schedule":null,"description":"","environment_variables":{},"id":"a28e7846-3b32-4556-ab08-c8adf7e6285d","image_uri":"docker.io/alpine:latest","job_timeout":"86400s","local_storage_capacity":2000,"memory_limit":256,"name":"test-jobs-job-definition-local-storage","project_id":"c1f69d33-c8a3-45fb-90be-05dbfa5ee465","region":"fr-par","updated_at":"2025-12-10T15:21:06.370049Z"}'
+        headers:
+            Content-Length:
+                - "453"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 10 Dec 2025 15:21:06 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 22e0c801-1a62-4831-8e1e-53da2176bc62
+        status: 200 OK
+        code: 200
+        duration: 116.302333ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/serverless-jobs/v1alpha1/regions/fr-par/job-definitions/a28e7846-3b32-4556-ab08-c8adf7e6285d/secrets
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 30
+        uncompressed: false
+        body: '{"secrets":[],"total_count":0}'
+        headers:
+            Content-Length:
+                - "30"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 10 Dec 2025 15:21:06 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 67c62dbc-50c0-418a-b8c5-1c7447ba649f
+        status: 200 OK
+        code: 200
+        duration: 46.455417ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/serverless-jobs/v1alpha1/regions/fr-par/job-definitions/a28e7846-3b32-4556-ab08-c8adf7e6285d
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 10 Dec 2025 15:21:07 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f9b73b66-59ee-4718-aa22-b4d2203cba3d
+        status: 204 No Content
+        code: 204
+        duration: 85.825042ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/serverless-jobs/v1alpha1/regions/fr-par/job-definitions/a28e7846-3b32-4556-ab08-c8adf7e6285d
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 41
+        uncompressed: false
+        body: '{"message":"job definition is not found"}'
+        headers:
+            Content-Length:
+                - "41"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 10 Dec 2025 15:21:07 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 5c999b18-4e50-4a70-8806-d8ee249ca904
+        status: 404 Not Found
+        code: 404
+        duration: 40.362542ms

--- a/templates/resources/job_definition.md.tmpl
+++ b/templates/resources/job_definition.md.tmpl
@@ -67,6 +67,7 @@ The following arguments are supported:
 
 - `cpu_limit` - (Required) The amount of vCPU computing resources to allocate to each container running the job.
 - `memory_limit` - (Required) The memory computing resources in MB to allocate to each container running the job.
+- `local_storage_capacity` - (Optional) The local storage capacity of the job in MiB.
 - `image_uri` - (Required) The uri of the container image that will be used for the job run.
 - `name` - (Optional) The name of the job.
 - `description` - (Optional) The description of the job


### PR DESCRIPTION
The Scaleway Jobs API supports configuring local storage capacity for job definitions, but this option was not exposed in the Terraform provider. This change adds the local_storage_capacity attribute to allow users to specify local storage in MiB for their job containers.