### PR TITLE
fix(secret): prevent secret version datasource double base64 encoding

### DIFF
--- a/internal/services/secret/version_data_source.go
+++ b/internal/services/secret/version_data_source.go
@@ -2,7 +2,6 @@ package secret
 
 import (
 	"context"
-	"encoding/base64"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -119,7 +118,7 @@ func datasourceSchemaFromResourceVersionSchema(ctx context.Context, d *schema.Re
 
 	d.SetId(secretVersionIDStr)
 
-	err = d.Set("data", base64.StdEncoding.EncodeToString(payloadSecretRaw))
+	err = d.Set("data", Base64Encoded(payloadSecretRaw))
 	if err != nil {
 		return diag.FromErr(err)
 	}


### PR DESCRIPTION
in secret_version datasource, prevent reencoding an already base64-encoded data.
Currently, we systematically reencode the data in base 64, regardless of whether it was already encoded as base64 in the first place. This means we sometimes return double (or more) encoded values.
With this change we will now check whether the data is already base64 encoded, and return it as a string if so, without over-encoding it.

I discovered this issue while working on the not-yet merged `verify` data source. Looking at other calls of this datasource in tests, I did not note any impact.